### PR TITLE
chore(ci): bump 9 actions to current major versions

### DIFF
--- a/.github/workflows/build-shared.yml
+++ b/.github/workflows/build-shared.yml
@@ -34,23 +34,23 @@ jobs:
       python-path: python-package/dist/
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: ${{ inputs.go-version != '' && inputs.go-version || '.go-version' }}
 
     - name: Set up Python
       if: inputs.build-type == 'python' || inputs.build-type == 'both'
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.13'
 
     - name: Cache Go modules
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |
           ~/.cache/go-build
@@ -74,7 +74,7 @@ jobs:
 
     - name: Upload binary artifact
       if: inputs.build-type == 'binary' || inputs.build-type == 'both'
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ferret-scan-binary-${{ github.sha }}
         path: bin/ferret-scan
@@ -82,7 +82,7 @@ jobs:
 
     - name: Upload Python package artifact
       if: inputs.build-type == 'python' || inputs.build-type == 'both'
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ferret-scan-python-${{ github.sha }}
         path: python-package/dist/

--- a/.github/workflows/docker-multiarch.yml
+++ b/.github/workflows/docker-multiarch.yml
@@ -65,21 +65,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
         with:
           platforms: all
 
       - name: Configure AWS credentials
         if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
@@ -87,13 +87,13 @@ jobs:
 
       - name: Log in to Amazon ECR Public
         if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2.1.5
         with:
           registry-type: public
 
       - name: Log in to GitHub Container Registry
         if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -116,7 +116,7 @@ jobs:
 
       - name: Extract metadata for multi-registry
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: |
             ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}
@@ -151,7 +151,7 @@ jobs:
           fi
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           file: ./Dockerfile
@@ -171,7 +171,7 @@ jobs:
 
       - name: Generate SBOM
         if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPOSITORY }}:${{ steps.meta.outputs.version }}
           format: spdx-json
@@ -180,7 +180,7 @@ jobs:
 
       - name: Upload SBOM
         if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom
           path: sbom.spdx.json
@@ -196,7 +196,7 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           sarif_file: "trivy-results.sarif"
           category: "trivy-container-scan"
@@ -265,7 +265,7 @@ jobs:
 
     steps:
       - name: Run Grype vulnerability scanner on GHCR
-        uses: anchore/scan-action@v3
+        uses: anchore/scan-action@3343887d815d7b07465f6fdcd395bd66508d486a # v3.6.4
         id: scan-ghcr
         with:
           image: ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPOSITORY }}:latest
@@ -273,7 +273,7 @@ jobs:
           severity-cutoff: high
 
       - name: Upload Grype scan results
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           sarif_file: ${{ steps.scan-ghcr.outputs.sarif }}
           category: "grype-container-scan"

--- a/.github/workflows/docker-multiarch.yml
+++ b/.github/workflows/docker-multiarch.yml
@@ -70,16 +70,16 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
         with:
           platforms: all
 
       - name: Configure AWS credentials
         if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
@@ -93,7 +93,7 @@ jobs:
 
       - name: Log in to GitHub Container Registry
         if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -116,7 +116,7 @@ jobs:
 
       - name: Extract metadata for multi-registry
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: |
             ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}
@@ -151,7 +151,7 @@ jobs:
           fi
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: ./Dockerfile
@@ -265,7 +265,7 @@ jobs:
 
     steps:
       - name: Run Grype vulnerability scanner on GHCR
-        uses: anchore/scan-action@3343887d815d7b07465f6fdcd395bd66508d486a # v3.6.4
+        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
         id: scan-ghcr
         with:
           image: ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPOSITORY }}:latest

--- a/.github/workflows/ferret-scan.yml
+++ b/.github/workflows/ferret-scan.yml
@@ -73,13 +73,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Fetch full history for better analysis
           fetch-depth: 0
 
       - name: Download binary
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ferret-scan-binary-${{ github.sha }}
           path: bin/
@@ -285,7 +285,7 @@ jobs:
 
       - name: Upload SARIF to GitHub Security
         if: always()
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           sarif_file: sarif/ferret-scan.sarif
           category: ferret-scan
@@ -293,7 +293,7 @@ jobs:
 
       - name: Create PR comment
         if: github.event_name == 'pull_request' && always()
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');
@@ -366,7 +366,7 @@ jobs:
 
       - name: Upload scan results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ferret-scan-results
           path: |

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -34,15 +34,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: '.go-version'
 
       - name: Cache Go modules
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cache/go-build

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -60,17 +60,17 @@ jobs:
     steps:
 
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: '.go-version'
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
 
@@ -250,7 +250,7 @@ jobs:
           fi
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-package-${{ github.sha }}
           path: python-package/dist/
@@ -258,7 +258,7 @@ jobs:
 
       - name: Publish to Test PyPI
         if: github.event.inputs.action == 'publish-testpypi'
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1 (2026-04-07)
         with:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: python-package/dist/
