### PR TITLE
fix(ci): authenticate to GHCR before grype scan in security-scan job

### DIFF
--- a/.github/workflows/docker-multiarch.yml
+++ b/.github/workflows/docker-multiarch.yml
@@ -264,6 +264,18 @@ jobs:
       security-events: write
 
     steps:
+      # Authenticate to GHCR before grype attempts to pull the image.
+      # Without this, anchore/scan-action@v7+ fails with
+      #   "UNAUTHORIZED: authentication required"
+      # because the GHCR package is private by default and the v7 grype
+      # resolver requires explicit auth on the oci-registry path.
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run Grype vulnerability scanner on GHCR
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
         id: scan-ghcr


### PR DESCRIPTION
## Summary

Fixes the `security-scan` job in `docker-multiarch.yml`, which started failing on the first tagged build (v1.8.2) after PR #65 bumped `anchore/scan-action` from v3.6.4 to v7.4.0.

## What failed

[Run 26310352062 / job 77459410516](https://github.com/awslabs/ferret-scan/actions/runs/26310352062/job/77459410516) — grype could not pull `ghcr.io/awslabs/ferret-scan:latest`:

```
docker: pull failed: Error response from daemon:
  Head "https://ghcr.io/v2/awslabs/ferret-scan/manifests/latest": unauthorized

oci-registry: failed to get image descriptor from registry:
  GET https://ghcr.io/token?scope=repository:awslabs/ferret-scan:pull&service=ghcr.io:
  UNAUTHORIZED: authentication required
```

## Root cause

The GHCR package `ghcr.io/awslabs/ferret-scan` is **private** by default at the org level. Anonymous `curl` confirms it (HTTP 401).

The `security-scan` job has `packages: read` in its permissions block but never actually used the `GITHUB_TOKEN` to authenticate — it relied on the previously installed `anchore/scan-action@v3.6.4`'s tolerant resolver, which worked against the private package somehow.

History confirms this: the same workflow on the **same private GHCR package** had `security-scan: success` on every tagged build going back to v1.7.0 (May 7) and earlier. The first failure was on **v1.8.2 (May 22)** — the first tagged build after PR #65 bumped the action to **v7.4.0**.

The v7 grype resolver tries each provider in sequence (`docker`, `podman`, `containerd`, `oci-registry`, `oci-model`, `snap`) and **all** of them fail with auth errors when the package is private and no login has been performed.

## Fix

One step inserted before the grype scan:

```yaml
- name: Log in to GitHub Container Registry
  uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
  with:
    registry: ghcr.io
    username: ${{ github.actor }}
    password: ${{ secrets.GITHUB_TOKEN }}
```

The `GITHUB_TOKEN` already has the correct scope for this — the job's existing `packages: read` grant is exactly what's needed. No new permissions, no secrets management.

## Why fix the workflow rather than flip GHCR visibility

Flipping the package to public in org settings would also work, but:

1. **Content-addressable to the repo** — package visibility is org-level state with no provenance in code review. The workflow change is reviewable here.
2. **Defensive** — works whether the package is public or private. If someone flips visibility back later, this doesn't silently break.
3. **Consistent with the existing pattern** — the `docker` job in the same workflow already uses `docker/login-action`. This change makes `security-scan` consistent with that.

## Verification (post-merge)

Verified end-to-end on the **v1.8.3 tagged build** ([run 26311572438](https://github.com/awslabs/ferret-scan/actions/runs/26311572438)):

| Job | v1.8.2 (pre-fix) | v1.8.3 (post-fix) |
|---|---|---|
| `docker` | ✅ success (15m5s) | ✅ success (8m6s) |
| `security-scan` | ❌ failure (45s) | ✅ success (53s) |

The 8-second delta on `security-scan` is the new `docker/login-action` step. The actual grype scan ran clean against the private GHCR package after authentication.

## Stack

Independent of all other open PRs. Only touches `docker-multiarch.yml`.
