### PR TITLE
fix(pdf): recover from PDF library panics on corrupted files

### DIFF
--- a/internal/preprocessors/text-extractors/text-extract-pdftextlib/pdf-text-extractor.go
+++ b/internal/preprocessors/text-extractors/text-extract-pdftextlib/pdf-text-extractor.go
@@ -24,11 +24,18 @@ type TextContent struct {
 }
 
 // ExtractText extracts text from a PDF document using ledongthuc/pdf
-func ExtractText(filePath string) (*TextContent, error) {
+func ExtractText(filePath string) (content *TextContent, err error) {
 	// Initialize content with basic file info
-	content := &TextContent{
+	content = &TextContent{
 		Filename: filepath.Base(filePath),
 	}
+
+	// Recover from panics in the PDF library (e.g. corrupted zlib streams)
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("PDF library panic on %s: %v", filepath.Base(filePath), r)
+		}
+	}()
 
 	// Open the PDF file
 	f, r, err := pdf.Open(filePath)


### PR DESCRIPTION
The ledongthuc/pdf library panics with 'zlib: invalid header' when processing PDFs with corrupted compressed streams. This caused the entire scan to crash instead of skipping the bad file.

Two-layer fix:
1. ExtractText() now uses named return values + defer/recover to catch panics from the PDF library and return them as errors
2. file_router.go preprocessor goroutines now wrap Process() calls in a recover to prevent any preprocessor panic from crashing the scan

The corrupted PDF is now skipped with an error logged, and scanning continues with the remaining files.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
