### PR TITLE
feat(web): folder drag-drop, --config/--suppression-file/--exclude in…

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -804,7 +804,7 @@ func main() {
 
 	// Handle web mode early - validate flags and start web server if requested
 	if flags.webMode {
-		if err := handleWebMode(flags.webPort, flag.Args(), flags.inputFile); err != nil {
+		if err := handleWebMode(flags.webPort, flag.Args(), flags.inputFile, flags.configFile, flags.suppressionFile, flags.excludePatterns); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
@@ -2179,7 +2179,7 @@ func parseChecksToRun(checks string, enableGenAI bool) map[string]bool {
 // }
 
 // handleWebMode validates web mode flags and starts the web server
-func handleWebMode(port string, args []string, inputFile string) error {
+func handleWebMode(port string, args []string, inputFile, configFile, suppressionFile string, excludePatterns []string) error {
 	// Validate that no file arguments are provided with web mode
 	if len(args) > 0 {
 		return fmt.Errorf("--web flag cannot be used with file arguments\n"+
@@ -2207,7 +2207,7 @@ func handleWebMode(port string, args []string, inputFile string) error {
 	}
 
 	// Start web server
-	return startWebServer(finalPort)
+	return startWebServer(finalPort, configFile, suppressionFile, excludePatterns)
 }
 
 // validateWebModeFlags validates that incompatible flags are not used with --web
@@ -2393,9 +2393,9 @@ func isPortAvailable(port string) bool {
 }
 
 // startWebServer starts the web server on the specified port with timeout and resilience
-func startWebServer(port string) error {
+func startWebServer(port, configFile, suppressionFile string, excludePatterns []string) error {
 	// Import web server package
-	webServer := web.NewWebServer(port)
+	webServer := web.NewWebServerWithOptions(port, configFile, suppressionFile, excludePatterns)
 
 	// Start the web server (this will block)
 	return webServer.Start()

--- a/internal/suppressions/suppression.go
+++ b/internal/suppressions/suppression.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -16,6 +17,20 @@ import (
 
 	"gopkg.in/yaml.v3"
 )
+
+// hashLineWithoutComment matches `hash:` lines that don't already carry a
+// trailing comment. Used to append `# pragma: allowlist secret` so secret
+// scanners (including ferret-scan itself) skip the high-entropy hash values.
+var hashLineWithoutComment = regexp.MustCompile(`(?m)^(\s*hash:\s*\S+)[ \t]*$`)
+
+// annotateHashesWithAllowlistPragma appends `# pragma: allowlist secret` to
+// every `hash:` line in the marshaled YAML that doesn't already have a
+// trailing comment. The hash field is a SHA-256 of the finding identity, not
+// the secret itself, but it has enough entropy to trip secret scanners — this
+// keeps the suppression file from generating false-positive findings.
+func annotateHashesWithAllowlistPragma(data []byte) []byte {
+	return hashLineWithoutComment.ReplaceAll(data, []byte("$1 # pragma: allowlist secret"))
+}
 
 // SuppressionRule represents a single suppression rule
 type SuppressionRule struct {
@@ -248,6 +263,7 @@ func (sm *SuppressionManager) saveConfig() error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal suppression config: %w", err)
 	}
+	data = annotateHashesWithAllowlistPragma(data)
 
 	// Create directory if it doesn't exist
 	dir := filepath.Dir(sm.configPath)
@@ -563,7 +579,7 @@ func getString(data map[string]interface{}, key string) string {
 			return str
 		}
 	}
-	return "Unknown"
+	return ""
 }
 
 func getFloat(data map[string]interface{}, key string) float64 {

--- a/internal/web/assets/template.html
+++ b/internal/web/assets/template.html
@@ -732,10 +732,10 @@
                                 <label class="form-field-label">Files to scan</label>
                                 <div class="form-field-description">Select one or more files to analyze for sensitive
                                     data</div>
-                                <div class="file-upload">
+                                <div class="file-upload" id="fileDropZone">
                                     <input type="file" id="fileInput" multiple
                                         accept=".bash,.bmp,.c,.cfg,.conf,.config,.cpp,.cs,.css,.csv,.docx,.env,.flac,.gif,.go,.h,.hpp,.html,.ini,.java,.jpeg,.jpg,.js,.json,.jsx,.kt,.less,.log,.m4a,.md,.mp3,.odp,.ods,.odt,.pdf,.php,.png,.pptx,.properties,.py,.rb,.rst,.rs,.sass,.scala,.scss,.sh,.sql,.tif,.tiff,.toml,.ts,.tsx,.txt,.wav,.webp,.xlsx,.xml,.yaml,.yml,.zsh">
-                                    <div>Choose files or drag and drop here</div>
+                                    <div id="fileDropZoneLabel">Choose files or drag files/folders here</div>
                                 </div>
                             </div>
 
@@ -1684,6 +1684,15 @@
         let lastScanResults = [];
         let newFindings = [];
 
+        // Files queued from drag-and-drop (including walked folder contents).
+        // Each entry is { file: File, relativePath: string }. When non-empty,
+        // submit uses these instead of the native fileInput.files list.
+        let pendingDroppedFiles = [];
+
+        // Exclude patterns from --exclude / config.defaults.exclude_patterns.
+        // Populated from /config-info on load. Applied during folder walks.
+        let excludePatterns = [];
+
         function toggleSection(header) {
             const content = header.nextElementSibling;
             const arrow = header.querySelector('span');
@@ -1735,10 +1744,17 @@
 
             if (scanning) return;
 
-            const fileInput = document.getElementById('fileInput');
-            const files = fileInput.files;
+            // Prefer drag-dropped files (which may carry relativePath info from
+            // a folder walk) over the native input list.
+            let queue;
+            if (pendingDroppedFiles.length > 0) {
+                queue = pendingDroppedFiles.slice();
+            } else {
+                const fileInput = document.getElementById('fileInput');
+                queue = Array.from(fileInput.files).map(f => ({ file: f, relativePath: f.name }));
+            }
 
-            if (files.length === 0) {
+            if (queue.length === 0) {
                 showAlert('Please select at least one file to scan.');
                 return;
             }
@@ -1752,7 +1768,7 @@
             document.getElementById('resultsContainer').classList.add('hidden');
 
             try {
-                await processScan(files);
+                await processScan(queue);
             } catch (error) {
                 showAlert('Scan failed: ' + error.message);
             } finally {
@@ -1763,35 +1779,43 @@
             }
         });
 
-        async function processScan(files) {
+        async function processScan(queue) {
             currentResults = [];
             window.suppressedCount = 0;
             window.suppressedFindings = [];
-            const totalFiles = files.length;
+            const totalFiles = queue.length;
 
             for (let i = 0; i < totalFiles; i++) {
-                const file = files[i];
+                const item = queue[i];
+                const file = item.file;
+                const relativePath = item.relativePath || file.name;
                 const progress = Math.round(((i + 1) / totalFiles) * 100);
 
                 document.getElementById('progressFill').style.width = progress + '%';
-                document.getElementById('progressText').textContent = `Scanning file ${i + 1} of ${totalFiles}: ${file.name}`;
+                document.getElementById('progressText').textContent = `Scanning file ${i + 1} of ${totalFiles}: ${relativePath}`;
 
                 try {
-                    const results = await scanSingleFile(file);
+                    const results = await scanSingleFile(file, relativePath);
                     if (results && results.length > 0) {
                         currentResults = currentResults.concat(results);
                     }
                 } catch (error) {
-                    showAlert(`Error scanning ${file.name}: ${error.message}`, 'warning');
+                    showAlert(`Error scanning ${relativePath}: ${error.message}`, 'warning');
                 }
             }
 
             await displayResults();
         }
 
-        async function scanSingleFile(file) {
+        async function scanSingleFile(file, relativePath) {
             const formData = new FormData();
             formData.append('files', file);
+            // Sent as a parallel field because Go's multipart parser strips
+            // directories from the filename header. The server uses this to
+            // display findings as "myrepo/src/foo.go" instead of "foo.go".
+            if (relativePath && relativePath !== file.name) {
+                formData.append('relative_path', relativePath);
+            }
             formData.append('confidence', document.getElementById('confidenceSelect').value);
             formData.append('checks', getSelectedChecks());
             formData.append('verbose', document.getElementById('verboseCheck').checked);
@@ -2443,6 +2467,168 @@
         document.getElementById('verboseCheck').addEventListener('change', updateCliCommand);
         document.getElementById('showMatchCheck').addEventListener('change', updateCliCommand);
         document.getElementById('recursiveCheck').addEventListener('change', updateCliCommand);
+
+        // Drag-and-drop: accept both files and folders. Folders are walked
+        // client-side via the webkitGetAsEntry API and every file inside is
+        // added with a relative path so reports show e.g. "myrepo/src/foo.go".
+        (function setupDropZone() {
+            const dropZone = document.getElementById('fileDropZone');
+            const label = document.getElementById('fileDropZoneLabel');
+            if (!dropZone) return;
+
+            const stop = (e) => { e.preventDefault(); e.stopPropagation(); };
+            ['dragenter', 'dragover'].forEach(evt => dropZone.addEventListener(evt, (e) => {
+                stop(e);
+                dropZone.style.borderColor = 'var(--color-text-accent)';
+                dropZone.style.background = '#f0f7ff';
+            }));
+            ['dragleave', 'drop'].forEach(evt => dropZone.addEventListener(evt, (e) => {
+                stop(e);
+                dropZone.style.borderColor = '';
+                dropZone.style.background = '';
+            }));
+
+            dropZone.addEventListener('drop', async (e) => {
+                const items = e.dataTransfer && e.dataTransfer.items;
+                if (!items || items.length === 0) return;
+
+                label.textContent = 'Reading files...';
+                try {
+                    const collected = await collectDroppedItems(items);
+                    if (collected.length === 0) {
+                        showAlert('No files found in dropped items.', 'warning');
+                        label.textContent = 'Choose files or drag files/folders here';
+                        return;
+                    }
+                    pendingDroppedFiles = collected;
+                    // Clear any previously-picked files from the native input so
+                    // the submit handler unambiguously picks the drop list.
+                    try { document.getElementById('fileInput').value = ''; } catch (_) {}
+                    updateDropZoneLabel();
+                } catch (err) {
+                    showAlert('Failed to read dropped items: ' + err.message);
+                    label.textContent = 'Choose files or drag files/folders here';
+                }
+            });
+
+            // When the user picks via the native file picker, drop the queued
+            // drag-drop files so the two sources don't combine unexpectedly.
+            document.getElementById('fileInput').addEventListener('change', () => {
+                if (document.getElementById('fileInput').files.length > 0) {
+                    pendingDroppedFiles = [];
+                    label.textContent = 'Choose files or drag files/folders here';
+                }
+            });
+
+            // Pull the configured exclude patterns from the server. Folder
+            // walks apply these to skip e.g. .git or node_modules when those
+            // are configured. Failure is non-fatal — we just won't filter.
+            fetch('/config-info').then(r => r.json()).then(d => {
+                if (d && Array.isArray(d.exclude_patterns)) {
+                    excludePatterns = d.exclude_patterns;
+                }
+            }).catch(() => {});
+        })();
+
+        function updateDropZoneLabel() {
+            const label = document.getElementById('fileDropZoneLabel');
+            if (!label) return;
+            const n = pendingDroppedFiles.length;
+            if (n === 0) {
+                label.textContent = 'Choose files or drag files/folders here';
+                return;
+            }
+            const folders = new Set();
+            for (const item of pendingDroppedFiles) {
+                const slash = item.relativePath.indexOf('/');
+                if (slash > 0) folders.add(item.relativePath.slice(0, slash));
+            }
+            if (folders.size > 0) {
+                label.textContent = `${n} file${n === 1 ? '' : 's'} ready from ${folders.size} folder${folders.size === 1 ? '' : 's'} (${[...folders].slice(0, 3).join(', ')}${folders.size > 3 ? '…' : ''})`;
+            } else {
+                label.textContent = `${n} file${n === 1 ? '' : 's'} ready`;
+            }
+        }
+
+        // Walk dropped DataTransferItems. Returns [{file, relativePath}].
+        async function collectDroppedItems(items) {
+            const entries = [];
+            for (let i = 0; i < items.length; i++) {
+                const entry = items[i].webkitGetAsEntry ? items[i].webkitGetAsEntry() : null;
+                if (entry) {
+                    entries.push(entry);
+                } else {
+                    // Browser without entry API — fall back to flat file.
+                    const file = items[i].getAsFile && items[i].getAsFile();
+                    if (file) entries.push({ _flatFile: file });
+                }
+            }
+            const out = [];
+            for (const entry of entries) {
+                if (entry._flatFile) {
+                    out.push({ file: entry._flatFile, relativePath: entry._flatFile.name });
+                } else {
+                    await walkEntry(entry, '', out);
+                }
+            }
+            return out;
+        }
+
+        async function walkEntry(entry, parentPath, out) {
+            if (!entry) return;
+            const relPath = parentPath ? `${parentPath}/${entry.name}` : entry.name;
+            if (isExcludedByPatterns(relPath, entry.name, excludePatterns)) return;
+
+            if (entry.isFile) {
+                const file = await new Promise((resolve, reject) => entry.file(resolve, reject));
+                out.push({ file, relativePath: relPath });
+                return;
+            }
+            if (entry.isDirectory) {
+                const reader = entry.createReader();
+                // readEntries yields up to 100 at a time; keep calling until empty.
+                while (true) {
+                    const batch = await new Promise((resolve, reject) => reader.readEntries(resolve, reject));
+                    if (!batch || batch.length === 0) break;
+                    for (const child of batch) {
+                        await walkEntry(child, relPath, out);
+                    }
+                }
+            }
+        }
+
+        // Mirrors the CLI's isExcluded matcher (see internal/exclude package):
+        //   - glob match against full relative path
+        //   - glob match against basename
+        //   - substring match against full path (matches the CLI behavior)
+        //   - patterns ending in '/' match any path segment (directory exclude)
+        function isExcludedByPatterns(relPath, baseName, patterns) {
+            if (!patterns || patterns.length === 0) return false;
+            for (const pat of patterns) {
+                if (!pat) continue;
+                if (matchGlob(pat, relPath)) return true;
+                if (matchGlob(pat, baseName)) return true;
+                if (relPath.indexOf(pat) >= 0) return true;
+                if (pat.endsWith('/')) {
+                    const dirPat = pat.slice(0, -1);
+                    for (const seg of relPath.split('/')) {
+                        if (matchGlob(dirPat, seg)) return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        // Minimal Go-style filepath.Match: supports * (no separator) and ? for
+        // a single char. No bracket classes — the existing CLI flag rarely
+        // uses them, and we can extend if needed.
+        function matchGlob(pattern, name) {
+            const re = new RegExp('^' + pattern
+                .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+                .replace(/\*/g, '[^/]*')
+                .replace(/\?/g, '[^/]') + '$');
+            return re.test(name);
+        }
         /* GENAI_DISABLED: GenAI main checkbox and region event listeners
         document.getElementById('genaiCheck').addEventListener('change', updateCliCommand);
         document.getElementById('regionSelect').addEventListener('change', updateCliCommand);

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -41,8 +41,11 @@ var embeddedTemplate string
 
 // WebServer represents the web server instance
 type WebServer struct {
-	port   string
-	server *http.Server
+	port             string
+	configPath       string
+	suppressionsPath string
+	excludePatterns  []string
+	server           *http.Server
 }
 
 // ScanResponse represents the response from a scan operation (wraps CLI JSON output)
@@ -57,6 +60,20 @@ type ScanResponse struct {
 func NewWebServer(port string) *WebServer {
 	return &WebServer{
 		port: port,
+	}
+}
+
+// NewWebServerWithOptions creates a new web server instance with config and
+// suppression file paths supplied by the caller. Empty strings preserve the
+// existing default behavior (search standard locations). excludePatterns from
+// --exclude take precedence; empty slice means fall back to whatever the
+// loaded config file specifies.
+func NewWebServerWithOptions(port, configPath, suppressionsPath string, excludePatterns []string) *WebServer {
+	return &WebServer{
+		port:             port,
+		configPath:       configPath,
+		suppressionsPath: suppressionsPath,
+		excludePatterns:  excludePatterns,
 	}
 }
 
@@ -158,6 +175,7 @@ func (ws *WebServer) setupRoutes() {
 	http.HandleFunc("/health", ws.handleHealth)
 	http.HandleFunc("/scan", ws.handleScan)
 	http.HandleFunc("/export", ws.handleExport)
+	http.HandleFunc("/config-info", ws.handleConfigInfo)
 
 	// Static asset serving with security validation
 	http.HandleFunc("/logo", ws.serveLogo)
@@ -220,6 +238,38 @@ func (ws *WebServer) loadTemplate() string {
 <body><h1>Ferret Scan</h1><p>Template not found. Please ensure template.html is embedded in the binary.</p></body></html>`
 }
 
+// resolveExcludePatterns returns the patterns the front-end should apply when
+// walking dropped folders. --exclude (passed at startup) takes precedence over
+// whatever the loaded config file specifies, matching the CLI's precedence
+// order.
+func (ws *WebServer) resolveExcludePatterns() []string {
+	if len(ws.excludePatterns) > 0 {
+		return ws.excludePatterns
+	}
+	cfg := ws.loadConfiguration(ws.configPath)
+	if cfg != nil && len(cfg.Defaults.ExcludePatterns) > 0 {
+		return cfg.Defaults.ExcludePatterns
+	}
+	return nil
+}
+
+// handleConfigInfo returns config-derived values the front-end needs at load
+// time (currently just exclude_patterns for client-side folder filtering).
+func (ws *WebServer) handleConfigInfo(responseWriter http.ResponseWriter, request *http.Request) {
+	if request.Method != "GET" {
+		http.Error(responseWriter, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	patterns := ws.resolveExcludePatterns()
+	if patterns == nil {
+		patterns = []string{}
+	}
+	responseWriter.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(responseWriter).Encode(map[string]interface{}{
+		"exclude_patterns": patterns,
+	})
+}
+
 // handleHealth provides a health check endpoint with CLI version information
 func (ws *WebServer) handleHealth(responseWriter http.ResponseWriter, request *http.Request) {
 	if request.Method != "GET" {
@@ -277,6 +327,10 @@ func (ws *WebServer) handleScan(responseWriter http.ResponseWriter, request *htt
 
 	verbose := request.FormValue("verbose") == "true"
 	recursive := request.FormValue("recursive") == "true"
+	// Optional relative path from a folder drop (e.g. "myrepo/src/foo.go") —
+	// Go strips path components from multipart filename headers, so the
+	// front-end sends it as a parallel field.
+	relativePath := request.FormValue("relative_path")
 
 	// Get uploaded files
 	files := request.MultipartForm.File["files"]
@@ -291,7 +345,13 @@ func (ws *WebServer) handleScan(responseWriter http.ResponseWriter, request *htt
 	suppressedCount := 0
 
 	for i, fileHeader := range files {
-		matches, suppressed, suppCount, err := ws.processUploadedFileWithCLILogic(fileHeader, i, confidence, checks, verbose, recursive)
+		displayName := fileHeader.Filename
+		// relative_path applies when there's a single file in the request,
+		// which is the front-end's per-file upload pattern.
+		if relativePath != "" && len(files) == 1 {
+			displayName = relativePath
+		}
+		matches, suppressed, suppCount, err := ws.processUploadedFileWithCLILogic(fileHeader, i, confidence, checks, verbose, recursive, displayName)
 		if err != nil {
 			ws.sendError(responseWriter, err.Error())
 			return
@@ -343,11 +403,15 @@ func (ws *WebServer) handleScan(responseWriter http.ResponseWriter, request *htt
 }
 
 // processUploadedFileWithCLILogic handles user file uploads using full CLI scanning logic
-func (ws *WebServer) processUploadedFileWithCLILogic(uploadedFile *multipart.FileHeader, fileIndex int, confidence, checks string, verbose, recursive bool) ([]detector.Match, []detector.SuppressedMatch, int, error) {
+func (ws *WebServer) processUploadedFileWithCLILogic(uploadedFile *multipart.FileHeader, fileIndex int, confidence, checks string, verbose, recursive bool, displayName string) ([]detector.Match, []detector.SuppressedMatch, int, error) {
+	if displayName == "" {
+		displayName = uploadedFile.Filename
+	}
+
 	// Open uploaded file
 	file, err := uploadedFile.Open()
 	if err != nil {
-		return nil, nil, 0, fmt.Errorf("failed to open file %s: %v", uploadedFile.Filename, err)
+		return nil, nil, 0, fmt.Errorf("failed to open file %s: %v", displayName, err)
 	}
 	defer file.Close()
 
@@ -372,24 +436,27 @@ func (ws *WebServer) processUploadedFileWithCLILogic(uploadedFile *multipart.Fil
 	normalizedTempPath := paths.NormalizePath(tempFile.Name())
 
 	// Run full CLI scanning logic on this file with original filename
-	return ws.runFullCLIScan(normalizedTempPath, uploadedFile.Filename, confidence, checks, verbose, recursive)
+	return ws.runFullCLIScan(normalizedTempPath, displayName, confidence, checks, verbose, recursive)
 }
 
 // runFullCLIScan executes the full CLI scanning logic with configuration and suppression support
 func (ws *WebServer) runFullCLIScan(filePath, originalFilename, confidence, checks string, verbose, recursive bool) ([]detector.Match, []detector.SuppressedMatch, int, error) {
-	cfg := ws.loadConfiguration("")
+	cfg := ws.loadConfiguration(ws.configPath)
 
 	var checksSlice []string
 	if checks != "" && checks != "all" {
 		checksSlice = strings.Split(checks, ",")
 	}
 
-	suppressionManager, err := ws.initializeSuppressionManager("")
+	suppressionManager, err := ws.initializeSuppressionManager(ws.suppressionsPath)
 	if err != nil {
 		return nil, nil, 0, fmt.Errorf("failed to initialize suppression manager: %v", err)
 	}
 
-	// Set original filename on matches before suppression matching
+	// Scan without applying suppressions — the filename on each match is the
+	// random temp path, but suppression hashes were created against the
+	// original upload filename. We rename below and then apply suppressions
+	// ourselves so the hashes match.
 	scanConfig := core.ScanConfig{
 		FilePath:            filePath,
 		Checks:              checksSlice,
@@ -400,7 +467,7 @@ func (ws *WebServer) runFullCLIScan(filePath, originalFilename, confidence, chec
 		EnableRedaction:     false,
 		Config:              cfg,
 		Profile:             nil,
-		SuppressionManager:  suppressionManager,
+		SuppressionManager:  nil,
 	}
 
 	result, err := core.ScanFile(scanConfig)
@@ -408,16 +475,31 @@ func (ws *WebServer) runFullCLIScan(filePath, originalFilename, confidence, chec
 		return nil, nil, 0, fmt.Errorf("scanning failed: %v", err)
 	}
 
-	// Update filenames to original name for suppression matching, then sanitize for display
+	// Rewrite each match's filename to the original upload name so hashes
+	// computed against the upload identity (rather than the temp path) match
+	// any existing suppression rules.
 	safeFilename := ws.sanitizeFilenameForDisplay(originalFilename)
 	for i := range result.Matches {
 		result.Matches[i].Filename = safeFilename
 	}
-	for i := range result.SuppressedMatches {
-		result.SuppressedMatches[i].Match.Filename = safeFilename
+
+	// Apply suppressions now that filenames are stable.
+	var unsuppressed []detector.Match
+	var suppressed []detector.SuppressedMatch
+	for _, match := range result.Matches {
+		if isSuppressed, rule := suppressionManager.IsSuppressed(match); isSuppressed {
+			suppressed = append(suppressed, detector.SuppressedMatch{
+				Match:        match,
+				SuppressedBy: rule.ID,
+				RuleReason:   rule.Reason,
+				ExpiresAt:    rule.ExpiresAt,
+			})
+		} else {
+			unsuppressed = append(unsuppressed, match)
+		}
 	}
 
-	return result.Matches, result.SuppressedMatches, result.SuppressedCount, nil
+	return unsuppressed, suppressed, len(suppressed), nil
 }
 
 // handleExport exports scan results in the requested format
@@ -729,7 +811,7 @@ func (ws *WebServer) handleSuppressions(responseWriter http.ResponseWriter, requ
 	}
 
 	// Initialize suppression manager using CLI logic
-	suppressionManager, err := ws.initializeSuppressionManager("")
+	suppressionManager, err := ws.initializeSuppressionManager(ws.suppressionsPath)
 	if err != nil {
 		ws.sendError(responseWriter, fmt.Sprintf("Failed to initialize suppression manager: %v", err))
 		return
@@ -760,7 +842,7 @@ func (ws *WebServer) handleSuppressionsCreate(responseWriter http.ResponseWriter
 	}
 
 	// Initialize suppression manager using CLI logic
-	suppressionManager, err := ws.initializeSuppressionManager("")
+	suppressionManager, err := ws.initializeSuppressionManager(ws.suppressionsPath)
 	if err != nil {
 		ws.sendError(responseWriter, fmt.Sprintf("Failed to initialize suppression manager: %v", err))
 		return
@@ -799,7 +881,7 @@ func (ws *WebServer) handleSuppressionsEdit(responseWriter http.ResponseWriter, 
 	}
 
 	// Initialize suppression manager using CLI logic
-	suppressionManager, err := ws.initializeSuppressionManager("")
+	suppressionManager, err := ws.initializeSuppressionManager(ws.suppressionsPath)
 	if err != nil {
 		ws.sendError(responseWriter, fmt.Sprintf("Failed to initialize suppression manager: %v", err))
 		return
@@ -839,7 +921,7 @@ func (ws *WebServer) handleSuppressionsRemove(responseWriter http.ResponseWriter
 	}
 
 	// Initialize suppression manager using CLI logic
-	suppressionManager, err := ws.initializeSuppressionManager("")
+	suppressionManager, err := ws.initializeSuppressionManager(ws.suppressionsPath)
 	if err != nil {
 		ws.sendError(responseWriter, fmt.Sprintf("Failed to initialize suppression manager: %v", err))
 		return
@@ -876,7 +958,7 @@ func (ws *WebServer) handleSuppressionsEnable(responseWriter http.ResponseWriter
 	}
 
 	// Initialize suppression manager using CLI logic
-	suppressionManager, err := ws.initializeSuppressionManager("")
+	suppressionManager, err := ws.initializeSuppressionManager(ws.suppressionsPath)
 	if err != nil {
 		ws.sendError(responseWriter, fmt.Sprintf("Failed to initialize suppression manager: %v", err))
 		return
@@ -920,7 +1002,7 @@ func (ws *WebServer) handleSuppressionsDisable(responseWriter http.ResponseWrite
 	}
 
 	// Initialize suppression manager using CLI logic
-	suppressionManager, err := ws.initializeSuppressionManager("")
+	suppressionManager, err := ws.initializeSuppressionManager(ws.suppressionsPath)
 	if err != nil {
 		ws.sendError(responseWriter, fmt.Sprintf("Failed to initialize suppression manager: %v", err))
 		return
@@ -957,7 +1039,7 @@ func (ws *WebServer) handleSuppressionsBulkEnable(responseWriter http.ResponseWr
 	}
 
 	// Initialize suppression manager using CLI logic
-	suppressionManager, err := ws.initializeSuppressionManager("")
+	suppressionManager, err := ws.initializeSuppressionManager(ws.suppressionsPath)
 	if err != nil {
 		ws.sendError(responseWriter, fmt.Sprintf("Failed to initialize suppression manager: %v", err))
 		return
@@ -1004,7 +1086,7 @@ func (ws *WebServer) handleSuppressionsBulkDisable(responseWriter http.ResponseW
 	}
 
 	// Initialize suppression manager using CLI logic
-	suppressionManager, err := ws.initializeSuppressionManager("")
+	suppressionManager, err := ws.initializeSuppressionManager(ws.suppressionsPath)
 	if err != nil {
 		ws.sendError(responseWriter, fmt.Sprintf("Failed to initialize suppression manager: %v", err))
 		return
@@ -1045,7 +1127,7 @@ func (ws *WebServer) handleSuppressionsBulkDelete(responseWriter http.ResponseWr
 	}
 
 	// Initialize suppression manager using CLI logic
-	suppressionManager, err := ws.initializeSuppressionManager("")
+	suppressionManager, err := ws.initializeSuppressionManager(ws.suppressionsPath)
 	if err != nil {
 		ws.sendError(responseWriter, fmt.Sprintf("Failed to initialize suppression manager: %v", err))
 		return
@@ -1086,7 +1168,7 @@ func (ws *WebServer) handleSuppressionsBulkCreate(responseWriter http.ResponseWr
 	}
 
 	// Initialize suppression manager using CLI logic
-	suppressionManager, err := ws.initializeSuppressionManager("")
+	suppressionManager, err := ws.initializeSuppressionManager(ws.suppressionsPath)
 	if err != nil {
 		ws.sendError(responseWriter, fmt.Sprintf("Failed to initialize suppression manager: %v", err))
 		return
@@ -1122,7 +1204,7 @@ func (ws *WebServer) handleSuppressionsDownload(responseWriter http.ResponseWrit
 	}
 
 	// Initialize suppression manager using CLI logic
-	suppressionManager, err := ws.initializeSuppressionManager("")
+	suppressionManager, err := ws.initializeSuppressionManager(ws.suppressionsPath)
 	if err != nil {
 		ws.sendError(responseWriter, fmt.Sprintf("Failed to initialize suppression manager: %v", err))
 		return
@@ -1159,7 +1241,7 @@ func (ws *WebServer) handleSuppressionsCheckHash(responseWriter http.ResponseWri
 	}
 
 	// Initialize suppression manager using CLI logic
-	suppressionManager, err := ws.initializeSuppressionManager("")
+	suppressionManager, err := ws.initializeSuppressionManager(ws.suppressionsPath)
 	if err != nil {
 		ws.sendError(responseWriter, fmt.Sprintf("Failed to initialize suppression manager: %v", err))
 		return


### PR DESCRIPTION
… web mode

- Wire --config, --suppression-file, and --exclude through web mode so the server uses the same configuration the CLI does instead of always reading ~/.ferret-scan/suppressions.yaml. Add /config-info to surface configured exclude patterns to the front-end.
- Drag-drop folders onto the upload zone: client-side walks the folder via webkitGetAsEntry, applies configured --exclude patterns during the walk, and uploads each file with its relative path so findings display as "myrepo/src/foo.go". File-only drops and the native picker still work.
- Append "# pragma: allowlist secret" to hash: lines in suppression YAML so the file itself doesn't trigger secret-scanner false positives. Idempotent on re-save.
- Fix two pre-existing suppression-matching bugs surfaced while testing: getString defaulted missing fields to "Unknown" (causing hash mismatch between create and re-scan when context fields were empty); and the web flow ran suppressions inside core.ScanFile against the temp filename before renaming to the upload's display name. Suppressions now apply after the rename.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
