### PR TITLE
feat(ip-validator,progress):  show current filename in progress bar

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,8 +3,8 @@
 
 # Global variables for version consistency
 variables:
-  GO_VERSION: "1.25.1"
-  GO_DOCKER_IMAGE: "golang:1.25.1-alpine"
+  GO_VERSION: "1.25.5"
+  GO_DOCKER_IMAGE: "golang:1.25.5-alpine"
   # Default resource limits for all jobs (increased for Docker builds)
   KUBERNETES_CPU_REQUEST: "1000m"
   KUBERNETES_CPU_LIMIT: "2000m"

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # Target: Absolute smallest possible image (~5-10MB)
 
 # Builder stage
-FROM public.ecr.aws/docker/library/golang:1.25.3-alpine AS builder
+FROM public.ecr.aws/docker/library/golang:1.25.5-alpine AS builder
 
 # Install minimal build dependencies
 # Add ca-certificates back if you uncomment the COPY line below

--- a/internal/parallel/parallel_processor.go
+++ b/internal/parallel/parallel_processor.go
@@ -56,7 +56,7 @@ func NewAdaptiveParallelProcessor(config AdaptiveConfig, observer *observability
 }
 
 // ProgressCallback is called when a file is completed
-type ProgressCallback func(completed, total int)
+type ProgressCallback func(completed, total int, currentFile string)
 
 // ProcessFiles processes multiple files in parallel
 func (pp *ParallelProcessor) ProcessFiles(filePaths []string, validators []detector.Validator, fileRouter *router.FileRouter, config *JobConfig, redactionManager *redactors.RedactionManager) ([]detector.Match, *ProcessingStats, error) {
@@ -111,7 +111,7 @@ func (pp *ParallelProcessor) ProcessFilesWithProgress(filePaths []string, valida
 
 		// Call progress callback if provided
 		if progressCallback != nil {
-			progressCallback(i+1, jobCount)
+			progressCallback(i+1, jobCount, result.FilePath)
 		}
 		mu.Unlock()
 	}


### PR DESCRIPTION
Progress Bar Enhancement:
- Add filename parameter to ProgressCallback type signature
- Update parallel processor to pass current filename to progress callback
- Display current file being scanned at end of progress bar
- Add \033[K escape sequence to clear line, preventing leftover characters
- Truncate long filenames to fit terminal width (30 chars max)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
