### PR TITLE
chore(ci): fix .gitlab-ci.yml parse error and add release-tag approval gate

### DIFF
--- a/.ferret-scan-suppressions.yaml
+++ b/.ferret-scan-suppressions.yaml
@@ -17,6 +17,9 @@
 #   example tokens for the replacement table.
 # - Benchmark fixtures (internal/.../*benchmark*.go): synthetic
 #   payloads for performance testing.
+# - CI configuration (.gitlab-ci.yml): git author email used for CI
+#   commits triggers the GITLAB validator but is convention, not a
+#   credential.
 #
 # Only HIGH-confidence rules (>=90) are enabled, matching the
 # pre-commit hook policy (FERRET_PRECOMMIT_EXIT_ON=high). Lower-
@@ -25,6 +28,9 @@
 #
 # To regenerate: ./bin/ferret-scan --suppression-file ./.ferret-scan-suppressions.yaml --generate-suppressions <files>
 # To audit a specific rule: search by hash or filename below.
+#
+# WARNING: --generate-suppressions strips this header. Restore it manually
+# after running the regenerate command.
 
 version: "1.0"
 rules:
@@ -3416,3 +3422,55 @@ rules:
         finding_type: DISCORD
         line_number: "1419"
         match_text_hash: a5501ee1be5fe022
+    - id: SUP-00000243
+      hash: 92d9515af1aa4cd634a901176e3dc9c4a8685cbb6d2c4be5794e5b1f43438439 # pragma: allowlist secret
+      reason: |-
+        Git author email used for CI commits in `git config user.email`.
+        Triggers the GITLAB validator's email pattern but is not a
+        credential — the value is hardcoded GitLab convention, not a
+        real account.
+      enabled: true
+      created_at: 2026-05-22T14:39:51.017305-04:00
+      last_seen_at: 2026-05-22T14:39:51.017305-04:00
+      expires_at: 2026-05-29T14:39:51.017305-04:00
+      metadata:
+        confidence: "100"
+        context_hash: 1023d2b9ae3773c3
+        filename: .gitlab-ci.yml
+        finding_type: GITLAB
+        line_number: "281"
+        match_text_hash: fdebb41e0fa8c3ef
+    - id: SUP-00000244
+      hash: 104e21bea998624ad15e4d39cfff8a038af8d4933fa5acc676fe1ef203115e8f # pragma: allowlist secret
+      reason: |-
+        Git author email used for CI commits in `git config user.email`.
+        Triggers the GITLAB validator's email pattern but is not a
+        credential.
+      enabled: true
+      created_at: 2026-05-22T14:39:51.017305-04:00
+      last_seen_at: 2026-05-22T14:39:51.017305-04:00
+      expires_at: 2026-05-29T14:39:51.017305-04:00
+      metadata:
+        confidence: "100"
+        context_hash: 1023d2b9ae3773c3
+        filename: .gitlab-ci.yml
+        finding_type: GITLAB
+        line_number: "354"
+        match_text_hash: fdebb41e0fa8c3ef
+    - id: SUP-00000245
+      hash: 001e6a5acc7b2db3a0a8436384fa3405ee16daba58c7831c3e4cf9e9fa6e2d6f # pragma: allowlist secret
+      reason: |-
+        Git author email used for CI commits in `git config user.email`.
+        Triggers the GITLAB validator's email pattern but is not a
+        credential.
+      enabled: true
+      created_at: 2026-05-22T14:39:51.017305-04:00
+      last_seen_at: 2026-05-22T14:39:51.017305-04:00
+      expires_at: 2026-05-29T14:39:51.017305-04:00
+      metadata:
+        confidence: "100"
+        context_hash: 1023d2b9ae3773c3
+        filename: .gitlab-ci.yml
+        finding_type: GITLAB
+        line_number: "413"
+        match_text_hash: fdebb41e0fa8c3ef

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -172,11 +172,17 @@ include:
   # AWS-internal; if mirroring this repo into a different GitLab instance,
   # swap it for whichever Kaniko / image-builder component your instance
   # publishes (the inputs schema is identical across most Kaniko wrappers).
-  - component: [redacted-internal-ci-component]/kaniko/executor@~latest
-    inputs:
-      name: ferret-scan
-      destination: $CI_REGISTRY_IMAGE/ferret-scan:latest
-      dockerfile: Dockerfile
+  #
+  # The block is commented out in the public repo because the placeholder
+  # path makes the YAML invalid — without this comment, the entire pipeline
+  # fails to parse and the security jobs (gosec-sast, ferret-sast,
+  # gemnasium-python-dependency_scanning) cannot run.
+  #
+  # - component: <your-kaniko-component-path>/kaniko/executor@~latest
+  #   inputs:
+  #     name: ferret-scan
+  #     destination: $CI_REGISTRY_IMAGE/ferret-scan:latest
+  #     dockerfile: Dockerfile
 
 # Comprehensive Go security scanning with Gosec
 gosec-sast:
@@ -378,9 +384,23 @@ auto-version-tag:
     - git push origin $NEW_VERSION
     - echo "Tag $NEW_VERSION created and pushed!"
   rules:
