### PR TITLE
fix(resilience): make TestRetryWithBackoff_ExponentialDelayGrowth Windows-stable

### DIFF
--- a/internal/resilience/retry_test.go
+++ b/internal/resilience/retry_test.go
@@ -145,14 +145,24 @@ func TestRetryWithBackoff_OnRetryCallback(t *testing.T) {
 }
 
 func TestRetryWithBackoff_ExponentialDelayGrowth(t *testing.T) {
-	// Verify that delays grow exponentially by measuring timing
+	// Verify that delays grow exponentially by measuring timing.
+	//
+	// Intervals are deliberately well above Windows' default 15.6 ms timer
+	// resolution: with InitialInterval=50ms the expected delays are ~50ms,
+	// 100ms, 200ms — gaps wide enough that quantization noise can't push
+	// delay[2] below delay[0]. The earlier 10ms baseline produced ~16ms /
+	// ~16-31ms delays on Windows runners, where adjacent values landed in
+	// the same noisy band and the strict delay[1] >= delay[0] assertion
+	// flaked. We now check the broader monotonic property delay[2] > delay[0]
+	// (a 4× growth ratio, easy to satisfy even with scheduler jitter) which
+	// is what "exponential growth" actually means.
 	delays := []time.Duration{}
 	transient := NewTransientError("fail", nil)
 	lastTime := time.Now()
 
 	RetryWithBackoff(context.Background(), RetryConfig{
 		MaxRetries:      3,
-		InitialInterval: 10 * time.Millisecond,
+		InitialInterval: 50 * time.Millisecond,
 		MaxInterval:     1 * time.Second,
 		Multiplier:      2.0,
 		Jitter:          false, // disable jitter for deterministic test
@@ -166,11 +176,14 @@ func TestRetryWithBackoff_ExponentialDelayGrowth(t *testing.T) {
 	})
 
 	if len(delays) != 3 {
-		t.Fatalf("expected 3 delays, got %d", delays)
+		t.Fatalf("expected 3 delays, got %d", len(delays))
 	}
-	// Each delay should be roughly double the previous (with some tolerance)
-	if delays[1] < delays[0] {
-		t.Errorf("delay[1] (%v) should be >= delay[0] (%v)", delays[1], delays[0])
+	// delay[2] is expected to be ~4× delay[0] (200ms vs 50ms). Asserting it
+	// is at least 1.5× larger keeps the test sensitive to the exponential
+	// shape while tolerating scheduler jitter on slow CI runners.
+	if delays[2] < delays[0]*3/2 {
+		t.Errorf("expected exponential growth: delay[2] (%v) should be >= 1.5 * delay[0] (%v); all delays: %v",
+			delays[2], delays[0], delays)
 	}
 }
 


### PR DESCRIPTION
## Summary
The Windows leg of the Go test workflow on `main` failed: [job 75091994672](https://github.com/awslabs/ferret-scan/actions/runs/25578657415/job/75091994672).

```
--- FAIL: TestRetryWithBackoff_ExponentialDelayGrowth (0.11s)
    retry_test.go:173: delay[1] (29.8211ms) should be >= delay[0] (35.0314ms)
```

This is a Windows timer-resolution issue, not a regression in the library.

## Root cause
The test's intended sleep schedule was 10 ms / 20 ms / 40 ms (`InitialInterval=10ms`, `Multiplier=2.0`). Windows' default kernel timer fires every **15.6 ms** (64 Hz), so:

| intended sleep | actual range on Windows |
|---:|---:|
| 10 ms | 10–15.6 ms |
| 20 ms | 20–31.2 ms |
| 40 ms | 40–55.6 ms |

The strict assertion `delay[1] >= delay[0]` reads like "exponential growth must be observable at every step," but at 10/20/40 ms intended it actually requires the noise floor (~16 ms) to be smaller than the gap between adjacent steps (10 ms). It isn't on Windows. Reproducible whenever the scheduler gives the first goroutine an extra-long quantum — which is what happened here: `delay[0]=35 ms` (one-and-a-half quanta), `delay[1]=29.8 ms` (a normal quantum for a 20 ms intended sleep).

## Fix
Two changes, both independently sufficient:

1. **`InitialInterval: 10ms → 50ms`** — intended delays become 50/100/200 ms, well above the 16 ms noise floor. Adjacent ranges (50–66 / 100–116 / 200–216 ms) no longer overlap.
2. **Assertion `delay[1] >= delay[0]` → `delay[2] >= 1.5 × delay[0]`** — compares first vs third (intended ratio 4×) with a 1.5× threshold. A genuine regression in exponential growth (e.g. `Multiplier=1.0`) still fails the test because `delay[2]` would equal `delay[0]`; scheduler jitter alone can't.

Also fixed a pre-existing bug: `t.Fatalf("expected 3 delays, got %d", delays)` formatted a `[]time.Duration` with `%d`, printing gibberish on failure. Now uses `len(delays)`.

## Test plan
- [x] 10 consecutive runs of `TestRetryWithBackoff_ExponentialDelayGrowth` pass locally
- [x] Full `internal/resilience` package passes 3× under `-race`
- [x] Cross-compile clean for `windows/amd64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)