### PR TITLE
fix(pre-commit): switch hook to language:python with PyPI install

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,6 +79,6 @@ repos:
 
 # Ferret Scan security check (from GitHub)
 - repo: https://github.com/awslabs/ferret-scan
-  rev: v1.3.29
+  rev: v1.5.0
   hooks:
     - id: ferret-scan

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,8 +1,9 @@
 - id: ferret-scan
   name: Ferret Scan Security Check
   description: Run Ferret Scan to detect secrets and sensitive data
-  entry: bin/ferret-scan
-  language: script
+  entry: ferret-scan
+  language: python
+  additional_dependencies: ['ferret-scan']
   files: '\.(go|js|py|java|txt|md|yaml|yml|json|xml|sql|sh|ts|jsx|tsx|php|rb|c|cpp|h|hpp|cs|kt|swift|rs|scala|clj|pl|r|m|mm)'
   exclude: '^(\.git/|bin/|dist/|node_modules/|\.cache/|test_|_test\.|vendor/|\.venv/|__pycache__/)'
   pass_filenames: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ferret-scan-hooks"
+version = "0.0.1"
+description = "Pre-commit hook stub for ferret-scan (Go binary installed via additional_dependencies)"
+
+[tool.setuptools]
+packages = []


### PR DESCRIPTION
Previously the hook used language:script with entry:bin/ferret-scan, requiring a pre-built binary to exist in the repo. Since binaries are no longer committed, the hook was failing with 'Executable not found'.

Changes:
- .pre-commit-hooks.yaml: language:script -> language:python, entry:bin/ferret-scan -> entry:ferret-scan, add additional_dependencies:['ferret-scan'] to install from PyPI
- pyproject.toml: minimal stub required by pre-commit's python language handler (empty package, no Python code)
- .pre-commit-config.yaml: bump ferret-scan rev v1.3.29 -> v1.5.0 via pre-commit autoupdate

Users running pre-commit will now get ferret-scan installed automatically from PyPI into an isolated virtualenv. First run takes ~30s to install, subsequent runs use the cached environment.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
