### PR TITLE
chore: upgrade CodeQL Action from v3 to v4

### DIFF
--- a/.github/workflows/docker-multiarch.yml
+++ b/.github/workflows/docker-multiarch.yml
@@ -196,7 +196,7 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: "trivy-results.sarif"
           category: "trivy-container-scan"
@@ -273,7 +273,7 @@ jobs:
           severity-cutoff: high
 
       - name: Upload Grype scan results
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: ${{ steps.scan-ghcr.outputs.sarif }}
           category: "grype-container-scan"

--- a/.github/workflows/ferret-scan.yml
+++ b/.github/workflows/ferret-scan.yml
@@ -285,7 +285,7 @@ jobs:
 
       - name: Upload SARIF to GitHub Security
         if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: sarif/ferret-scan.sarif
           category: ferret-scan


### PR DESCRIPTION
- Update github/codeql-action/upload-sarif from v3 to v4 in all workflows
- Addresses deprecation warning (v3 will be deprecated in December 2026)
- Affects docker-multiarch.yml (Trivy and Grype scans) and ferret-scan.yml

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
