### PR TITLE
chore(ci): add dependabot config + workflow conventions doc

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,95 @@
+# Dependabot configuration for ferret-scan
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Notes:
+# - GitHub Actions are SHA-pinned with a trailing version comment (`# v6.0.2`).
+#   Dependabot understands this pattern and updates both the SHA and the
+#   version comment together. Without this config, the SHA pins would rot
+#   silently and contributors would gradually re-introduce floating @vN tags.
+# - Minor + patch action updates are grouped to limit CI churn. Major bumps
+#   open per-action so they can be reviewed against changelogs.
+# - The Go module updates section makes the existing auto-config explicit in
+#   source control.
+
+version: 2
+updates:
+  # GitHub Actions used in .github/workflows/*.yml
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      # Group all non-major updates so a typical week opens one PR, not many.
+      # Major bumps stay separate for changelog review.
+      actions-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Go module dependencies in go.mod / go.sum
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "go"
+    groups:
+      go-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Python build/runtime dependencies in python-package/
+  - package-ecosystem: "pip"
+    directory: "/python-package"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "python"
+    groups:
+      python-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Docker base images referenced in Dockerfile
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "docker"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,62 @@
+# GitHub Actions workflow conventions
+
+## Action pinning
+
+External `uses:` references in this directory are **pinned to a full commit
+SHA** with a trailing version comment, not to a floating tag like `@v6`.
+
+```yaml
+# correct — pinned to immutable commit, version comment for dependabot
+- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+# wrong — floating tag is mutable and trusts the upstream maintainer's
+# account security plus GitHub's tag-rewrite controls
+- uses: actions/checkout@v6
+```
+
+### Why
+
+These workflows run with elevated privileges (`contents: write`,
+`packages: write`, `id-token: write` for PyPI trusted publishing and AWS
+OIDC). A compromised third-party action with floating-tag trust can read
+secrets, exfiltrate the GitHub token, push to `main`, or publish a tampered
+package — without any code change in this repo.
+
+SHA pinning shifts the trust model from "tag mutability + maintainer account
+security" to "git's content-addressing + reviewable update PRs."
+
+### How upgrades happen
+
+[Dependabot is configured](../dependabot.yml) for the `github-actions`
+ecosystem and **understands this format**. Each Monday it opens grouped PRs
+for minor + patch updates and per-action PRs for majors. Each PR updates
+both the SHA and the version comment together; review surface is the same as
+any other dependency PR.
+
+### Adding a new action
+
+1. Find the action's latest release tag.
+2. Resolve it to the underlying commit SHA:
+   ```bash
+   gh api /repos/<owner>/<action>/git/refs/tags/<tag> \
+     --jq '.object.sha, .object.type'
+   # If type is "tag" (annotated), dereference:
+   gh api /repos/<owner>/<action>/git/tags/<tag-object-sha> \
+     --jq '.object.sha'
+   ```
+3. Use `uses: <owner>/<action>@<commit-sha> # <version>` in the workflow.
+4. Verify the action manifest resolves at that ref:
+   ```bash
+   gh api "/repos/<owner>/<action>/contents/action.yml?ref=<sha>"
+   ```
+
+### Verifying drift
+
+```bash
+# Should return nothing. Matches floating @vN or @vN.N.N references on
+# external actions (i.e. SHA-less pins). Local workflow_call refs (./...)
+# and SHA-pinned refs with version comments are correctly excluded.
+# README.md is excluded because it documents the wrong-pattern example.
+grep -rE 'uses: [^@]+@v[0-9]+(\.[0-9]+)*$' .github/workflows/ \
+  --exclude=README.md
+```


### PR DESCRIPTION
## Summary

Closes the maintainability gap from #64. Without dependabot configured for `github-actions`, the SHA pins from #64 would have rotted silently and contributors would have gradually re-introduced floating `@vN` tags via copy-paste from external examples.

## Why

#64 SHA-pinned every external `uses:` reference. The version-comment format used (`@de0fac2e... # v6.0.2`) is exactly what dependabot reads to track upstream releases — but only if dependabot is *configured* for the `github-actions` ecosystem. The repo had no `.github/dependabot.yml` at all, only the auto-detected Go module tracking, which doesn't cover actions.

## What this PR adds

### `.github/dependabot.yml`

Enables dependabot for four ecosystems on a weekly schedule:
- `github-actions` — the missing piece
- `gomod` — makes the existing auto-config explicit and reviewable
- `pip` (`python-package/`) — covers Python build/runtime deps
- `docker` (`Dockerfile`) — covers base image upgrades

PR grouping:
- **Minor + patch** updates grouped into one weekly PR per ecosystem to limit CI churn (otherwise we'd get 21 separate PRs every time GitHub releases a batch of action updates).
- **Major bumps** stay separate, one PR per action, so reviewers can read each changelog against the call sites.

### `.github/workflows/README.md`

Documents the SHA-pin convention next to the code it governs:
- Right vs wrong example
- Why the pattern matters (privileged CI surface)
- How to add a new action (resolve tag → commit SHA, verify manifest)
- A drift-detection grep that anyone can run locally

## How dependabot handles SHA pins

Given:

```yaml
uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
```

When `v6.0.3` lands upstream, dependabot opens a PR that updates BOTH the SHA and the trailing version comment in one edit. The trailing comment is normative — that's how dependabot knows what version is currently in use. The review surface is the same as any other dependency PR.

## Verification

- YAML schema-validated: 4 ecosystems, weekly schedule, valid IANA timezone (`America/New_York`).
- Drift-check command tested cross-branch:

| Branch | Floating-tag matches |
|---|---|
| `main` (pre-#64) | 44 (true positive) |
| `chore/sha-pin-github-actions` (#64 applied) | 0 (true negative) |

- README's intentional counter-example is excluded with `--exclude=README.md` so the check stays clean.

## Stack ordering

This PR is independent of #64 and #65 — it only adds new files. Merge order is flexible, but the dependabot config is most useful **after #64 lands** because that's when the SHA-pin pattern is in place to be tracked.

Suggested merge order: #64 → this PR → #65.
