### PR TITLE
feat: change output text from "[REDACTED]" to "[HIDDEN]"

### DIFF
--- a/.github/workflows/ferret-scan.yml
+++ b/.github/workflows/ferret-scan.yml
@@ -353,7 +353,7 @@ jobs:
       
       - name: Upload scan results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ferret-scan-results
           path: |

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ go build -ldflags="-s -w" -o ferret-scan cmd/main.go
 - `--debug`: Enable debug logging to show preprocessing and validation flow
 - `--output`: Path to output file (if not specified, output to stdout)
 - `--no-color`: Disable colored output (useful for logging or non-terminal output)
-- `--show-match`: Display the actual matched text in findings
+- `--show-match`: Display the actual matched text in findings (otherwise shows [HIDDEN])
 - `--quiet`: Suppress progress output (useful for scripts and CI/CD)
 - `--help`: Show help information
 - `--version`: Show version information

--- a/docs/DOCKER_INTEGRATION.md
+++ b/docs/DOCKER_INTEGRATION.md
@@ -184,7 +184,7 @@ jobs:
             --confidence high,medium --no-color --quiet
       
       - name: Upload results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ferret-scan-results
           path: results.json

--- a/docs/PRE_COMMIT_INTEGRATION.md
+++ b/docs/PRE_COMMIT_INTEGRATION.md
@@ -560,7 +560,7 @@ jobs:
             --format json --output /data/results.json
       
       - name: Upload results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ferret-scan-results
           path: results.json

--- a/docs/development/WINDOWS_CROSS_COMPILATION.md
+++ b/docs/development/WINDOWS_CROSS_COMPILATION.md
@@ -518,7 +518,7 @@ jobs:
         wine ferret-scan-${{ matrix.name }}.exe --version || echo "Wine test completed"
     
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ferret-scan-${{ matrix.name }}
         path: |

--- a/docs/development/comprehend_implementation_summary.md
+++ b/docs/development/comprehend_implementation_summary.md
@@ -27,7 +27,7 @@ This document summarizes the Amazon Comprehend PII detection integration impleme
   - Implements standard Validator interface
   - Enabled only with `--enable-genai` flag
   - Processes text content via `ValidateContent` method
-  - Context redaction for security (PII shown as [REDACTED])
+  - Context redaction for security (PII shown as [HIDDEN])
 
 ### 3. Integration with GenAI System
 - **Reuses existing `--enable-genai` flag** (no new flags needed)
@@ -77,7 +77,7 @@ This document summarizes the Amazon Comprehend PII detection integration impleme
 - **PHI Classification**: Identifies Protected Health Information
 
 ### 2. Security and Privacy
-- **Context Redaction**: PII values shown as [REDACTED] in context
+- **Context Redaction**: PII values shown as [HIDDEN] in context
 - **Secure Output**: Sensitive values masked in all output formats
 - **Debug Safety**: Debug output avoids exposing actual PII values
 

--- a/docs/user-guides/README-Enhanced-Metadata.md
+++ b/docs/user-guides/README-Enhanced-Metadata.md
@@ -401,7 +401,7 @@ fi
 
 ### Security Considerations
 
-1. **Avoid Exposing Sensitive Data**: Use `--show-match false` in production environments
+1. **Avoid Exposing Sensitive Data**: Avoid using `--show-match` in production environments (data will show as [HIDDEN] by default)
 2. **Secure Result Storage**: Ensure scan results are stored securely
 3. **Regular Scanning**: Implement regular metadata scanning in your workflow
 4. **Access Control**: Limit access to metadata scanning results

