### PR TITLE
feat: add PyPI publishing workflow and upgrade to Python 3.13

### DIFF
--- a/.github/workflows/build-shared.yml
+++ b/.github/workflows/build-shared.yml
@@ -47,7 +47,7 @@ jobs:
       if: inputs.build-type == 'python' || inputs.build-type == 'both'
       uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: '3.13'
     
     - name: Cache Go modules
       uses: actions/cache@v4

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: Install build dependencies
         run: |
@@ -214,20 +214,19 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "### Installation" >> $GITHUB_STEP_SUMMARY
             echo '```bash' >> $GITHUB_STEP_SUMMARY
-            echo 'pip install ferret-scan==${{ steps.version.outputs.version }}' >> $GITHUB_STEP_SUMMARY
+            echo 'pip install ferret-scan' >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
           elif [[ "${{ github.event.inputs.action }}" == "publish-testpypi" ]]; then
             echo "✅ **Published to Test PyPI**: https://test.pypi.org/p/ferret-scan" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "### Installation" >> $GITHUB_STEP_SUMMARY
+            echo "### Test Installation" >> $GITHUB_STEP_SUMMARY
             echo '```bash' >> $GITHUB_STEP_SUMMARY
-            echo 'pip install --index-url https://test.pypi.org/simple/ ferret-scan==${{ steps.version.outputs.version }}' >> $GITHUB_STEP_SUMMARY
+            echo 'pip install --index-url https://test.pypi.org/simple/ ferret-scan' >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
           else
             echo "📦 **Test build completed** (not published)" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "Package is ready for publishing. Use workflow dispatch with:" >> $GITHUB_STEP_SUMMARY
-            echo "- \`publish-testpypi\` for Test PyPI" >> $GITHUB_STEP_SUMMARY
-            echo "- \`publish-pypi\` for production PyPI" >> $GITHUB_STEP_SUMMARY
-            echo "- Or create a GitHub release for automatic PyPI publishing" >> $GITHUB_STEP_SUMMARY
+            echo "Ready for publishing:" >> $GITHUB_STEP_SUMMARY
+            echo "- Create a GitHub release for automatic PyPI publishing" >> $GITHUB_STEP_SUMMARY
+            echo "- Or use workflow dispatch for manual publishing" >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: Download Python package
         uses: actions/download-artifact@v4
