### PR TITLE
feat: Make ferret-scan a truly standalone binary

### DIFF
--- a/.github/workflows/ferret-scan.yml
+++ b/.github/workflows/ferret-scan.yml
@@ -152,9 +152,9 @@ jobs:
                 --no-color \
                 --quiet > "results/${file//\//_}.json" 2>/dev/null; then
 
-                # Count findings
-                file_high=$(jq -r '.findings[] | select(.confidence == "HIGH") | .confidence' "results/${file//\//_}.json" 2>/dev/null | wc -l || echo "0")
-                file_medium=$(jq -r '.findings[] | select(.confidence == "MEDIUM") | .confidence' "results/${file//\//_}.json" 2>/dev/null | wc -l || echo "0")
+                # Count findings (using .results[] for new JSON format)
+                file_high=$(jq -r '.results[]? | select(.confidence == "HIGH") | .confidence' "results/${file//\//_}.json" 2>/dev/null | wc -l || echo "0")
+                file_medium=$(jq -r '.results[]? | select(.confidence == "MEDIUM") | .confidence' "results/${file//\//_}.json" 2>/dev/null | wc -l || echo "0")
 
                 high_findings=$((high_findings + file_high))
                 medium_findings=$((medium_findings + file_medium))
@@ -169,11 +169,11 @@ jobs:
             fi
           done < changed_files.txt
 
