### PR TITLE
chore(docker): pin builder image to digest + document GOPROXY=direct

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,23 @@
 # Target: Absolute smallest possible image (~5-10MB)
 
 # Builder stage
-FROM public.ecr.aws/docker/library/golang:1.26.3-alpine AS builder
+# Pinned to digest for supply-chain integrity (TM-10). The trailing tag
+# is informational; the @sha256:... digest is what determines what's
+# pulled. To update, run:
+#   crane digest public.ecr.aws/docker/library/golang:1.26.3-alpine
+# or use `docker manifest inspect` and replace both the tag and digest.
+FROM public.ecr.aws/docker/library/golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
 
 # Install minimal build dependencies
 # Add ca-certificates back if you uncomment the COPY line below
 RUN apk add --no-cache git ca-certificates
 
 # Set Go environment - critical for module downloads
+# GOPROXY=direct fetches modules from upstream VCS hosts directly,
+# bypassing proxy.golang.org. The go.sum hash check still applies
+# (and GOSUMDB=sum.golang.org is left at the default), so the
+# integrity guarantee is unchanged. Tradeoff: no proxy caching, no
+# DOS protection for upstream hosts.
 ENV GOPROXY=direct
 RUN go env -w GOPROXY=direct
 


### PR DESCRIPTION
## Summary

Closes **TM-10** from the threat model (Dockerfile builder-stage `FROM` not pinned by digest). Pins the builder image to its content-addressed `@sha256:<digest>` and documents the existing `GOPROXY=direct` setting so the security tradeoff is explicit for future maintainers.

## Why

`THREAT_MODEL.md` TB-8 / TM-10 calls out the Dockerfile builder `FROM` as relying on upstream tag mutability. The final image is `FROM scratch` so the runtime impact is bounded to the builder stage's compiled binary, but the upstream image-swap surface is real — defense-in-depth fix is digest pinning.

## Changes

### Builder image digest pin

```diff
-FROM public.ecr.aws/docker/library/golang:1.26.3-alpine AS builder
+FROM public.ecr.aws/docker/library/golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
```

The trailing tag is informational; the `@sha256:...` digest is what determines what gets pulled. Verified the digest is a multi-arch manifest list covering both `linux/amd64` and `linux/arm64v8` — matches the platforms `docker-multiarch.yml` builds.

### `GOPROXY=direct` documentation

Adds an inline comment block making the security implication of the existing setting explicit:
- Fetches modules from upstream VCS hosts directly, bypassing `proxy.golang.org`.
- The `go.sum` hash check still runs (`GOSUMDB=sum.golang.org` is the default and is not disabled anywhere in the repo).
- The integrity guarantee is therefore unchanged.
- Tradeoff: no proxy caching, no DOS protection for upstream hosts.

I did not remove `GOPROXY=direct` because the build environment may depend on direct fetches (the comment "critical for module downloads" suggests intent). Documenting the tradeoff keeps the next maintainer informed without changing behavior.

## How to update the digest

The version-comment pattern matches what PR #64 introduced for GitHub Actions (`@<sha> # vX.Y.Z`). To rotate:

```bash
crane digest public.ecr.aws/docker/library/golang:1.26.3-alpine
# or
docker manifest inspect public.ecr.aws/docker/library/golang:1.26.3-alpine
```

Then replace both the tag and digest in the `FROM` line. Dependabot's `docker` ecosystem (configured in #66) tracks digest pins automatically and will open update PRs.

## Verification

- Resolved digest verified via ECR Public registry HTTP API + token: `sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d`
- Multi-arch manifest list confirmed: `linux/amd64` + `linux/arm64v8` both present
- Pre-commit hooks pass (no PII regressions in Dockerfile)
- Final stage `FROM scratch` is unchanged — no runtime image impact

## Verification on PR (next steps)

The full multi-arch docker build runs against this branch as part of the `Multi-Architecture Docker Build` workflow when triggered. I'll dispatch it manually after the PR opens to validate the digest-pinned image actually pulls and builds end-to-end.

## Independent of other open PRs

This PR only touches `Dockerfile`. Independent of #64-#69. Can land in any order.
