### PR TITLE
Potential fix for code scanning alert no. 1198: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ferret-scan-simple.yml
+++ b/.github/workflows/ferret-scan-simple.yml
@@ -2,6 +2,8 @@
 # Basic sensitive data detection for pull requests
 
 name: Security Scan
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/awslabs/ferret-scan/security/code-scanning/1198](https://github.com/awslabs/ferret-scan/security/code-scanning/1198)

To resolve the issue, we should add a `permissions` block which restricts the GITHUB_TOKEN to only what is necessary for the workflow to function. In this case, the workflow performs read-only operations (fetching git metadata, scanning files, etc.), so it only needs `contents: read` to access repository files. The recommended fix is to add:

```yaml
permissions:
  contents: read
```

at the root of the workflow file (before the `jobs:` key), ensuring all jobs run with these restricted permissions by default. No other changes to imports or job steps are needed. The fix should be applied near the top of `.github/workflows/ferret-scan-simple.yml`, after the `name` and before the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
