### PR TITLE
docs: realign with v1.7.0 — folder upload, web caching, O(1) suppressions, 100MB limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,81 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+<a name="v1.7.0"></a>
+## [v1.7.0] - 2026-05-08
+
+### 🚀 Features
+
+- **web:** drag-and-drop folders onto the upload zone — the browser walks the folder client-side via `webkitGetAsEntry`, applies any configured `--exclude` patterns during the walk, and uploads each file with its relative path so findings display as `myrepo/src/foo.go`. Single-file drops and the native picker still work; PR #52 also unifies "Choose Files" / "Choose Folder" into matching styled buttons and uses `showDirectoryPicker` where available so excluded dirs (`.git`, `node_modules`, `__pycache__`) are skipped before the browser prompts.
+- **web:** wire `--config`, `--suppression-file`, and `--exclude` through web mode so the server uses the same configuration as the CLI instead of always reading `~/.ferret-scan/suppressions.yaml`. New `/config-info` endpoint surfaces configured exclude patterns to the front-end.
+- **suppressions:** append `# pragma: allowlist secret` to `hash:` lines in the suppression YAML so the file itself doesn't trigger secret-scanner false positives. Idempotent on re-save.
+- **web:** suppression expiration bulk operations — Make Permanent / Renew 30 Days actions on selected rules, backed by `POST /suppressions/bulk-update-expiration`.
+
+### ⚡ Performance
+
+- **suppressions:** `IsSuppressed` is now O(1) via a hash index rebuilt on load and on every save. Per-call microbench (no-op match against a non-matching rule set):
+
+    | rules  | before     | after    | speedup |
+    |-------:|-----------:|---------:|--------:|
+    | 100    |   870 ns   |  620 ns  |   1.4×  |
+    | 1,000  | 2,984 ns   |  631 ns  |   4.7×  |
+    | 10,000 | 23,236 ns  |  640 ns  |  36×    |
+    | 50,000 | 113,155 ns |  619 ns  | 183×    |
+
+- **web:** cache `SuppressionManager` on the `WebServer` with mtime-based reload — eliminates the per-request YAML re-parse that previously dominated `/scan` and `/suppressions` latency. With a 5,000-rule (45k-line) suppression file across 50 sequential requests:
+  - `/scan`: 68.7 ms → 28.5 ms per request (**2.4×**)
+  - `/suppressions`: 67.3 ms → 29.6 ms per request (**2.3×**)
+
+- **validators:** hoist hot-path regex compilations to package level. Per-call microbench:
+
+    | function                      | before     | after     | speedup | allocs   |
+    |-------------------------------|-----------:|----------:|--------:|---------:|
+    | `containsEnhancedPhoneNumber` | 8,293 ns   | 1,057 ns  |   7.8×  | 200 → 0  |
+    | `extractEmail`                | 1,653 ns   |   378 ns  |   4.4×  |  37 → 0  |
+    | `containsEnhancedGPSData`     |   432 ns   |   184 ns  |   2.4×  |   8 → 0  |
+    | `isVersionNumber`             | 1,562 ns   |    86 ns  |  18×    |  62 → 1  |
+    | `calculateCopyrightConfidence`| 1,376 ns   |   199 ns  |   6.9×  |  35 → 0  |
+
+  Multi-line PEM regexes (SSH/cert/PGP) in the secrets validator and the year pattern in the intellectual-property validator are now compiled once at package init instead of recompiled per call.
+
+- **parallel:** unbounded goroutine spawn in `ResourceMonitor.notifyCallbacks` replaced with synchronous invocation; callbacks that need async work spawn their own goroutine.
+
+### 🐛 Bug Fixes
+
+- **suppressions:** the web flow's hash mismatch — `getString` defaulted missing finding fields to `"Unknown"`, so `mockMatch.Context.AfterText` became the literal string `"Unknown"` when re-creating from a JSON body that omitted empty fields. Returns `""` now, so suppress-then-rescan in the web UI correctly suppresses the finding.
+- **web:** suppressions inside `core.ScanFile` ran against the random temp filename, then matches were renamed to the upload's display name *after*. Suppressions now apply after the rename, so cross-mode rules (CLI rule applied to web scan and vice versa) match consistently.
+- **parallel:** fix goroutine leak in `AdaptiveProcessor.adaptiveScalingLoop` — `Stop()` only stopped the ticker; the loop kept blocking on a channel that would never close. Now gated on a `done` chan closed via `sync.Once`. Also fixes a pre-existing data race in `Stop()` between the scaling loop's `adjustWorkerCount` (which swaps the worker pool) and the teardown's pool stop, via `sync.WaitGroup`.
+- **suppressions:** parse errors on a malformed YAML file no longer silently produce an empty rule set — a stderr warning now names the file and the underlying error so users notice that their rules aren't being applied. Missing-file remains silent (the legitimate first-run case).
+- **suppressions:** `RWMutex` around the new hash index makes `IsSuppressed` safe for concurrent use; previously the manager had no synchronization around shared state.
+- **resilience:** `RetryWithBackoff` now treats `MaxInterval=0` as "no cap" instead of clamping every delay to zero, fixing a long-standing flake in `TestRetryWithBackoff_ContextCancellation`. Test rewritten to be deterministic.
+- **preprocessors:** `readTextFile` now opens the file once instead of twice — closes the TOCTOU window between the size check and the read.
+
+### 📦 Code Refactoring
+
+- **web:** dedup 12 near-identical suppression HTTP handlers into a shared `suppressionEndpoint` wrapper plus typed `suppressionRequest` struct. `internal/web/server.go` shrank from 1,350 to 1,183 LOC (−167, −12%).
+- **web:** delete unused `normalizePathForWeb` (strict subset of the live `sanitizeFilenameForDisplay`; zero callers since the initial commit).
+- **parallel:** simplify `WorkerPool.Submit` — the `default` arm fell into an inner `select` identical to the outer one and had no behavioral effect.
+
+### ✅ Tests
+
+- new cross-platform GitHub Actions workflow `.github/workflows/go-test.yml` runs `go test -race -count=1 ./...` on `ubuntu-latest`, `macos-latest`, and `windows-latest`. Previously the repo had no Go unit-test workflow at all (only a secret-scanning workflow and a build-binary workflow). `tests/integration` is excluded from the test step (Windows-only files have separate pre-existing bugs); `vet` and `build` still cover them.
+- restore `tests/helpers` package (was imported by `tests/integration/windows_*_test.go` but never committed).
+- new tests: multi-line PEM detection covering 8 PEM types end-to-end, concurrent `IsSuppressed` under `-race`, `AdaptiveProcessor.Stop` goroutine-exit verification.
+- track two validator test files (`internal/validators/email/validator_test.go`, `internal/validators/intellectualproperty/validator_test.go`, ~850 LOC combined) that the prior `*_test.go` ignore rule had been silently dropping from version control.
+- `make test` targets repointed from the non-existent `./tests/unit/...` to `./internal/...`.
+
+### 🛠 Build System
+
+- bump GitHub Actions to versions running on Node 24 across all workflows: `actions/checkout@v6`, `actions/setup-go@v6`, `actions/cache@v5`, `actions/setup-python@v6`, `actions/upload-artifact@v7`, `actions/download-artifact@v8`, `actions/github-script@v9`. GitHub is removing Node 20 from runners on 2026-09-16.
+- remove `*_test.go` and `tests/` patterns from `.gitignore` — they had been silently dropping every Go test file from version control; existing tests survived only via `git add -f`.
+
+### Pull Requests
+
+- Merge pull request [#52](https://github.com/awslabs/ferret-scan/pull/52) from awslabs/feature/web-enhancements
+- Merge pull request [#51](https://github.com/awslabs/ferret-scan/pull/51) from awslabs/dev/web-server-caching
+- Merge pull request [#50](https://github.com/awslabs/ferret-scan/pull/50) from awslabs/dev/perf-and-cleanup
+- Merge pull request [#48](https://github.com/awslabs/ferret-scan/pull/48) from awslabs/dev/web-folder-scan-and-suppression-fixes
+
 <a name="v1.5.2"></a>
 ## [v1.5.2] - 2026-02-18
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Ferret Scan is extensively documented with comprehensive guides for users, devel
 
 - **🚀 Getting Started**: [Installation](#installation) | [Configuration Guide](docs/configuration.md) | [Architecture Overview](docs/architecture-diagram.md)
 - **👥 User Guides**: [Web UI](docs/user-guides/README-WebUI.md) | [Docker](docs/user-guides/README-Docker.md) | [Preprocess-Only](docs/user-guides/README-Preprocess-Only.md) | [Suppressions](docs/user-guides/README-Suppressions.md)
-- **🛠 Development**: [Creating Validators](docs/development/creating_validators.md) | [Testing Guide](docs/testing/TESTING.md)
+- **🛠 Development**: [Creating Validators](docs/development/creating_validators.md) | run `make test` (Go test suite) | [Cross-platform Test Workflow](.github/workflows/go-test.yml)
 - **🚀 Deployment**: [GitLab Integration](docs/GITLAB_INTEGRATION.md) | [GitLab Security Scanner Setup](docs/deployment/GITLAB_SECURITY_SCANNER_SETUP.md) | [CI/CD Setup](docs/deployment/GITLAB_CI_SETUP.md)
 
 ## Architecture
@@ -246,12 +246,23 @@ See the [Redaction Guide](docs/user-guides/README-Redaction.md) for strategy det
 
 #### Suppression Management
 - `--generate-suppressions`: Generate suppression rules for all findings (disabled by default, updates last_seen_at for existing rules)
-- `--suppression-file`: Path to suppression configuration file (default: ".ferret-scan-suppressions.yaml")
+- `--suppression-file`: Path to suppression configuration file (default: `$XDG_CONFIG_HOME/ferret-scan/suppressions.yaml` on Unix — falls back to `~/.ferret-scan/suppressions.yaml`; `%APPDATA%\ferret-scan\suppressions.yaml` on Windows)
 - `--show-suppressed`: Include suppressed findings in output with suppression details (marked as [SUPP] in text format)
 
 #### Web Server Mode
 - `--web`: Start web server mode instead of CLI scanning
 - `--port`: Port for web server (default: 8080, only used with --web)
+
+The web server honors `--config`, `--suppression-file`, and `--exclude` so it can use the same configuration as the CLI:
+
+```bash
+# Use a team-shared suppressions file and exclude common build dirs
+./ferret-scan --web --port 8080 \
+  --suppression-file ./team-suppressions.yaml \
+  --exclude '.git,node_modules,dist,target'
+```
+
+Without these flags, the web server uses the platform default suppression path (`~/.ferret-scan/suppressions.yaml` on Unix, `%APPDATA%\ferret-scan\suppressions.yaml` on Windows). Configured exclude patterns are applied client-side during folder drag-drop walks so excluded directories are never uploaded.
 
 
 
@@ -540,8 +551,10 @@ Generate suppression rules for findings to reduce false positives:
 # Use custom suppression file
 ./ferret-scan --file document.txt --suppression-file custom-suppressions.yaml
 
-# Default suppression file location
-# ~/.ferret-scan/suppressions.yaml
+# Default suppression file location (when --suppression-file is omitted):
+#   Unix:    $XDG_CONFIG_HOME/ferret-scan/suppressions.yaml  (falls back to ~/.ferret-scan/suppressions.yaml)
+#   Windows: %APPDATA%\ferret-scan\suppressions.yaml
+# Override via FERRET_CONFIG_DIR env var.
 ```
 
 **Web UI Management**: The web interface provides comprehensive suppression management:
@@ -836,9 +849,11 @@ Then open http://localhost:8080 in your browser (or the port you specified).
 
 - **Single File**: Click "Choose Files" and select one file
 - **Multiple Files**: Hold Ctrl/Cmd while selecting files, or drag multiple files onto the upload area
+- **Folder Upload**: Click "Choose Folder" or drag-and-drop a folder onto the upload zone — the browser walks the folder client-side and uploads every file with its relative path, so findings show as `myrepo/src/foo.go`. Configured `--exclude` patterns are applied during the walk, so excluded directories (e.g. `.git`, `node_modules`) are never uploaded. On browsers that support `showDirectoryPicker` (recent Chrome / Edge) the picker prompts directly; older browsers fall back to `<input webkitdirectory>`.
 - **Real-time Processing**: Results appear progressively as each file is scanned
 - **Visual Progress Bar**: Shows completion percentage and current file being processed
-- **Progress Tracking**: Shows current file being processed (e.g., "Scanning file 2 of 5: document.pdf")
+- **Progress Tracking**: Shows current file being processed (e.g., "Scanning file 2 of 5: myrepo/src/document.pdf")
+- **Per-file Limit**: 100 MB per file (decompression-bomb guard); folder uploads are unbounded in count
 
 #### Scan Configuration
 
@@ -874,12 +889,14 @@ Then open http://localhost:8080 in your browser (or the port you specified).
 #### Suppression Management
 
 - **Bulk Operations**: Select multiple suppressions using checkboxes for batch enable/disable/delete
+- **Bulk Expiration**: "Make Permanent" and "Renew 30 Days" actions on selected rules
 - **Individual Actions**: Quick enable/disable/edit/remove buttons for single rules
 - **Undo Functionality**: Undo button appears after operations to reverse the last change
 - **New Findings Integration**: Scan results show new findings that can be added as suppressions
 - **Rule Details**: Click rule IDs to view complete suppression information
 - **Status Indicators**: Visual ENABLED (green) and DISABLED (red) status badges
 - **Smart Pagination**: Navigate large suppression rule sets efficiently
+- **Cached Manager**: The web server caches the parsed suppressions file in memory and reloads only when the file's mtime changes. CLI-side or manual edits to the YAML are picked up on the next request.
 
 ### Supported File Types
 
@@ -981,9 +998,9 @@ The web UI supports all file types available in the CLI version:
 
 #### File Size Limits
 
-- Maximum upload: 10MB per file
+- Maximum upload: 100 MB per file (decompression-bomb guard, applied in both `/scan` and the multipart parser)
 <!-- GENAI_DISABLED: - Audio files: 500MB limit (for GenAI transcription) -->
-- Multiple files: No limit on total count
+- Multiple files / folder uploads: No limit on total count
 
 #### Performance
 
@@ -1018,7 +1035,7 @@ The web UI automatically finds an available port. Check the console output for t
 
 #### Large file uploads failing
 
-- Check file size limits (10MB for most files, 500MB for audio)
+- Check file size limits (100 MB per file)
 <!-- GENAI_DISABLED: - Ensure stable internet connection for GenAI features -->
 - Try processing files individually if bulk upload fails
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -812,7 +812,7 @@ func main() {
 	// genaiServices := flag.String("genai-services", "all", "Comma-separated list of GenAI services to use: textract, transcribe, comprehend, or 'all' (only used with --enable-genai)")
 	// textractRegion := flag.String("textract-region", "us-east-1", "AWS region for Textract service (only used with --enable-genai)")
 	// transcribeBucket := flag.String("transcribe-bucket", "", "S3 bucket name for Transcribe audio uploads (optional, creates temporary bucket if not specified)")
-	suppressionFile := flag.String("suppression-file", "", "Path to suppression configuration file (default: .ferret-scan-suppressions.yaml)")
+	suppressionFile := flag.String("suppression-file", "", "Path to suppression configuration file (default: $XDG_CONFIG_HOME/ferret-scan/suppressions.yaml on Unix, %APPDATA%\\ferret-scan\\suppressions.yaml on Windows)")
 	generateSuppressions := flag.Bool("generate-suppressions", false, "Generate suppression rules for all findings (disabled by default, can be enabled in YAML)")
 
 	showSuppressed := flag.Bool("show-suppressed", false, "Include suppressed findings in output with suppression details (marked as [SUPP] in text format)")
@@ -1025,7 +1025,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		if flags.suppressionFile != "" && flags.suppressionFile != ".ferret-scan-suppressions.yaml" {
+		if flags.suppressionFile != "" {
 			fmt.Fprintf(os.Stderr, "Error: --preprocess-only cannot be used with --suppression-file\n")
 			fmt.Fprintf(os.Stderr, "Preprocess-only mode does not perform validation.\n")
 			os.Exit(1)

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,10 +24,9 @@ Welcome to the comprehensive documentation for Ferret Scan - a sensitive data de
 - [Suppression Architecture](suppression-system.md) - Technical suppression system details
 
 ### 🧪 Testing & Quality Assurance
-- [Testing Guide](testing/TESTING.md) - Comprehensive testing documentation
-- [Testing Strategy](testing/testing-strategy.md) - Overall testing approach and architecture
-- [Implementation Summary](testing/TESTING_IMPLEMENTATION_SUMMARY.md) - What was implemented
-- [Success Summary](testing/TESTING_SUCCESS_SUMMARY.md) - Final results and achievements
+
+- [GitLab CI Testing Tracker](testing/GITLAB_CI_TESTING_TRACKER.md) - Status of the GitLab CI test suite
+- [Cross-platform Go Test Workflow](../.github/workflows/go-test.yml) - GitHub Actions matrix that runs `go test -race -count=1 ./...` on `ubuntu-latest`, `macos-latest`, and `windows-latest`. The `tests/integration/` package is excluded from the test step (Windows-only files have separate pre-existing bugs); `vet` and `build` still cover them. Run locally with `make test` (which targets `./internal/...`).
 
 ### 🚀 Deployment & CI/CD
 - [GitLab Integration](GITLAB_INTEGRATION.md) - GitLab Ultimate integration guide
@@ -63,10 +62,10 @@ Welcome to the comprehensive documentation for Ferret Scan - a sensitive data de
 
 ### By Use Case
 - **New Users**: Start with [Main README](../README.md) → [Configuration Guide](configuration.md)
-- **Developers**: [Creating Validators](development/creating_validators.md) → [Testing Guide](testing/TESTING.md)
+- **Developers**: [Creating Validators](development/creating_validators.md) → run `make test` and check the [cross-platform Go Test Workflow](../.github/workflows/go-test.yml)
 - **DevOps/CI**: [GitLab Integration](GITLAB_INTEGRATION.md) → [GitLab Security Scanner Setup](deployment/GITLAB_SECURITY_SCANNER_SETUP.md)
 - **Web Interface**: [Web UI Guide](user-guides/README-WebUI.md) → [Docker Guide](user-guides/README-Docker.md)
-- **Testing**: [Testing Guide](testing/TESTING.md) → [Testing Strategy](testing/testing-strategy.md)
+- **Testing**: [GitLab CI Testing Tracker](testing/GITLAB_CI_TESTING_TRACKER.md) — `make test` runs the full Go suite locally; CI runs `go test -race ./...` on Linux/macOS/Windows
 
 ### By Topic
 - **🔧 Configuration**: [Configuration Guide](configuration.md)
@@ -75,21 +74,13 @@ Welcome to the comprehensive documentation for Ferret Scan - a sensitive data de
 - **🆕 Enhanced Metadata**: [Enhanced Metadata Guide](user-guides/README-Enhanced-Metadata.md)
 - **🔒 Redaction**: [Redaction Guide](user-guides/README-Redaction.md)
 <!-- GENAI_DISABLED: - **🤖 AI Features**: [GenAI Integration](development/genai_integration.md) -->
-- **🧪 Testing**: [Testing Guide](testing/TESTING.md)
+- **🧪 Testing**: [GitLab CI Testing Tracker](testing/GITLAB_CI_TESTING_TRACKER.md)
 - **🚀 Deployment**: [GitLab Security Scanner Setup](deployment/GITLAB_SECURITY_SCANNER_SETUP.md)
 - **🔧 Troubleshooting**: [GitLab Integration Troubleshooting](troubleshooting/GITLAB_INTEGRATION_TROUBLESHOOTING.md)
 
 ## 📋 Document Status
 
-| Category | Documents | Status |
-|----------|-----------|---------|
-| User Guides | 4 | ✅ Complete |
-| Development | 12 | ✅ Complete |
-| Testing | 4 | ✅ Complete |
-| Deployment | 3 | ✅ Complete |
-| Reference | 5 | ✅ Complete |
-| Troubleshooting | 1 | ✅ Complete |
-| **Total** | **29** | **✅ Complete** |
+Documents in this index are kept in sync with the codebase as features land. The CHANGELOG at the root of the repo is the source of truth for what shipped in each release; the per-topic guides above describe how each feature works in the current version.
 
 ## 🤝 Contributing to Documentation
 
@@ -109,4 +100,4 @@ When adding new documentation:
 
 ---
 
-*This documentation is maintained alongside the Ferret Scan codebase. Last updated: $(date)*
+*This documentation is maintained alongside the Ferret Scan codebase.*

--- a/docs/architecture-diagram.md
+++ b/docs/architecture-diagram.md
@@ -31,7 +31,7 @@ flowchart TD
     CLIArgs["⚙️ CLI Arguments<br/>--file, --format, --checks, etc."]
     ConfigFile["📋 Configuration File<br/>YAML Config with defaults"]
     Profiles["👤 Configuration Profiles<br/>Named configuration sets"]
-    SuppressionRules["🚫 Suppression Rules<br/>.ferret-scan-suppressions.yaml"]
+    SuppressionRules["🚫 Suppression Rules<br/>$XDG_CONFIG_HOME/ferret-scan/suppressions.yaml<br/>(or %APPDATA% on Windows)"]
 
     %% Processing
     ConfigResolver["🔧 Configuration Resolver<br/>resolveConfiguration()"]
@@ -423,7 +423,7 @@ flowchart TD
     %% Results Processing
     ResultsAggregator["📋 Results Aggregator<br/>Collects all worker results<br/>from parallel processing"]
 
-    SuppressionManager["🚫 Suppression Manager<br/>IsSuppressed() rule matching<br/>• Rule-based filtering<br/>• Expiration tracking"]
+    SuppressionManager["🚫 Suppression Manager<br/>IsSuppressed() — O(1) hash-indexed<br/>• Rule-based filtering<br/>• Expiration tracking<br/>• Cached on WebServer with mtime reload"]
 
     ConfidenceFilter["📊 Confidence Filter<br/>parseConfidenceLevels()<br/>• High/Medium/Low filtering<br/>• User-specified thresholds"]
 
@@ -550,7 +550,7 @@ A key architectural innovation is the inline redaction capability that occurs du
 
 ### **Configuration-Driven Flexibility**
 
-The **Results Processing & Output Generation** stage demonstrates the system's adaptability through configuration-driven suppression and confidence filtering. The Suppression Manager applies rule-based filtering from `.ferret-scan-suppressions.yaml` files, allowing organizations to customize detection behavior without code changes. Multiple output formatters (text, JSON, CSV, YAML, JUnit, GitLab SAST) ensure compatibility with various downstream systems and workflows.
+The **Results Processing & Output Generation** stage demonstrates the system's adaptability through configuration-driven suppression and confidence filtering. The Suppression Manager applies rule-based filtering from a platform-aware default path (`$XDG_CONFIG_HOME/ferret-scan/suppressions.yaml` on Unix, `%APPDATA%\ferret-scan\suppressions.yaml` on Windows) or any `--suppression-file` override, allowing organizations to customize detection behavior without code changes. Lookups are O(1) via a hash index rebuilt on load and on every save, and the web server caches the parsed manager with mtime-based invalidation so per-request latency does not depend on rule-set size. Multiple output formatters (text, JSON, CSV, YAML, JUnit, GitLab SAST) ensure compatibility with various downstream systems and workflows.
 
 ### **Resilience & Observability**
 

--- a/docs/development/WINDOWS_CROSS_COMPILATION.md
+++ b/docs/development/WINDOWS_CROSS_COMPILATION.md
@@ -467,14 +467,14 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v6
       with:
-        go-version: 1.21
+        go-version-file: .go-version
 
     - name: Get version
       id: version
@@ -518,7 +518,7 @@ jobs:
         wine ferret-scan-${{ matrix.name }}.exe --version || echo "Wine test completed"
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ferret-scan-${{ matrix.name }}
         path: |

--- a/docs/development/WINDOWS_DEVELOPMENT.md
+++ b/docs/development/WINDOWS_DEVELOPMENT.md
@@ -734,15 +734,15 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version-file: .go-version
 
     - name: Cache Go modules
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}

--- a/docs/ferret-application-flow.md
+++ b/docs/ferret-application-flow.md
@@ -174,10 +174,10 @@ sequenceDiagram
 
     ParallelProc-->>CLI: All matches + processing stats
 
-    Note over CLI: 10. Apply suppressions
+    Note over CLI: 10. Apply suppressions (O(1) hash-indexed lookup per match)
     CLI->>Suppression: NewSuppressionManager(suppressionFile)
     loop For each match
-        CLI->>Suppression: IsSuppressed(match)
+        CLI->>Suppression: IsSuppressed(match) [O(1) hash index]
         Suppression-->>CLI: suppressed status + rule
     end
     CLI->>CLI: Separate suppressed and active matches

--- a/docs/reference/SUPPRESSION_SYSTEM_IMPROVEMENTS.md
+++ b/docs/reference/SUPPRESSION_SYSTEM_IMPROVEMENTS.md
@@ -160,17 +160,28 @@ Detection → Filename Normalization → Suppression → Confidence Filtering �
 - Comprehensive documentation
 - Future-proof architecture
 
+## Shipped (v1.7.0)
+
+### ✅ Performance Optimizations
+
+1. **Hash Indexing**: O(1) `IsSuppressed` lookup via `map[string][]int` keyed on rule hash, rebuilt on load and on every save. 183× faster than the previous linear scan at 50,000 rules. (PR [#50](https://github.com/awslabs/ferret-scan/pull/50))
+2. **Web-mode Manager Caching**: `SuppressionManager` cached on `WebServer` with mtime-based reload; eliminated the per-request YAML re-parse. 2.4× / 2.3× faster on `/scan` and `/suppressions`. (PR [#51](https://github.com/awslabs/ferret-scan/pull/51))
+3. **Bulk Operations**: Bulk enable/disable/delete plus bulk expiration management ("Make Permanent" / "Renew 30 Days") in the Web UI. (PRs [#48](https://github.com/awslabs/ferret-scan/pull/48), [#52](https://github.com/awslabs/ferret-scan/pull/52))
+4. **Concurrency Safety**: `RWMutex` around the hash index + lazy-init guard; concurrent `IsSuppressed` callers are now safe under `-race`.
+5. **YAML Pragma**: `# pragma: allowlist secret` auto-appended to `hash:` lines so the suppressions file doesn't trigger ferret-scan's own scanner.
+
 ## Future Considerations
 
 ### Potential Optimizations
-1. **Hash Indexing**: O(1) lookup for large suppression rule sets
-2. **Rule Caching**: In-memory caching for frequently accessed rules
-3. **Bulk Operations**: Efficient bulk suppression management
+
+- **Pattern Suppressions**: Support for regex-based suppression patterns
+- **Hot-reload via fsnotify**: Replace mtime polling with inotify/kqueue for instant pickup of external edits
 
 ### Monitoring Recommendations
-1. **Suppression Effectiveness**: Track suppression hit rates
-2. **Rule Management**: Monitor rule creation and expiration
-3. **Performance Metrics**: Hash generation and lookup times
+
+- **Suppression Effectiveness**: Track suppression hit rates
+- **Rule Management**: Monitor rule creation and expiration
+- **Performance Metrics**: Hash generation and lookup times
 
 ## Conclusion
 

--- a/docs/reference/quotas-and-limits.md
+++ b/docs/reference/quotas-and-limits.md
@@ -8,7 +8,7 @@ This document provides a comprehensive reference for all file size limits, proce
 
 | Component | Limit | AWS Service | Configurable | Notes |
 |-----------|-------|-------------|--------------|-------|
-| **Web UI Upload** | 10MB | No | No | Hardcoded limit for web interface |
+| **Web UI Upload** | 100MB | No | No | Per-file decompression-bomb guard (`internal/web/server.go`); folder uploads have no count limit |
 | **CLI General** | 100MB | No | Yes | Default for most file types |
 | **Text Files** | 100MB | No | No | Plaintext preprocessor limit |
 <!-- GENAI_DISABLED: | **Audio Files (GenAI)** | 500MB | AWS Transcribe | No | For transcription services | -->
@@ -45,7 +45,7 @@ This document provides a comprehensive reference for all file size limits, proce
 
 | Error Message | Cause | Solution |
 |---------------|-------|----------|
-| `File exceeds 10MB upload limit` | Web UI file too large | Use CLI or reduce file size |
+| `File too large: ... bytes (max: 104857600 bytes)` | Web UI / CLI file > 100 MB | Reduce file size or split into chunks |
 | `File too large (max: 100MB)` | CLI file exceeds default | Configure larger limit or use streaming |
 | `File too large: chunk offset exceeds int32 maximum` | File exceeds ~214GB | Split file into smaller parts |
 | `System under memory pressure` | Insufficient memory | Reduce worker count or batch size |

--- a/docs/social-media-configuration.md
+++ b/docs/social-media-configuration.md
@@ -314,7 +314,7 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Scan for social media
         run: |
           ./ferret-scan --checks SOCIAL_MEDIA --format json --output social-media-report.json --recursive --file ./documents/

--- a/docs/suppression-system.md
+++ b/docs/suppression-system.md
@@ -100,15 +100,29 @@ rules:
 ## Performance Characteristics
 
 ### Efficiency Features
-- **O(n) Lookup**: Linear scan through suppression rules (typically small dataset)
+
+- **O(1) Lookup**: Hash-indexed lookup in `IsSuppressed`. The index is rebuilt from `config.Rules` on every load and on every save, so it stays consistent across mutations. Microbench (per-call cost on a non-matching match):
+
+    | rules  | per-call cost |
+    |-------:|--------------:|
+    | 100    | 620 ns        |
+    | 1,000  | 631 ns        |
+    | 10,000 | 640 ns        |
+    | 50,000 | 619 ns        |
+
+  Previous linear scan grew with rule count (113 µs at 50,000 rules); the new index is constant-time. Replaced in v1.7.0.
+
+- **Web-mode caching**: When running with `--web`, the `SuppressionManager` is held on the `WebServer` and reloaded only when the underlying file's mtime changes. This eliminates the per-request YAML parse cost. Measured 2.4× / 2.3× speedup on `/scan` and `/suppressions` against a 5,000-rule file.
+- **Concurrent reads**: `RWMutex` around the hash index makes `IsSuppressed` safe for concurrent use. Mutating methods are still expected to be called serially (documented on the manager type).
 - **Memory Efficient**: Hash-based storage minimizes memory footprint
 - **Single Processing**: No duplicate filtering operations
 - **Fast Hashing**: SHA-256 provides good performance for small inputs
 
 ### Scalability Considerations
-- **Rule Limit**: Practical limit of ~1000 suppression rules for optimal performance
+
+- **Rule Limit**: With the hash index, lookup cost is constant up to and beyond 50,000 rules. Practical limits now come from YAML parse + write times, not lookup.
 - **Hash Collisions**: Cryptographically unlikely with SHA-256
-- **File Size**: Suppression file typically <100KB for normal usage
+- **File Size**: Suppression file typically well under 1 MB for normal usage; file mtime is checked on every web request to invalidate the cache
 
 ## Security Features
 
@@ -143,9 +157,15 @@ rules:
 
 ## Future Enhancements
 
+### Recently Shipped (v1.6.0)
+
+- ✅ **Rule Indexing**: Hash-based indexing for O(1) lookup performance
+- ✅ **Bulk Operations**: Efficient bulk enable/disable/delete and bulk expiration management
+- ✅ **Web-mode caching**: `SuppressionManager` cached on `WebServer` with mtime-based reload
+- ✅ **YAML pragma comments**: `# pragma: allowlist secret` auto-added to `hash:` lines so the file doesn't trip ferret-scan's own scanner
+
 ### Planned Improvements
-- **Rule Indexing**: Hash-based indexing for O(1) lookup performance
-- **Bulk Operations**: Efficient bulk suppression rule management
+
 - **Pattern Suppressions**: Support for regex-based suppression patterns
 - **Rule Analytics**: Usage statistics and effectiveness metrics
 

--- a/docs/user-guides/README-Suppressions.md
+++ b/docs/user-guides/README-Suppressions.md
@@ -21,18 +21,33 @@ The suppression system uses **cryptographic hashing** to uniquely identify findi
 
 ## Configuration Files
 
-Ferret Scan automatically looks for suppression files in this order:
+Ferret Scan resolves the suppression file path in this order:
+
 1. Path specified with `--suppression-file` flag
-2. `.ferret-scan-suppressions.yaml` in current directory
-3. `.ferret-scan-suppressions.yaml` in home directory
+2. `$FERRET_CONFIG_DIR/suppressions.yaml` if `FERRET_CONFIG_DIR` env var is set
+3. Platform default:
+   - **Unix**: `$XDG_CONFIG_HOME/ferret-scan/suppressions.yaml` (or `~/.ferret-scan/suppressions.yaml` if `XDG_CONFIG_HOME` is unset)
+   - **Windows**: `%APPDATA%\ferret-scan\suppressions.yaml` (falls back to `%USERPROFILE%\.ferret-scan\suppressions.yaml`)
+
+The `--suppression-file` flag is honored in **both** CLI and `--web` mode — the web server uses whichever path you pass it, not always the platform default.
+
+### Web server caching
+
+When running with `--web`, the suppression manager is cached in memory and reloaded only when the file's mtime changes. This makes per-request latency on `/scan` and `/suppressions` independent of rule-set size — measured 2.4× / 2.3× speedup on a 5,000-rule file. CLI-side or manual edits to the YAML are picked up on the next request because mtime is checked on every read.
+
+### Hash-indexed lookup
+
+`IsSuppressed` uses a hash index keyed on the rule hash, so suppression matching is O(1) regardless of how many rules exist. With 50,000 rules a per-call lookup runs in ~620 ns versus ~113 µs under the previous linear scan (183× faster).
 
 ## Suppression File Format
+
+> **Note on `# pragma: allowlist secret`**: every `hash:` line is automatically annotated with this pragma when the file is written. The hash field is a SHA-256 of the finding identity (not the secret itself), but it has enough entropy to trip secret scanners — including ferret-scan running over its own suppressions file. The pragma silences those false positives. Re-saves are idempotent: existing pragma comments are preserved, never duplicated.
 
 ```yaml
 version: "1.0"
 rules:
   - id: "SUP-1703123456"
-    hash: "a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456"
+    hash: "a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456" # pragma: allowlist secret
     reason: "Test data - not actual sensitive information"
     enabled: true                     # Required: true to suppress, false to disable
     created_by: "security-team"
@@ -51,7 +66,7 @@ rules:
 
   # Auto-generated disabled rule (can be enabled by changing enabled: true)
   - id: "SUP-1703123457"
-    hash: "b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef1234567"
+    hash: "b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef1234567" # pragma: allowlist secret
     reason: "Auto-generated suppression rule (disabled by default)"
     enabled: false                    # Disabled - change to true to activate
     created_at: 2023-12-21T16:45:00Z

--- a/docs/user-guides/README-WebUI.md
+++ b/docs/user-guides/README-WebUI.md
@@ -7,14 +7,17 @@ A simple web interface for the Ferret Scan sensitive data detection tool.
 ## Features
 
 - **File Upload**: Upload single or multiple files directly through the web browser
-- **Drag & Drop**: Drag files directly onto the upload area
+- **Folder Upload**: Drag-and-drop a folder onto the upload zone, or click "Choose Folder" — the browser walks the directory client-side and uploads every file with its relative path. Configured `--exclude` patterns are applied during the walk so excluded directories (`.git`, `node_modules`, etc.) are never uploaded.
+- **Drag & Drop**: Drag files or folders directly onto the upload area
+- **CLI-Equivalent Flags**: `--web` honors `--config`, `--suppression-file`, and `--exclude` so the server uses the same configuration as the CLI
 - **Configurable Scans**: Choose confidence levels and specific detection types
 - **Real-time Results**: View scan results immediately in a clean, organized format
 - **Interactive Statistics**: Click stat cards to filter results by confidence level
 - **Color-coded Results**: High, medium, and low confidence findings are visually distinguished
 - **Sortable Tables**: Click column headers to sort results
 - **Export Options**: Download results as CSV, JSON, YAML, JUnit, or Text
-- **Suppression Management**: Create, edit, enable/disable, and bulk manage suppression rules
+- **Suppression Management**: Create, edit, enable/disable, and bulk manage suppression rules — including bulk "Make Permanent" / "Renew 30 Days" expiration actions
+- **Cached Suppression Manager**: Web server caches the parsed suppressions file in memory and reloads only when the file's mtime changes, so per-request latency does not depend on rule-set size
 - **Detailed Metadata**: View additional information about detected sensitive data
 - **Progress Tracking**: Real-time progress indicators during scanning
 - **Help System**: Built-in documentation and feature explanations
@@ -87,7 +90,7 @@ The web UI supports the same file types as the CLI version:
 - **Local Processing**: Files are processed locally on your machine - no data sent to external servers by default
 - **Temporary Storage**: Files are temporarily stored during scanning and automatically deleted
 - **Memory Scrubbing**: Secure memory handling for sensitive data
-- **Upload Limits**: Maximum file upload size is 50MB
+- **Upload Limits**: Maximum file upload size is 100 MB per file (decompression-bomb guard)
 - **No Data Retention**: Scan results are displayed in browser only, not stored permanently
 - **Audit Trail**: Comprehensive logging for compliance requirements
 <!-- GENAI_DISABLED: When GenAI features are enabled, files may be sent to AWS services (Textract, Transcribe, Comprehend) -->
@@ -101,9 +104,22 @@ To modify the web UI:
    ./bin/ferret-scan --web --port 3000
    ```
 
-2. **Modify the interface**: Edit `internal/web/server.go` to customize the web server or add new features
+2. **Use a custom config / suppressions file**: Web mode honors the same flags as the CLI
+   ```bash
+   ./bin/ferret-scan --web --port 8080 \
+     --config ./team-config.yaml \
+     --suppression-file ./team-suppressions.yaml
+   ```
 
-3. **Add new scan options**: Extend the form in the HTML template and update the scan handler
+3. **Configure folder-walk excludes**: `--exclude` patterns are surfaced to the front-end via `/config-info` and applied during folder drag-drop walks, so excluded directories never get uploaded
+   ```bash
+   ./bin/ferret-scan --web --port 8080 \
+     --exclude '.git,node_modules,dist,target,__pycache__'
+   ```
+
+4. **Modify the interface**: Edit `internal/web/server.go` to customize the web server or add new features
+
+5. **Add new scan options**: Extend the form in the HTML template and update the scan handler
 
 ## Suppression Management
 
@@ -132,9 +148,11 @@ The web UI includes a comprehensive suppression management system:
 - The web UI is integrated into the main `./bin/ferret-scan` binary
 
 **File upload fails**:
-- Check that the file is under 50MB
+
+- Check that the file is under 100 MB
 - Ensure the file type is supported by Ferret Scan
 - Try uploading files one at a time if multiple uploads fail
+- For folder drops: very large directory trees can take a moment to enumerate client-side; the upload zone shows "Reading files…" while the walk is in progress
 
 **Scan takes too long**:
 - Large files or complex documents may take longer to process


### PR DESCRIPTION
## Summary
Audit-driven sweep to bring the documentation in line with what's actually shipping in v1.7.0 (PRs #48 / #50 / #51 / #52). 14 files updated; no behavior changes other than two small cleanups in `cmd/main.go`.

## What was stale and got fixed

| Where | Was | Now |
|---|---|---|
| README + WebUI guide + quotas | "10 MB" / "50 MB" upload limit | 100 MB (matches the code) |
| README Web Server Mode | Listed only `--web` and `--port` | Documents `--config`, `--suppression-file`, `--exclude` flag pass-through |
| README + WebUI guide | "Multiple Files: drag onto upload area" | Folder drag-drop section, `showDirectoryPicker`, `--exclude` walk filtering |
| README + WebUI guide | Bulk enable/disable/delete | Plus bulk expiration (Make Permanent / Renew 30 Days) |
| Suppression docs | "current dir / home dir" fallback paths | Real platform-aware default `$XDG_CONFIG_HOME/ferret-scan/suppressions.yaml` / `%APPDATA%\ferret-scan\suppressions.yaml` |
| README flag list + `cmd/main.go` flag help | "default: .ferret-scan-suppressions.yaml" (wrong) | Real default. Also removed dead sentinel comparison in `cmd/main.go` |
| `suppression-system.md` | "O(n) Lookup: Linear scan" | "O(1) Lookup: Hash-indexed" with actual benchmark numbers |
| Suppressions guide | YAML example with bare `hash:` | Shows `# pragma: allowlist secret` comment that v1.7 auto-appends |
| `architecture-diagram.md` + `ferret-application-flow.md` | Implied linear suppression scan | Annotated O(1) hash-indexed + cached on `WebServer` with mtime reload |
| `docs/README.md` | 4 broken links to `testing/TESTING.md` etc. | Pointers to live `.github/workflows/go-test.yml` + existing tracker |
| `docs/README.md` | `Last updated: $(date)` literal placeholder | Removed |
| `docs/development/*.md` + `social-media-configuration.md` | Sample workflows pinned to `actions/checkout@v3`, `setup-go@v3` | Bumped to v6/v6/v5 to match Node-24 reality |
| `CHANGELOG.md` | Last entry was v1.5.2 (Feb 2026) | New v1.7.0 entry covering PRs #48/#50/#51/#52 |

## Code changes (small)

- `cmd/main.go`: fix `--suppression-file` flag help text (was claiming a default the code doesn't use); remove dead sentinel comparison `flags.suppressionFile != ".ferret-scan-suppressions.yaml"` (the zero value is `""`, so the branch was unreachable).

## Verification

- [x] `go build ./...` clean
- [x] `go test ./internal/...` all green
- [x] Cross-compiles still clean for windows/amd64 and linux/amd64

🤖 Generated with [Claude Code](https://claude.com/claude-code)