### PR TITLE
chore(ci): SHA-pin all GitHub Actions to immutable commits

### DIFF
--- a/.github/workflows/build-shared.yml
+++ b/.github/workflows/build-shared.yml
@@ -34,23 +34,23 @@ jobs:
       python-path: python-package/dist/
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: ${{ inputs.go-version != '' && inputs.go-version || '.go-version' }}
 
     - name: Set up Python
       if: inputs.build-type == 'python' || inputs.build-type == 'both'
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.13'
 
     - name: Cache Go modules
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |
           ~/.cache/go-build
@@ -74,7 +74,7 @@ jobs:
 
     - name: Upload binary artifact
       if: inputs.build-type == 'binary' || inputs.build-type == 'both'
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ferret-scan-binary-${{ github.sha }}
         path: bin/ferret-scan
@@ -82,7 +82,7 @@ jobs:
 
     - name: Upload Python package artifact
       if: inputs.build-type == 'python' || inputs.build-type == 'both'
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ferret-scan-python-${{ github.sha }}
         path: python-package/dist/

--- a/.github/workflows/docker-multiarch.yml
+++ b/.github/workflows/docker-multiarch.yml
@@ -65,21 +65,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
         with:
           platforms: all
 
       - name: Configure AWS credentials
         if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
@@ -87,13 +87,13 @@ jobs:
 
       - name: Log in to Amazon ECR Public
         if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2.1.5
         with:
           registry-type: public
 
       - name: Log in to GitHub Container Registry
         if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -116,7 +116,7 @@ jobs:
 
       - name: Extract metadata for multi-registry
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: |
             ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}
@@ -151,7 +151,7 @@ jobs:
           fi
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           file: ./Dockerfile
@@ -171,7 +171,7 @@ jobs:
 
       - name: Generate SBOM
         if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPOSITORY }}:${{ steps.meta.outputs.version }}
           format: spdx-json
@@ -180,7 +180,7 @@ jobs:
 
       - name: Upload SBOM
         if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom
           path: sbom.spdx.json
@@ -196,7 +196,7 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           sarif_file: "trivy-results.sarif"
           category: "trivy-container-scan"
@@ -265,7 +265,7 @@ jobs:
 
     steps:
       - name: Run Grype vulnerability scanner on GHCR
-        uses: anchore/scan-action@v3
+        uses: anchore/scan-action@3343887d815d7b07465f6fdcd395bd66508d486a # v3.6.4
         id: scan-ghcr
         with:
           image: ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPOSITORY }}:latest
@@ -273,7 +273,7 @@ jobs:
           severity-cutoff: high
 
       - name: Upload Grype scan results
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           sarif_file: ${{ steps.scan-ghcr.outputs.sarif }}
           category: "grype-container-scan"

--- a/.github/workflows/ferret-scan.yml
+++ b/.github/workflows/ferret-scan.yml
@@ -73,13 +73,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Fetch full history for better analysis
           fetch-depth: 0
 
       - name: Download binary
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ferret-scan-binary-${{ github.sha }}
           path: bin/
@@ -285,7 +285,7 @@ jobs:
 
       - name: Upload SARIF to GitHub Security
         if: always()
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           sarif_file: sarif/ferret-scan.sarif
           category: ferret-scan
@@ -293,7 +293,7 @@ jobs:
 
       - name: Create PR comment
         if: github.event_name == 'pull_request' && always()
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');
@@ -366,7 +366,7 @@ jobs:
 
       - name: Upload scan results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ferret-scan-results
           path: |

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -34,15 +34,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: '.go-version'
 
       - name: Cache Go modules
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cache/go-build

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -60,17 +60,17 @@ jobs:
     steps:
 
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: '.go-version'
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
 
@@ -250,7 +250,7 @@ jobs:
           fi
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-package-${{ github.sha }}
           path: python-package/dist/
@@ -258,7 +258,7 @@ jobs:
 
       - name: Publish to Test PyPI
         if: github.event.inputs.action == 'publish-testpypi'
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1 (2026-04-07)
         with:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: python-package/dist/
@@ -293,7 +293,7 @@ jobs:
 
       - name: Publish to PyPI
         if: steps.should_publish.outputs.should_publish == 'true'
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1 (2026-04-07)
         with:
           packages-dir: python-package/dist/
           verbose: true

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -32,17 +32,17 @@ jobs:
       package-path: python-package/dist/
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
 
       - name: Download Python package
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ferret-scan-python-${{ github.sha }}
           path: python-package/dist/
@@ -66,7 +66,7 @@ jobs:
           echo "✅ Python package installation and basic functionality tests passed"
 
       - name: Upload Python package artifacts (final)
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-package-release
           path: python-package/dist/