@@ -79,20 +79,16 @@ jobs:
           files: python-package/dist/*
           generate_release_notes: true
           body: |
-            ## Python Package Installation
+            ## 🐍 Python Package Installation
 
-            ### From GitHub Release:
             ```bash
-            # Download the .whl file from this release
-            pip install ferret_scan-*.whl
+            pip install ferret-scan
             ```
 
-            ### Direct from Git Repository:
+            ### Quick Start:
             ```bash
-            pip install git+https://github.com/${{ github.repository }}.git#subdirectory=python-package
+            ferret-scan --version
+            ferret-scan --help
             ```
 
-            ### Using pip with GitHub:
-            ```bash
-            pip install https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/ferret_scan-*.whl
-            ```
+            **Requirements**: Python 3.7 or higher

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -96,45 +96,13 @@ release:
 
     ### 🚀 Quick Installation
 
-    Download the binary for your platform from the assets below, then follow the installation steps.
-
-    #### Linux/macOS Installation
+    #### Recommended: Install from PyPI
     ```bash
-    # Download the binary for your platform (example for Linux amd64)
-    # From GitHub releases, download: ferret-scan_{{ .Tag }}_linux_amd64
-
-    # Make it executable and handle macOS security if needed
-    chmod +x ferret-scan_{{ .Tag }}_linux_amd64
-
-    # macOS only: Remove quarantine attribute
-    xattr -d com.apple.quarantine ferret-scan_{{ .Tag }}_linux_amd64
-
-    # Rename and install system-wide
-    sudo mv ferret-scan_{{ .Tag }}_linux_amd64 /usr/local/bin/ferret-scan
-
-    # Verify installation
-    ferret-scan --version
+    pip install ferret-scan
     ```
 
-    **⚠️ macOS Security Note**: If macOS blocks execution with "cannot be opened because it is from an unidentified developer", run:
-    ```bash
-    xattr -d com.apple.quarantine ferret-scan_{{ .Tag }}_darwin_amd64
-    ```
-    Only use this command for executables from trusted sources.
-
-    #### Windows Installation
-    ```powershell
-    # Download the binary: ferret-scan_{{ .Tag }}_windows_amd64.exe
-
-    # Rename to ferret-scan.exe
-    Rename-Item ferret-scan_{{ .Tag }}_windows_amd64.exe ferret-scan.exe
-
-    # Move to a directory in your PATH (example: C:\Program Files\ferret-scan\)
-    # Or add the current directory to your PATH
-
-    # Verify installation
-    ferret-scan --version
-    ```
+    #### Alternative: Download Binary
+    Download the binary for your platform from the assets below if you prefer not to use pip.
 
     ### 📦 Available Binaries
     Choose the binary that matches your system:

--- a/README.md
+++ b/README.md
@@ -20,54 +20,17 @@ Ferret Scan is a sensitive data detection tool that scans files for potential se
 
 ## Installation
 
-### Quick Start (Recommended)
+### Recommended: Install from PyPI
 
-#### Linux/macOS
 ```bash
-# macOS: Handle security for downloaded binary installation
-chmod +x ferret-scan
-xattr -d com.apple.quarantine ferret-scan
-
-# System-wide installation (installs to /usr/local/bin/ferret-scan)
-sudo scripts/install-system.sh
-
-# Verify installation
-ferret-scan --version
-
-# Set up pre-commit integration (see docs/PRE_COMMIT_INTEGRATION.md)
-pip install pre-commit
-# Create .pre-commit-config.yaml with ferret-scan hook
-```
-
-**⚠️ macOS Security Note**: If macOS blocks execution with "cannot be opened because it is from an unidentified developer", run these commands on the downloaded binary BEFORE installation:
-```bash
-chmod +x ferret-scan
-xattr -d com.apple.quarantine ferret-scan
-```
-Only use these commands for executables from trusted sources.
-
-#### Windows
-```powershell
-# Run PowerShell as Administrator and install system-wide
-.\scripts\install-system-windows.ps1
-
-# Or install for current user only (no admin required)
-.\scripts\install-system-windows.ps1 -UserInstall
-
-# Verify installation
-ferret-scan --version
-
-# Set up pre-commit integration (see docs/PRE_COMMIT_INTEGRATION.md)
-pip install pre-commit
-# Create .pre-commit-config.yaml with ferret-scan hook
+pip install ferret-scan
 ```
 
 ### Alternative Installation Methods
 
-- **📦 [Release Installation](docs/INSTALL.md)** - Quick guide for release downloads
+- **📦 [Release Installation](docs/INSTALL.md)** - Binary downloads from GitHub releases
 - **📖 [Complete Installation Guide](docs/INSTALLATION.md)** - Comprehensive installation options
 - **🗑️ [Uninstallation Guide](docs/UNINSTALL.md)** - Complete removal instructions
-- **🔧 Manual Installation**: Download from [GitLab Releases](https://code.aws.dev/personal_projects/alias_a/adifabio/Ferret-Scan/-/releases)
 - **🏗️ Build from Source**: `make build` (see [Building the Application](#building-the-application))
 
 ## 📚 Documentation

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -65,46 +65,24 @@ This installs:
 
 ## Installation Methods
 
-### 1. Python Package Installation (Recommended for Pre-commit)
+### 1. Python Package Installation (Recommended)
 
-The Python package provides the easiest way to use ferret-scan in pre-commit workflows:
+Install ferret-scan from PyPI for the easiest setup:
 
 ```bash
-# Install the Python package
+# Install from PyPI
 pip install ferret-scan
 
 # Verify installation
 ferret-scan --version
-
-# Use in pre-commit
-cat > .pre-commit-config.yaml << 'EOF'
-repos:
-  - repo: local
-    hooks:
-      - id: ferret-scan
-        name: Ferret Scan
-        entry: ferret-scan --pre-commit-mode
-        language: python
-        files: \.(py|js|ts|go|java|json|yaml|yml)$
-        pass_filenames: true
-EOF
-
-# Install pre-commit hooks
-pre-commit install
-
-# Copy configuration file for IP detection
-cp examples/ferret.yaml ferret.yaml
-git add ferret.yaml
 ```
 
 **Features:**
-- ✅ Automatic binary management
+- ✅ Simple installation with pip
 - ✅ Cross-platform compatibility  
-- ✅ No manual binary downloads
+- ✅ Automatic updates with pip
 - ✅ Perfect for pre-commit integration
 - ✅ Supports all ferret-scan features
-
-**Important:** The Python package requires a `ferret.yaml` configuration file in your project root for IP detection and full functionality.
 
 ### 2. Automated System Installation (Recommended for Teams)
 

--- a/docs/PRE_COMMIT_INTEGRATION.md
+++ b/docs/PRE_COMMIT_INTEGRATION.md
@@ -49,9 +49,14 @@ repos:
         pass_filenames: true
 ```
 
-### 3. Python Package Integration
+### 3. Python Package Integration (Recommended)
 
-If you prefer using the Python package:
+Using the PyPI package:
+
+```bash
+# Install ferret-scan from PyPI
+pip install ferret-scan
+```
 
 ```yaml
 repos:
@@ -612,7 +617,7 @@ Many CI/CD systems can run pre-commit hooks directly:
 # GitLab CI example
 pre-commit-scan:
   stage: test
-  image: python:3.11
+  image: python:3.13
   before_script:
     - pip install pre-commit
     - docker pull ferret-scan:latest

--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -21,6 +21,8 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Security",
     "Topic :: Software Development :: Quality Assurance",
 ]

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -35,6 +35,8 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Topic :: Security",
         "Topic :: Software Development :: Quality Assurance",
     ],


### PR DESCRIPTION
- Automated PyPI publishing on GitHub releases
- Manual workflow dispatch for testing and pre-releases
- Built-in package validation and testing
- Trusted publishing (OIDC) authentication
- Upgrade CI/CD to Python 3.13, support 3.7-3.13
- Simplify documentation to focus on pip install
- Comprehensive safety checks and troubleshooting

Enables seamless PyPI distribution with modern Python toolchain.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
