### PR TITLE
docs(threat-model): add TB-8 supply chain trust boundary (CI/CD)

### DIFF
--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -101,8 +101,8 @@ Ferret Scan is a Go-based CLI/web tool that detects sensitive content (PII, secr
 | TM-06 | Cloudscape design-system stylesheet loaded from `https://d0.awsstatic.com` (CSP allow-listed) | Minor (defense-in-depth) | **Open** — tracked. Self-host the CSS in the embed to drop the third-party `style-src` allowance. |
 | TM-07 | SSRF defense-in-depth on Transcribe transcript URI fetch (TB-6) | Minor | **Deferred** — file is `GENAI_DISABLED` and not compiled in. Re-evaluate when GenAI is re-enabled. |
 | TM-08 | Floating-tag GitHub Actions chained with elevated runner permissions and auto-commit (TB-8) | **Major** | **In progress** — added 2026-05-22 by REPO scan. PR #64 SHA-pins every `uses:` reference (`@<sha> # vX.Y.Z` pattern); PR #66 adds dependabot config so the pins stay maintainable. Worst offender pre-fix was `pypa/gh-action-pypi-publish@release/v1` (a branch reference); now pinned to `cef22109... # release/v1 (2026-04-07)`. |
-| TM-09 | `auto-version-tag` GitLab job pushes tags without manual approval (TB-8) | Minor | **Open** — added 2026-05-22 by REPO scan. Add an explicit approval gate or scope `GITLAB_RELEASE_TOKEN` to `write_repository`. |
-| TM-10 | Dockerfile builder-stage `FROM` not pinned by digest (TB-8) | Minor | **Open** — added 2026-05-22 by REPO scan. Pin to `@sha256:<digest>` for defense in depth. |
+| TM-09 | `auto-version-tag` GitLab job pushes tags without manual approval (TB-8) | Minor | **In progress** — added 2026-05-22 by REPO scan. PR #69 adds `when: manual` + `allow_failure: true` on the rule (a maintainer must click "play" in the GitLab UI for the tag to push) and inline-documents the expectation that `GITLAB_RELEASE_TOKEN` is scoped `write_repository` only. Final closure also requires verifying the token scope in the GitLab project-settings UI. |
+| TM-10 | Dockerfile builder-stage `FROM` not pinned by digest (TB-8) | Minor | **In progress** — added 2026-05-22 by REPO scan. PR #70 pins `golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d`. The digest references a multi-arch manifest list covering both `linux/amd64` and `linux/arm64v8`, matching the platforms `docker-multiarch.yml` builds. Final stage is `FROM scratch` and is unaffected. |
 
 ## 4.5 Highest-leverage attack paths
 
@@ -115,16 +115,16 @@ Three numbered chains the model should be evaluated against. Each names the star
    Starting position: A1 unauthenticated remote attacker on the same LAN as an operator who has passed `--bind 0.0.0.0`. Chain: attacker sends `POST /suppressions/create` with a spoofed `Origin` header matching the operator's `host:port`. Defense that breaks the chain: `originCheckMiddleware` requires the Origin / Referer to be in `sameOriginHostSet`, which excludes LAN-resolvable hostnames the server can't enumerate. Today's mitigation is "best-effort" by design; re-evaluate if a future deployment moves to LAN-default. Stays at "compensating control" until then.
 
 3. **Operator scans an attacker-supplied PDF / DOCX → preprocessor parser exploit.**
-   Starting position: operator runs `ferret-scan --file <attacker-supplied.pdf>`. Chain: bug in `pdfcpu`, `ledongthuc/pdf`, or office-extractor library is triggered. Defense: dependency provenance (gemnasium dep-scan in `.gitlab-ci.yml`, `go mod tidy` pre-commit hook), 100 MB size cap, sandboxed `FROM scratch` runtime. Still relies on upstream library quality; if `gemnasium-python-dependency_scanning` does not run (currently blocked by Phase 3 #3 YAML parse error), this defense is offline.
+   Starting position: operator runs `ferret-scan --file <attacker-supplied.pdf>`. Chain: bug in `pdfcpu`, `ledongthuc/pdf`, or office-extractor library is triggered. Defense: dependency provenance (gemnasium dep-scan in `.gitlab-ci.yml`, `go mod tidy` pre-commit hook), 100 MB size cap, sandboxed `FROM scratch` runtime. Still relies on upstream library quality; the `gemnasium-python-dependency_scanning` job was previously blocked by the Phase 3 #3 YAML parse error and is restored in PR #69.
 
 ## 4.6 Action items
 
 In priority order. Numbered for cross-reference from the REPO scan punch list.
 
-1. **~~Pin every `uses:` in `.github/workflows/*` to commit SHA with version comment.~~** (TM-08 / Phase 3 #1.) Shipped in PR #64. Companion PR #66 adds dependabot tracking and a workflow-conventions README so the pins stay maintainable.
-2. **Fix `.gitlab-ci.yml` line 175** (`[redacted-internal-ci-component]/kaniko/executor@~latest`). Without this fix the GitLab pipeline doesn't parse, so `gosec-sast`, `ferret-sast`, and `gemnasium-python-dependency_scanning` don't run.
-3. **Pin Dockerfile `FROM` lines to `@sha256:<digest>`.** (TM-10.) Defense-in-depth, low effort.
-4. **Add a manual approval gate or token-scope reduction on `auto-version-tag`.** (TM-09.)
+1. **~~Pin every `uses:` in `.github/workflows/*` to commit SHA with version comment.~~** (TM-08 / Phase 3 #1.) Shipped in PR #64. Companion PR #66 adds dependabot tracking and a workflow-conventions README so the pins stay maintainable. PR #65 takes available major-version upgrades on top of the pins.
+2. **~~Fix `.gitlab-ci.yml` line 175~~** (`[redacted-internal-ci-component]/kaniko/executor@~latest`). Shipped in PR #69. With the parse error fixed, `gosec-sast`, `ferret-sast`, and `gemnasium-python-dependency_scanning` are restored.
+3. **~~Pin Dockerfile `FROM` lines to `@sha256:<digest>`.~~** (TM-10.) Shipped in PR #70.
+4. **~~Add a manual approval gate or token-scope reduction on `auto-version-tag`.~~** (TM-09.) Shipped in PR #69. Final closure of TM-09 also requires verifying `GITLAB_RELEASE_TOKEN` scope in GitLab project settings — the YAML inline comment points to the right place.
 5. **Refactor `internal/web/assets/template.html` to drop `'unsafe-inline'`** from CSP `script-src` and `style-src`. (TM-05.) Tracked, no time pressure.
 6. **Self-host the Cloudscape stylesheet** to drop the `https://d0.awsstatic.com` allowance. (TM-06.)
 

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -25,6 +25,7 @@ Ferret Scan is a Go-based CLI/web tool that detects sensitive content (PII, secr
 | TB-5 | Process → AWS APIs (Textract/Transcribe/Comprehend) | outbound | Only when GenAI flag enabled. Credentials from standard AWS chain (env, profile, IAM role). Currently disabled in source. |
 | TB-6 | Process → external HTTP (Transcribe transcript URI) | outbound | `http.Get(uri)` in transcribe-extractor.go:186 against a URI returned by `GetTranscriptionJob`. Service-controlled, not user-controlled. |
 | TB-7 | Pre-commit hook → ferret-scan binary | inbound (developer machine) | Pre-commit invokes the binary against staged files; same trust as CLI. |
+| TB-8 | GitHub Actions runners → external registries (ECR Public / GHCR / PyPI) | outbound | Build, package, and publish flow. Workflows run with `contents: write`, `packages: write`, and `id-token: write` (PyPI trusted publishing + AWS OIDC for ECR). Third-party actions are SHA-pinned with version comments (`@<sha> # vX.Y.Z`) — see PR #64 and `.github/workflows/README.md`. Auto-version-tag job pushes tags to `main` on every push. |
 
 ## 3. STRIDE threats and mitigations
 
@@ -80,6 +81,14 @@ Ferret Scan is a Go-based CLI/web tool that detects sensitive content (PII, secr
 |---|---|---|
 | Pre-commit hook bypassed (`--no-verify`) | E | **Compensating control** — server-side ferret-scan in CI (gitlab-ci.yml has `ferret-sast` and `gosec-sast` jobs). Pre-commit is best-effort developer hygiene. |
 
+### TB-8 (CI runners → external registries)
+
+| Threat | STRIDE | Mitigation |
+|---|---|---|
+| Compromised third-party action (e.g. attacker repoints `softprops/action-gh-release@v3` upstream) reads `${{ secrets.* }}`, exfiltrates `GITHUB_TOKEN` / OIDC issuance, pushes commits to `main` as `github-actions[bot]`, publishes a tampered `ferret-scan` to PyPI / ECR Public / GHCR. | T (Tampering), E (Elevation of Privilege) | **Mitigated** — every external `uses:` reference is SHA-pinned (PR #64). Dependabot tracks upstream releases against the version-comment field (PR #66). The trust path is now git's content-addressing + dependabot review surface, not GitHub's tag mutability. Tracked as TM-08. |
+| `auto-version-tag` job in `.gitlab-ci.yml` pushes tags to `main` on every push using `GITLAB_RELEASE_TOKEN`. No human approval gate beyond the originating commit. | E | **Compensating control** — `if:` condition limits the job to default-branch pushes by humans (not MRs, not tag pushes). Token can still issue a release without explicit `/release`-style gate. Tracked as TM-09. |
+| Dockerfile `FROM` lines reference upstream images by tag (`golang:1.26.3-alpine`), not by `@sha256:<digest>`. Final image is `FROM scratch`, so the runtime impact is bounded to the builder stage's compiled binary, but the upstream image swap surface is real. | T | **Compensating control** — final stage is `FROM scratch` with no upstream layer; only the builder-stage compilation is at risk. Defense-in-depth fix is digest pinning. Tracked as TM-10. |
+
 ## 4. Open items / unmitigated threats blocking publication
 
 | ID | Threat | Severity | Status |
@@ -91,6 +100,33 @@ Ferret Scan is a Go-based CLI/web tool that detects sensitive content (PII, secr
 | TM-05 | Embedded HTML template has ~90 inline event handlers and ~301 inline `style` attributes; CSP must include `'unsafe-inline'` until refactored | Minor (defense-in-depth) | **Open** — tracked. Refactor handlers to `addEventListener`, hoist inline styles into the embedded stylesheet, then tighten CSP. |
 | TM-06 | Cloudscape design-system stylesheet loaded from `https://d0.awsstatic.com` (CSP allow-listed) | Minor (defense-in-depth) | **Open** — tracked. Self-host the CSS in the embed to drop the third-party `style-src` allowance. |
 | TM-07 | SSRF defense-in-depth on Transcribe transcript URI fetch (TB-6) | Minor | **Deferred** — file is `GENAI_DISABLED` and not compiled in. Re-evaluate when GenAI is re-enabled. |
+| TM-08 | Floating-tag GitHub Actions chained with elevated runner permissions and auto-commit (TB-8) | **Major** | **In progress** — added 2026-05-22 by REPO scan. PR #64 SHA-pins every `uses:` reference (`@<sha> # vX.Y.Z` pattern); PR #66 adds dependabot config so the pins stay maintainable. Worst offender pre-fix was `pypa/gh-action-pypi-publish@release/v1` (a branch reference); now pinned to `cef22109... # release/v1 (2026-04-07)`. |
+| TM-09 | `auto-version-tag` GitLab job pushes tags without manual approval (TB-8) | Minor | **Open** — added 2026-05-22 by REPO scan. Add an explicit approval gate or scope `GITLAB_RELEASE_TOKEN` to `write_repository`. |
+| TM-10 | Dockerfile builder-stage `FROM` not pinned by digest (TB-8) | Minor | **Open** — added 2026-05-22 by REPO scan. Pin to `@sha256:<digest>` for defense in depth. |
+
+## 4.5 Highest-leverage attack paths
+
+Three numbered chains the model should be evaluated against. Each names the starting trust zone, the chain of steps to impact, and the defense that breaks the chain.
+
+1. **Compromised third-party GitHub Action → tampered PyPI / GHCR / ECR release.**
+   Starting position: attacker controls one upstream action (or its mutable tag/branch). Chain: floating tag in `.github/workflows/*.yml` → action runs with `id-token: write` and `contents: write` → exfiltrates OIDC token / `GITHUB_TOKEN` → pushes a tampered package to PyPI via the `pypi` environment, or pushes a tampered image to GHCR / ECR Public. Impact: every downstream `pip install ferret-scan` or `docker pull ghcr.io/awslabs/ferret-scan:latest` receives the tampered artefact. Defense that breaks the chain: SHA-pin every `uses:` (TM-08).
+
+2. **Operator binds web UI to LAN → cross-origin POST forges suppression rule.**
+   Starting position: A1 unauthenticated remote attacker on the same LAN as an operator who has passed `--bind 0.0.0.0`. Chain: attacker sends `POST /suppressions/create` with a spoofed `Origin` header matching the operator's `host:port`. Defense that breaks the chain: `originCheckMiddleware` requires the Origin / Referer to be in `sameOriginHostSet`, which excludes LAN-resolvable hostnames the server can't enumerate. Today's mitigation is "best-effort" by design; re-evaluate if a future deployment moves to LAN-default. Stays at "compensating control" until then.
+
+3. **Operator scans an attacker-supplied PDF / DOCX → preprocessor parser exploit.**
+   Starting position: operator runs `ferret-scan --file <attacker-supplied.pdf>`. Chain: bug in `pdfcpu`, `ledongthuc/pdf`, or office-extractor library is triggered. Defense: dependency provenance (gemnasium dep-scan in `.gitlab-ci.yml`, `go mod tidy` pre-commit hook), 100 MB size cap, sandboxed `FROM scratch` runtime. Still relies on upstream library quality; if `gemnasium-python-dependency_scanning` does not run (currently blocked by Phase 3 #3 YAML parse error), this defense is offline.
+
+## 4.6 Action items
+
+In priority order. Numbered for cross-reference from the REPO scan punch list.
+
+1. **~~Pin every `uses:` in `.github/workflows/*` to commit SHA with version comment.~~** (TM-08 / Phase 3 #1.) Shipped in PR #64. Companion PR #66 adds dependabot tracking and a workflow-conventions README so the pins stay maintainable.
+2. **Fix `.gitlab-ci.yml` line 175** (`[redacted-internal-ci-component]/kaniko/executor@~latest`). Without this fix the GitLab pipeline doesn't parse, so `gosec-sast`, `ferret-sast`, and `gemnasium-python-dependency_scanning` don't run.
+3. **Pin Dockerfile `FROM` lines to `@sha256:<digest>`.** (TM-10.) Defense-in-depth, low effort.
+4. **Add a manual approval gate or token-scope reduction on `auto-version-tag`.** (TM-09.)
+5. **Refactor `internal/web/assets/template.html` to drop `'unsafe-inline'`** from CSP `script-src` and `style-src`. (TM-05.) Tracked, no time pressure.
+6. **Self-host the Cloudscape stylesheet** to drop the `https://d0.awsstatic.com` allowance. (TM-06.)
 
 ## 5. Out of scope
 


### PR DESCRIPTION
## Summary

Adds a new trust boundary (TB-8) to `THREAT_MODEL.md` covering the GitHub Actions runners that build, package, and publish ferret-scan to PyPI / GHCR / ECR Public. The CI/CD chain has elevated permissions (`contents: write`, `packages: write`, `id-token: write` for both PyPI trusted publishing and AWS OIDC to ECR), so it deserves explicit modeling.

## What this PR adds

- **TB-8** row in section 2 (trust boundaries)
- **TB-8 STRIDE** table in section 3 covering three threats:
  - compromised third-party action exfiltrating tokens / pushing tampered packages (T, E)
  - GitLab `auto-version-tag` pushing without approval (E)
  - unpinned Dockerfile `FROM` lines (T)
- **TM-08, TM-09, TM-10** entries in section 4 (open items)
- New section **4.5 "Highest-leverage attack paths"** — three numbered chains tracing starting trust zone to impact, naming the defense that breaks each chain
- New section **4.6 "Action items"** — cross-referenced to the REPO scan punch list, ordered by priority

## Status reflects in-flight mitigation

| Threat | Status in this PR | Reason |
|---|---|---|
| TM-08 (action SHA-pinning) | **In progress** | #64 SHA-pins every `uses:`; #66 adds dependabot tracking |
| TM-09 (GitLab auto-version-tag) | **Open** | Not addressed yet |
| TM-10 (Dockerfile digest pinning) | **Open** | Not addressed yet |

The TB-8 description in section 2 reflects the post-#64 pinning convention. The TB-8 STRIDE row in section 3 is marked "Mitigated" with reference to #64 and #66. §4.6 item #1 is struck through with a "shipped in #64" note.

## Dependency on other PRs

Status text references PR #64 and #66 by number. If those are renumbered/closed before this merges, the text will need a quick edit. Otherwise this PR is independent.