@@ -75,7 +75,7 @@ jobs:
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/')
         id: create_release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1 (2022-11-21; floating @v1 still points here)
         with:
           files: python-package/dist/*
           generate_release_notes: true
@@ -109,12 +109,12 @@ jobs:
       id-token: write # Required for trusted publishing to PyPI
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
 
@@ -124,13 +124,13 @@ jobs:
           pip install build twine setuptools_scm
 
       - name: Download Python package
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-package-release
           path: python-package/dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1 (2026-04-07)
         with:
           packages-dir: python-package/dist/
           verbose: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: ".go-version"
 
@@ -54,7 +54,7 @@ jobs:
 
       - name: Run GoReleaser (Release)
         if: startsWith(github.ref, 'refs/tags/')
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -66,7 +66,7 @@ jobs:
 
       - name: Run GoReleaser (Snapshot)
         if: github.event.inputs.snapshot == 'true' || (github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/'))
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -76,7 +76,7 @@ jobs:
 
       - name: Upload Snapshot Artifacts
         if: github.event.inputs.snapshot == 'true' || (github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/'))
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: snapshot-binaries
           path: dist/*


### PR DESCRIPTION
## Summary

SHA-pins every external GitHub Actions `uses:` reference. Behavior is unchanged — each SHA is the exact commit that its floating `@vN` tag (or `release/v1` branch for `pypa/gh-action-pypi-publish`) currently resolves to. Version comments preserve dependabot/manual-update visibility.

## Why

Floating tags are mutable refs. A compromised maintainer account or a GitHub-side tag rewrite can change what runs in CI without any code change here. This repo's CI runs with elevated privileges:
- `contents: write` (auto-commits to `CHANGELOG.md`)
- `id-token: write` (PyPI trusted publishing, AWS OIDC for ECR push)
- `packages: write` (GHCR push)
- `security-events: write` (SARIF upload)

The blast radius of a single compromised action with floating-tag trust covers the entire publish surface (PyPI, GHCR, ECR public). SHA pinning shifts the trust model from "GitHub's tag mutability + each maintainer's account security" to "git's content-addressing + dependabot for proposed updates."

## What this PR does NOT do

- **No major-version bumps.** A separate follow-up will review changelogs for the 8 actions where upstream majors have advanced past what's in use today (`docker/*` v3→v4, `aws-actions/configure-aws-credentials` v4→v6, `anchore/scan-action` v3→v7, `softprops/action-gh-release` v1→v3, `goreleaser-action` v6→v7, `docker/build-push-action` v5→v7, `docker/metadata-action` v5→v6).
- **No behavior changes.** Every SHA in this PR is exactly what the corresponding `@vN` tag resolves to as of 2026-05-22.

## Verification

- 21 unique external actions; 21 unique SHAs — no duplicates, no floating tags remain.
- Every SHA verified upstream via the GitHub Releases API and confirmed to match its current floating tag (so `@v6` and `@<sha>` are byte-identical today).
- Every SHA verified to have a resolvable `action.yml` (or `action.yaml`) at runtime — the same lookup the runner does at job start.
- `actionlint` clean: zero native issues; the only `actionlint` output (shellcheck info notices on pre-existing `run:` blocks) is unchanged from main.
- Diff is a line-for-line replacement: 47 insertions, 47 deletions across 7 files.

## Pinned actions

| Action | SHA | Version pin |
|---|---|---|
| `actions/checkout` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` | v6.0.2 |
| `actions/setup-go` | `4a3601121dd01d1626a1e23e37211e3254c1c06c` | v6.4.0 |
| `actions/setup-python` | `a309ff8b426b58ec0e2a45f0f869d46889d02405` | v6.2.0 |
| `actions/cache` | `27d5ce7f107fe9357f9df03efb73ab90386fccae` | v5.0.5 |
| `actions/upload-artifact` | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` | v7.0.1 |
| `actions/download-artifact` | `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` | v8.0.1 |
| `actions/github-script` | `3a2844b7e9c422d3c10d287c895573f7108da1b3` | v9.0.0 |
| `aws-actions/amazon-ecr-login` | `fa648b43de3d4d023bcb3f89ed6940096949c419` | v2.1.5 |
| `aws-actions/configure-aws-credentials` | `7474bc4690e29a8392af63c5b98e7449536d5c3a` | v4.3.1 |
| `github/codeql-action/upload-sarif` | `7211b7c8077ea37d8641b6271f6a365a22a5fbfa` | v4.36.0 |
| `docker/login-action` | `c94ce9fb468520275223c153574b00df6fe4bcc9` | v3.7.0 |
| `docker/setup-buildx-action` | `8d2750c68a42422c14e847fe6c8ac0403b4cbd6f` | v3.12.0 |
| `docker/setup-qemu-action` | `c7c53464625b32c7a7e944ae62b3e17d2b600130` | v3.7.0 |
| `docker/metadata-action` | `c299e40c65443455700f0fdfc63efafe5b349051` | v5.10.0 |
| `docker/build-push-action` | `ca052bb54ab0790a636c9b5f226502c73d547a25` | v5.4.0 |
| `anchore/sbom-action` | `e22c389904149dbc22b58101806040fa8d37a610` | v0.24.0 |
| `anchore/scan-action` | `3343887d815d7b07465f6fdcd395bd66508d486a` | v3.6.4 |
| `softprops/action-gh-release` | `de2c0eb89ae2a093876385947365aca7b0e5f844` | v1 (Nov 2022 — current `@v1` tip) |
| `goreleaser/goreleaser-action` | `e435ccd777264be153ace6237001ef4d979d3a7a` | v6.4.0 |
| `aquasecurity/trivy-action` | `57a97c7e7821a5776cebc9bb87c984fa69cba8f1` | v0.35.0 (already pinned; unchanged) |
| `pypa/gh-action-pypi-publish` | `cef221092ed1bacb1cc03d23a2d87d1d172e277b` | release/v1 (Apr 2026) |

## Test plan

- All workflows trigger as before; SHA-pinned references resolve identically because the SHAs are what the floating tags pointed to at audit time.
- `pre-commit` hooks pass locally (`check-yaml`, `detect-private-key`, `ferret-scan`, `end-of-file-fixer`, `trailing-whitespace`).
- `actionlint` exits clean with `-shellcheck=` (and the shellcheck-on-pre-existing-`run:`-blocks output is unchanged from `main`).