-    # Only run on main/master branch pushes (not merge requests, not tag pushes)
+    # SECURITY GATE: this job pushes a release tag using GITLAB_RELEASE_TOKEN.
+    # The token must be scoped to `write_repository` only (NOT `api`, NOT
+    # `read_api`) — configure in GitLab project settings → CI/CD → Variables.
+    # The job runs only on protected default-branch pushes initiated by a
+    # human, never on MR pipelines or tag pushes (which would loop). The
+    # `when: manual` clause adds an explicit human approval step; a
+    # maintainer must click "play" in the GitLab UI for the tag to be
+    # pushed. This is the gate that prevents an attacker who lands a
+    # commit on main from auto-issuing a release.
+    #
+    # To re-enable fully automatic tagging, set AUTO_VERSION_ENABLED to
+    # "true" AND change `when: manual` to `when: on_success` — but only
+    # do that if the project's branch protection rules require ≥2 reviewer
+    # approvals on every main-targeted MR.
     - if: ($CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH == "master") && $CI_COMMIT_TAG == null && $AUTO_VERSION_ENABLED == "true" && $CI_PIPELINE_SOURCE == "push"
-      when: on_success
+      when: manual
+      allow_failure: true
   dependencies:
     - build
 


### PR DESCRIPTION
## Summary

Closes two findings from the 2026-05-22 prep scan punch list (`prep-report-REPO-38017da4.md`):

- **Phase 3 #3** — `.gitlab-ci.yml` line 175 placeholder makes the entire pipeline fail to parse. Result: `gosec-sast`, `ferret-sast`, `gemnasium-python-dependency_scanning`, build, and `auto-version-tag` are all dead code today.
- **Phase 3 #4** — `auto-version-tag` pushes a release tag using `GITLAB_RELEASE_TOKEN` on every qualifying main push, with no human approval gate.

Adds a small bonus fix: 3 hash-based suppression rules for the `ci@gitlab.com` self-detections in `.gitlab-ci.yml` and the suppression-file header — the same self-detection pattern flagged in Phase 2 of the report.

## Changes

### 1. `.gitlab-ci.yml` line 175 — placeholder breaks YAML parse

The Kaniko component reference `[redacted-internal-ci-component]/kaniko/executor@~latest` isn't valid YAML — square brackets in unquoted scalar position fail the parser at the colon. Comments out the block with a pointer to the right replacement pattern for downstream forks. The component is AWS-internal and can't be referenced from the public repo.

**Verification:**
```
Before: GitLab CI YAML: PARSE ERROR (line 175, column 5)
After:  GitLab CI YAML parses: 12 top-level keys, 9 jobs visible
```

### 2. `auto-version-tag` — manual approval gate added

Changes the rule from `when: on_success` to `when: manual` with `allow_failure: true`. A human must click "play" in the GitLab UI for the tag to push; the pipeline still succeeds either way.

Adds an inline comment block documenting:
- `GITLAB_RELEASE_TOKEN` should be scoped `write_repository` only (not `api`, not `read_api`) — pointer to GitLab project settings.
- Conditions under which fully automatic tagging would be safe to re-enable (≥2 reviewer MR approvals on main).

This is the gate that prevents an attacker who lands a single commit on main from auto-issuing a tagged release (which then triggers the GitHub Actions build/publish chain).

### 3. Suppression rules for self-detection in CI config

Three hash-based suppression rules for the `ci@gitlab.com` git author email in `.gitlab-ci.yml`. The validator's GITLAB pattern matches the substring; the value is hardcoded GitLab convention, not a credential. Pre-commit ferret-scan now passes against `.gitlab-ci.yml` cleanly.

Also adds the `.gitlab-ci.yml` category note to the suppression file's leading header (which the `--generate-suppressions` flag had stripped — added a warning about that quirk).

## Verification

- `.gitlab-ci.yml` parses: 12 top-level keys, 9 jobs (including the security jobs that were dead code before).
- `auto-version-tag.rules[0]` confirmed `when: manual`, `allow_failure: true`.
- `ferret-scan --file .gitlab-ci.yml`: 0 findings (was: 3 high-confidence false positives).
- `ferret-scan --file .ferret-scan-suppressions.yaml`: 0 findings (the suppression file's reason text deliberately avoids the trigger string).
- Pre-commit hooks all pass on commit, including the `Ferret Scan Security Check` self-test.

## Out of scope

Closing TM-09 (auto-version-tag approval) fully also requires verifying the `GITLAB_RELEASE_TOKEN` scope in the GitLab project settings UI. That's a settings change, not a YAML change — the inline comment in this PR points the maintainer to the right place.

This PR doesn't address:
- TM-10 (Dockerfile digest pinning) — separate PR
- `GOPROXY=direct` defense-in-depth — separate PR
- Path-based suppressions for documentation files (the broader Phase 3 #5) — needs an upstream feature in the suppression system; documented in `docs/suppression-system.md` line 169 as "Pattern Suppressions" future work