--- a/docs/user-guides/README-Suppressions.md
+++ b/docs/user-guides/README-Suppressions.md
@@ -119,7 +119,7 @@ ferret-scan --file document.txt --format json
 
 # The output will include suppression info for each finding:
 {
-  "text": "[REDACTED]",
+  "text": "[HIDDEN]",
   "type": "SSN",
   "suppression_info": {
     "hash": "abc123...",

--- a/examples/ferret-dev-windows.yaml
+++ b/examples/ferret-dev-windows.yaml
@@ -46,7 +46,7 @@ redaction:
 
   strategies:
     simple:
-      replacement: "[DEV-REDACTED]" # Clear development redaction marker
+      replacement: "[DEV-HIDDEN]" # Clear development redaction marker
 
     format_preserving:
       preserve_length: true # Maintain formatting for development analysis

--- a/examples/ferret-enterprise-windows.yaml
+++ b/examples/ferret-enterprise-windows.yaml
@@ -46,7 +46,7 @@ redaction:
 
   strategies:
     simple:
-      replacement: "[ENTERPRISE-REDACTED]" # Clear enterprise redaction marker
+      replacement: "[ENTERPRISE-HIDDEN]" # Clear enterprise redaction marker
 
     format_preserving:
       preserve_length: true # Maintain document formatting

--- a/examples/ferret-powershell.yaml
+++ b/examples/ferret-powershell.yaml
@@ -46,7 +46,7 @@ redaction:
 
   strategies:
     simple:
-      replacement: "[REDACTED]"
+      replacement: "[HIDDEN]"
     format_preserving:
       preserve_length: true
       preserve_format: true

--- a/examples/ferret-windows.yaml
+++ b/examples/ferret-windows.yaml
@@ -48,7 +48,7 @@ redaction:
   # Strategy-specific configurations
   strategies:
     simple:
-      replacement: "[REDACTED]" # Text to replace sensitive data with
+      replacement: "[HIDDEN]" # Text to replace sensitive data with
 
     format_preserving:
       preserve_length: true # Maintain original text length

--- a/examples/ferret.yaml
+++ b/examples/ferret.yaml
@@ -95,7 +95,7 @@ redaction:
   # Strategy-specific configurations
   strategies:
     simple:
-      replacement: "[REDACTED]" # Text to replace sensitive data with
+      replacement: "[HIDDEN]" # Text to replace sensitive data with
 
     format_preserving:
       preserve_length: true # Maintain original text length

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -158,7 +158,7 @@ func LoadConfig(configPath string) (*Config, error) {
 	config.Redaction.IndexFile = ""
 	config.Redaction.MemoryScrub = true
 	config.Redaction.AuditTrail = true
-	config.Redaction.Strategies.Simple.Replacement = "[REDACTED]"
+	config.Redaction.Strategies.Simple.Replacement = "[HIDDEN]"
 	config.Redaction.Strategies.FormatPreserving.PreserveLength = true
 	config.Redaction.Strategies.FormatPreserving.PreserveFormat = true
 	config.Redaction.Strategies.Synthetic.Secure = true

--- a/internal/formatters/csv/formatter.go
+++ b/internal/formatters/csv/formatter.go
@@ -95,7 +95,7 @@ func (f *Formatter) createCSVRow(match detector.Match, options formatters.Format
 	} else {
 		// Full format for normal mode
 		// Determine display text based on ShowMatch option
-		displayText := "[REDACTED]"
+		displayText := "[HIDDEN]"
 		if options.ShowMatch {
 			displayText = match.Text
 		}

--- a/internal/formatters/gitlab-sast/sanitizer.go
+++ b/internal/formatters/gitlab-sast/sanitizer.go
@@ -25,7 +25,7 @@ func NewDataSanitizer() DataSanitizerInterface {
 func (s *DataSanitizer) SanitizeMessage(match detector.Match) string {
 	// Use secure defaults - never show actual sensitive data in GitLab reports
 	// This ensures GitLab Security Dashboard doesn't expose sensitive information
-	matchText := "[REDACTED]"
+	matchText := "[HIDDEN]"
 
 	// Create context-aware message based on check type
 	checkTypeDescription := s.GetCheckTypeDescription(match.Type)

--- a/internal/formatters/text/formatter.go
+++ b/internal/formatters/text/formatter.go
@@ -169,7 +169,7 @@ func (f *Formatter) appendHeaders(builder *strings.Builder, matches []detector.M
 
 // calculateMatchColumnWidth calculates the optimal width for the match column
 func (f *Formatter) calculateMatchColumnWidth(matches []detector.Match, options formatters.FormatterOptions) int {
-	maxWidth := 10 // Minimum width for "[REDACTED]"
+	maxWidth := 10 // Minimum width for "[HIDDEN]"
 	for _, match := range matches {
 		if options.ShowMatch || options.Verbose {
 			matchText := strings.ReplaceAll(match.Text, "\n", " ")
@@ -280,7 +280,7 @@ func (f *Formatter) appendSummaryLine(builder *strings.Builder, match detector.M
 			matchText = string(runes[:targetWidth-3]) + "..."
 		}
 	} else {
-		matchText = "[REDACTED]"
+		matchText = "[HIDDEN]"
 	}
 	// Ensure exactly targetWidth visible characters by padding with spaces
 	runeCount := len([]rune(matchText))
@@ -774,7 +774,7 @@ func (f *Formatter) getPrecommitResolutionGuidance(matches []detector.Match) str
 	guidance.WriteString("Resolution options:\n")
 	guidance.WriteString("1. Remove or redact the sensitive data\n")
 	guidance.WriteString("2. Add suppression rules if data is intentional (see docs/suppression-system.md)\n")
-	guidance.WriteString("3. Use --show-match flag to see exact matches for review\n")
+	guidance.WriteString("3. Use --show-match flag to see exact matches for review (otherwise shows [HIDDEN])\n")
 
 	// Check if there are high confidence findings that should block
 	hasHighConfidence := false

--- a/internal/help/help.go
+++ b/internal/help/help.go
@@ -105,7 +105,7 @@ func (h *System) ShowGeneralHelp() {
 	fmt.Fprintln(w, "  --debug\t\tEnable debug logging to show preprocessing, content routing, and validation flow")
 	fmt.Fprintln(w, "  --output\t<path>\tPath to output file (if not specified, output to stdout)")
 	fmt.Fprintln(w, "  --no-color\t\tDisable colored output")
-	fmt.Fprintln(w, "  --show-match\t\tDisplay the actual matched text in findings")
+	fmt.Fprintln(w, "  --show-match\t\tDisplay the actual matched text in findings (otherwise shows [HIDDEN])")
 	fmt.Fprintln(w, "  --enable-preprocessors\t\tEnable text extraction from documents (PDF, Office files) (default: true, use --enable-preprocessors=false to disable)")
 	fmt.Fprintln(w, "  --preprocess-only, -p\t\tOutput preprocessed text and exit (no validation or redaction)")
 	// GENAI_DISABLED: GenAI-related command line options

--- a/internal/monitoring/debug_logger.go
+++ b/internal/monitoring/debug_logger.go
@@ -427,7 +427,7 @@ func (dl *DebugLogger) shouldLogDetailed() bool {
 
 func (dl *DebugLogger) redactSensitiveContent(content string) string {
 	if !dl.config.LogSensitiveContent {
-		return "[REDACTED]"
+		return "[HIDDEN]"
 	}
 
 	// Limit content length

--- a/internal/preprocessors/meta-extractors/meta-extract-pdflib/pdf-extractor.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-pdflib/pdf-extractor.go
@@ -433,7 +433,7 @@ func extractDirectField(data []byte, fieldName string) string {
 	if fieldName == "Producer" {
 		// Try different TCPDF patterns
 		tcpdfPatterns := []string{
-			`TCPDF\s+([\d\.]+)\s+\(http://www.tcpdf.org\)`,
+			`TCPDF\s+([\d\.]+)\s+\(http://www\.tcpdf\.org\)`,
 			`TCPDF\s*([\d\.]+)`,
 			`Producer.*?TCPDF`,
 			`tcpdf`,

--- a/internal/redactors/office/redactor.go
+++ b/internal/redactors/office/redactor.go
@@ -993,7 +993,7 @@ func (or *OfficeRedactor) generateVerificationHash(text string, startPos, endPos
 		return redactors.GenerateContextHash("invalid_context")
 	}
 
-	context := text[contextStart:startPos] + "[REDACTED]" + text[endPos:contextEnd]
+	context := text[contextStart:startPos] + "[HIDDEN]" + text[endPos:contextEnd]
 	return redactors.GenerateContextHash(context)
 }
 

--- a/internal/redactors/pdf/redactor.go
+++ b/internal/redactors/pdf/redactor.go
@@ -671,7 +671,7 @@ func (pr *PDFRedactor) generateVerificationHash(text string, startPos, endPos in
 		return redactors.GenerateContextHash("invalid_context")
 	}
 
-	context := text[contextStart:startPos] + "[REDACTED]" + text[endPos:contextEnd]
+	context := text[contextStart:startPos] + "[HIDDEN]" + text[endPos:contextEnd]
 	return redactors.GenerateContextHash(context)
 }
 

--- a/internal/redactors/plaintext/redactor.go
+++ b/internal/redactors/plaintext/redactor.go
@@ -739,7 +739,7 @@ func (ptr *PlainTextRedactor) generateVerificationHash(text string, startPos, en
 		return redactors.GenerateContextHash("invalid_context")
 	}
 
-	context := text[contextStart:startPos] + "[REDACTED]" + text[endPos:contextEnd]
+	context := text[contextStart:startPos] + "[HIDDEN]" + text[endPos:contextEnd]
 	return redactors.GenerateContextHash(context)
 }
 

--- a/internal/redactors/strategies/format_preserving.go
+++ b/internal/redactors/strategies/format_preserving.go
@@ -108,7 +108,7 @@ func (fps *FormatPreservingStrategy) ValidateRedaction(original, redacted, dataT
 			Severity:    SeverityError,
 			Type:        IssueTypeLength,
 			Description: "Length was not preserved in format-preserving redaction",
-			Suggestion:  "Ensure redacted text maintains original length",
+			Suggestion:  "Ensure hidden text maintains original length",
 		})
 	}
 
@@ -128,8 +128,8 @@ func (fps *FormatPreservingStrategy) ValidateRedaction(original, redacted, dataT
 		issues = append(issues, ValidationIssue{
 			Severity:    SeverityCritical,
 			Type:        IssueTypeSecurity,
-			Description: "Potential data leakage detected in redacted text",
-			Suggestion:  "Ensure no original sensitive data remains in redacted text",
+			Description: "Potential data leakage detected in hidden text",
+			Suggestion:  "Ensure no original sensitive data remains in hidden text",
 		})
 	}
 

--- a/internal/redactors/strategies/simple.go
+++ b/internal/redactors/strategies/simple.go
@@ -37,9 +37,9 @@ func NewSimpleRedactionStrategy() *SimpleRedactionStrategy {
 			"DATE":        "[DATE-REDACTED]",
 			"IP_ADDRESS":  "[IP-ADDRESS-REDACTED]",
 			"URL":         "[URL-REDACTED]",
-			"PASSWORD":    "[PASSWORD-REDACTED]",
-			"API_KEY":     "[API-KEY-REDACTED]",
-			"DEFAULT":     "[REDACTED]",
+			"PASSWORD":    "[PASSWORD-HIDDEN]",
+			"API_KEY":     "[API-KEY-HIDDEN]",
+			"DEFAULT":     "[HIDDEN]",
 		},
 	}
 
@@ -106,7 +106,7 @@ func (srs *SimpleRedactionStrategy) ValidateRedaction(original, redacted, dataTy
 		issues = append(issues, ValidationIssue{
 			Severity:    SeverityCritical,
 			Type:        IssueTypeSecurity,
-			Description: "Original data found in redacted text",
+			Description: "Original data found in hidden text",
 			Suggestion:  "Ensure complete replacement of sensitive data",
 		})
 	}
@@ -117,7 +117,7 @@ func (srs *SimpleRedactionStrategy) ValidateRedaction(original, redacted, dataTy
 			Severity:    SeverityWarning,
 			Type:        IssueTypePattern,
 			Description: "Redacted text doesn't look like a standard redaction placeholder",
-			Suggestion:  "Use standard redaction placeholder format like [TYPE-REDACTED]",
+			Suggestion:  "Use standard redaction placeholder format like TYPE-HIDDEN",
 		})
 	}
 
@@ -190,8 +190,8 @@ func (srs *SimpleRedactionStrategy) applyBasicFormatPreservation(original, repla
 func (srs *SimpleRedactionStrategy) looksLikeRedactionPlaceholder(text string) bool {
 	// Check for common redaction patterns
 	redactionPatterns := []string{
-		"[REDACTED]",
-		"[.*-REDACTED]",
+		"[HIDDEN]",
+		"[.*-HIDDEN]",
 		"\\*\\*\\*+",
 		"XXX+",
 		"####+",

--- a/internal/validators/comprehend/README.md
+++ b/internal/validators/comprehend/README.md
@@ -172,15 +172,15 @@ File: document.txt
 Type: COMPREHEND_PII
 
 HIGH CONFIDENCE MATCHES:
-- SSN: [REDACTED] (95% confidence)
-  Context: "Please provide your ... [REDACTED] ... for verification"
+- SSN: [HIDDEN] (95% confidence)
+  Context: "Please provide your ... [HIDDEN] ... for verification"
 
-- EMAIL: [REDACTED] (92% confidence)
-  Context: "Contact us at ... [REDACTED] ... for support"
+- EMAIL: [HIDDEN] (92% confidence)
+  Context: "Contact us at ... [HIDDEN] ... for support"
 
 MEDIUM CONFIDENCE MATCHES:
-- PHONE: [REDACTED] (78% confidence)
-  Context: "Call ... [REDACTED] ... during business hours"
+- PHONE: [HIDDEN] (78% confidence)
+  Context: "Call ... [HIDDEN] ... during business hours"
 ```
 
 ### JSON Output
@@ -190,11 +190,11 @@ MEDIUM CONFIDENCE MATCHES:
     {
       "type": "PII",
       "subtype": "SSN",
-      "value": "[REDACTED]",
+      "value": "[HIDDEN]",
       "confidence": 95,
       "line": 1,
       "column": 45,
-      "context": "Please provide your ... [REDACTED] ... for verification",
+      "context": "Please provide your ... [HIDDEN] ... for verification",
       "file_path": "document.txt",
       "description": "Amazon Comprehend detected SSN with 95.2% confidence"
     }

--- a/internal/validators/comprehend/validator.go
+++ b/internal/validators/comprehend/validator.go
@@ -244,7 +244,7 @@ func (v *Validator) buildContextInfo(content string, beginOffset, endOffset int)
 	if beginOffset >= start && endOffset <= end {
 		relativeBegin := beginOffset - start
 		relativeEnd := endOffset - start
-		fullContext = fullContext[:relativeBegin] + "[REDACTED]" + fullContext[relativeEnd:]
+		fullContext = fullContext[:relativeBegin] + "[HIDDEN]" + fullContext[relativeEnd:]
 	}
 
 	// Clean up context (remove newlines, extra spaces)

--- a/web/template.html
+++ b/web/template.html
@@ -839,7 +839,7 @@
                                         </div>
                                         <div class="checkbox-item">
                                             <input type="checkbox" id="showMatchCheck" onchange="updateCliCommand()">
-                                            <label>Display actual matched text (otherwise shows [REDACTED])</label>
+                                            <label>Display actual matched text (otherwise shows [HIDDEN])</label>
                                         </div>
                                         <div class="checkbox-item">
                                             <input type="checkbox" id="recursiveCheck">
@@ -1511,7 +1511,7 @@
                                     <li><strong>Confidence Levels:</strong> Filter by HIGH, MEDIUM, LOW, or all</li>
                                     <li><strong>Detection Types:</strong> Select specific validators or run all</li>
                                     <li><strong>Verbose Output:</strong> Show detailed metadata for findings</li>
-                                    <li><strong>Show Match:</strong> Display actual text (otherwise shows [REDACTED])
+                                    <li><strong>Show Match:</strong> Display actual text (otherwise shows [HIDDEN])
                                     </li>
                                 </ul>
 
@@ -2108,7 +2108,7 @@
                     <td>${Math.round(result.confidence)}%</td>
                     <td>${result.line_number}</td>
                     <td>
-                        <div class="finding-text" style="max-width: 350px; word-break: break-word; overflow-wrap: break-word; white-space: normal;">${showMatch ? escapeHtml(extractMetadataValue(result.text, validator)) : `<span class="redacted-link" onclick="toggleRedactedText(this, ${index})" title="Click to reveal">🔒 [REDACTED]</span>`}</div>
+                        <div class="finding-text" style="max-width: 350px; word-break: break-word; overflow-wrap: break-word; white-space: normal;">${showMatch ? escapeHtml(extractMetadataValue(result.text, validator)) : `<span class="redacted-link" onclick="toggleRedactedText(this, ${index})" title="Click to reveal">🔒 [HIDDEN]</span>`}</div>
                         ${verbose && result.metadata ? formatMetadata(result.metadata) : ''}
                     </td>
                     <td title="${escapeHtml(result.filename)}">${escapeHtml(formatPathForDisplay(result.filename))}</td>
@@ -4048,7 +4048,7 @@
                     <td style="white-space: nowrap;"><span class="confidence-badge confidence-${confidenceLevel}">${confidenceLevel.toUpperCase()}</span> (${Math.round(confidence)}%)</td>
                     <td style="white-space: nowrap;" title="${escapeHtml(actualFinding.Filename || actualFinding.filename)}">${escapeHtml(formatPathForDisplay(actualFinding.Filename || actualFinding.filename))}</td>
                     <td style="white-space: nowrap; text-align: center;">${finding.line_number || 'N/A'}</td>
-                    <td><div class="finding-text">${document.getElementById('showMatchCheck').checked ? `<span style="word-wrap: break-word; overflow-wrap: break-word; white-space: normal;">${escapeHtml(actualFinding.Text || actualFinding.text)}</span>` : `<span class="redacted-link" data-text="${(actualFinding.Text || actualFinding.text).replace(/"/g, '&quot;').replace(/'/g, '&#39;').replace(/</g, '&lt;').replace(/>/g, '&gt;')}" onclick="toggleSuppressedTextFromData(this)" title="Click to reveal">🔒 [REDACTED]</span>`}</div></td>
+                    <td><div class="finding-text">${document.getElementById('showMatchCheck').checked ? `<span style="word-wrap: break-word; overflow-wrap: break-word; white-space: normal;">${escapeHtml(actualFinding.Text || actualFinding.text)}</span>` : `<span class="redacted-link" data-text="${(actualFinding.Text || actualFinding.text).replace(/"/g, '&quot;').replace(/'/g, '&#39;').replace(/</g, '&lt;').replace(/>/g, '&gt;')}" onclick="toggleSuppressedTextFromData(this)" title="Click to reveal">🔒 [HIDDEN]</span>`}</div></td>
                     <td style="font-family: monospace; font-size: 12px; white-space: nowrap;">${suppressed.suppressed_by}</td>
                     <td style="word-wrap: break-word; overflow-wrap: break-word;">${escapeHtml(suppressed.rule_reason)}</td>
                     <td style="white-space: nowrap;">${expirationStatus}</td>
@@ -4078,7 +4078,7 @@
         // Function to toggle redacted text visibility
         function toggleRedactedText(element, index) {
             if (element.classList.contains('revealed')) {
-                element.innerHTML = '🔒 [REDACTED]';
+                element.innerHTML = '🔒 [HIDDEN]';
                 element.classList.remove('revealed');
                 element.title = 'Click to reveal';
             } else {
@@ -4092,7 +4092,7 @@
         // Function for suppressed findings modal
         function toggleSuppressedText(element, actualText) {
             if (element.classList.contains('revealed')) {
-                element.innerHTML = '🔒 [REDACTED]';
+                element.innerHTML = '🔒 [HIDDEN]';
                 element.classList.remove('revealed');
                 element.title = 'Click to reveal';
             } else {
@@ -4109,7 +4109,7 @@
                 .replace(/&lt;/g, '<')
                 .replace(/&gt;/g, '>');
             if (element.classList.contains('revealed')) {
-                element.innerHTML = '🔒 [REDACTED]';
+                element.innerHTML = '🔒 [HIDDEN]';
                 element.classList.remove('revealed');
                 element.title = 'Click to reveal';
                 element.style.whiteSpace = 'nowrap';


### PR DESCRIPTION
Updates all CLI and web interface outputs to display "[HIDDEN]" instead of "[REDACTED]" when sensitive data is masked (when --show-match flag is not used).

Changes:

CLI formatters (text, CSV, GitLab SAST)
Web UI template and JavaScript functions
Default redaction strategies and configurations
Documentation and help text
All example configuration files
PDF extractor: Fixed regex pattern escaping for TCPDF detection Testing: Verified CLI and web outputs work correctly with and without --show-match flag.

Impact: Cosmetic change only - no functional changes or breaking changes.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
