### PR TITLE
refactor: simplify Docker workflow to only publish to ECR Public

### DIFF
--- a/.github/workflows/docker-multiarch.yml
+++ b/.github/workflows/docker-multiarch.yml
@@ -26,13 +26,10 @@ on:
 
 permissions:
   contents: read
-  packages: write
   security-events: write
   id-token: write # Required for AWS OIDC
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
   ECR_REGISTRY: public.ecr.aws/g4m5x5s3
   ECR_REPOSITORY: awslabs/ferret-scan
 
@@ -41,7 +38,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # Needed for SBOM action to attach to releases
-      packages: write
       id-token: write
       security-events: write
 
@@ -67,40 +63,14 @@ jobs:
           aws-region: us-east-1
           role-session-name: GitHubActions-ECR-Push
 
-      - name: Log in to GitHub Container Registry
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Log in to Amazon ECR Public
         if: github.event_name != 'pull_request'
         uses: aws-actions/amazon-ecr-login@v2
         with:
           registry-type: public
 
-      - name: Extract metadata for GitHub Registry
-        id: meta-github
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=sha,prefix=sha-,format=short
-          labels: |
-            org.opencontainers.image.title=Ferret Scan
-            org.opencontainers.image.description=Multi-architecture sensitive data detection tool
-            org.opencontainers.image.vendor=${{ github.repository_owner }}
-
       - name: Extract metadata for ECR
-        id: meta-ecr
+        id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}
@@ -137,14 +107,12 @@ jobs:
           file: ./Dockerfile
           platforms: ${{ steps.platforms.outputs.platforms }}
           push: ${{ github.event_name != 'pull_request' && (github.event.inputs.push_image != 'false') }}
-          tags: |
-            ${{ steps.meta-github.outputs.tags }}
-            ${{ steps.meta-ecr.outputs.tags }}
-          labels: ${{ steps.meta-github.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            VERSION=${{ steps.meta-github.outputs.version }}
+            VERSION=${{ steps.meta.outputs.version }}
             GIT_COMMIT=${{ github.sha }}
-            BUILD_DATE=${{ fromJSON(steps.meta-github.outputs.json).labels['org.opencontainers.image.created'] }}
+            BUILD_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: false
@@ -154,7 +122,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: anchore/sbom-action@v0
         with:
-          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta-github.outputs.version }}
+          image: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ steps.meta.outputs.version }}
           format: spdx-json
           output-file: sbom.spdx.json
         continue-on-error: true # Don't fail workflow if SBOM generation fails
@@ -171,7 +139,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta-github.outputs.version }}
+          image-ref: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ steps.meta.outputs.version }}
           format: "sarif"
           output: "trivy-results.sarif"
 
@@ -188,21 +156,18 @@ jobs:
         run: |
           echo "🧪 Testing built images..."
 
-          # Test each platform for both registries
+          # Test each platform
           for platform in $(echo "${{ steps.platforms.outputs.platforms }}" | tr ',' ' '); do
             echo "Testing $platform..."
             
-            # Test GitHub Registry image
-            echo "Testing GitHub Registry image..."
-            docker run --rm --platform=$platform \
-              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta-github.outputs.version }} \
-              --version || echo "⚠️ GitHub Registry version check failed for $platform"
-              
             # Test ECR image
-            echo "Testing ECR image..."
             docker run --rm --platform=$platform \
-              ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ steps.meta-ecr.outputs.version }} \
+              ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ steps.meta.outputs.version }} \
               --version || echo "⚠️ ECR version check failed for $platform"
+              
+            docker run --rm --platform=$platform \
+              ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ steps.meta.outputs.version }} \
+              --help | head -5 || echo "⚠️ ECR help check failed for $platform"
           done
 
       - name: Create release summary
@@ -210,21 +175,15 @@ jobs:
         run: |
           echo "## 🐳 Multi-Architecture Docker Build Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### GitHub Container Registry" >> $GITHUB_STEP_SUMMARY
-          echo "**Image:** \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Tags:** ${{ steps.meta-github.outputs.tags }}" | tr ',' '\n' | sed 's/^/- `/' | sed 's/$/`/' >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Amazon ECR Public" >> $GITHUB_STEP_SUMMARY
           echo "**Image:** \`${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Tags:** ${{ steps.meta-ecr.outputs.tags }}" | tr ',' '\n' | sed 's/^/- `/' | sed 's/$/`/' >> $GITHUB_STEP_SUMMARY
+          echo "**Gallery:** https://gallery.ecr.aws/g4m5x5s3/awslabs/ferret-scan" >> $GITHUB_STEP_SUMMARY
+          echo "**Tags:** ${{ steps.meta.outputs.tags }}" | tr ',' '\n' | sed 's/^/- `/' | sed 's/$/`/' >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Platforms:** ${{ steps.platforms.outputs.platforms }}" | tr ',' '\n' | sed 's/^/- /' >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Usage Examples:" >> $GITHUB_STEP_SUMMARY
           echo '```bash' >> $GITHUB_STEP_SUMMARY
-          echo "# Pull from GitHub Container Registry" >> $GITHUB_STEP_SUMMARY
-          echo "docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
           echo "# Pull from Amazon ECR Public" >> $GITHUB_STEP_SUMMARY
           echo "docker pull ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:latest" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -241,21 +200,20 @@ jobs:
     if: github.event_name != 'pull_request'
     permissions:
       contents: read
-      packages: read
       security-events: write
 
     steps:
-      - name: Run Grype vulnerability scanner on GitHub Registry
+      - name: Run Grype vulnerability scanner on ECR
         uses: anchore/scan-action@v3
-        id: scan-github
+        id: scan-ecr
         with:
-          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          image: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:latest
           fail-build: false
           severity-cutoff: high
 
       - name: Upload Grype scan results
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: ${{ steps.scan-github.outputs.sarif }}
+          sarif_file: ${{ steps.scan-ecr.outputs.sarif }}
           category: "grype-container-scan"
         continue-on-error: true # Don't fail the workflow if SARIF upload fails


### PR DESCRIPTION
- Remove GitHub Container Registry (ghcr.io) publishing
- Focus exclusively on Amazon ECR Public registry
- Simplify permissions by removing packages scope
- Update testing and security scans for ECR-only workflow
- Add ECR Gallery link to build summary

Images now available only at: public.ecr.aws/g4m5x5s3/awslabs/ferret-scan

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
