### PR TITLE
ci: only trigger Docker builds on code changes

### DIFF
--- a/.github/workflows/docker-multiarch.yml
+++ b/.github/workflows/docker-multiarch.yml
@@ -7,10 +7,28 @@ on:
       - master
     tags:
       - "v*"
+    paths:
+      - '**.go'
+      - 'internal/web/assets/**'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Dockerfile'
+      - 'cmd/**'
+      - 'internal/**'
+      - 'Makefile'
   pull_request:
     branches:
       - main
       - master
+    paths:
+      - '**.go'
+      - 'internal/web/assets/**'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Dockerfile'
+      - 'cmd/**'
+      - 'internal/**'
+      - 'Makefile'
   workflow_dispatch:
     inputs:
       platforms:


### PR DESCRIPTION
Add path filters to docker-multiarch workflow to build only when:
- Go source files change (**.go)
- Web assets change (internal/web/assets/**)
- Dependencies change (go.mod, go.sum)
- Build files change (Dockerfile, Makefile)

Prevents unnecessary builds on documentation/workflow changes

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