@@ -293,7 +293,7 @@ jobs:
 
       - name: Publish to PyPI
         if: steps.should_publish.outputs.should_publish == 'true'
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1 (2026-04-07)
         with:
           packages-dir: python-package/dist/
           verbose: true

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/')
         id: create_release
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1 (2022-11-21; floating @v1 still points here)
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           files: python-package/dist/*
           generate_release_notes: true

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -32,17 +32,17 @@ jobs:
       package-path: python-package/dist/
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
 
       - name: Download Python package
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ferret-scan-python-${{ github.sha }}
           path: python-package/dist/
@@ -66,7 +66,7 @@ jobs:
           echo "✅ Python package installation and basic functionality tests passed"
 
       - name: Upload Python package artifacts (final)
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-package-release
           path: python-package/dist/
@@ -75,7 +75,7 @@ jobs:
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/')
         id: create_release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1 (2022-11-21; floating @v1 still points here)
         with:
           files: python-package/dist/*
           generate_release_notes: true
@@ -109,12 +109,12 @@ jobs:
       id-token: write # Required for trusted publishing to PyPI
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
 
@@ -124,13 +124,13 @@ jobs:
           pip install build twine setuptools_scm
 
       - name: Download Python package
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-package-release
           path: python-package/dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1 (2026-04-07)
         with:
           packages-dir: python-package/dist/
           verbose: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Run GoReleaser (Release)
         if: startsWith(github.ref, 'refs/tags/')
-        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -66,7 +66,7 @@ jobs:
 
       - name: Run GoReleaser (Snapshot)
         if: github.event.inputs.snapshot == 'true' || (github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/'))
-        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: ".go-version"
 
@@ -54,7 +54,7 @@ jobs:
 
       - name: Run GoReleaser (Release)
         if: startsWith(github.ref, 'refs/tags/')
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -66,7 +66,7 @@ jobs:
 
       - name: Run GoReleaser (Snapshot)
         if: github.event.inputs.snapshot == 'true' || (github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/'))
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -76,7 +76,7 @@ jobs:
 
       - name: Upload Snapshot Artifacts
         if: github.event.inputs.snapshot == 'true' || (github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/'))
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: snapshot-binaries
           path: dist/*


### PR DESCRIPTION
## Summary

Bumps 9 GitHub Actions whose upstream major has advanced past the version pinned in #64. Each upgrade was individually researched against its upstream changelog and the call-site checked for breaking-change relevance.

**Stacks on #64.** Merge #64 first; this PR's base is `chore/sha-pin-github-actions`. After #64 merges to main, GitHub will auto-rebase this PR's base onto main.

## Per-action analysis

| Action | From | To | Breaking changes | Impact on this repo |
|---|---|---|---|---|
| `aws-actions/configure-aws-credentials` | v4.3.1 | v6.1.1 | v5: invalid-boolean input handling. v6: Node 24 runtime. | None. We pass `role-to-assume`, `aws-region`, `role-session-name` only — all strings. github-hosted runners have Node 24 since runner v2.327.1. |
| `docker/login-action` | v3.7.0 | v4.0.0 | Node 24 runtime. | None. Standard `registry`/`username`/`password` inputs unchanged. |
| `docker/setup-buildx-action` | v3.12.0 | v4.1.0 | Node 24 runtime; removed deprecated inputs/outputs. | None. We pass no inputs to this step. |
| `docker/setup-qemu-action` | v3.7.0 | v4.0.0 | Node 24 runtime. | None. `platforms: all` input unchanged. |
| `docker/metadata-action` | v5.10.0 | v6.1.0 | Node 24 runtime; list inputs preserve `#` inside values while still supporting full-line `#` comments. | None. Our `tags:` block uses full-line `#` comments only. |
| `docker/build-push-action` | v5.4.0 | v7.2.0 | v6: enables build summary by default (cosmetic). v7: Node 24 + removes legacy `DOCKER_BUILD_NO_SUMMARY` and `DOCKER_BUILD_EXPORT_RETENTION_DAYS` envs. | None. We don't set those legacy envs. The new build summary will appear in workflow runs. |
| **`anchore/scan-action`** | **v3.6.4** | **v7.4.0** | **v6 BREAKING:** SARIF no longer written to working dir; consumers must reference `${{ steps.<id>.outputs.sarif }}`. | **None — call site already uses `steps.scan-ghcr.outputs.sarif`** (see `.github/workflows/docker-multiarch.yml:280`). |
| `softprops/action-gh-release` | v1 (Nov 2022) | v3.0.0 | v2: Node 20 runtime. v3: Node 24 runtime. | None. `files` and `generate_release_notes` inputs unchanged. |
| `goreleaser/goreleaser-action` | v6.4.0 | v7.2.2 | Node 24 runtime; ESM internals. | None. `distribution`/`version` inputs unchanged. |

## What this PR does NOT do

- Does not bump `aquasecurity/trivy-action` (v0.35.0 → v0.36.0 is a minor bump, intentionally deferred from this "majors-only" PR).
- Does not change any workflow logic, inputs, env vars, or step ordering. The diff is 10/10 line-for-line replacements across 3 files.

## Verification

- All 9 upgrade SHAs verified to be real commits in their upstream repos and to map to the claimed semver tags.
- All 9 upgrade SHAs have a resolvable action manifest at the pinned ref (the GraphQL contents lookup the runner does at job start).
- YAML parses cleanly on all 7 workflows.
- `actionlint -shellcheck=` exits 0 (zero native issues).
- `anchore` v6 breaking change pre-empted: existing call site already uses `steps.scan-ghcr.outputs.sarif`, so no SARIF-path migration is needed.
- 3 files modified, 10 insertions, 10 deletions.

## Test plan

- [ ] Workflow runs on this PR — all jobs that touched-up actions pass (`docker-multiarch.yml`, `python-package.yml`, `release.yml`).
- [ ] On any tagged release after merge: GoReleaser v7 produces an identical release artifact set.
- [ ] On any container build after merge: ECR Public + GHCR receive multi-arch images, Anchore Grype produces SARIF, SARIF uploads to GitHub Security tab.
- [ ] On any tagged release after merge: PyPI release artifacts attach correctly via `softprops/action-gh-release@v3`.