-          # Combine all results for JSON (backward compatibility)
-          echo '{"findings": []}' > results/combined.json
+          # Combine all results for JSON (using new .results format)
+          echo '{"results": []}' > results/combined.json
           for result_file in results/*.json; do
             if [ "$result_file" != "results/combined.json" ] && [ -f "$result_file" ]; then
-              jq -s '.[0].findings + .[1].findings | {findings: .}' results/combined.json "$result_file" > temp.json
+              jq -s '.[0].results + (.[1].results // []) | {results: .}' results/combined.json "$result_file" > temp.json
               mv temp.json results/combined.json
             fi
           done
@@ -252,11 +252,11 @@ jobs:
             scan_args_sarif+=("--config" "ferret-config.yaml")
           fi
 
-          # Run the scan in JSON format (for PR comments - backward compatibility)
+          # Run the scan in JSON format (for PR comments)
           if ./bin/ferret-scan "${scan_args_json[@]}"; then
-            # Count findings
-            high_findings=$(jq -r '.findings[] | select(.confidence == "HIGH") | .confidence' results/full-scan.json 2>/dev/null | wc -l || echo "0")
-            medium_findings=$(jq -r '.findings[] | select(.confidence == "MEDIUM") | .confidence' results/full-scan.json 2>/dev/null | wc -l || echo "0")
+            # Count findings (using .results[] for new JSON format)
+            high_findings=$(jq -r '.results[]? | select(.confidence == "HIGH") | .confidence' results/full-scan.json 2>/dev/null | wc -l || echo "0")
+            medium_findings=$(jq -r '.results[]? | select(.confidence == "MEDIUM") | .confidence' results/full-scan.json 2>/dev/null | wc -l || echo "0")
 
             echo "high_findings=$high_findings" >> $GITHUB_ENV
             echo "medium_findings=$medium_findings" >> $GITHUB_ENV
@@ -290,15 +290,15 @@ jobs:
           script: |
             const fs = require('fs');
 
-            // Read results
+            // Read results (using new .results format)
             let findings = [];
             try {
               if (fs.existsSync('results/combined.json')) {
                 const data = JSON.parse(fs.readFileSync('results/combined.json', 'utf8'));
-                findings = data.findings || [];
+                findings = data.results || [];
               } else if (fs.existsSync('results/full-scan.json')) {
                 const data = JSON.parse(fs.readFileSync('results/full-scan.json', 'utf8'));
-                findings = data.findings || [];
+                findings = data.results || [];
               }
             } catch (e) {
               console.log('No results file found or error reading results');

--- a/.github/workflows/ferret-scan.yml
+++ b/.github/workflows/ferret-scan.yml
@@ -152,9 +152,9 @@ jobs:
                 --no-color \
                 --quiet > "results/${file//\//_}.json" 2>/dev/null; then
 
-                # Count findings (using .results[] for new JSON format)
-                file_high=$(jq -r '.results[]? | select(.confidence == "HIGH") | .confidence' "results/${file//\//_}.json" 2>/dev/null | wc -l || echo "0")
-                file_medium=$(jq -r '.results[]? | select(.confidence == "MEDIUM") | .confidence' "results/${file//\//_}.json" 2>/dev/null | wc -l || echo "0")
+                # Count findings (handle both array and object formats)
+                file_high=$(jq -r 'if type == "array" then .[] else .results[]? end | select(.confidence == "HIGH") | .confidence' "results/${file//\//_}.json" 2>/dev/null | wc -l || echo "0")
+                file_medium=$(jq -r 'if type == "array" then .[] else .results[]? end | select(.confidence == "MEDIUM") | .confidence' "results/${file//\//_}.json" 2>/dev/null | wc -l || echo "0")
 
                 high_findings=$((high_findings + file_high))
                 medium_findings=$((medium_findings + file_medium))
@@ -169,11 +169,16 @@ jobs:
             fi
           done < changed_files.txt
 
-          # Combine all results for JSON (using new .results format)
+          # Combine all results for JSON (handle both array and object formats)
           echo '{"results": []}' > results/combined.json
           for result_file in results/*.json; do
             if [ "$result_file" != "results/combined.json" ] && [ -f "$result_file" ]; then
-              jq -s '.[0].results + (.[1].results // []) | {results: .}' results/combined.json "$result_file" > temp.json
+              # Handle both array format [] and object format {results: []}
+              jq -s '
+                .[0].results + 
+                (if .[1] | type == "array" then .[1] else (.[1].results // []) end) | 
+                {results: .}
+              ' results/combined.json "$result_file" > temp.json
               mv temp.json results/combined.json
             fi
           done
@@ -254,9 +259,9 @@ jobs:
 
           # Run the scan in JSON format (for PR comments)
           if ./bin/ferret-scan "${scan_args_json[@]}"; then
-            # Count findings (using .results[] for new JSON format)
-            high_findings=$(jq -r '.results[]? | select(.confidence == "HIGH") | .confidence' results/full-scan.json 2>/dev/null | wc -l || echo "0")
-            medium_findings=$(jq -r '.results[]? | select(.confidence == "MEDIUM") | .confidence' results/full-scan.json 2>/dev/null | wc -l || echo "0")
+            # Count findings (handle both array and object formats)
+            high_findings=$(jq -r 'if type == "array" then .[] else .results[]? end | select(.confidence == "HIGH") | .confidence' results/full-scan.json 2>/dev/null | wc -l || echo "0")
+            medium_findings=$(jq -r 'if type == "array" then .[] else .results[]? end | select(.confidence == "MEDIUM") | .confidence' results/full-scan.json 2>/dev/null | wc -l || echo "0")
 
             echo "high_findings=$high_findings" >> $GITHUB_ENV
             echo "medium_findings=$medium_findings" >> $GITHUB_ENV

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,35 +31,11 @@ builds:
 # Use: ferret-scan --web to start web server mode
 
 archives:
-  - id: default
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  - id: binaries
+    format: binary
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if eq .Os "windows" }}.exe{{ end }}'
     ids:
       - ferret-scan-cli
-    files:
-      # Documentation
-      - README.md
-      - LICENSE*
-      - CHANGELOG.md
-      - docs/*
-      - docs/**/*
-
-      # Configuration files
-      - src: examples/ferret.yaml
-        dst: config.yaml
-      - examples/*
-
-      # Installation scripts
-      - scripts/install-system.sh
-      - scripts/setup-team-config.sh
-      - scripts/install-system-windows.ps1
-
-      # Pre-commit configuration examples
-      - .pre-commit-config.yaml
-      - .pre-commit-config-examples.yaml
-
-      # Web UI template
-      - src: web/template.html
-        dst: template.html
 
 checksum:
   name_template: "checksums.txt"
@@ -120,70 +96,60 @@ release:
 
     ### 🚀 Quick Installation
 
-    #### Linux/macOS System-wide Installation (Recommended)
+    Download the binary for your platform from the assets below, then follow the installation steps.
+
+    #### Linux/macOS Installation
     ```bash
-    # Download and extract the archive for your platform
-    tar -xzf ferret-scan_{{ .Tag }}_linux_amd64.tar.gz
-    cd ferret-scan_{{ .Tag }}_linux_amd64
+    # Download the binary for your platform (example for Linux amd64)
+    # From GitHub releases, download: ferret-scan_{{ .Tag }}_linux_amd64
 
-    # macOS: Handle security for downloaded binary installation
-    chmod +x ferret-scan
-    xattr -d com.apple.quarantine ferret-scan
+    # Make it executable and handle macOS security if needed
+    chmod +x ferret-scan_{{ .Tag }}_linux_amd64
 
-    # Install system-wide (installs to /usr/local/bin/ferret-scan)
-    sudo scripts/install-system.sh
+    # macOS only: Remove quarantine attribute
+    xattr -d com.apple.quarantine ferret-scan_{{ .Tag }}_linux_amd64
 
-    # Set up pre-commit integration (see docs/PRE_COMMIT_INTEGRATION.md)
-    pip install pre-commit
+    # Rename and install system-wide
+    sudo mv ferret-scan_{{ .Tag }}_linux_amd64 /usr/local/bin/ferret-scan
+
+    # Verify installation
+    ferret-scan --version
     ```
 
-    **⚠️ macOS Security Note**: If macOS blocks execution with "cannot be opened because it is from an unidentified developer", run these commands on the downloaded binary BEFORE installation:
+    **⚠️ macOS Security Note**: If macOS blocks execution with "cannot be opened because it is from an unidentified developer", run:
     ```bash
-    chmod +x ferret-scan
-    xattr -d com.apple.quarantine ferret-scan
+    xattr -d com.apple.quarantine ferret-scan_{{ .Tag }}_darwin_amd64
     ```
-    Only use these commands for executables from trusted sources.
+    Only use this command for executables from trusted sources.
 
     #### Windows Installation
     ```powershell
-    # Download and extract the archive for Windows
-    # Extract ferret-scan_{{ .Tag }}_windows_amd64.zip
-    cd ferret-scan_{{ .Tag }}_windows_amd64
+    # Download the binary: ferret-scan_{{ .Tag }}_windows_amd64.exe
 
-    # Run PowerShell as Administrator and install system-wide
-    .\scripts\install-system-windows.ps1
+    # Rename to ferret-scan.exe
+    Rename-Item ferret-scan_{{ .Tag }}_windows_amd64.exe ferret-scan.exe
 
-    # Test installation
+    # Move to a directory in your PATH (example: C:\Program Files\ferret-scan\)
+    # Or add the current directory to your PATH
+
+    # Verify installation
     ferret-scan --version
     ```
 
-    #### Manual Installation
-    ```bash
-    # Linux/macOS: Download binary and handle security
-    chmod +x ferret-scan
-    xattr -d com.apple.quarantine ferret-scan  # macOS only
-    sudo mv ferret-scan /usr/local/bin/
-
-    # Windows: Download ferret-scan.exe and add to PATH
-    # Test installation
-    ferret-scan --version
-    ```
-
-    ### 📦 What's Included
-    - `ferret-scan` (Linux/macOS) or `ferret-scan.exe` (Windows) - Main binary with CLI and web UI modes
-    - `scripts/install-system.sh` - Automated system installation (Linux/macOS)
-    - `scripts/install-system-windows.ps1` - Automated system installation (Windows)
-    - `docs/PRE_COMMIT_INTEGRATION.md` - Pre-commit integration guide
-
-    - `config.yaml` - Ready-to-use configuration with profiles
-    - `examples/ferret-windows.yaml` - Windows-specific configuration examples
-    - `docs/` - Complete documentation
-    - `.pre-commit-config.yaml` - Pre-commit configuration example
+    ### 📦 Available Binaries
+    Choose the binary that matches your system:
+    - **Linux AMD64**: `ferret-scan_{{ .Tag }}_linux_amd64`
+    - **Linux ARM64**: `ferret-scan_{{ .Tag }}_linux_arm64`
+    - **macOS AMD64 (Intel)**: `ferret-scan_{{ .Tag }}_darwin_amd64`
+    - **macOS ARM64 (Apple Silicon)**: `ferret-scan_{{ .Tag }}_darwin_arm64`
+    - **Windows AMD64**: `ferret-scan_{{ .Tag }}_windows_amd64.exe`
+    - **Windows ARM64**: `ferret-scan_{{ .Tag }}_windows_arm64.exe`
+    - **Checksums**: `checksums.txt` - Verify your download integrity
 
     ### 📖 Documentation
-    - [Installation Guide](docs/INSTALLATION.md) - Comprehensive installation options
-    - [Pre-commit Integration](docs/PRE_COMMIT_INTEGRATION.md) - Git workflow integration
-    - [Configuration Guide](docs/configuration.md) - Settings and profiles
+    - [Installation Guide](https://github.com/awslabs/ferret-scan/blob/main/docs/INSTALLATION.md)
+    - [Pre-commit Integration](https://github.com/awslabs/ferret-scan/blob/main/docs/PRE_COMMIT_INTEGRATION.md)
+    - [Configuration Guide](https://github.com/awslabs/ferret-scan/blob/main/docs/configuration.md)
 
     **Full Changelog**: https://github.com/awslabs/ferret-scan/compare/{{ .PreviousTag }}...{{ .Tag }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,16 +75,8 @@ COPY --from=builder /scratch-fs/home/ferret /home/ferret
 COPY --from=builder /scratch-fs/etc/passwd /etc/passwd
 COPY --from=builder /scratch-fs/etc/group /etc/group
 
-# Copy static binary (single executable)
+# Copy static binary (single executable with embedded web template)
 COPY --from=builder /app/ferret-scan /ferret-scan
-
-# Note: No entrypoint script needed - using direct binary execution
-
-# Copy web template (required for web UI)
-COPY --from=builder /app/web/template.html /web/template.html
-
-# Copy all documentation for web UI access
-COPY --from=builder /app/docs /docs
 
 # Minimal environment variables
 ENV FERRET_CONTAINER_MODE=true

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ help:
 
 
 # Build the application
-build:
+build: sync-web-template
 	@echo "Building..."
 	@go env -w GOPROXY=direct
 	@VERSION=$$(git describe --tags --exact-match 2>/dev/null || git describe --tags 2>/dev/null || echo "0.0.0-development"); \
@@ -673,6 +673,15 @@ check-commits-range:
 version:
 	@echo "Current version information:"
 	@./bin/ferret-scan --version 2>/dev/null || echo "Binary not built. Run 'make build' first."
+
+# Sync web template from source to embed location
+sync-web-template:
+	@if [ "web/template.html" -nt "internal/web/assets/template.html" ] || [ ! -f "internal/web/assets/template.html" ]; then \
+		echo "📋 Syncing web template..."; \
+		mkdir -p internal/web/assets; \
+		cp web/template.html internal/web/assets/template.html; \
+		echo "✓ Web template synced"; \
+	fi
 
 # Check Go version consistency across project
 check-go-version:

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ help:
 
 
 # Build the application
-build: sync-web-template
+build:
 	@echo "Building..."
 	@go env -w GOPROXY=direct
 	@VERSION=$$(git describe --tags --exact-match 2>/dev/null || git describe --tags 2>/dev/null || echo "0.0.0-development"); \
@@ -673,15 +673,6 @@ check-commits-range:
 version:
 	@echo "Current version information:"
 	@./bin/ferret-scan --version 2>/dev/null || echo "Binary not built. Run 'make build' first."
-
-# Sync web template from source to embed location
-sync-web-template:
-	@if [ "web/template.html" -nt "internal/web/assets/template.html" ] || [ ! -f "internal/web/assets/template.html" ]; then \
-		echo "📋 Syncing web template..."; \
-		mkdir -p internal/web/assets; \
-		cp web/template.html internal/web/assets/template.html; \
-		echo "✓ Web template synced"; \
-	fi
 
 # Check Go version consistency across project
 check-go-version:

--- a/internal/web/assets/template.html
+++ b/internal/web/assets/template.html
@@ -1458,7 +1458,7 @@
             </div>
 
             <!-- Help Navigation Tabs -->
-            <div style="display: flex; gap: 0; border-bottom: 2px solid #d5dbdb; margin-bottom: 16px;">
+            <div style="display: flex; gap: 0; border-bottom: 2px solid #d5dbdb; margin-bottom: 16px; align-items: center;">
                 <button class="help-tab-button active" onclick="switchHelpTab('webui')" id="webuiHelpTab"
                     style="background: transparent; border: none; padding: 8px 16px; font-size: 14px; font-weight: 600; cursor: pointer; border-bottom: 2px solid transparent; color: #5f6b7a;">
                     🌐 Web Interface
@@ -1467,10 +1467,13 @@
                     style="background: transparent; border: none; padding: 8px 16px; font-size: 14px; font-weight: 600; cursor: pointer; border-bottom: 2px solid transparent; color: #5f6b7a;">
                     🎯 Features
                 </button>
-                <button class="help-tab-button" onclick="switchHelpTab('docs')" id="docsHelpTab"
-                    style="background: transparent; border: none; padding: 8px 16px; font-size: 14px; font-weight: 600; cursor: pointer; border-bottom: 2px solid transparent; color: #5f6b7a;">
-                    📚 Documentation
-                </button>
+                <a href="https://github.com/awslabs/ferret-scan/blob/main/docs/README.md" target="_blank"
+                    style="padding: 8px 16px; font-size: 14px; font-weight: 600; text-decoration: none; color: #0972d3; border-bottom: 2px solid transparent; display: flex; align-items: center; gap: 4px;">
+                    📚 Online Documentation
+                    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" style="opacity: 0.7;">
+                        <path d="M10.5 10.5H1.5V1.5H6V0H1.5C0.675 0 0 0.675 0 1.5V10.5C0 11.325 0.675 12 1.5 12H10.5C11.325 12 12 11.325 12 10.5V6H10.5V10.5ZM7.5 0V1.5H9.879L3.2895 8.1895L4.3605 9.2605L11.05 2.571V5H12.5V0H7.5Z" fill="currentColor"/>
+                    </svg>
+                </a>
             </div>
 
             <div class="help-content" style="color: #16191f; line-height: 1.6; font-size: 14px;">
@@ -1660,60 +1663,7 @@
                     </div>
                 </div>
 
-                <!-- Documentation Help Tab -->
-                <div id="docsHelpContent" class="help-tab-content hidden">
-                    <div
-                        style="background: #eafaf1; border: 1px solid #037f0c; border-radius: 6px; padding: 16px; margin-bottom: 20px;">
-                        <h3 style="color: #037f0c; margin: 0 0 8px 0;">📚 Live Documentation</h3>
-                        <p style="margin: 0 0 8px 0; font-size: 13px;">This documentation is loaded directly from the
-                            markdown files and stays up-to-date with any changes.</p>
-                        <select id="docSelector" onchange="loadSelectedDoc()"
-                            style="width: 100%; padding: 8px; border: 1px solid #d5dbdb; border-radius: 4px; font-size: 13px;">
-                            <option value="README.md">📚 Main Documentation Index</option>
-                            <option value="configuration.md">⚙️ Configuration Guide</option>
-                            <option value="development/creating_validators.md">🛠 Creating Validators</option>
-                            <option value="user-guides/README-Docker.md">🐳 Docker Guide</option>
-                            <option value="GITLAB_INTEGRATION.md">🚀 GitLab Integration</option>
-                            <option value="user-guides/README-Suppressions.md">🚫 Suppression System</option>
-                            <option value="testing/TESTING.md">🧪 Testing Guide</option>
-                            <option value="user-guides/README-WebUI.md">🌐 Web UI Guide</option>
-                        </select>
-                    </div>
 
-                    <div id="docLoadingIndicator"
-                        style="text-align: center; padding: 20px; color: #5f6b7a; display: none;">
-                        <div
-                            style="display: inline-block; width: 20px; height: 20px; border: 3px solid #f3f3f3; border-top: 3px solid #0972d3; border-radius: 50%; animation: spin 1s linear infinite;">
-                        </div>
-                        <p style="margin: 8px 0 0 0;">Loading documentation...</p>
-                    </div>
-
-                    <div id="docContent"
-                        style="background: white; border: 1px solid #d5dbdb; border-radius: 6px; padding: 20px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; max-height: 400px; overflow-y: auto;">
-                        <p style="color: #5f6b7a; text-align: center; margin: 40px 0;">Select a documentation file above
-                            to view its contents.</p>
-                    </div>
-
-                    <div
-                        style="background: #f0f8ff; border: 1px solid #0972d3; border-radius: 6px; padding: 16px; margin-top: 20px;">
-                        <h3 style="color: #0972d3; margin: 0 0 8px 0;">🔍 Quick Navigation by Use Case</h3>
-                        <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 16px; font-size: 13px;">
-                            <div>
-                                <p style="margin: 0 0 4px 0;"><strong>New Users:</strong> Main Documentation Index →
-                                    Configuration Guide</p>
-                                <p style="margin: 0 0 4px 0;"><strong>Developers:</strong> Creating Validators → Testing
-                                    Guide</p>
-                                <p style="margin: 0 0 4px 0;"><strong>DevOps/CI:</strong> GitLab Integration</p>
-                            </div>
-                            <div>
-                                <p style="margin: 0 0 4px 0;"><strong>Web Interface:</strong> Web UI Guide → Docker
-                                    Guide</p>
-                                <p style="margin: 0 0 4px 0;"><strong>Testing:</strong> Testing Guide</p>
-                                <p style="margin: 0 0 4px 0;"><strong>Suppressions:</strong> Suppression System</p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
             </div>
 
             <div style="margin-top: 20px; text-align: right; border-top: 1px solid #d5dbdb; padding-top: 12px;">
@@ -2388,163 +2338,7 @@
                 selectedTab.style.background = '#f0f8ff';
             }
 
-            // If switching to docs tab, load the default document if none is loaded
-            if (tabName === 'docs' && !document.getElementById('docContent').hasAttribute('data-loaded')) {
-                loadSelectedDoc();
-            }
-        }
-
-        function loadSelectedDoc() {
-            const selector = document.getElementById('docSelector');
-            const docPath = selector.value;
-            const loadingIndicator = document.getElementById('docLoadingIndicator');
-            const docContent = document.getElementById('docContent');
-
-            // Show loading indicator
-            loadingIndicator.style.display = 'block';
-            docContent.style.display = 'none';
-
-            // Fetch the documentation
-            fetch('/docs/' + docPath)
-                .then(response => {
-                    if (!response.ok) {
-                        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-                    }
-                    return response.text();
-                })
-                .then(markdown => {
-                    // Convert markdown to HTML (basic conversion)
-                    const html = convertMarkdownToHTML(markdown);
-                    docContent.innerHTML = html;
-                    docContent.setAttribute('data-loaded', 'true');
-                })
-                .catch(error => {
-                    docContent.innerHTML = `
-                        <div style="color: #d13212; text-align: center; padding: 20px;">
-                            <h3>📄 Documentation Not Available</h3>
-                            <p>Could not load: <code>${docPath}</code></p>
-                            <p style="font-size: 12px; color: #5f6b7a;">Error: ${error.message}</p>
-                            <p style="font-size: 12px; color: #5f6b7a;">Make sure the web server is running from the correct directory.</p>
-                        </div>
-                    `;
-                })
-                .finally(() => {
-                    // Hide loading indicator and show content
-                    loadingIndicator.style.display = 'none';
-                    docContent.style.display = 'block';
-                });
-        }
-
-        function loadDocumentByPath(docPath) {
-            // Find the option in the selector that matches this path
-            const selector = document.getElementById('docSelector');
-            const options = selector.options;
-
-            for (let i = 0; i < options.length; i++) {
-                if (options[i].value === docPath || options[i].value.endsWith(docPath)) {
-                    selector.selectedIndex = i;
-                    loadSelectedDoc();
-                    return;
-                }
-            }
-
-            // If not found in dropdown, try to load it directly
-            const loadingIndicator = document.getElementById('docLoadingIndicator');
-            const docContent = document.getElementById('docContent');
-
-            loadingIndicator.style.display = 'block';
-            docContent.style.display = 'none';
-
-            fetch('/docs/' + docPath)
-                .then(response => {
-                    if (!response.ok) {
-                        throw new Error(`Document not found: ${docPath}`);
-                    }
-                    return response.text();
-                })
-                .then(markdown => {
-                    const html = convertMarkdownToHTML(markdown);
-                    docContent.innerHTML = html;
-                    docContent.setAttribute('data-loaded', 'true');
-                })
-                .catch(error => {
-                    docContent.innerHTML = `
-                        <div style="color: #d13212; text-align: center; padding: 20px;">
-                            <h3>📄 Document Not Available</h3>
-                            <p>Could not load: <code>${docPath}</code></p>
-                            <p style="font-size: 12px; color: #5f6b7a;">This document may not be included in the web interface.</p>
-                            <button onclick="loadSelectedDoc()" style="margin-top: 12px; padding: 6px 12px; background: #0972d3; color: white; border: none; border-radius: 4px; cursor: pointer;">← Back to Document List</button>
-                        </div>
-                    `;
-                })
-                .finally(() => {
-                    loadingIndicator.style.display = 'none';
-                    docContent.style.display = 'block';
-                });
-        }
-
-        function convertMarkdownToHTML(markdown) {
-            // Basic markdown to HTML conversion
-            let html = markdown
-                // Headers
-                .replace(/^### (.*$)/gim, '<h3 style="color: #0972d3; margin: 16px 0 8px 0; font-size: 16px;">$1</h3>')
-                .replace(/^## (.*$)/gim, '<h2 style="color: #232f3e; margin: 20px 0 12px 0; font-size: 18px;">$1</h2>')
-                .replace(/^# (.*$)/gim, '<h1 style="color: #232f3e; margin: 24px 0 16px 0; font-size: 22px;">$1</h1>')
-                // Bold and italic
-                .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
-                .replace(/\*(.*?)\*/g, '<em>$1</em>')
-                // Code blocks
-                .replace(/```[\s\S]*?```/g, function (match) {
-                    return '<pre style="background: #f6f8fa; border: 1px solid #d0d7de; border-radius: 6px; padding: 16px; overflow-x: auto; font-family: monospace; font-size: 13px; margin: 12px 0;">' +
-                        match.replace(/```(\w+)?\n?/, '').replace(/```$/, '') +
-                        '</pre>';
-                })
-                // Inline code
-                .replace(/`([^`]+)`/g, '<code style="background: #f6f8fa; padding: 2px 4px; border-radius: 3px; font-family: monospace; font-size: 13px;">$1</code>')
-                // Links - handle relative documentation links specially
-                .replace(/\[([^\]]+)\]\(([^)]+)\)/g, function (match, linkText, linkUrl) {
-                    // Check if it's a relative link to a .md file
-                    if (linkUrl.endsWith('.md') && !linkUrl.startsWith('http') && !linkUrl.startsWith('#')) {
-                        // Convert relative path to work with our doc selector
-                        let docPath = linkUrl;
-
-                        // Handle relative paths like ../README.md or ./config.md
-                        if (docPath.startsWith('../')) {
-                            docPath = docPath.substring(3);
-                        } else if (docPath.startsWith('./')) {
-                            docPath = docPath.substring(2);
-                        }
-
-                        // Create a clickable link that loads the document in the same interface
-                        return `<a href="#" onclick="loadDocumentByPath('${docPath}'); return false;" style="color: #0972d3; text-decoration: none; cursor: pointer;" onmouseover="this.style.textDecoration='underline'" onmouseout="this.style.textDecoration='none'" title="Click to load: ${docPath}">${linkText} 📄</a>`;
-                    } else if (linkUrl.startsWith('#')) {
-                        // Handle anchor links within the same document
-                        return `<a href="${linkUrl}" style="color: #0972d3; text-decoration: none;" onmouseover="this.style.textDecoration='underline'" onmouseout="this.style.textDecoration='none'">${linkText}</a>`;
-                    } else if (linkUrl.startsWith('http')) {
-                        // External links - open in new tab
-                        return `<a href="${linkUrl}" target="_blank" rel="noopener noreferrer" style="color: #0972d3; text-decoration: none;" onmouseover="this.style.textDecoration='underline'" onmouseout="this.style.textDecoration='none'">${linkText} 🔗</a>`;
-                    } else {
-                        // Other relative links - show as disabled with explanation
-                        return `<span style="color: #5f6b7a; text-decoration: line-through;" title="Relative link not available in web interface: ${linkUrl}">${linkText}</span>`;
-                    }
-                })
-                // Lists
-                .replace(/^\- (.*$)/gim, '<li style="margin: 4px 0;">$1</li>')
-                .replace(/^\* (.*$)/gim, '<li style="margin: 4px 0;">$1</li>')
-                // Wrap consecutive list items in ul tags
-                .replace(/(<li.*<\/li>\s*)+/g, function (match) {
-                    return '<ul style="margin: 8px 0; padding-left: 20px;">' + match + '</ul>';
-                })
-                // Line breaks
-                .replace(/\n\n/g, '</p><p style="margin: 12px 0;">')
-                .replace(/\n/g, '<br>');
-
-            // Wrap in paragraph tags if not already wrapped
-            if (!html.startsWith('<h1') && !html.startsWith('<h2') && !html.startsWith('<h3') && !html.startsWith('<ul') && !html.startsWith('<pre')) {
-                html = '<p style="margin: 12px 0;">' + html + '</p>';
-            }
-
-            return html;
+            // Documentation is now accessed via external GitHub link - no tab switching needed
         }
 
         function getSelectedChecks() {


### PR DESCRIPTION
- Embed web template in binary using go:embed
- Move template to internal/web/assets/template.html
- Remove external file dependencies for web UI
- Replace documentation tab with GitHub links
- Update goreleaser to publish raw binaries instead of archives
- Simplify Dockerfile by removing unnecessary COPY commands
- Binary now works anywhere without external files

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
