### PR TITLE
fix(validators): 46 detection-quality fixes across 10 validators (TP recovery + FP reduction)

### DIFF
--- a/internal/core/scanner_test.go
+++ b/internal/core/scanner_test.go
@@ -176,10 +176,16 @@ func TestScanContent_DetectsCommonPII(t *testing.T) {
 	// the suite. Validators emit specific subtypes (e.g. "VISA", "BUSINESS")
 	// in Match.Type and the producing validator name in Match.Validator;
 	// we assert against the latter for stability.
+	//
+	// The SSN must be a *realistic* value, not a denylisted fake: the SSN
+	// validator (correctly) drops well-known test numbers such as 123-45-6789 as
+	// false positives, so using one here would assert that a fake SSN is reported
+	// as PII. 449-87-4100 has a valid area/group/serial and is not on any
+	// test/sequential denylist.
 	content := strings.Join([]string{
 		"credit card: 4532-0151-1283-0366",
 		"contact: alice@example.com",
-		"ssn: 123-45-6789",
+		"ssn: 449-87-4100",
 	}, "\n")
 
 	result, err := ScanContent(content, ContentScanConfig{

--- a/internal/validators/creditcard/validator.go
+++ b/internal/validators/creditcard/validator.go
@@ -38,6 +38,13 @@ type Validator struct {
 	positiveKeywords []string
 	negativeKeywords []string
 
+	// Pre-compiled word-boundary keyword matchers. Built from the slices above,
+	// these match a keyword only as a whole word (\bkw\b) so short tokens like
+	// "id"/"tel"/"sha" no longer match inside "david"/"hotel"/"sha256" — a
+	// substring match there was forcing Luhn-valid cards to -100 (dropped).
+	positiveKeywordRegex *regexp.Regexp
+	negativeKeywordRegex *regexp.Regexp
+
 	// Observability
 	observer *observability.StandardObserver
 }
@@ -61,7 +68,11 @@ func NewValidator() *Validator {
 		// 5. Fixed boundary issue that was causing false matches across columns
 		// 6. Added support for space-only separators and no separators
 		// 7. Improved quoted string handling
-		pattern: `(?:^|[\s\t,;|"'(){}[\]<>])(\d{4}[\s\-]\d{4}[\s\-]\d{4}[\s\-]\d{4}|\d{4}[\s\-]\d{6}[\s\-]\d{5}|\d{4}[\s\-]\d{4}[\s\-]\d{4}[\s\-]\d{3}|\d{4}[\s\-]\d{4}[\s\-]\d{4}[\s\-]\d{2}|\d{4}\s\d{4}\s\d{4}\s\d{4}|\d{4}\s\d{6}\s\d{5}|\d{4}\s\d{4}\s\d{4}\s\d{3}|\d{4}\s\d{4}\s\d{4}\s\d{2}|\d{16}|\d{15}|\d{14})(?:[\s\t,;|"'(){}[\]<>]|$)`,
+		// 8. '=' and ':' added to the delimiter classes so PANs in config /
+		//    key=value / key:value logs (the dominant leak format) are matched.
+		// 9. Added bare \d{13} (legacy Visa) and \d{19} (ISO/IEC 7812 extended)
+		//    lengths; \d{19} precedes \d{16} so a 19-digit PAN is not truncated.
+		pattern: `(?:^|[\s\t,;|"'(){}[\]<>=:])(\d{4}[\s\-]\d{4}[\s\-]\d{4}[\s\-]\d{4}|\d{4}[\s\-]\d{6}[\s\-]\d{5}|\d{4}[\s\-]\d{4}[\s\-]\d{4}[\s\-]\d{3}|\d{4}[\s\-]\d{4}[\s\-]\d{4}[\s\-]\d{2}|\d{4}\s\d{4}\s\d{4}\s\d{4}|\d{4}\s\d{6}\s\d{5}|\d{4}\s\d{4}\s\d{4}\s\d{3}|\d{4}\s\d{4}\s\d{4}\s\d{2}|\d{19}|\d{16}|\d{15}|\d{14}|\d{13})(?:[\s\t,;|"'(){}[\]<>=:]|$)`,
 
 		binRanges: initBINRanges(),
 
@@ -75,6 +86,10 @@ func NewValidator() *Validator {
 		negativeKeywords: []string{
 			"account", "id", "identifier", "serial", "tracking", "reference",
 			"order", "invoice", "timestamp", "unix", "epoch", "phone", "tel",
+			// "telephone" is kept as an explicit keyword: with whole-word
+			// matching "tel" no longer matches inside "telephone", but a phone
+			// label is still a legitimate negative signal.
+			"telephone",
 			"md5", "sha", "hash", "uuid", "guid", "crc", "checksum",
 			"version", "build", "test", "example", "fake", "mock", "sample",
 		},
@@ -82,6 +97,10 @@ func NewValidator() *Validator {
 
 	// Compile regex once
 	v.regex = regexp.MustCompile(v.pattern)
+
+	// Build word-boundary keyword matchers from the slices above.
+	v.positiveKeywordRegex = buildKeywordRegex(v.positiveKeywords)
+	v.negativeKeywordRegex = buildKeywordRegex(v.negativeKeywords)
 
 	// Pre-compile test patterns for fast rejection
 	v.testPatterns = []*regexp.Regexp{
@@ -158,15 +177,33 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 	lines := strings.Split(content, "\n")
 
 	for lineNum, line := range lines {
-		// Find potential matches using improved regex
-		regexMatches := v.regex.FindAllStringSubmatch(line, -1)
+		// Find potential matches. The pattern requires a delimiter on BOTH sides
+		// of the number, so a naive FindAllStringSubmatch (non-overlapping over
+		// the FULL match, delimiters included) consumes the single space/comma
+		// between two adjacent PANs as card N's trailing delimiter, leaving it
+		// unavailable as card N+1's leading delimiter — every even-positioned
+		// card in a dump/CSV ("pan1,pan2,pan3") was silently dropped. We instead
+		// scan manually and resume from the end of the captured number (group 1)
+		// rather than the end of the full match, so a shared delimiter can serve
+		// as the next match's leading boundary.
+		for pos := 0; pos <= len(line); {
+			loc := v.regex.FindStringSubmatchIndex(line[pos:])
+			if loc == nil {
+				break
+			}
+			// loc is relative to line[pos:]; group 1 (the number) is loc[2]:loc[3].
+			matchStart, matchEnd := pos+loc[2], pos+loc[3]
+			match := line[matchStart:matchEnd]
 
-		for _, regexMatch := range regexMatches {
-			if len(regexMatch) < 2 {
-				continue
+			// Resume scanning from the end of the captured number so the trailing
+			// delimiter remains available to the next candidate. Guard against a
+			// zero-width advance.
+			if matchEnd > pos {
+				pos = matchEnd
+			} else {
+				pos++
 			}
 
-			match := regexMatch[1] // Extract the captured group (the actual number)
 			cleanMatch := v.cleanCreditCardNumber(match)
 
 			// OPTIMIZATION 1: Early rejection for obvious non-credit cards
@@ -261,10 +298,13 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 	return matches, nil
 }
 
-// isValidLength checks if the number has a valid credit card length
+// isValidLength checks if the number has a valid credit card length.
+// 13 (legacy Visa) and 19 (ISO/IEC 7812 extended, in active use by Visa/Discover/
+// Maestro) are valid PAN lengths alongside Diners (14), Amex (15) and standard (16).
+// Luhn + BIN validation suppress the extra false-positive surface 13/19 add.
 func (v *Validator) isValidLength(number string) bool {
 	length := len(number)
-	return length == 14 || length == 15 || length == 16 // Support Diners (14), Amex (15), and standard (16)
+	return length == 13 || length == 14 || length == 15 || length == 16 || length == 19
 }
 
 // isKnownTestPattern uses pre-compiled regexes for fast test pattern detection
@@ -379,13 +419,18 @@ func (v *Validator) calculateConfidence(match, cleanMatch string) (float64, map[
 func (v *Validator) hasRepeatingPatterns(number string) bool {
 	// This should catch patterns that are unlikely to be real credit cards
 
-	// Check for excessive consecutive identical digits (8+ consecutive)
-	// Real cards can have some repetition, but 8+ consecutive is suspicious
+	// Check for excessive consecutive identical digits. The previous threshold of
+	// 8 was too aggressive: a genuine Luhn-valid PAN can legitimately contain a
+	// run of 8-11 identical digits (the canonical Discover test card
+	// 6011111111111117 has eleven consecutive 1s), and tripping this hard-capped
+	// real cards at confidence 15 (LOW). The all-same / alternating / sequential
+	// checks below still reject obvious junk, so we only treat a very long run
+	// (12+) as a repeating pattern here.
 	consecutiveCount := 1
 	for i := 1; i < len(number); i++ {
 		if number[i] == number[i-1] {
 			consecutiveCount++
-			if consecutiveCount >= 8 {
+			if consecutiveCount >= 12 {
 				return true
 			}
 		} else {
@@ -458,27 +503,46 @@ func (v *Validator) calculateEntropy(number string) float64 {
 	return float64(uniqueDigits) * 0.5 // Rough approximation
 }
 
-// analyzeContext provides faster context analysis with better false positive detection
+// buildKeywordRegex compiles a slice of keywords into a single case-insensitive
+// whole-word matcher: \b(kw1|kw2|...)\b. Keywords are lowercased and regex-quoted
+// (so multi-word entries like "american express" still match, with \b sitting at
+// the outer edges and the space matched literally). Matching on word boundaries
+// — rather than strings.Contains — prevents short keywords ("id", "tel", "sha")
+// from matching inside unrelated words ("david", "hotel", "sha256").
+func buildKeywordRegex(keywords []string) *regexp.Regexp {
+	if len(keywords) == 0 {
+		return nil
+	}
+	escaped := make([]string, len(keywords))
+	for i, k := range keywords {
+		escaped[i] = regexp.QuoteMeta(strings.ToLower(k))
+	}
+	return regexp.MustCompile(`\b(?:` + strings.Join(escaped, "|") + `)\b`)
+}
+
+// analyzeContext provides faster context analysis with better false positive detection.
+//
+// Keyword matching is done on WHOLE WORDS (see buildKeywordRegex). The previous
+// implementation used strings.Contains, so a negative keyword like "id"/"tel"/"sha"
+// matched inside ordinary words ("david", "hotel", "sha256") and returned -100,
+// dropping Luhn-valid cards outright even under explicit "credit card" context.
+// Whole-word matching is a strict subset of the old substring matching, so this
+// change can only RECOVER cards that were wrongly dropped — it can never newly
+// drop a card or surface one that carries a genuine negative keyword.
 func (v *Validator) analyzeContext(match string, context detector.ContextInfo) float64 {
 	fullContext := strings.ToLower(context.FullLine)
 
 	// Quick negative keyword check (more important for false positive reduction)
-	for _, keyword := range v.negativeKeywords {
-		if strings.Contains(fullContext, keyword) {
-			return -100 // Very strong negative impact to ensure rejection
-		}
+	if v.negativeKeywordRegex != nil && v.negativeKeywordRegex.MatchString(fullContext) {
+		return -100 // Very strong negative impact to ensure rejection
 	}
 
 	// Quick positive keyword check
-	confidenceImpact := 0.0
-	for _, keyword := range v.positiveKeywords {
-		if strings.Contains(fullContext, keyword) {
-			confidenceImpact += 15 // Increased boost for positive context
-			break                  // Only count one positive keyword to avoid over-boosting
-		}
+	if v.positiveKeywordRegex != nil && v.positiveKeywordRegex.MatchString(fullContext) {
+		return 15 // Boost for positive context (single boost; avoid over-boosting)
 	}
 
-	return confidenceImpact
+	return 0.0
 }
 
 // buildContextInfo efficiently builds context information

--- a/internal/validators/creditcard/validator_test.go
+++ b/internal/validators/creditcard/validator_test.go
@@ -4,6 +4,7 @@
 package creditcard
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/awslabs/ferret-scan/internal/detector"
@@ -668,11 +669,14 @@ func TestCreditCardValidator_IsValidLength(t *testing.T) {
 		number string
 		valid  bool
 	}{
-		{"12345678901234", true},     // 14 digits (Diners)
-		{"123456789012345", true},    // 15 digits (Amex)
-		{"1234567890123456", true},   // 16 digits (standard)
-		{"1234567890123", false},     // 13 digits
-		{"12345678901234567", false}, // 17 digits
+		{"1234567890123", true},       // 13 digits (legacy Visa)
+		{"12345678901234", true},      // 14 digits (Diners)
+		{"123456789012345", true},     // 15 digits (Amex)
+		{"1234567890123456", true},    // 16 digits (standard)
+		{"4532015112830366123", true}, // 19 digits (ISO/IEC 7812 extended)
+		{"123456789012", false},       // 12 digits
+		{"12345678901234567", false},  // 17 digits
+		{"123456789012345678", false}, // 18 digits
 	}
 
 	for _, tt := range tests {
@@ -739,5 +743,186 @@ func TestCreditCardValidator_KnownTestPattern(t *testing.T) {
 				t.Errorf("isKnownTestPattern(%s) should return false", pattern)
 			}
 		})
+	}
+}
+
+// TestCreditCardValidator_AdjacentCards is a regression test for the
+// single-delimiter false negative: the pattern requires a delimiter on both
+// sides of the number, so a non-overlapping FindAll consumed the single
+// space/comma between two PANs and dropped every even-positioned card in a
+// dump/CSV. The manual scan now resumes from the end of the captured number, so
+// all adjacent cards are found (without duplicating a standalone card).
+func TestCreditCardValidator_AdjacentCards(t *testing.T) {
+	v := NewValidator()
+
+	multi := []struct {
+		name    string
+		content string
+		want    int
+	}{
+		{"space-separated triple", "credit cards: 4532015112830366 5425233430109903 6011111111111117", 3},
+		{"comma-separated triple", "4532015112830366,5425233430109903,6011111111111117", 3},
+		{"dash-formatted pair", "4532-0151-1283-0366 5425-2334-3010-9903", 2},
+	}
+	for _, tt := range multi {
+		t.Run(tt.name, func(t *testing.T) {
+			matches, err := v.ValidateContent(tt.content, "test.txt")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			distinct := map[string]int{}
+			for _, m := range matches {
+				distinct[v.cleanCreditCardNumber(m.Text)]++
+			}
+			if len(distinct) != tt.want {
+				t.Errorf("expected %d distinct cards, got %d (%v)", tt.want, len(distinct), distinct)
+			}
+			for card, n := range distinct {
+				if n > 1 {
+					t.Errorf("card %s detected %d times (should not duplicate)", card, n)
+				}
+			}
+		})
+	}
+
+	// A standalone card must still produce exactly one match.
+	single, err := v.ValidateContent("payment 4532015112830366 received", "test.txt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(single) != 1 {
+		t.Errorf("standalone card should produce exactly 1 match, got %d", len(single))
+	}
+}
+
+// TestCreditCardValidator_NegativeKeywordWordBoundary is a regression test for the
+// substring-keyword false negative: short negative keywords ("id", "tel", "sha")
+// matched inside ordinary words ("david", "hotel", "sha256") and forced a
+// Luhn-valid card's context impact to -100, dropping it entirely. Matching is now
+// on whole words, so these benign words must no longer suppress a real card, while
+// genuine negative keywords still do.
+func TestCreditCardValidator_NegativeKeywordWordBoundary(t *testing.T) {
+	validator := NewValidator()
+	const card = "4532015112830366" // Luhn-valid, not a known test pattern
+
+	// AnalyzeContext must NOT return the -100 rejection for these benign words
+	// that merely *contain* a negative keyword as a substring.
+	notSuppressed := []string{
+		"david paid with card " + card,   // "david" contains "id"; "paid"/"card" positive
+		"valid card " + card,             // "valid" contains "id"
+		"hotel charge to card " + card,   // "hotel" contains "tel"
+		"sha256 unrelated, card " + card, // "sha256" contains "sha"
+	}
+	for _, line := range notSuppressed {
+		impact := validator.AnalyzeContext(card, detector.ContextInfo{FullLine: line})
+		if impact <= -100 {
+			t.Errorf("benign word should not trigger -100 rejection for %q, got impact %.1f", line, impact)
+		}
+	}
+
+	// Genuine negative keywords (whole words) must still suppress.
+	suppressed := []string{
+		"order id: " + card,
+		"account number " + card,
+		"telephone " + card,
+		"md5 hash " + card,
+	}
+	for _, line := range suppressed {
+		impact := validator.AnalyzeContext(card, detector.ContextInfo{FullLine: line})
+		if impact > -100 {
+			t.Errorf("genuine negative keyword should still suppress for %q, got impact %.1f", line, impact)
+		}
+	}
+
+	// End-to-end: a Luhn-valid card in benign "david"/"hotel" context must now
+	// surface (it was previously dropped to zero confidence).
+	for _, line := range []string{
+		"customer david card on file " + card,
+		"hotel reservation card " + card,
+	} {
+		matches, err := validator.ValidateContent(line, "test.txt")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		found := false
+		for _, m := range matches {
+			if strings.Contains(m.Text, card) && m.Confidence > 15 {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected Luhn-valid card to surface for %q, got %d matches", line, len(matches))
+		}
+	}
+}
+
+// TestCreditCardValidator_EqualsColonDelimiters is a regression test for M4:
+// the delimiter classes omitted '=' and ':', so PANs in config / key=value /
+// key:value logs (the dominant leak format) were missed.
+func TestCreditCardValidator_EqualsColonDelimiters(t *testing.T) {
+	v := NewValidator()
+	for _, line := range []string{
+		"VISA=4532015112830366",
+		"cc:4532015112830366",
+		"card=4532015112830366 logged",
+		"config: pan:4532015112830366;",
+	} {
+		matches, err := v.ValidateContent(line, "test.txt")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(matches) == 0 {
+			t.Errorf("PAN after '='/':' should be detected for %q, got none", line)
+		}
+	}
+}
+
+// TestCreditCardValidator_ThirteenAndNineteenDigit is a regression test for M5:
+// legacy 13-digit Visa and 19-digit ISO/IEC 7812 PANs were not matched.
+func TestCreditCardValidator_ThirteenAndNineteenDigit(t *testing.T) {
+	v := NewValidator()
+	// Luhn-valid 13-digit and 19-digit PANs.
+	for _, line := range []string{
+		"card 4929000000006 here",          // 13-digit, Luhn-valid
+		"pan 4532015112830366120 recorded", // 19-digit, Luhn-valid
+	} {
+		matches, err := v.ValidateContent(line, "test.txt")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(matches) == 0 {
+			t.Errorf("13/19-digit PAN should be detected for %q, got none", line)
+		}
+	}
+}
+
+// TestCreditCardValidator_LongDigitRunNotCapped is a regression test for M3: a
+// Luhn-valid PAN with a run of 8-11 identical digits was hard-capped at
+// confidence 15 by the >=8-consecutive rule. The threshold is now 12, so a
+// genuine card with a long-but-not-degenerate run can surface above LOW.
+func TestCreditCardValidator_LongDigitRunNotCapped(t *testing.T) {
+	v := NewValidator()
+	// Luhn-valid Visa numbers with an 11-digit identical run, not known test cards.
+	for _, num := range []string{"4111111111110006", "4999999999990003"} {
+		if v.isKnownTestPattern(num) {
+			t.Fatalf("test fixture %s should not be a known test pattern", num)
+		}
+		if v.hasRepeatingPatterns(num) {
+			t.Errorf("%s (11-digit run) should no longer be flagged as a repeating pattern", num)
+		}
+		matches, _ := v.ValidateContent("payment credit card "+num+" charged", "test.txt")
+		if len(matches) == 0 || matches[0].Confidence <= 15 {
+			conf := -1.0
+			if len(matches) > 0 {
+				conf = matches[0].Confidence
+			}
+			t.Errorf("genuine PAN %s with payment context should exceed LOW cap, got %.1f", num, conf)
+		}
+	}
+
+	// All-same-digit and sequential junk must still be rejected/capped.
+	if !v.hasRepeatingPatterns("4444444444444444") {
+		t.Error("all-same-digit number should still be flagged as repeating")
 	}
 }

--- a/internal/validators/email/validator.go
+++ b/internal/validators/email/validator.go
@@ -712,6 +712,14 @@ func (v *Validator) isTestDomain(domain string) bool {
 			return true
 		}
 	}
+	// Non-routable / reserved pseudo-TLD suffixes (RFC 2606/6761) are dev-only
+	// and not real deliverable addresses (L8): treat them as test domains so
+	// user@host.local / .localhost / .test / .invalid don't surface at HIGH.
+	for _, suffix := range []string{".local", ".localhost", ".test", ".invalid", ".example"} {
+		if strings.HasSuffix(domain, suffix) {
+			return true
+		}
+	}
 	return false
 }
 
@@ -867,8 +875,11 @@ func (v *Validator) hasValidTLD(domain string) bool {
 		"wf": true, "ws": true, "ye": true, "yt": true, "za": true, "zm": true,
 		"zw": true,
 
-		// Special/testing domains (keep for compatibility)
-		"local": true, "localhost": true, "test": true,
+		// NOTE: the pseudo-TLDs "local", "localhost" and "test" are deliberately
+		// NOT in this set (L8). They are dev/non-routable suffixes (k8s manifests,
+		// /etc/hosts, .env files) and treating them as valid TLDs let
+		// user@host.local surface at HIGH. Excluding them routes such addresses
+		// through the small unknown-TLD penalty instead of full TLD validity.
 	}
 
 	parts := strings.Split(domain, ".")

--- a/internal/validators/email/validator.go
+++ b/internal/validators/email/validator.go
@@ -12,6 +12,42 @@ import (
 	"github.com/awslabs/ferret-scan/internal/observability"
 )
 
+// containsKeyword reports whether text contains keyword as a whole word/phrase,
+// case-insensitively. The previous code used strings.Contains, so short negative
+// keywords matched inside ordinary words — "bar" in "barack", "baz" in "bazaar",
+// "temp" in "temptation" — suppressing real emails (and short positives like
+// "to"/"info" spuriously boosting). Implemented as a plain string scan (a word
+// byte is [a-z0-9]) rather than a per-keyword regex to keep context analysis
+// cheap in the hot path.
+func containsKeyword(text, keyword string) bool {
+	if keyword == "" {
+		return false
+	}
+	lt := strings.ToLower(text)
+	lk := strings.ToLower(keyword)
+	for from := 0; from+len(lk) <= len(lt); {
+		i := strings.Index(lt[from:], lk)
+		if i < 0 {
+			return false
+		}
+		i += from
+		leftOK := i == 0 || !isEmailWordByte(lt[i-1])
+		right := i + len(lk)
+		rightOK := right >= len(lt) || !isEmailWordByte(lt[right])
+		if leftOK && rightOK {
+			return true
+		}
+		from = i + 1
+	}
+	return false
+}
+
+// isEmailWordByte reports whether b is a word character ([a-z0-9]) for keyword
+// boundary detection. text is already lowercased by the caller.
+func isEmailWordByte(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= '0' && b <= '9')
+}
+
 // Pre-compiled regex patterns to avoid repeated compilation in hot paths.
 var (
 	validCharsPattern      = regexp.MustCompile(`^[A-Za-z0-9._%+-]+$`)
@@ -136,9 +172,16 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 	re := v.regex
 
 	for lineNum, line := range lines {
-		foundMatches := re.FindAllString(line, -1)
+		// Use match offsets (not just the strings) so that when the same email
+		// text appears more than once on a line, each occurrence is analyzed with
+		// ITS OWN surrounding context. The previous code re-ran strings.Index,
+		// which always returned the first occurrence and mis-scored duplicates.
+		matchLocs := re.FindAllStringIndex(line, -1)
 
-		for _, match := range foundMatches {
+		for _, loc := range matchLocs {
+			matchIndex, matchEnd := loc[0], loc[1]
+			match := line[matchIndex:matchEnd]
+
 			// Calculate confidence
 			confidence, checks := v.CalculateConfidence(match)
 
@@ -150,24 +193,21 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 				FullLine: line,
 			}
 
-			// Extract context around the match in the line
-			matchIndex := strings.Index(line, match)
-			if matchIndex >= 0 {
-				start := matchIndex - 50
-				if start < 0 {
-					start = 0
-				}
-				end := matchIndex + len(match) + 50
-				if end > len(line) {
-					end = len(line)
-				}
-
-				contextInfo.BeforeText = line[start:matchIndex]
-				contextInfo.AfterText = line[matchIndex+len(match) : end]
+			// Extract context around THIS occurrence of the match.
+			start := matchIndex - 50
+			if start < 0 {
+				start = 0
 			}
+			end := matchEnd + 50
+			if end > len(line) {
+				end = len(line)
+			}
+			contextInfo.BeforeText = line[start:matchIndex]
+			contextInfo.AfterText = line[matchEnd:end]
 
-			// Analyze context and adjust confidence
-			contextImpact := v.AnalyzeContext(match, contextInfo)
+			// Analyze context and adjust confidence. The true after-match text is
+			// passed so the URL-structure check inspects this occurrence.
+			contextImpact := v.analyzeContextAt(match, contextInfo, line[matchEnd:])
 
 			// Check for tabular data and boost confidence
 			if v.isTabularData(contextInfo.FullLine, match) {
@@ -227,8 +267,22 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 	return matches, nil
 }
 
-// AnalyzeContext analyzes the context around a match and returns a confidence adjustment
+// AnalyzeContext analyzes the context around a match and returns a confidence
+// adjustment. It satisfies the detector.Validator interface; it derives the
+// after-match text from the first occurrence on the line (back-compat for
+// external callers). The scan loop calls analyzeContextAt directly with the
+// exact occurrence offset so duplicate matches are scored correctly.
 func (v *Validator) AnalyzeContext(match string, context detector.ContextInfo) float64 {
+	afterMatch := ""
+	if idx := strings.Index(context.FullLine, match); idx >= 0 {
+		afterMatch = context.FullLine[idx+len(match):]
+	}
+	return v.analyzeContextAt(match, context, afterMatch)
+}
+
+// analyzeContextAt is AnalyzeContext with the exact post-match text supplied by
+// the caller, so the URL-structure check inspects the correct occurrence.
+func (v *Validator) analyzeContextAt(match string, context detector.ContextInfo, afterMatch string) float64 {
 	// Combine all context text for analysis
 	var sb strings.Builder
 	sb.WriteString(context.BeforeText)
@@ -242,16 +296,16 @@ func (v *Validator) AnalyzeContext(match string, context detector.ContextInfo) f
 
 	// CRITICAL: Check for URL/URI structure first (highest priority)
 	// Any user@host pattern followed by :, /, or :// is a URL/URI, not an email
-	if v.hasURLStructure(match, context.FullLine) {
+	if hasURLStructureAfter(afterMatch) {
 		// This is a URL/URI (git@host:path, user@host/path, etc.), not an email
 		return -100 // Zero out confidence completely
 	}
 
-	// Check for positive keywords (increase confidence)
+	// Check for positive keywords (increase confidence). Whole-word matching only.
 	for _, keyword := range v.positiveKeywords {
-		if strings.Contains(fullContext, strings.ToLower(keyword)) {
+		if containsKeyword(fullContext, keyword) {
 			// Give more weight to keywords that are closer to the match
-			if strings.Contains(context.FullLine, strings.ToLower(keyword)) {
+			if containsKeyword(context.FullLine, keyword) {
 				confidenceImpact += 8 // +8% for keywords in the same line
 			} else {
 				confidenceImpact += 4 // +4% for keywords in surrounding context
@@ -259,11 +313,12 @@ func (v *Validator) AnalyzeContext(match string, context detector.ContextInfo) f
 		}
 	}
 
-	// Check for negative keywords (decrease confidence)
+	// Check for negative keywords (decrease confidence). Whole-word matching only,
+	// so "bar"/"baz"/"foo"/"temp" no longer fire inside barack/bazaar/temptation.
 	for _, keyword := range v.negativeKeywords {
-		if strings.Contains(fullContext, strings.ToLower(keyword)) {
+		if containsKeyword(fullContext, keyword) {
 			// Give more weight to keywords that are closer to the match
-			if strings.Contains(context.FullLine, strings.ToLower(keyword)) {
+			if containsKeyword(context.FullLine, keyword) {
 				confidenceImpact -= 20 // -20% for negative keywords in the same line
 			} else {
 				confidenceImpact -= 10 // -10% for negative keywords in surrounding context
@@ -293,7 +348,7 @@ func (v *Validator) findKeywords(context detector.ContextInfo, keywords []string
 
 	var found []string
 	for _, keyword := range keywords {
-		if strings.Contains(fullContext, strings.ToLower(keyword)) {
+		if containsKeyword(fullContext, keyword) {
 			found = append(found, keyword)
 		}
 	}
@@ -343,9 +398,14 @@ func (v *Validator) CalculateConfidence(match string) (float64, map[string]bool)
 			checks["not_test_email"] = false
 		}
 
-		// Check TLD validity - invalid TLDs should zero out confidence
+		// TLD recognition. The hardcoded list is incomplete (it omits many
+		// delegated gTLDs such as .amazon/.google/.aws/.phd), so a -100
+		// "zero it out" penalty silently dropped real emails on those TLDs.
+		// The regex already requires a 2+ alphabetic TLD, so an unrecognized
+		// TLD is only weak evidence of a fake address: apply a small penalty
+		// instead of suppressing the finding entirely.
 		if !v.hasValidTLD(domain) {
-			confidence -= 100 // Zero out confidence for fake TLDs
+			confidence -= 10
 			checks["valid_tld"] = false
 		}
 	}
@@ -875,17 +935,11 @@ func (v *Validator) isDebugEnabled() bool {
 	return os.Getenv("FERRET_DEBUG") != ""
 }
 
-// hasURLStructure checks if the match is actually a URL/URI, not an email
-// This uses structural analysis (what comes AFTER the match) rather than
-// keyword matching, making it future-proof and protocol-agnostic.
-func (v *Validator) hasURLStructure(match string, line string) bool {
-	matchIndex := strings.Index(line, match)
-	if matchIndex < 0 || matchIndex+len(match) >= len(line) {
-		return false // Can't analyze structure at end of line
-	}
-
-	// Get the characters immediately after the match
-	afterMatch := line[matchIndex+len(match):]
+// hasURLStructureAfter checks if the match is actually a URL/URI, not an email,
+// from the text that immediately follows the match. Taking afterMatch directly
+// (rather than re-running strings.Index on the line) ensures the correct
+// occurrence is analyzed when the same email text appears more than once.
+func hasURLStructureAfter(afterMatch string) bool {
 	if len(afterMatch) == 0 {
 		return false
 	}

--- a/internal/validators/email/validator_test.go
+++ b/internal/validators/email/validator_test.go
@@ -423,3 +423,30 @@ func TestEmailValidator_DuplicateOccurrenceContext(t *testing.T) {
 		t.Errorf("expected exactly 1 surfaced email (URL occurrence suppressed), got %d", len(matches))
 	}
 }
+
+// TestEmailValidator_PseudoTLDsGated is a regression test for L8: non-routable
+// reserved pseudo-TLDs (.local/.localhost/.test) were treated as valid TLDs, so
+// dev addresses like user@host.local surfaced at HIGH. They are now gated below
+// the HIGH bucket while real emails are unaffected.
+func TestEmailValidator_PseudoTLDsGated(t *testing.T) {
+	v := NewValidator()
+	best := func(line string) float64 {
+		matches, _ := v.ValidateContent(line, "test.txt")
+		var b float64
+		for _, m := range matches {
+			if m.Confidence > b {
+				b = m.Confidence
+			}
+		}
+		return b
+	}
+	for _, line := range []string{"user@db.local", "svc@api.localhost", "x@h.test"} {
+		if c := best(line); c >= 90 {
+			t.Errorf("L8: pseudo-TLD address %q should not reach HIGH, got %.1f", line, c)
+		}
+	}
+	// A real email on a routable TLD must still be HIGH.
+	if c := best("contact alice@realcompany.com"); c < 90 {
+		t.Errorf("L8: real email should stay HIGH, got %.1f", c)
+	}
+}

--- a/internal/validators/email/validator_test.go
+++ b/internal/validators/email/validator_test.go
@@ -1,6 +1,7 @@
 package email
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/awslabs/ferret-scan/internal/detector"
@@ -160,8 +161,6 @@ func TestEmailValidator_URLStructureDetection(t *testing.T) {
 }
 
 func TestEmailValidator_StructuralAnalysis(t *testing.T) {
-	validator := NewValidator()
-
 	tests := []struct {
 		match    string
 		line     string
@@ -184,10 +183,14 @@ func TestEmailValidator_StructuralAnalysis(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.match+" in "+tt.line, func(t *testing.T) {
-			result := validator.hasURLStructure(tt.match, tt.line)
+			afterMatch := ""
+			if idx := strings.Index(tt.line, tt.match); idx >= 0 {
+				afterMatch = tt.line[idx+len(tt.match):]
+			}
+			result := hasURLStructureAfter(afterMatch)
 			if result != tt.expected {
-				t.Errorf("hasURLStructure(%q, %q) = %v, want %v",
-					tt.match, tt.line, result, tt.expected)
+				t.Errorf("hasURLStructureAfter(%q) = %v, want %v",
+					afterMatch, result, tt.expected)
 			}
 		})
 	}
@@ -365,4 +368,58 @@ func TestEmailValidator_RegressionTests(t *testing.T) {
 			t.Errorf("Legitimate email should be detected")
 		}
 	})
+}
+
+// TestEmailValidator_DelegatedTLDs is a regression test for M13: real emails on
+// delegated gTLDs absent from the hardcoded allowlist (.amazon/.google/.aws)
+// were zeroed out by a -100 penalty and dropped. They must now surface.
+func TestEmailValidator_DelegatedTLDs(t *testing.T) {
+	v := NewValidator()
+	for _, line := range []string{
+		"contact user@brand.amazon today",
+		"mail x@team.google here",
+		"ping admin@svc.aws now",
+	} {
+		matches, err := v.ValidateContent(line, "test.txt")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(matches) == 0 {
+			t.Errorf("email on delegated TLD should be detected for %q, got none", line)
+		}
+	}
+}
+
+// TestEmailValidator_KeywordWordBoundary is a regression test for M14: negative
+// keywords matched as substrings ("bar" in "barack") suppressed real emails.
+func TestEmailValidator_KeywordWordBoundary(t *testing.T) {
+	v := NewValidator()
+	// "barack" contains "bar", "bazaar" contains "baz" — must not suppress.
+	for _, line := range []string{
+		"email barack@whitehouse.gov now",
+		"owner person@bazaar-trading.com replied",
+	} {
+		matches, err := v.ValidateContent(line, "test.txt")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(matches) == 0 {
+			t.Errorf("real email should not be suppressed by a substring keyword in %q", line)
+		}
+	}
+}
+
+// TestEmailValidator_DuplicateOccurrenceContext is a regression test for M15:
+// the same email text appearing twice on a line was always analyzed with the
+// first occurrence's context. Here one occurrence is a git URL (git@host:repo)
+// and one is a real email; only the real one should surface.
+func TestEmailValidator_DuplicateOccurrenceContext(t *testing.T) {
+	v := NewValidator()
+	matches, err := v.ValidateContent("mail git@github.com and clone git@github.com:repo", "test.txt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Errorf("expected exactly 1 surfaced email (URL occurrence suppressed), got %d", len(matches))
+	}
 }

--- a/internal/validators/intellectualproperty/validator.go
+++ b/internal/validators/intellectualproperty/validator.go
@@ -20,6 +20,26 @@ import (
 // on every call.
 var copyrightYearPattern = regexp.MustCompile(`\d{4}(-\d{4})?`)
 
+// openSourceLicenseMarkers are unambiguous indicators that a line/file is
+// openly licensed (or public domain), and therefore not a trade secret.
+var openSourceLicenseMarkers = []string{
+	"open source", "open-source", "public domain", "creative commons",
+	"mit license", "apache license", "apache-2.0", "bsd license",
+	"gpl", "lgpl", "mpl", "mozilla public license", "spdx-license-identifier",
+}
+
+// containsOpenSourceLicense reports whether the line carries a recognized
+// open-source / public-domain license marker (case-insensitive).
+func containsOpenSourceLicense(line string) bool {
+	lower := strings.ToLower(line)
+	for _, m := range openSourceLicenseMarkers {
+		if strings.Contains(lower, m) {
+			return true
+		}
+	}
+	return false
+}
+
 // leadingFlagGroup matches a genuine inline-flag group at the start of a regex —
 // (?i), (?im), (?-i), (?s:...) — but NOT a non-capturing group "(?:..." or a
 // named group "(?P<...". Used by ensureCaseInsensitive to decide whether a
@@ -942,6 +962,17 @@ func (v *Validator) detectPatternsByLine(content string, originalPath string) ma
 				// Analyze context and adjust confidence
 				contextImpact := v.AnalyzeContext(match, contextInfo)
 				confidence += contextImpact
+
+				// A recognized open-source / public-domain license marker on the
+				// line is decisive evidence the content is NOT a trade secret (L12):
+				// hard-cap a trade_secret finding below the 60 MEDIUM threshold so a
+				// file clearly marked MIT/Apache/GPL/"open source"/"public domain"
+				// does not emit a MEDIUM "Proprietary"/"Confidential" finding. The
+				// matched word and "license" are themselves positive keywords, so
+				// the per-keyword penalty alone could not reliably suppress these.
+				if ipType == "trade_secret" && containsOpenSourceLicense(line) && confidence > 45 {
+					confidence = 45
+				}
 
 				// Ensure confidence stays within bounds
 				if confidence > 100 {

--- a/internal/validators/intellectualproperty/validator.go
+++ b/internal/validators/intellectualproperty/validator.go
@@ -20,6 +20,12 @@ import (
 // on every call.
 var copyrightYearPattern = regexp.MustCompile(`\d{4}(-\d{4})?`)
 
+// leadingFlagGroup matches a genuine inline-flag group at the start of a regex —
+// (?i), (?im), (?-i), (?s:...) — but NOT a non-capturing group "(?:..." or a
+// named group "(?P<...". Used by ensureCaseInsensitive to decide whether a
+// user-supplied pattern already carries case flags.
+var leadingFlagGroup = regexp.MustCompile(`^\(\?[imsU-]+[):]`)
+
 // Validator implements the detector.Validator interface for detecting
 // intellectual property identifiers and references using regex patterns and contextual analysis.
 // Internal URL detection is configuration-driven and requires explicit pattern configuration.
@@ -172,14 +178,30 @@ func NewValidator() *Validator {
 	// #nosec G101 -- detector definitions: regex patterns and keyword lists
 	// for detecting IP markers (patents, trademarks, copyrights). Not credentials.
 	v := &Validator{
-		// Patent pattern: US patent numbers (e.g., US9123456, US 9,123,456) - case insensitive
-		patternPatent: `(?i)\b(US|EP|JP|CN|WO)[ -]?(\d{1,3}[,.]?\d{3}[,.]?\d{3}|\d{1,3}[,.]?\d{3}[,.]?\d{2}[A-Z]\d?)\b`,
+		// Patent pattern: patent-office numbers (e.g. US9123456, US 9,123,456).
+		// The prefix is CASE-SENSITIVE (office codes are uppercase): with the old
+		// (?i) flag, ordinary comma-grouped figures preceded by a lowercase
+		// "cn"/"jp"/"ep" token ("cn 100,000,000 yuan", "jp 123,456,789 yen")
+		// matched as patents. Dropping (?i) keeps real uppercase patents while
+		// excluding currency/quantity prose.
+		patternPatent: `\b(US|EP|JP|CN|WO)[ -]?(\d{1,3}[,.]?\d{3}[,.]?\d{3}|\d{1,3}[,.]?\d{3}[,.]?\d{2}[A-Z]\d?)\b`,
 
-		// Trademark pattern: ™, ®, or phrases like "TM" or "Registered Trademark" - case insensitive
-		patternTrademark: `(?i)\b(\w+\s*[™®]|\w+\s*\(TM\)|\w+\s*\(R\)|\w+\s+Trademark|\w+\s+Registered\s+Trademark)\b`,
+		// Trademark pattern: ™, ®, or phrases like "TM" or "Registered Trademark" - case insensitive.
+		// NOTE: the symbol/paren alternatives (™, ®, (TM), (R)) end in a non-word character,
+		// so a trailing \b can NEVER be satisfied after them (a word boundary needs a word char
+		// on one side). The previous pattern ended the whole group in \b, which made the symbol
+		// forms — the dominant real-world trademark markers — match nothing. The trailing \b is
+		// kept only on the "...Trademark" word forms so "Trademarked" can't partial-match.
+		patternTrademark: `(?i)\b(\w+\s*\(TM\)|\w+\s*\(R\)|\w+\s*[™®]|\w+\s+Registered\s+Trademark\b|\w+\s+Trademark\b)`,
 
-		// Copyright pattern: © or (c) followed by year and name - case insensitive
-		patternCopyright: `(?i)(©|\(c\)|\(C\)|Copyright|\bCopyright\b)\s*\d{4}[-,]?(\d{4})?\s+[A-Za-z0-9\s\.,]+`,
+		// Copyright pattern: © / (c) / "Copyright" marker, optionally followed by
+		// a year (or year range) and an entity. The year is now OPTIONAL and the
+		// entity class is broadened to include parentheses, ampersands,
+		// apostrophes, en/em dashes and Unicode letters. The previous pattern
+		// REQUIRED a 4-digit year + an ASCII-only name, so common real footers
+		// ("© 2024", "© 2024 — Acme", "© 2024 (Acme)", "© Acme Corporation",
+		// year-less "Copyright Acme Inc.") were all missed.
+		patternCopyright: `(?i)(©|\(c\)|Copyright)\s*(\d{4}([-,–—]\s?\d{4})?)?[\s,–—-]*[\p{L}0-9][\p{L}0-9\s\.,&'()\-–—]*`,
 
 		// Trade secret pattern: confidential markings and classifications - case insensitive
 		patternTradeSecret: `(?i)\b(Confidential|Trade\s+Secret|Proprietary|Company\s+Confidential|Internal\s+Use\s+Only|Restricted|Classified)\b`, // pragma: allowlist secret
@@ -463,14 +485,16 @@ func (v *Validator) applyIPPatternOverride(
 // ensureCaseInsensitive adds the case-insensitive flag (?i) to a regex pattern
 // if it doesn't already have case sensitivity flags
 func (v *Validator) ensureCaseInsensitive(pattern string) string {
-	// Check if pattern already has case sensitivity flags
-	// Look for (?i), (?-i), (?s), (?m), etc. at the beginning
-	if len(pattern) >= 4 && pattern[0] == '(' && pattern[1] == '?' {
-		// Pattern already has flags, don't modify
+	// Only treat the pattern as already-flagged when it begins with a genuine
+	// inline-flag group: (?flags) or (?flags:...) where flags are i/m/s/U (with
+	// an optional '-'). The previous check was just pattern[0]=='(' &&
+	// pattern[1]=='?', which also matched non-capturing groups "(?:..." and named
+	// groups "(?P<...", so a user override starting with one of those was left
+	// case-SENSITIVE despite the documented (?i) default — silently missing
+	// matches. Otherwise prepend (?i).
+	if leadingFlagGroup.MatchString(pattern) {
 		return pattern
 	}
-
-	// Add case-insensitive flag
 	return "(?i)" + pattern
 }
 
@@ -1136,15 +1160,23 @@ func (v *Validator) calculateCopyrightConfidence(match string, checks map[string
 	return confidence, checks
 }
 
-// calculateTradeSecretConfidence calculates confidence for trade secret matches
+// calculateTradeSecretConfidence calculates confidence for trade secret matches.
+//
+// Trade-secret markers split into two tiers. "Explicit" phrases are unambiguous
+// confidentiality statements (e.g. "Trade Secret", "Internal Use Only") and earn
+// a MEDIUM-capable base. The bare single generic words "Restricted", "Classified"
+// and "Proprietary" are common in ordinary English ("restricted area", "the data
+// is classified", "proprietary blend") and previously scored 70-80 (MEDIUM) with
+// no corroboration, a significant false-positive source. They now start below the
+// 60 MEDIUM threshold, so they only surface as MEDIUM when nearby positive context
+// keywords (added by AnalyzeContext) push them up.
 func (v *Validator) calculateTradeSecretConfidence(match string, checks map[string]bool) (float64, map[string]bool) {
-	confidence := 70.0 // Start slightly lower for trade secrets as they're more context-dependent
-
-	// Check for strong confidentiality markers
-	strongMarkers := []string{"Confidential", "Trade Secret", "Proprietary", "Company Confidential", "Privileged"}
-	for _, marker := range strongMarkers {
+	// Explicit, unambiguous confidentiality phrases keep a MEDIUM base.
+	explicitMarkers := []string{"Company Confidential", "Trade Secret", "Internal Use Only", "Confidential", "Privileged"}
+	confidence := 45.0 // bare generic words (Restricted/Classified/Proprietary) start below MEDIUM
+	for _, marker := range explicitMarkers {
 		if strings.Contains(match, marker) {
-			confidence += 10
+			confidence = 70.0
 			break
 		}
 	}

--- a/internal/validators/intellectualproperty/validator_test.go
+++ b/internal/validators/intellectualproperty/validator_test.go
@@ -713,3 +713,30 @@ func TestEnsureCaseInsensitive(t *testing.T) {
 		}
 	}
 }
+
+// TestTradeSecretSuppressedByOpenSourceLicense is a regression test for L12: a
+// trade-secret marker (Proprietary/Confidential/Trade Secret) on a line that
+// also carries a recognized open-source / public-domain license must be capped
+// below the MEDIUM threshold, since open licensing contradicts trade-secrecy.
+func TestTradeSecretSuppressedByOpenSourceLicense(t *testing.T) {
+	v := NewValidator()
+	tsConf := func(line string) float64 {
+		matches, _ := v.ValidateContent(line+"\n", "test.txt")
+		for _, m := range matches {
+			if mt, ok := m.Metadata["ip_type"]; ok && mt == "trade_secret" {
+				return m.Confidence
+			}
+		}
+		return -1
+	}
+	for _, line := range []string{
+		"Proprietary blend, MIT license applies",
+		"Confidential? No, this is open source",
+		"Trade Secret SPDX-License-Identifier: Apache-2.0",
+		"Proprietary algorithm released under the GPL",
+	} {
+		if c := tsConf(line); c >= 60 {
+			t.Errorf("L12: %q should be capped below MEDIUM with an OSS license present, got %.1f", line, c)
+		}
+	}
+}

--- a/internal/validators/intellectualproperty/validator_test.go
+++ b/internal/validators/intellectualproperty/validator_test.go
@@ -559,3 +559,157 @@ func TestConfigure_ValidPatternOverrideApplied(t *testing.T) {
 		t.Error("narrowed override should still match 'Trade Secret'")
 	}
 }
+
+// TestTrademarkSymbolForms is a regression test for the trailing-\b bug: the ™, ®,
+// (TM), and (R) markers — the dominant real-world trademark indicators — were never
+// detected because a trailing ASCII \b cannot follow a non-word character. The word
+// forms ("X Trademark") DID match, which is why earlier tests missed the gap.
+func TestTrademarkSymbolForms(t *testing.T) {
+	v := NewValidator()
+
+	// True positives that must now be detected.
+	positives := []string{
+		"Acme™",    // Acme™
+		"Acme®",    // Acme®
+		"Acme(TM)", // (TM)
+		"Acme(R)",  // (R)
+		"Use of Photoshop™ is governed by license.", // ™ mid-line
+		"the Windows® operating system",             // ® mid-line
+		"ProductName Trademark is registered.",      // word form (unchanged)
+		"FooBar Registered Trademark notice",        // registered word form
+	}
+	for _, line := range positives {
+		matches, err := v.ValidateContent(line+"\n", "test.txt")
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", line, err)
+		}
+		if !matchesContainIPType(matches, "trademark") {
+			t.Errorf("expected trademark detection for %q, got none", line)
+		}
+	}
+
+	// Must NOT false-match: no trademark marker present, and "Trademarked" must not
+	// partial-match the "...Trademark" word alternative (trailing \b on word forms).
+	negatives := []string{
+		"This is a normal line of code.",
+		"version 2.0 of the library",
+		"FooBar Trademarked goods are sold here", // 'Trademarked' != 'Trademark'
+	}
+	for _, line := range negatives {
+		matches, err := v.ValidateContent(line+"\n", "test.txt")
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", line, err)
+		}
+		if matchesContainIPType(matches, "trademark") {
+			t.Errorf("expected NO trademark detection for %q, but got one", line)
+		}
+	}
+}
+
+// tradeSecretConfidence returns the confidence of the first trade_secret match on
+// the line, or -1 if none was produced.
+func tradeSecretConfidence(t *testing.T, v *Validator, line string) float64 {
+	t.Helper()
+	matches, err := v.ValidateContent(line+"\n", "test.txt")
+	if err != nil {
+		t.Fatalf("unexpected error for %q: %v", line, err)
+	}
+	for _, m := range matches {
+		if mt, ok := m.Metadata["ip_type"]; ok && mt == "trade_secret" {
+			return m.Confidence
+		}
+	}
+	return -1
+}
+
+// TestTradeSecretBareWordScoring is a regression test for bare generic trade-secret
+// words surfacing at MEDIUM with no context. "Restricted"/"Classified"/"Proprietary"
+// used to score 70-80 (>=60 MEDIUM); they now start below 60 so they only reach
+// MEDIUM with corroborating context, while explicit confidentiality phrases stay
+// MEDIUM-capable. We still detect all of them (so nothing is lost at LOW), but the
+// bucket must differ.
+func TestTradeSecretBareWordScoring(t *testing.T) {
+	v := NewValidator()
+	const mediumThreshold = 60.0
+
+	// Bare generic words: detected, but BELOW the MEDIUM threshold without context.
+	bare := []string{"Restricted", "Classified", "Proprietary"}
+	for _, w := range bare {
+		conf := tradeSecretConfidence(t, v, "Status: "+w)
+		if conf < 0 {
+			t.Errorf("%q should still be detected (at LOW), got no trade_secret match", w)
+			continue
+		}
+		if conf >= mediumThreshold {
+			t.Errorf("bare %q should score below MEDIUM (%.0f) without context, got %.1f", w, mediumThreshold, conf)
+		}
+	}
+
+	// Explicit confidentiality phrases must remain MEDIUM-capable.
+	explicit := []string{"Trade Secret", "Company Confidential", "Internal Use Only", "Confidential"}
+	for _, w := range explicit {
+		conf := tradeSecretConfidence(t, v, "Notice: "+w)
+		if conf < mediumThreshold {
+			t.Errorf("explicit marker %q should stay MEDIUM (>=%.0f), got %.1f", w, mediumThreshold, conf)
+		}
+	}
+}
+
+// TestPatentPrefixCaseSensitive is a regression test for M28: the patent prefix
+// was case-insensitive, so lowercase currency/quantity figures ("cn 100,000,000
+// yuan") matched as patents. The prefix is now case-sensitive (office codes are
+// uppercase) while real uppercase patents still match.
+func TestPatentPrefixCaseSensitive(t *testing.T) {
+	v := NewValidator()
+	// Currency/quantity prose must NOT be a patent.
+	for _, line := range []string{"the cn 100,000,000 yuan", "jp 123,456,789 yen", "ep 12,345,678"} {
+		matches, _ := v.ValidateContent(line+"\n", "test.txt")
+		if matchesContainIPType(matches, "patent") {
+			t.Errorf("lowercase currency %q should not match as a patent", line)
+		}
+	}
+	// Real uppercase patents must still match.
+	for _, line := range []string{"US 9,123,456 patent", "filed EP1234567 today"} {
+		matches, _ := v.ValidateContent(line+"\n", "test.txt")
+		if !matchesContainIPType(matches, "patent") {
+			t.Errorf("real patent %q should be detected", line)
+		}
+	}
+}
+
+// TestCopyrightFooterVariants is a regression test for M29: copyright notices
+// without a year, with em-dash ranges, or with parenthesized/no-year entities
+// were missed because the pattern required a 4-digit year + ASCII-only name.
+func TestCopyrightFooterVariants(t *testing.T) {
+	v := NewValidator()
+	for _, line := range []string{
+		"© 2024",
+		"© 2024 — Acme",
+		"© 2024 (Acme)",
+		"© Acme Corporation",
+		"Copyright Acme Inc. All rights reserved",
+		"© 2020-2024 Example LLC",
+	} {
+		matches, _ := v.ValidateContent(line+"\n", "test.txt")
+		if !matchesContainIPType(matches, "copyright") {
+			t.Errorf("copyright footer %q should be detected", line)
+		}
+	}
+}
+
+// TestEnsureCaseInsensitive is a regression test for M30: non-capturing "(?:..."
+// and named "(?P<..." groups were mistaken for inline-flag groups, so a config
+// override starting with one was left case-sensitive instead of getting (?i).
+func TestEnsureCaseInsensitive(t *testing.T) {
+	v := NewValidator()
+	cases := map[string]bool{ // want (?i) prepended?
+		`(?:US\d+)`: true, `(?P<x>a)`: true, `plain`: true,
+		`(?i)foo`: false, `(?im)foo`: false, `(?-i)foo`: false, `(?s:.*)`: false,
+	}
+	for p, want := range cases {
+		got := v.ensureCaseInsensitive(p)
+		if (got != p) != want {
+			t.Errorf("ensureCaseInsensitive(%q)=%q, prepended=%v want=%v", p, got, got != p, want)
+		}
+	}
+}

--- a/internal/validators/ipaddress/validator.go
+++ b/internal/validators/ipaddress/validator.go
@@ -223,6 +223,9 @@ func NewValidator() *Validator {
 		"192.0.2.0/24",    // RFC 5737 TEST-NET-1
 		"198.51.100.0/24", // RFC 5737 TEST-NET-2
 		"203.0.113.0/24",  // RFC 5737 TEST-NET-3
+		"100.64.0.0/10",   // RFC 6598 carrier-grade NAT shared space (not end-user identifying)
+		"198.18.0.0/15",   // RFC 2544 benchmarking
+		"192.0.0.0/24",    // RFC 7335 IETF protocol assignments
 	} {
 		if _, network, err := net.ParseCIDR(cidr); err == nil {
 			v.nonSensitiveNets = append(v.nonSensitiveNets, network)
@@ -438,11 +441,12 @@ func (v *Validator) AnalyzeContext(match string, context detector.ContextInfo) f
 
 	var confidenceImpact float64 = 0
 
-	// Check for positive keywords (increase confidence)
+	// Check for positive keywords (increase confidence). Whole-word matching only,
+	// so short keywords ("ip"/"nat") don't fire inside "description"/"signature".
 	for _, keyword := range v.positiveKeywords {
-		if strings.Contains(fullContext, strings.ToLower(keyword)) {
+		if ipContainsKeyword(fullContext, keyword) {
 			// Give more weight to keywords that are closer to the match
-			if strings.Contains(context.FullLine, strings.ToLower(keyword)) {
+			if ipContainsKeyword(context.FullLine, keyword) {
 				confidenceImpact += 12 // +12% for keywords in the same line
 			} else {
 				confidenceImpact += 6 // +6% for keywords in surrounding context
@@ -450,11 +454,12 @@ func (v *Validator) AnalyzeContext(match string, context detector.ContextInfo) f
 		}
 	}
 
-	// Check for negative keywords (decrease confidence)
+	// Check for negative keywords (decrease confidence). Whole-word matching, so
+	// "null"/"bar"/"baz"/"temp" don't fire inside nullable/barometer/bazaar/template.
 	for _, keyword := range v.negativeKeywords {
-		if strings.Contains(fullContext, strings.ToLower(keyword)) {
+		if ipContainsKeyword(fullContext, keyword) {
 			// Give more weight to keywords that are closer to the match
-			if strings.Contains(context.FullLine, strings.ToLower(keyword)) {
+			if ipContainsKeyword(context.FullLine, keyword) {
 				confidenceImpact -= 30 // -30% for negative keywords in the same line
 			} else {
 				confidenceImpact -= 15 // -15% for negative keywords in surrounding context
@@ -484,7 +489,7 @@ func (v *Validator) findKeywords(context detector.ContextInfo, keywords []string
 
 	var found []string
 	for _, keyword := range keywords {
-		if strings.Contains(fullContext, strings.ToLower(keyword)) {
+		if ipContainsKeyword(fullContext, keyword) {
 			found = append(found, keyword)
 		}
 	}
@@ -630,14 +635,21 @@ func (v *Validator) cleanIPAddress(ip string) string {
 func (v *Validator) isTestIP(ip string) bool {
 	cleanIP := v.cleanIPAddress(ip)
 
-	// Check against known test patterns
+	// Single-host test/example addresses are matched by EXACT equality, not
+	// HasPrefix: a prefix test made "1.1.1.1" also match real public IPs like
+	// "1.1.1.10".."1.1.1.199" and "8.8.8.8" match "8.8.8.88", silently dropping
+	// genuine addresses (L15). Multi-host /24 prefixes keep HasPrefix below.
 	for _, pattern := range v.knownTestPatterns {
-		if strings.HasPrefix(cleanIP, pattern) {
+		if strings.HasSuffix(pattern, ".") {
+			if strings.HasPrefix(cleanIP, pattern) {
+				return true
+			}
+		} else if cleanIP == pattern {
 			return true
 		}
 	}
 
-	// RFC 5737 test ranges
+	// RFC 5737 test ranges (/24 prefixes)
 	testRanges := []string{
 		"192.0.2.",    // TEST-NET-1
 		"198.51.100.", // TEST-NET-2
@@ -826,6 +838,19 @@ func (v *Validator) isEmbeddedInString(match, line string) bool {
 		if (charAfter >= 'a' && charAfter <= 'z') ||
 			(charAfter >= 'A' && charAfter <= 'Z') ||
 			(charAfter >= '0' && charAfter <= '9') {
+			return true
+		}
+	}
+
+	// For a dotted-decimal IPv4 match, a '.' immediately before or after means the
+	// match is the leading/trailing four octets of a LONGER dotted sequence (e.g.
+	// "40.71.74.0" extracted from "40.71.74.0.99") — not a standalone IP. The
+	// previous alnum-only check missed this because '.' is not alphanumeric.
+	if strings.Contains(match, ".") && !strings.Contains(match, ":") {
+		if matchIndex > 0 && line[matchIndex-1] == '.' {
+			return true
+		}
+		if matchEnd < len(line) && line[matchEnd] == '.' {
 			return true
 		}
 	}

--- a/internal/validators/ipaddress/validator.go
+++ b/internal/validators/ipaddress/validator.go
@@ -13,6 +13,47 @@ import (
 	"github.com/awslabs/ferret-scan/internal/observability"
 )
 
+// Structural signals that a dotted-decimal token is being used as a network
+// address rather than (say) a software version: a trailing port (":8080") or
+// CIDR suffix ("/24").
+var (
+	rePortSuffix = regexp.MustCompile(`^:\d{1,5}\b`)
+	reCIDRSuffix = regexp.MustCompile(`^/\d{1,2}\b`)
+)
+
+// ipContainsKeyword reports whether text contains keyword as a whole word,
+// case-insensitively. Whole-word matching avoids "ip"/"nat" firing inside
+// unrelated words. Implemented as a plain string scan (not a regex) to keep the
+// per-match context check cheap; a word byte is [a-z0-9].
+func ipContainsKeyword(text, keyword string) bool {
+	if keyword == "" {
+		return false
+	}
+	lt := strings.ToLower(text)
+	lk := strings.ToLower(keyword)
+	for from := 0; from+len(lk) <= len(lt); {
+		i := strings.Index(lt[from:], lk)
+		if i < 0 {
+			return false
+		}
+		i += from
+		leftOK := i == 0 || !isIPWordByte(lt[i-1])
+		right := i + len(lk)
+		rightOK := right >= len(lt) || !isIPWordByte(lt[right])
+		if leftOK && rightOK {
+			return true
+		}
+		from = i + 1
+	}
+	return false
+}
+
+// isIPWordByte reports whether b is a word character ([a-z0-9]) for keyword
+// boundary detection. text is already lowercased by the caller.
+func isIPWordByte(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= '0' && b <= '9')
+}
+
 // Validator implements the detector.Validator interface for detecting
 // IP addresses using regex patterns and contextual analysis.
 type Validator struct {
@@ -37,6 +78,11 @@ type Validator struct {
 	privateNetworks  []*net.IPNet
 	reservedNetworks []*net.IPNet
 	multicastNetwork *net.IPNet
+	// nonSensitiveNets holds ranges that should never be reported (documentation,
+	// link-local, ULA, loopback, APIPA). Membership is tested via net.IPNet so
+	// that zero-padding and "::" compression are normalized — a textual prefix
+	// check missed the canonical RFC 3849 form 2001:0db8:... written zero-padded.
+	nonSensitiveNets []*net.IPNet
 
 	// Observability
 	observer *observability.StandardObserver
@@ -110,8 +156,31 @@ func NewValidator() *Validator {
 			description: "Full IPv6 address",
 		},
 		{
-			name:        "IPv6_Compressed",
-			regex:       regexp.MustCompile(`\b(?:[0-9a-fA-F]{1,4}:)*::(?:[0-9a-fA-F]{1,4}:)*[0-9a-fA-F]{1,4}\b`),
+			name: "IPv6_Compressed",
+			// Compressed IPv6 (with a "::" run). The previous pattern
+			// `\b(?:hex:)*::(?:hex:)*hex\b` was broken for FindString: the
+			// leading \b plus a greedy prefix meant that for an address like
+			// "2606:4700:4700::1111" RE2's leftmost-first matcher anchored at
+			// the "::" and captured only the "::1111" fragment, which the
+			// isEmbeddedInString guard (alnum char immediately before "::")
+			// then discarded — so virtually all real public IPv6 was missed.
+			//
+			// This is the canonical compressed-form alternation, ordered by
+			// POST-"::" group count DESCENDING so leftmost-first selects the
+			// form capturing the most trailing groups (otherwise a
+			// 1-trailing-group form truncates "2001:db8::ff00:42:8329"). No
+			// surrounding \b: the boundary is handled by isEmbeddedInString,
+			// and any over-match is rejected downstream by net.ParseIP in
+			// isSensitiveIP (unparseable IPs are dropped), so the broader
+			// pattern cannot introduce false positives.
+			regex: regexp.MustCompile(`(?:[0-9A-Fa-f]{1,4}:){1,2}(?::[0-9A-Fa-f]{1,4}){1,5}` +
+				`|(?:[0-9A-Fa-f]{1,4}:){1,3}(?::[0-9A-Fa-f]{1,4}){1,4}` +
+				`|(?:[0-9A-Fa-f]{1,4}:){1,4}(?::[0-9A-Fa-f]{1,4}){1,3}` +
+				`|(?:[0-9A-Fa-f]{1,4}:){1,5}(?::[0-9A-Fa-f]{1,4}){1,2}` +
+				`|(?:[0-9A-Fa-f]{1,4}:){1,6}:[0-9A-Fa-f]{1,4}` +
+				`|[0-9A-Fa-f]{1,4}:(?::[0-9A-Fa-f]{1,4}){1,6}` +
+				`|(?:[0-9A-Fa-f]{1,4}:){1,7}:` +
+				`|:(?::[0-9A-Fa-f]{1,4}){1,7}`),
 			version:     "IPv6",
 			description: "Compressed IPv6 address with ::",
 		},
@@ -143,6 +212,22 @@ func NewValidator() *Validator {
 		}
 	}
 	_, v.multicastNetwork, _ = net.ParseCIDR("224.0.0.0/4")
+
+	// Non-sensitive ranges, parsed so zero-padded / compressed forms are matched.
+	for _, cidr := range []string{
+		"2001:db8::/32",   // RFC 3849 IPv6 documentation
+		"fe80::/10",       // IPv6 link-local
+		"fc00::/7",        // IPv6 unique local (ULA)
+		"::1/128",         // IPv6 loopback
+		"169.254.0.0/16",  // IPv4 APIPA / link-local
+		"192.0.2.0/24",    // RFC 5737 TEST-NET-1
+		"198.51.100.0/24", // RFC 5737 TEST-NET-2
+		"203.0.113.0/24",  // RFC 5737 TEST-NET-3
+	} {
+		if _, network, err := net.ParseCIDR(cidr); err == nil {
+			v.nonSensitiveNets = append(v.nonSensitiveNets, network)
+		}
+	}
 
 	return v
 }
@@ -188,7 +273,24 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 
 	// Process each pattern type
 	for lineNum, line := range lines {
+		// Cheap per-line fast paths: every IPv6 form needs a ":" and the
+		// compressed form additionally needs a "::". Skipping the (multi-branch)
+		// IPv6 regexes on lines that cannot possibly contain such an address
+		// avoids the bulk of their cost on ordinary text without changing any
+		// match result.
+		hasColon := strings.Contains(line, ":")
+		hasDoubleColon := strings.Contains(line, "::")
+
 		for _, pattern := range v.patterns {
+			if pattern.version == "IPv6" {
+				if !hasColon {
+					continue
+				}
+				if pattern.name == "IPv6_Compressed" && !hasDoubleColon {
+					continue
+				}
+			}
+
 			foundMatches := pattern.regex.FindAllString(line, -1)
 
 			for _, match := range foundMatches {
@@ -232,6 +334,23 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 				// Analyze context and adjust confidence
 				contextImpact := v.AnalyzeContext(match, contextInfo)
 				confidence += contextImpact
+
+				// A bare dotted-decimal IPv4 with no corroborating signal is
+				// ambiguous: software versions (5.4.36.180), pi digits
+				// (3.14.15.92) and arbitrary numeric tuples are structurally
+				// identical to a routable IP, and previously scored 100 (HIGH)
+				// because the base is 100 + a +10 public boost. The same applies
+				// to a FULL-form 8-group IPv6 with no "::" — a MAC-like or random
+				// hex tuple (12:34:56:78:90:ab:cd:ef) parses as valid IPv6 and
+				// scored 100. Cap such context-free matches below HIGH so they
+				// surface as MEDIUM unless an IP keyword or structural signal
+				// (port, CIDR) is present. A compressed IPv6 (contains "::") is
+				// unambiguous and is left untouched.
+				ambiguousShape := pattern.version == "IPv4" ||
+					(pattern.name == "IPv6_Full" && !strings.Contains(match, "::"))
+				if ambiguousShape && confidence >= 90 && !v.hasIPContextSignal(match, contextInfo.FullLine) {
+					confidence = 75
+				}
 
 				// Ensure confidence stays within bounds
 				if confidence > 100 {
@@ -629,22 +748,14 @@ func (v *Validator) isSensitiveIP(ip string) bool {
 		return false
 	}
 
-	// Skip documentation IP ranges (RFC 5737)
-	documentationRanges := []string{
-		"192.0.2.",    // TEST-NET-1
-		"198.51.100.", // TEST-NET-2
-		"203.0.113.",  // TEST-NET-3
-	}
-
-	for _, docRange := range documentationRanges {
-		if strings.HasPrefix(ip, docRange) {
+	// Skip documentation / link-local / ULA / loopback / APIPA ranges. Tested via
+	// pre-parsed net.IPNet membership so zero-padded ("2001:0db8:...") and
+	// "::"-compressed forms are normalized — a textual prefix check missed the
+	// canonical zero-padded RFC 3849 documentation address.
+	for _, network := range v.nonSensitiveNets {
+		if network.Contains(parsedIP) {
 			return false
 		}
-	}
-
-	// Skip IPv6 documentation prefix (RFC 3849)
-	if strings.HasPrefix(strings.ToLower(ip), "2001:db8:") {
-		return false
 	}
 
 	// Skip localhost variations
@@ -652,23 +763,8 @@ func (v *Validator) isSensitiveIP(ip string) bool {
 		return false
 	}
 
-	// Skip link-local addresses
-	if strings.HasPrefix(ip, "169.254.") {
-		return false
-	}
-
-	// Skip APIPA (Automatic Private IP Addressing) range
-	_, apipaNet, _ := net.ParseCIDR("169.254.0.0/16")
-	if apipaNet != nil && apipaNet.Contains(parsedIP) {
-		return false
-	}
-
-	// Skip IPv6 link-local addresses (fe80::/10)
-	if strings.HasPrefix(strings.ToLower(ip), "fe80:") {
-		return false
-	}
-
-	// Skip IPv6 unique local addresses (fc00::/7)
+	// Skip IPv6 unique local addresses written fd.. (covered by fc00::/7 above,
+	// but keep the textual guard for any non-parsing edge form)
 	if strings.HasPrefix(strings.ToLower(ip), "fc") || strings.HasPrefix(strings.ToLower(ip), "fd") {
 		return false
 	}
@@ -681,6 +777,26 @@ func (v *Validator) isSensitiveIP(ip string) bool {
 	// At this point, the IP appears to be a public, routable IP address
 	// that could potentially be sensitive/identifying
 	return true
+}
+
+// hasIPContextSignal reports whether the line carries a corroborating signal
+// that `match` is a network address rather than an incidental dotted-decimal
+// number (a version, build tag, or numeric tuple). A signal is either an IP
+// context keyword on the line (host/server/endpoint/...) or a structural suffix
+// immediately after the address — a port (":8080") or CIDR ("/24").
+func (v *Validator) hasIPContextSignal(match, line string) bool {
+	for _, kw := range v.positiveKeywords {
+		if ipContainsKeyword(line, kw) {
+			return true
+		}
+	}
+	if idx := strings.Index(line, match); idx >= 0 {
+		after := line[idx+len(match):]
+		if rePortSuffix.MatchString(after) || reCIDRSuffix.MatchString(after) {
+			return true
+		}
+	}
+	return false
 }
 
 // isEmbeddedInString checks if an IP address match is embedded within a longer alphanumeric string

--- a/internal/validators/ipaddress/validator_test.go
+++ b/internal/validators/ipaddress/validator_test.go
@@ -902,3 +902,51 @@ func TestIPAddressValidator_FullFormHexTupleNotHigh(t *testing.T) {
 		t.Errorf("compressed public IPv6 with context should stay HIGH, got %.1f", best)
 	}
 }
+
+// TestIPAddressValidator_LowSeverityFindings covers four LOW-severity fixes:
+// L13 5+-octet dotted sequences don't leak their leading IPv4; L14 CGNAT /
+// benchmark ranges are non-sensitive; L15 single-host test IPs match exactly
+// (not by prefix); L16 context keywords match whole words.
+func TestIPAddressValidator_LowSeverityFindings(t *testing.T) {
+	v := NewValidator()
+
+	// L13: a 5+-octet dotted sequence must not surface its leading four octets.
+	if m, _ := v.ValidateContent("ref 40.71.74.0.99 here", "test.txt"); len(m) > 0 {
+		t.Errorf("L13: 5-octet sequence should not yield an IP match, got %d", len(m))
+	}
+
+	// L14: CGNAT (RFC 6598) and benchmarking (RFC 2544) are not sensitive.
+	for _, line := range []string{"host 100.64.1.1 connected", "bench 198.18.0.5 ran"} {
+		if m, _ := v.ValidateContent(line, "test.txt"); len(m) > 0 {
+			t.Errorf("L14: non-sensitive range in %q should be filtered, got %d", line, len(m))
+		}
+	}
+
+	// L15: a real public IP adjacent to a single-host test IP value must still
+	// surface (prefix matching previously suppressed 1.1.1.10-1.1.1.199 etc.).
+	if v.isTestIP("8.8.8.88") {
+		t.Error("L15: 8.8.8.88 is a real IP, not the test host 8.8.8.8")
+	}
+	if v.isTestIP("1.1.1.123") {
+		t.Error("L15: 1.1.1.123 is a real IP, not the test host 1.1.1.1")
+	}
+	// The exact test hosts are still classified as test IPs.
+	for _, ip := range []string{"1.1.1.1", "8.8.8.8"} {
+		if !v.isTestIP(ip) {
+			t.Errorf("L15: %s should still be a known test IP", ip)
+		}
+	}
+
+	// L16: a public IP near prose containing a substring of a negative keyword
+	// ("nullable" contains "null") should not be demoted out of HIGH.
+	matches, _ := v.ValidateContent("the nullable server 13.52.11.22 responded", "test.txt")
+	var best float64
+	for _, m := range matches {
+		if m.Confidence > best {
+			best = m.Confidence
+		}
+	}
+	if best < 90 {
+		t.Errorf("L16: 'nullable' should not demote a real IP below HIGH, got %.1f", best)
+	}
+}

--- a/internal/validators/ipaddress/validator_test.go
+++ b/internal/validators/ipaddress/validator_test.go
@@ -728,3 +728,177 @@ func TestIPAddressValidator_IsMulticastIP(t *testing.T) {
 		})
 	}
 }
+
+// TestIPAddressValidator_BareIPv4ContextSignal is a regression test for the
+// IPv4 over-matching false positive: a context-free dotted-decimal that happens
+// to be a routable public IPv4 (a software version "5.4.36.180", pi digits
+// "3.14.15.92", an arbitrary tuple "11.22.33.44") scored 100 (HIGH). Such bare
+// IPv4 with no corroborating signal is now capped below HIGH, while a real IP
+// carrying an IP keyword or a port/CIDR suffix stays HIGH.
+func TestIPAddressValidator_BareIPv4ContextSignal(t *testing.T) {
+	v := NewValidator()
+
+	// No IP context: must surface BELOW the HIGH (>=90) bucket.
+	bare := []string{
+		"upgraded to 5.4.36.180 today",
+		"tuple 11.22.33.44 in the dataset",
+		"pi digits 3.14.15.92 approx",
+	}
+	for _, line := range bare {
+		matches, err := v.ValidateContent(line, "test.txt")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, m := range matches {
+			if m.Confidence >= 90 {
+				t.Errorf("context-free dotted-decimal in %q should be < HIGH, got %.1f", line, m.Confidence)
+			}
+		}
+	}
+
+	// Corroborating signal present (keyword or port/CIDR): must stay HIGH.
+	withSignal := []string{
+		"connection to server 172.217.14.206 established", // keyword "server"
+		"network endpoint 54.239.28.85 configured",        // keyword "endpoint"/"network"
+		"backend 13.52.11.22:8080 responded",              // port suffix
+		"route 13.52.11.22/24 added",                      // CIDR suffix
+	}
+	for _, line := range withSignal {
+		matches, err := v.ValidateContent(line, "test.txt")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(matches) == 0 {
+			t.Errorf("expected detection for %q", line)
+			continue
+		}
+		var best float64
+		for _, m := range matches {
+			if m.Confidence > best {
+				best = m.Confidence
+			}
+		}
+		if best < 90 {
+			t.Errorf("IP with corroborating signal in %q should stay HIGH, got %.1f", line, best)
+		}
+	}
+}
+
+// TestIPAddressValidator_CompressedIPv6 is a regression test for the compressed-IPv6
+// matching bug: the old pattern captured only the "::suffix" fragment of a real
+// compressed address (e.g. "::1111" out of "2606:4700:4700::1111"), which the
+// embedded-string guard then dropped, so essentially all public IPv6 was missed.
+// We assert the FULL address is detected (not a truncated fragment) and that
+// non-IPv6 "::" constructs and IPv6 documentation ranges are not surfaced.
+func TestIPAddressValidator_CompressedIPv6(t *testing.T) {
+	v := NewValidator()
+
+	// Real public compressed IPv6 — must be detected, and the reported Text must
+	// be the entire address (the bug truncated it to a fragment).
+	publicV6 := []string{
+		"2606:4700:4700::1111",     // Cloudflare
+		"2a00:1450:4001:81b::200e", // Google
+		"2001:4860:4860::8888",     // Google DNS
+		"2607:f8b0:4005:80b::200e",
+	}
+	for _, ip := range publicV6 {
+		content := "connecting to host " + ip + " over ipv6"
+		matches, err := v.ValidateContent(content, "test.txt")
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", ip, err)
+		}
+		found := false
+		for _, m := range matches {
+			if m.Text == ip {
+				found = true
+				break
+			}
+		}
+		if !found {
+			got := make([]string, 0, len(matches))
+			for _, m := range matches {
+				got = append(got, m.Text)
+			}
+			t.Errorf("expected full compressed IPv6 %q to be detected, got matches %v", ip, got)
+		}
+	}
+
+	// Must NOT surface: non-IPv6 "::" tokens (code/namespace separators) and the
+	// IPv6 documentation prefix 2001:db8::/32 (RFC 3849), which isSensitiveIP filters.
+	negatives := []struct {
+		name    string
+		content string
+	}{
+		{"C++ scope resolution", "calling std::vector::push_back here"},
+		{"AWS CFN resource type", "Type: AWS::EC2::Instance in template"},
+		{"IPv6 documentation prefix", "example 2001:db8::ff00:42:8329 from the RFC"},
+	}
+	for _, tt := range negatives {
+		t.Run(tt.name, func(t *testing.T) {
+			matches, err := v.ValidateContent(tt.content, "test.txt")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(matches) > 0 {
+				got := make([]string, 0, len(matches))
+				for _, m := range matches {
+					got = append(got, m.Text)
+				}
+				t.Errorf("expected no IPv6 detection for %q, got %v", tt.content, got)
+			}
+		})
+	}
+}
+
+// TestIPAddressValidator_DocIPv6ZeroPadded is a regression test for M16: the
+// RFC 3849 documentation prefix was filtered by a textual "2001:db8:" prefix
+// check, which missed the canonical zero-padded form "2001:0db8:...". Now
+// filtered via parsed net.IPNet membership.
+func TestIPAddressValidator_DocIPv6ZeroPadded(t *testing.T) {
+	v := NewValidator()
+	for _, line := range []string{
+		"doc 2001:0db8:85a3:0000:0000:8a2e:0370:7334 here", // zero-padded
+		"compressed 2001:db8::1 here",                      // canonical compressed
+	} {
+		matches, err := v.ValidateContent(line, "test.txt")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(matches) > 0 {
+			t.Errorf("RFC 3849 documentation IPv6 should be filtered for %q, got %d matches", line, len(matches))
+		}
+	}
+}
+
+// TestIPAddressValidator_FullFormHexTupleNotHigh is a regression test for M17:
+// a full-form 8-group hex tuple (MAC-like or arbitrary hex) parses as valid
+// IPv6 and scored 100 with no context. It must now be capped below HIGH, while
+// a compressed public IPv6 with context stays HIGH.
+func TestIPAddressValidator_FullFormHexTupleNotHigh(t *testing.T) {
+	v := NewValidator()
+	for _, line := range []string{
+		"mac 12:34:56:78:90:ab:cd:ef here",
+		"hex 2024:1234:5678:90ab:cdef:1111:2222:3333 token",
+	} {
+		matches, err := v.ValidateContent(line, "test.txt")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, m := range matches {
+			if m.Confidence >= 90 {
+				t.Errorf("context-free full-form hex tuple should be < HIGH for %q, got %.1f", line, m.Confidence)
+			}
+		}
+	}
+	// Compressed public IPv6 with a keyword stays HIGH.
+	matches, _ := v.ValidateContent("endpoint 2606:4700:4700::1111 online", "test.txt")
+	var best float64
+	for _, m := range matches {
+		if m.Confidence > best {
+			best = m.Confidence
+		}
+	}
+	if best < 90 {
+		t.Errorf("compressed public IPv6 with context should stay HIGH, got %.1f", best)
+	}
+}

--- a/internal/validators/metadata/metadata_validator.go
+++ b/internal/validators/metadata/metadata_validator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/awslabs/ferret-scan/internal/validators"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 )
@@ -50,7 +51,26 @@ var (
 	// version number (e.g. "Software: Adobe Photoshop 21.0").
 	gpsCoordRefPattern   = regexp.MustCompile(`(?i)[+-]?\d{1,3}\.\d+\s*°?\s*[NSEW]\b`)
 	versionNumberPattern = regexp.MustCompile(`^\d+(\.\d+)*$`)
+	// leadingDecimalPattern extracts a leading signed decimal from a coordinate
+	// value that may carry a trailing degree symbol / hemisphere ref.
+	leadingDecimalPattern = regexp.MustCompile(`^[+-]?\d+(?:\.\d+)?`)
 )
+
+// parseCoordinate extracts the leading signed decimal from a coordinate string
+// (e.g. "40.7128", "40.7128° N") and returns it with ok=true. ok is false when
+// no leading numeric value is present (e.g. a DMS string or placeholder text),
+// in which case the caller treats the value as unparseable rather than invalid.
+func parseCoordinate(s string) (float64, bool) {
+	m := leadingDecimalPattern.FindString(strings.TrimSpace(s))
+	if m == "" {
+		return 0, false
+	}
+	f, err := strconv.ParseFloat(m, 64)
+	if err != nil {
+		return 0, false
+	}
+	return f, true
+}
 
 // ValidationRule defines validation rules for specific preprocessor types
 type ValidationRule struct {
@@ -1542,20 +1562,56 @@ func (v *Validator) getGPSDetectionReason(line string) string {
 // isVersionNumber checks if a line contains only a version number (not sensitive)
 func (v *Validator) isVersionNumber(line string) bool {
 	// Check for version number patterns like "15.0000", "1.0", "2.1.3", etc.
-	// These are typically software versions and not sensitive information
+	// These are typically software versions and not sensitive information.
 	lineLower := strings.ToLower(strings.TrimSpace(line))
 
-	// If the line contains a colon, extract the value part
+	// If the line contains a colon, extract the key and value parts.
 	if strings.Contains(line, ":") {
 		parts := strings.SplitN(line, ":", 2)
 		if len(parts) == 2 {
+			key := strings.ToLower(strings.TrimSpace(parts[0]))
 			value := strings.TrimSpace(parts[1])
-			return versionNumberPattern.MatchString(value)
+			if !versionNumberPattern.MatchString(value) {
+				return false
+			}
+			// Only treat a numeric value as a version when the field key is
+			// version-related, OR the value is short and version-shaped (L18).
+			// A bare long all-digit value in a NAME/AUTHOR/COPYRIGHT/MANAGER
+			// field is far more likely a numeric ID/phone than a version, and
+			// suppressing it hid real metadata.
+			return isVersionishKey(key) || isVersionShapedValue(value)
 		}
 	}
 
-	// Check if the entire line is just a version number
-	return versionNumberPattern.MatchString(lineLower)
+	// A bare line with no key: only a short, dotted, version-shaped value counts.
+	return versionNumberPattern.MatchString(lineLower) && isVersionShapedValue(lineLower)
+}
+
+// isVersionishKey reports whether a metadata field key denotes a software version.
+func isVersionishKey(key string) bool {
+	for _, k := range []string{"version", "ver.", "ver ", "software", "application", "app", "build", "revision", "release", "schema", "format"} {
+		if strings.Contains(key, k) {
+			return true
+		}
+	}
+	return false
+}
+
+// isVersionShapedValue reports whether a numeric value looks like a version
+// rather than an ID: at most 3 dotted groups (e.g. "1", "1.0", "2.1.3") and a
+// short first component. A long undotted integer ("1234567890") is treated as
+// an ID, not a version.
+func isVersionShapedValue(value string) bool {
+	groups := strings.Split(value, ".")
+	if len(groups) > 4 {
+		return false
+	}
+	if len(groups) == 1 {
+		// A bare integer is only "version-shaped" if it is short (<=2 digits).
+		return len(groups[0]) <= 2
+	}
+	// Dotted form: first component should be a small number (<=4 digits).
+	return len(groups[0]) <= 4
 }
 
 // hasNonEmptyValue checks if a metadata field has non-empty content after the colon
@@ -2405,14 +2461,32 @@ func (v *Validator) combineGPSCoordinates(gpsCoordinates map[string]string, gpsL
 			combinedText = fmt.Sprintf("%s, %s", latitude, longitude)
 		}
 
+		// Validate the coordinate pair (L17): reject 0/0 (Null Island / unset GPS)
+		// and out-of-range values rather than always scoring 100. Confidence is
+		// scaled by parse validity so a syntactically valid in-range pair stays
+		// HIGH while a malformed/placeholder pair drops out.
+		latVal, latOK := parseCoordinate(latitude)
+		longVal, longOK := parseCoordinate(longitude)
+		if latOK && longOK {
+			if (latVal == 0 && longVal == 0) ||
+				latVal < -90 || latVal > 90 || longVal < -180 || longVal > 180 {
+				return matches // not a real location; skip emitting a GPS pair
+			}
+		}
+
 		// Use the earlier line number
 		lineNumber := latLine
 		if longLine < latLine && longLine > 0 {
 			lineNumber = longLine
 		}
 
-		// Calculate confidence for combined coordinates
-		confidence := 1.0 // High confidence for coordinate pairs
+		// Calculate confidence for combined coordinates. A pair that parsed to a
+		// valid in-range decimal is high confidence; one we could not parse (DMS
+		// strings, unusual formats) is still emitted but slightly lower.
+		confidence := 1.0
+		if !latOK || !longOK {
+			confidence = 0.75
+		}
 		checks := map[string]bool{
 			"contains_coordinate_pair": true,
 			"contains_gps_coords":      true,

--- a/internal/validators/metadata/metadata_validator.go
+++ b/internal/validators/metadata/metadata_validator.go
@@ -22,10 +22,13 @@ import (
 // per-call helpers below; for a metadata-heavy scan that runs into the
 // hundreds-of-thousands of allocations on the hot path.
 var (
-	// `phoneBasic` is the loose three-three-four digit pattern used by
-	// containsEnhancedPhoneNumber's first slot AND by an unrelated fallback
-	// path in calculateMatchConfidence — same literal in two places.
-	phoneBasic         = regexp.MustCompile(`\b\d{3}[-.]?\d{3}[-.]?\d{4}\b`)
+	// `phoneBasic` is the three-three-four digit phone pattern. A separator
+	// (- or .) between the groups is now REQUIRED: the previous optional
+	// separator (`[-.]?`) matched any bare 10-digit run (timestamps, asset/ID
+	// numbers like "ID: 1234567890"), producing phantom phone confidence. Bare
+	// 10-digit numbers are too ambiguous to treat as phones in metadata; the
+	// space-separated and parenthesized forms cover the other real layouts.
+	phoneBasic         = regexp.MustCompile(`\b\d{3}[-.]\d{3}[-.]\d{4}\b`)
 	phoneParenAreaCode = regexp.MustCompile(`\b\(\d{3}\)\s?\d{3}[-.]?\d{4}\b`)
 	phoneInternational = regexp.MustCompile(`\b\+\d{1,3}[-.\s]?\d{3}[-.\s]?\d{3}[-.\s]?\d{4}\b`)
 	phoneSpaceSep      = regexp.MustCompile(`\b\d{3}\s\d{3}\s\d{4}\b`)
@@ -37,8 +40,15 @@ var (
 		phoneSpaceSep,
 	}
 
-	emailExtractPattern  = regexp.MustCompile(`[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}`)
-	gpsCoordPattern      = regexp.MustCompile(`[+-]?\d+\.\d+`)
+	emailExtractPattern = regexp.MustCompile(`[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}`)
+	gpsCoordPattern     = regexp.MustCompile(`[+-]?\d+\.\d+`)
+	// gpsCoordRefPattern matches a decimal-degree coordinate with an adjacent
+	// N/S/E/W hemisphere reference (optionally a degree symbol), e.g. "40.7128 N"
+	// or "74.0060° W". The directional letter must sit next to the number — this
+	// replaces the old "decimal anywhere AND the letters n/s/e/w appear anywhere
+	// on the line" test, which matched almost any English text containing a
+	// version number (e.g. "Software: Adobe Photoshop 21.0").
+	gpsCoordRefPattern   = regexp.MustCompile(`(?i)[+-]?\d{1,3}\.\d+\s*°?\s*[NSEW]\b`)
 	versionNumberPattern = regexp.MustCompile(`^\d+(\.\d+)*$`)
 )
 
@@ -797,11 +807,18 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 			matches = append(matches, *officeMatch)
 		}
 
+		// The priority helpers below cover the same fields (author, manager,
+		// comments, description, keywords) as the legacy inline blocks further
+		// down. Track whether any helper emitted for this line so we can skip the
+		// redundant legacy blocks and avoid emitting the SAME field twice (M31).
+		priorityFieldMatched := false
+
 		// Check for high priority sensitive fields
 		if highPriorityMatch := v.checkHighPrioritySensitive(line); highPriorityMatch != nil {
 			highPriorityMatch.LineNumber = lineNumber + 1
 			highPriorityMatch.Filename = filename
 			matches = append(matches, *highPriorityMatch)
+			priorityFieldMatched = true
 		}
 
 		// Check for medium priority sensitive fields
@@ -809,6 +826,7 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 			mediumPriorityMatch.LineNumber = lineNumber + 1
 			mediumPriorityMatch.Filename = filename
 			matches = append(matches, *mediumPriorityMatch)
+			priorityFieldMatched = true
 		}
 
 		// Check for low priority sensitive fields
@@ -816,188 +834,197 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 			lowPriorityMatch.LineNumber = lineNumber + 1
 			lowPriorityMatch.Filename = filename
 			matches = append(matches, *lowPriorityMatch)
+			priorityFieldMatched = true
 		}
 
-		// Check for LastModifiedBy field specifically (high priority)
-		if v.containsLastModifiedBy(line) {
-			confidence, checks := v.CalculateConfidence(line)
-			contextInfo := detector.ContextInfo{FullLine: line}
-			contextImpact := v.AnalyzeContext(line, contextInfo)
-			confidence += contextImpact
-			if confidence > 1.0 {
-				confidence = 1.0
-			} else if confidence < 0.0 {
-				confidence = 0.0
-			}
-			contextInfo.ConfidenceImpact = contextImpact
-			matches = append(matches, detector.Match{
-				Text:       v.extractSensitiveValue(line, "LAST_MODIFIED_BY"),
-				LineNumber: lineNumber + 1,
-				Type:       "LAST_MODIFIED_BY",
-				Confidence: confidence * 100,
-				Filename:   filename,
-				Validator:  "metadata",
-				Context:    contextInfo,
-				Metadata: map[string]any{
-					"metadata_type":     "last_modified_by",
-					"validation_checks": checks,
-					"context_impact":    contextImpact,
-					"source":            "preprocessed_content",
-					"original_file":     originalPath,
-				},
-			})
-		}
+		// Legacy inline field blocks (LastModifiedBy/Manager/Comments/Description/
+		// Keywords/AuthorInfo) duplicate the priority helpers above. Skip them when
+		// a helper already emitted for this line so the same field is not reported
+		// twice; otherwise fall through so any field the helpers don't cover is
+		// still detected.
+		if !priorityFieldMatched {
 
-		// Check for Manager field (high priority)
-		if v.containsManager(line) {
-			confidence, checks := v.CalculateConfidence(line)
-			contextInfo := detector.ContextInfo{FullLine: line}
-			contextImpact := v.AnalyzeContext(line, contextInfo)
-			confidence += contextImpact + 0.1 // Boost for manager field
-			if confidence > 1.0 {
-				confidence = 1.0
-			} else if confidence < 0.0 {
-				confidence = 0.0
+			// Check for LastModifiedBy field specifically (high priority)
+			if v.containsLastModifiedBy(line) {
+				confidence, checks := v.CalculateConfidence(line)
+				contextInfo := detector.ContextInfo{FullLine: line}
+				contextImpact := v.AnalyzeContext(line, contextInfo)
+				confidence += contextImpact
+				if confidence > 1.0 {
+					confidence = 1.0
+				} else if confidence < 0.0 {
+					confidence = 0.0
+				}
+				contextInfo.ConfidenceImpact = contextImpact
+				matches = append(matches, detector.Match{
+					Text:       v.extractSensitiveValue(line, "LAST_MODIFIED_BY"),
+					LineNumber: lineNumber + 1,
+					Type:       "LAST_MODIFIED_BY",
+					Confidence: confidence * 100,
+					Filename:   filename,
+					Validator:  "metadata",
+					Context:    contextInfo,
+					Metadata: map[string]any{
+						"metadata_type":     "last_modified_by",
+						"validation_checks": checks,
+						"context_impact":    contextImpact,
+						"source":            "preprocessed_content",
+						"original_file":     originalPath,
+					},
+				})
 			}
-			contextInfo.ConfidenceImpact = contextImpact
-			matches = append(matches, detector.Match{
-				Text:       v.extractSensitiveValue(line, "MANAGER_INFO"),
-				LineNumber: lineNumber + 1,
-				Type:       "MANAGER_INFO",
-				Confidence: confidence * 100,
-				Filename:   filename,
-				Validator:  "metadata",
-				Context:    contextInfo,
-				Metadata: map[string]any{
-					"metadata_type":     "manager_info",
-					"validation_checks": checks,
-					"context_impact":    contextImpact,
-					"source":            "preprocessed_content",
-					"original_file":     originalPath,
-				},
-			})
-		}
 
-		// Check for Comments field (high priority)
-		if v.containsComments(line) {
-			confidence, checks := v.CalculateConfidence(line)
-			contextInfo := detector.ContextInfo{FullLine: line}
-			contextImpact := v.AnalyzeContext(line, contextInfo)
-			confidence += contextImpact + 0.15 // High boost for comments
-			if confidence > 1.0 {
-				confidence = 1.0
-			} else if confidence < 0.0 {
-				confidence = 0.0
+			// Check for Manager field (high priority)
+			if v.containsManager(line) {
+				confidence, checks := v.CalculateConfidence(line)
+				contextInfo := detector.ContextInfo{FullLine: line}
+				contextImpact := v.AnalyzeContext(line, contextInfo)
+				confidence += contextImpact + 0.1 // Boost for manager field
+				if confidence > 1.0 {
+					confidence = 1.0
+				} else if confidence < 0.0 {
+					confidence = 0.0
+				}
+				contextInfo.ConfidenceImpact = contextImpact
+				matches = append(matches, detector.Match{
+					Text:       v.extractSensitiveValue(line, "MANAGER_INFO"),
+					LineNumber: lineNumber + 1,
+					Type:       "MANAGER_INFO",
+					Confidence: confidence * 100,
+					Filename:   filename,
+					Validator:  "metadata",
+					Context:    contextInfo,
+					Metadata: map[string]any{
+						"metadata_type":     "manager_info",
+						"validation_checks": checks,
+						"context_impact":    contextImpact,
+						"source":            "preprocessed_content",
+						"original_file":     originalPath,
+					},
+				})
 			}
-			contextInfo.ConfidenceImpact = contextImpact
-			matches = append(matches, detector.Match{
-				Text:       v.extractSensitiveValue(line, "DOCUMENT_COMMENTS"),
-				LineNumber: lineNumber + 1,
-				Type:       "DOCUMENT_COMMENTS",
-				Confidence: confidence * 100,
-				Filename:   filename,
-				Validator:  "metadata",
-				Context:    contextInfo,
-				Metadata: map[string]any{
-					"metadata_type":     "document_comments",
-					"validation_checks": checks,
-					"context_impact":    contextImpact,
-					"source":            "preprocessed_content",
-					"original_file":     originalPath,
-				},
-			})
-		}
 
-		// Check for Description field (high priority)
-		if v.containsDescription(line) {
-			confidence, checks := v.CalculateConfidence(line)
-			contextInfo := detector.ContextInfo{FullLine: line}
-			contextImpact := v.AnalyzeContext(line, contextInfo)
-			confidence += contextImpact + 0.1 // Boost for description
-			if confidence > 1.0 {
-				confidence = 1.0
-			} else if confidence < 0.0 {
-				confidence = 0.0
+			// Check for Comments field (high priority)
+			if v.containsComments(line) {
+				confidence, checks := v.CalculateConfidence(line)
+				contextInfo := detector.ContextInfo{FullLine: line}
+				contextImpact := v.AnalyzeContext(line, contextInfo)
+				confidence += contextImpact + 0.15 // High boost for comments
+				if confidence > 1.0 {
+					confidence = 1.0
+				} else if confidence < 0.0 {
+					confidence = 0.0
+				}
+				contextInfo.ConfidenceImpact = contextImpact
+				matches = append(matches, detector.Match{
+					Text:       v.extractSensitiveValue(line, "DOCUMENT_COMMENTS"),
+					LineNumber: lineNumber + 1,
+					Type:       "DOCUMENT_COMMENTS",
+					Confidence: confidence * 100,
+					Filename:   filename,
+					Validator:  "metadata",
+					Context:    contextInfo,
+					Metadata: map[string]any{
+						"metadata_type":     "document_comments",
+						"validation_checks": checks,
+						"context_impact":    contextImpact,
+						"source":            "preprocessed_content",
+						"original_file":     originalPath,
+					},
+				})
 			}
-			contextInfo.ConfidenceImpact = contextImpact
-			matches = append(matches, detector.Match{
-				Text:       v.extractSensitiveValue(line, "DOCUMENT_DESCRIPTION"),
-				LineNumber: lineNumber + 1,
-				Type:       "DOCUMENT_DESCRIPTION",
-				Confidence: confidence * 100,
-				Filename:   filename,
-				Validator:  "metadata",
-				Context:    contextInfo,
-				Metadata: map[string]any{
-					"metadata_type":     "document_description",
-					"validation_checks": checks,
-					"context_impact":    contextImpact,
-					"source":            "preprocessed_content",
-					"original_file":     originalPath,
-				},
-			})
-		}
 
-		// Check for Keywords field (medium priority)
-		if v.containsKeywords(line) {
-			confidence, checks := v.CalculateConfidence(line)
-			contextInfo := detector.ContextInfo{FullLine: line}
-			contextImpact := v.AnalyzeContext(line, contextInfo)
-			confidence += contextImpact
-			if confidence > 1.0 {
-				confidence = 1.0
-			} else if confidence < 0.0 {
-				confidence = 0.0
+			// Check for Description field (high priority)
+			if v.containsDescription(line) {
+				confidence, checks := v.CalculateConfidence(line)
+				contextInfo := detector.ContextInfo{FullLine: line}
+				contextImpact := v.AnalyzeContext(line, contextInfo)
+				confidence += contextImpact + 0.1 // Boost for description
+				if confidence > 1.0 {
+					confidence = 1.0
+				} else if confidence < 0.0 {
+					confidence = 0.0
+				}
+				contextInfo.ConfidenceImpact = contextImpact
+				matches = append(matches, detector.Match{
+					Text:       v.extractSensitiveValue(line, "DOCUMENT_DESCRIPTION"),
+					LineNumber: lineNumber + 1,
+					Type:       "DOCUMENT_DESCRIPTION",
+					Confidence: confidence * 100,
+					Filename:   filename,
+					Validator:  "metadata",
+					Context:    contextInfo,
+					Metadata: map[string]any{
+						"metadata_type":     "document_description",
+						"validation_checks": checks,
+						"context_impact":    contextImpact,
+						"source":            "preprocessed_content",
+						"original_file":     originalPath,
+					},
+				})
 			}
-			contextInfo.ConfidenceImpact = contextImpact
-			matches = append(matches, detector.Match{
-				Text:       v.extractSensitiveValue(line, "DOCUMENT_KEYWORDS"),
-				LineNumber: lineNumber + 1,
-				Type:       "DOCUMENT_KEYWORDS",
-				Confidence: confidence * 100,
-				Filename:   filename,
-				Validator:  "metadata",
-				Context:    contextInfo,
-				Metadata: map[string]any{
-					"metadata_type":     "document_keywords",
-					"validation_checks": checks,
-					"context_impact":    contextImpact,
-					"source":            "preprocessed_content",
-					"original_file":     originalPath,
-				},
-			})
-		}
 
-		// Check for author/creator information (legacy)
-		if !seenAuthor && v.containsAuthorInfo(line) {
-			confidence, checks := v.CalculateConfidence(line)
-			contextInfo := detector.ContextInfo{FullLine: line}
-			contextImpact := v.AnalyzeContext(line, contextInfo)
-			confidence += contextImpact
-			if confidence > 1.0 {
-				confidence = 1.0
-			} else if confidence < 0.0 {
-				confidence = 0.0
+			// Check for Keywords field (medium priority)
+			if v.containsKeywords(line) {
+				confidence, checks := v.CalculateConfidence(line)
+				contextInfo := detector.ContextInfo{FullLine: line}
+				contextImpact := v.AnalyzeContext(line, contextInfo)
+				confidence += contextImpact
+				if confidence > 1.0 {
+					confidence = 1.0
+				} else if confidence < 0.0 {
+					confidence = 0.0
+				}
+				contextInfo.ConfidenceImpact = contextImpact
+				matches = append(matches, detector.Match{
+					Text:       v.extractSensitiveValue(line, "DOCUMENT_KEYWORDS"),
+					LineNumber: lineNumber + 1,
+					Type:       "DOCUMENT_KEYWORDS",
+					Confidence: confidence * 100,
+					Filename:   filename,
+					Validator:  "metadata",
+					Context:    contextInfo,
+					Metadata: map[string]any{
+						"metadata_type":     "document_keywords",
+						"validation_checks": checks,
+						"context_impact":    contextImpact,
+						"source":            "preprocessed_content",
+						"original_file":     originalPath,
+					},
+				})
 			}
-			contextInfo.ConfidenceImpact = contextImpact
-			matches = append(matches, detector.Match{
-				Text:       v.extractSensitiveValue(line, "AUTHOR_INFO"),
-				LineNumber: lineNumber + 1,
-				Type:       "AUTHOR_INFO",
-				Confidence: confidence * 100,
-				Filename:   filename,
-				Validator:  "metadata",
-				Context:    contextInfo,
-				Metadata: map[string]any{
-					"metadata_type":     "author_info",
-					"validation_checks": checks,
-					"context_impact":    contextImpact,
-					"source":            "preprocessed_content",
-					"original_file":     originalPath,
-				},
-			})
-			seenAuthor = true
-		}
+
+			// Check for author/creator information (legacy)
+			if !seenAuthor && v.containsAuthorInfo(line) {
+				confidence, checks := v.CalculateConfidence(line)
+				contextInfo := detector.ContextInfo{FullLine: line}
+				contextImpact := v.AnalyzeContext(line, contextInfo)
+				confidence += contextImpact
+				if confidence > 1.0 {
+					confidence = 1.0
+				} else if confidence < 0.0 {
+					confidence = 0.0
+				}
+				contextInfo.ConfidenceImpact = contextImpact
+				matches = append(matches, detector.Match{
+					Text:       v.extractSensitiveValue(line, "AUTHOR_INFO"),
+					LineNumber: lineNumber + 1,
+					Type:       "AUTHOR_INFO",
+					Confidence: confidence * 100,
+					Filename:   filename,
+					Validator:  "metadata",
+					Context:    contextInfo,
+					Metadata: map[string]any{
+						"metadata_type":     "author_info",
+						"validation_checks": checks,
+						"context_impact":    contextImpact,
+						"source":            "preprocessed_content",
+						"original_file":     originalPath,
+					},
+				})
+				seenAuthor = true
+			}
+		} // end legacy inline field blocks (skipped when a priority helper matched)
 
 		// Check for other potentially sensitive metadata patterns
 		if v.containsSensitiveMetadata(line) {
@@ -1402,9 +1429,12 @@ func (v *Validator) containsEnhancedGPSData(match string) bool {
 		}
 	}
 
-	// Check for coordinate patterns
-	if gpsCoordPattern.MatchString(match) && (strings.Contains(matchLower, "n") || strings.Contains(matchLower, "s") ||
-		strings.Contains(matchLower, "e") || strings.Contains(matchLower, "w")) {
+	// Check for coordinate patterns. A real coordinate is a decimal value with an
+	// adjacent N/S/E/W hemisphere reference. The previous test OR-ed single
+	// letters across the whole line, so any field carrying a decimal version
+	// number (e.g. "Software: Adobe Photoshop 21.0") was misclassified as GPS and
+	// pushed to HIGH confidence.
+	if gpsCoordRefPattern.MatchString(match) {
 		return true
 	}
 
@@ -2293,10 +2323,20 @@ func (v *Validator) combineGPSCoordinates(gpsCoordinates map[string]string, gpsL
 	var latitude, longitude, latRef, longRef string
 	var latLine, longLine int
 
-	// Check for already consolidated GPS coordinates first
+	// Emit any already-consolidated GPS coordinate entries. We do NOT return
+	// early here (M33): a stray "Coordinates:" field — possibly a placeholder
+	// like "N/A" — must not short-circuit the separate GPSLatitude/GPSLongitude
+	// pairing below, and a placeholder value must not be emitted as a GPS match.
+	// We therefore validate the value looks like a real coordinate before
+	// emitting, and fall through to the component-pairing logic regardless.
 	for field, value := range gpsCoordinates {
 		fieldLower := strings.ToLower(field)
 		if strings.Contains(fieldLower, "gps_coordinates") || strings.Contains(fieldLower, "coordinates") {
+			// A real coordinate value contains digits; skip placeholders such as
+			// "N/A", "unknown", or empty so they aren't emitted as GPS matches.
+			if !v.isMeaningfulGPSValue(field, value) || !strings.ContainsAny(value, "0123456789") {
+				continue
+			}
 			// This is already a consolidated GPS coordinate entry
 			confidence, checks := v.CalculateConfidence(fmt.Sprintf("%s: %s", field, value))
 			contextInfo := detector.ContextInfo{FullLine: fmt.Sprintf("%s: %s", field, value)}
@@ -2324,7 +2364,6 @@ func (v *Validator) combineGPSCoordinates(gpsCoordinates map[string]string, gpsL
 				},
 			}
 			matches = append(matches, match)
-			return matches // Return early since we found consolidated coordinates
 		}
 	}
 

--- a/internal/validators/metadata/metadata_validator_test.go
+++ b/internal/validators/metadata/metadata_validator_test.go
@@ -117,3 +117,52 @@ func TestMetadata_CombineGPSNoEarlyReturn(t *testing.T) {
 		t.Error("real lat/long pair should still be combined despite the stray Coordinates field")
 	}
 }
+
+// TestMetadata_GPSPairValidation is a regression test for L17: the combined GPS
+// pair was hardcoded to confidence 100 with no validation, so a 0/0 (Null
+// Island / unset GPS) or out-of-range pair surfaced as HIGH. Such pairs are now
+// rejected; a valid in-range pair still scores HIGH.
+func TestMetadata_GPSPairValidation(t *testing.T) {
+	v := NewValidator()
+
+	// 0/0 and out-of-range pairs must not be emitted.
+	for _, tc := range []struct{ lat, long string }{
+		{"0", "0"},
+		{"999.0", "5.0"},
+		{"10.0", "200.0"},
+	} {
+		res := v.combineGPSCoordinates(
+			map[string]string{"gpslatitude": tc.lat, "gpslongitude": tc.long},
+			map[string]int{"gpslatitude": 1, "gpslongitude": 2}, "f.jpg", "")
+		if len(res) > 0 {
+			t.Errorf("L17: invalid pair (%s,%s) should not be emitted, got %d", tc.lat, tc.long, len(res))
+		}
+	}
+	// A valid in-range pair is still HIGH.
+	res := v.combineGPSCoordinates(
+		map[string]string{"gpslatitude": "40.7128", "gpslongitude": "-74.0060"},
+		map[string]int{"gpslatitude": 1, "gpslongitude": 2}, "f.jpg", "")
+	if len(res) != 1 || res[0].Confidence < 90 {
+		t.Errorf("L17: valid pair should be one HIGH GPS match, got %d", len(res))
+	}
+}
+
+// TestMetadata_VersionNumberVsID is a regression test for L18: isVersionNumber
+// blanket-suppressed any all-numeric value, hiding numeric IDs placed in
+// author/manager/copyright fields. It now only treats version-keyed or
+// version-shaped values as versions.
+func TestMetadata_VersionNumberVsID(t *testing.T) {
+	v := NewValidator()
+	// Genuine version values.
+	for _, line := range []string{"Application: 16.0", "Version: 2.1.3", "Software: 21.0"} {
+		if !v.isVersionNumber(line) {
+			t.Errorf("L18: %q should be treated as a version", line)
+		}
+	}
+	// Numeric IDs in non-version fields must NOT be suppressed as versions.
+	for _, line := range []string{"Author: 1234567890", "Manager: 12345", "Copyright: 100200300"} {
+		if v.isVersionNumber(line) {
+			t.Errorf("L18: %q is a numeric ID, not a version", line)
+		}
+	}
+}

--- a/internal/validators/metadata/metadata_validator_test.go
+++ b/internal/validators/metadata/metadata_validator_test.go
@@ -1,0 +1,119 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package metadata
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestContainsEnhancedGPSData_NoLetterFalsePositive is a regression test for the
+// enhanced-GPS detector. The old coordinate fallback matched any decimal number
+// AND OR-ed the single letters n/s/e/w across the whole line, so benign metadata
+// carrying a version number (e.g. "Software: Adobe Photoshop 21.0") was flagged
+// as GPS and pushed toward HIGH confidence. The fix requires a real
+// decimal-degree coordinate with an adjacent N/S/E/W hemisphere reference.
+func TestContainsEnhancedGPSData_NoLetterFalsePositive(t *testing.T) {
+	v := NewValidator()
+
+	// Real GPS coordinates / explicit GPS fields must still be detected.
+	gps := []string{
+		"GPSLatitude: 40.7128 N",
+		"40.7128° N, 74.0060° W",
+		"location 51.5074 N",
+		"GPSLongitude: 0.1278 W",
+		"coordinates: 48.8566, 2.3522", // matched by the explicit "coordinates" keyword
+	}
+	for _, s := range gps {
+		if !v.containsEnhancedGPSData(s) {
+			t.Errorf("expected GPS detection for %q", s)
+		}
+	}
+
+	// Benign metadata with decimals (and incidental n/s/e/w inside words) must
+	// NOT be classified as GPS.
+	notGPS := []string{
+		"Software: Adobe Photoshop 21.0",
+		"Application: Microsoft Excel 16.0",
+		"Creator: GIMP 2.10",
+		"Aperture: f/2.8",
+		"ISO: 100.0",
+		"FocalLength: 35.0 mm",
+		"Resolution: 72.0 dpi west", // 'west' present but not adjacent to a number
+		"Version: 1.2.3",
+	}
+	for _, s := range notGPS {
+		if v.containsEnhancedGPSData(s) {
+			t.Errorf("expected NO GPS detection for %q, but got one", s)
+		}
+	}
+}
+
+// TestMetadata_NoDuplicateFieldEmission is a regression test for M31: a single
+// Author/Manager/Comments line was emitted twice (once by the priority helper,
+// once by a legacy inline block).
+func TestMetadata_NoDuplicateFieldEmission(t *testing.T) {
+	v := NewValidator()
+	for _, tc := range []struct {
+		line    string
+		typeStr string
+	}{
+		{"Manager: Jane Doe", "MANAGER_INFO"},
+		{"Author: John Smith", "AUTHOR_INFO"},
+	} {
+		matches, err := v.ValidateContent(tc.line, "f.docx")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		count := 0
+		for _, m := range matches {
+			if m.Type == tc.typeStr {
+				count++
+			}
+		}
+		if count > 1 {
+			t.Errorf("%q emitted %s %d times; expected at most 1", tc.line, tc.typeStr, count)
+		}
+	}
+}
+
+// TestMetadata_PhoneBasicRequiresSeparator is a regression test for M32: the
+// phoneBasic pattern matched any bare 10-digit run (timestamps, IDs), producing
+// phantom phone confidence. A separator is now required.
+func TestMetadata_PhoneBasicRequiresSeparator(t *testing.T) {
+	for _, s := range []string{"1234567890", "2021012345"} {
+		if phoneBasic.MatchString(s) {
+			t.Errorf("bare 10-digit %q should not match phoneBasic", s)
+		}
+	}
+	for _, s := range []string{"123-456-7890", "123.456.7890"} {
+		if !phoneBasic.MatchString(s) {
+			t.Errorf("separated phone %q should match phoneBasic", s)
+		}
+	}
+}
+
+// TestMetadata_CombineGPSNoEarlyReturn is a regression test for M33: a stray
+// "Coordinates:" placeholder field used to short-circuit the lat/long pairing
+// and be emitted itself. The placeholder is now skipped and the real pair is
+// still combined.
+func TestMetadata_CombineGPSNoEarlyReturn(t *testing.T) {
+	v := NewValidator()
+	gps := map[string]string{"coordinates": "N/A", "gpslatitude": "40.7128", "gpslongitude": "-74.0060"}
+	lines := map[string]int{"coordinates": 1, "gpslatitude": 2, "gpslongitude": 3}
+	res := v.combineGPSCoordinates(gps, lines, "f.jpg", "")
+
+	pairFound := false
+	for _, r := range res {
+		if strings.Contains(strings.ToLower(r.Text), "n/a") {
+			t.Errorf("placeholder 'N/A' should not be emitted as GPS, got %q", r.Text)
+		}
+		if strings.Contains(r.Text, "40.7128") && strings.Contains(r.Text, "-74.0060") {
+			pairFound = true
+		}
+	}
+	if !pairFound {
+		t.Error("real lat/long pair should still be combined despite the stray Coordinates field")
+	}
+}

--- a/internal/validators/personname/patterns.go
+++ b/internal/validators/personname/patterns.go
@@ -17,6 +17,34 @@ type NamePattern struct {
 	Cultural    []string // Cultural contexts where this pattern is common
 }
 
+// Latin letter character classes used to build name patterns.
+//
+// The previous patterns used [A-ZÀ-ÿ] / [a-zà-ÿ]. Those have two problems:
+//  1. A leading/trailing ASCII \b does not fire next to an accented letter, so
+//     names starting with an accented capital (Ángel, Óscar) never matched and
+//     names ending in an accent (José) were truncated ("Jos").
+//  2. The range À-ÿ wrongly includes U+00D7 (×) and U+00F7 (÷), which are math
+//     symbols, not letters.
+//
+// We therefore use explicit Latin-1 letter ranges that exclude × and ÷, and
+// build word boundaries by consuming a non-letter (or string edge) on each side
+// via wrapNamePattern (RE2 has no look-around), capturing the actual name in
+// group 1.
+const (
+	nameUpper  = `A-ZÀ-ÖØ-Þ` // Latin-1 uppercase letters (excludes × at U+00D7)
+	nameLower  = `a-zß-öø-ÿ` // Latin-1 lowercase letters (excludes ÷ at U+00F7)
+	nameLetter = nameUpper + nameLower
+)
+
+// wrapNamePattern turns a "core" name pattern into a boundary-anchored pattern
+// with the name captured in group 1. The leading/trailing groups consume a
+// non-letter character (or the string start/end) so the match does not run into
+// an adjacent word, while correctly handling accented letters that ASCII \b
+// cannot. Callers must read submatch group 1 (see FindMatches).
+func wrapNamePattern(core string) string {
+	return `(?:^|[^` + nameLetter + `])(` + core + `)(?:[^` + nameLetter + `]|$)`
+}
+
 // PatternManager manages name detection patterns
 type PatternManager struct {
 	patterns []NamePattern
@@ -40,105 +68,126 @@ func (pm *PatternManager) compileAllPatterns() {
 	}{
 		{
 			name:        "basic_western_name",
-			pattern:     `\b[A-ZÀ-ÿ][a-zà-ÿ]{1,29}\s+[A-ZÀ-ÿ][a-zà-ÿ]{1,29}\b`,
+			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `][` + nameLower + `]{1,29}`,
 			description: "Basic Western name format: First Last (minimum 2 chars each)",
 			priority:    5,
 			cultural:    []string{"western", "english", "european"},
 		},
 		{
+			name: "all_caps_name",
+			// ALL-CAPS names (JOHN SMITH, GRACE HILL) are common in forms,
+			// spreadsheets and legal records but never matched the Title-case
+			// patterns. This pattern surfaces them, but it is only a candidate
+			// finder: CalculateConfidenceWithComponents still requires a name-DB
+			// hit (lowercasing the tokens), so non-name all-caps prose ("ERROR
+			// CODE", "TODO FIXME") is rejected, and the common-word-bigram gate
+			// keeps DB-colliding word pairs out of the HIGH bucket. Low priority —
+			// all-caps is weaker evidence than mixed-case.
+			pattern:     `[` + nameUpper + `]{2,30}\s+[` + nameUpper + `]{2,30}`,
+			description: "All-caps name: FIRST LAST",
+			priority:    3,
+			cultural:    []string{"western", "formal"},
+		},
+		{
 			name:        "name_with_middle_initial",
-			pattern:     `\b[A-ZÀ-ÿ][a-zà-ÿ]{1,29}\s+[A-ZÀ-ÿ]\.\s+[A-ZÀ-ÿ][a-zà-ÿ]{1,29}\b`,
+			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `]\.\s+[` + nameUpper + `][` + nameLower + `]{1,29}`,
 			description: "Name with middle initial: First M. Last",
 			priority:    7,
 			cultural:    []string{"western", "american"},
 		},
 		{
 			name:        "name_with_title",
-			pattern:     `\b(?:Mr|Ms|Mrs|Dr|Prof|Sir|Dame|Lord|Lady)\.\s+[A-ZÀ-ÿ][a-zà-ÿ]{1,29}\s+[A-ZÀ-ÿ][a-zà-ÿ]{1,29}\b`,
+			pattern:     `(?:Mr|Ms|Mrs|Dr|Prof|Sir|Dame|Lord|Lady)\.\s+[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `][` + nameLower + `]{1,29}`,
 			description: "Name with title: Dr. First Last",
 			priority:    8,
 			cultural:    []string{"western", "formal"},
 		},
 		{
-			name:        "name_with_suffix",
-			pattern:     `\b[A-ZÀ-ÿ][a-zà-ÿ]{1,29}\s+[A-ZÀ-ÿ][a-zà-ÿ]{1,29}\s+(?:Jr\.?|Sr\.?|III|IV|V|PhD|MD|Esq\.?)`,
+			name: "name_with_suffix",
+			// Bare single-letter "V" was dropped from the suffix alternation: as a
+			// lone Roman numeral it matched ordinary "First Last Vword" triples
+			// ("Grace Park Verified") far more often than a real generational
+			// suffix. Jr/Sr/III/IV plus the academic suffixes cover the common
+			// cases; wrapNamePattern supplies the trailing boundary that stops
+			// "IV"/"III" matching inside "IVory"/"IIIumination".
+			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `][` + nameLower + `]{1,29}\s+(?:Jr\.?|Sr\.?|III|IV|PhD|MD|Esq\.?)`,
 			description: "Name with suffix: First Last Jr.",
 			priority:    8,
 			cultural:    []string{"western", "american", "academic"},
 		},
 		{
 			name:        "three_part_name",
-			pattern:     `\b[A-ZÀ-ÿ][a-zà-ÿ]{1,29}\s+[A-ZÀ-ÿ][a-zà-ÿ]{1,29}\s+[A-ZÀ-ÿ][a-zà-ÿ]{1,29}\b`,
+			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `][` + nameLower + `]{1,29}`,
 			description: "Three-part name: First Middle Last",
 			priority:    6,
 			cultural:    []string{"western", "hispanic", "compound"},
 		},
 		{
 			name:        "hyphenated_last_name",
-			pattern:     `\b[A-ZÀ-ÿ][a-zà-ÿ]{1,29}\s+[A-ZÀ-ÿ][a-zà-ÿ]{1,29}-[A-ZÀ-ÿ][a-zà-ÿ]{1,29}\b`,
+			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `][` + nameLower + `]{1,29}-[` + nameUpper + `][` + nameLower + `]{1,29}`,
 			description: "Hyphenated last name: First Last-Name",
 			priority:    7,
 			cultural:    []string{"western", "modern", "compound"},
 		},
 		{
 			name:        "name_with_apostrophe_first",
-			pattern:     `\b[A-ZÀ-ÿ][a-zà-ÿ]*'[A-ZÀ-ÿ][a-zà-ÿ]{1,29}\s+[A-ZÀ-ÿ][a-zà-ÿ]{1,29}\b`,
+			pattern:     `[` + nameUpper + `][` + nameLower + `]*'[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `][` + nameLower + `]{1,29}`,
 			description: "Name with apostrophe in first name: O'Connor Smith",
 			priority:    7,
 			cultural:    []string{"irish", "scottish", "western"},
 		},
 		{
 			name:        "name_with_apostrophe_last",
-			pattern:     `\b[A-ZÀ-ÿ][a-zà-ÿ]{1,29}\s+[A-ZÀ-ÿ][a-zà-ÿ]*'[A-ZÀ-ÿ][a-zà-ÿ]{1,29}\b`,
+			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `][` + nameLower + `]*'[` + nameUpper + `][` + nameLower + `]{1,29}`,
 			description: "Name with apostrophe in last name: David O'Connor",
 			priority:    7,
 			cultural:    []string{"irish", "scottish", "western"},
 		},
 		{
 			name:        "compound_first_name",
-			pattern:     `\b[A-ZÀ-ÿ][a-zà-ÿ]{1,29}-[A-ZÀ-ÿ][a-zà-ÿ]{1,29}\s+[A-ZÀ-ÿ][a-zà-ÿ]{1,29}\b`,
+			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29}-[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `][` + nameLower + `]{1,29}`,
 			description: "Compound first name: Mary-Jane Smith",
 			priority:    6,
 			cultural:    []string{"western", "compound", "modern"},
 		},
 		{
 			name:        "name_with_multiple_titles",
-			pattern:     `\b(?:Dr|Prof)\.\s+(?:Mr|Ms|Mrs)\.\s+[A-ZÀ-ÿ][a-zà-ÿ]{1,29}\s+[A-ZÀ-ÿ][a-zà-ÿ]{1,29}\b`,
+			pattern:     `(?:Dr|Prof)\.\s+(?:Mr|Ms|Mrs)\.\s+[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `][` + nameLower + `]{1,29}`,
 			description: "Multiple titles: Dr. Ms. First Last",
 			priority:    9,
 			cultural:    []string{"academic", "formal"},
 		},
 		{
 			name:        "four_part_name",
-			pattern:     `\b[A-ZÀ-ÿ][a-zà-ÿ]{1,29}\s+[A-ZÀ-ÿ][a-zà-ÿ]{1,29}\s+[A-ZÀ-ÿ][a-zà-ÿ]{1,29}\s+[A-ZÀ-ÿ][a-zà-ÿ]{1,29}\b`,
+			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `][` + nameLower + `]{1,29}`,
 			description: "Four-part name: First Middle Middle Last",
 			priority:    4,
 			cultural:    []string{"hispanic", "compound", "formal"},
 		},
 		{
 			name:        "last_comma_first",
-			pattern:     `\b[A-ZÀ-ÿ][a-zà-ÿ]{1,29},\s+[A-ZÀ-ÿ][a-zà-ÿ]{1,29}\b`,
+			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29},\s+[` + nameUpper + `][` + nameLower + `]{1,29}`,
 			description: "Last, First format (database/directory style)",
 			priority:    8,
 			cultural:    []string{"formal", "database", "directory"},
 		},
 		{
 			name:        "last_comma_first_middle",
-			pattern:     `\b[A-ZÀ-ÿ][a-zà-ÿ]{1,29},\s+[A-ZÀ-ÿ][a-zà-ÿ]{1,29}\s+[A-ZÀ-ÿ][a-zà-ÿ]{1,29}\b`,
+			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29},\s+[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `][` + nameLower + `]{1,29}`,
 			description: "Last, First Middle format",
 			priority:    8,
 			cultural:    []string{"formal", "database", "directory"},
 		},
 		{
 			name:        "last_comma_first_initial",
-			pattern:     `\b[A-ZÀ-ÿ][a-zà-ÿ]{1,29},\s+[A-ZÀ-ÿ][a-zà-ÿ]{1,29}\s+[A-ZÀ-ÿ]\.\b`,
+			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29},\s+[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `]\.`,
 			description: "Last, First M. format",
 			priority:    8,
 			cultural:    []string{"formal", "database", "directory"},
 		},
 		{
 			name:        "name_with_professional_suffix",
-			pattern:     `\b[A-ZÀ-ÿ][a-zà-ÿ]{1,29}\s+[A-ZÀ-ÿ][a-zà-ÿ]{1,29},\s+(?:PhD|MD|DDS|JD|EdD|PharmD|PsyD|DVM|RN|CPA|PE)\b`,
+			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `][` + nameLower + `]{1,29},\s+(?:PhD|MD|DDS|JD|EdD|PharmD|PsyD|DVM|RN|CPA|PE)`,
 			description: "Name with professional suffix: John Smith, PhD",
 			priority:    9,
 			cultural:    []string{"academic", "professional", "formal"},
@@ -147,7 +196,9 @@ func (pm *PatternManager) compileAllPatterns() {
 
 	pm.patterns = make([]NamePattern, len(patternDefinitions))
 	for i, def := range patternDefinitions {
-		compiled := regexp.MustCompile(def.pattern)
+		// Each definition is a "core" pattern; wrapNamePattern adds Unicode-aware
+		// word boundaries and captures the name in group 1.
+		compiled := regexp.MustCompile(wrapNamePattern(def.pattern))
 		pm.patterns[i] = NamePattern{
 			Pattern:     compiled,
 			Name:        def.name,
@@ -163,21 +214,31 @@ func (pm *PatternManager) GetPatterns() []NamePattern {
 	return pm.patterns
 }
 
-// FindMatches finds all pattern matches in the given text
+// FindMatches finds all pattern matches in the given text.
+//
+// Patterns are boundary-wrapped (see wrapNamePattern): group 0 includes the
+// consumed boundary characters, while group 1 is the actual name. We therefore
+// read group 1 and use its exact submatch offsets — this both strips the
+// boundary chars from the reported name and gives correct StartIndex/EndIndex
+// even when the same name appears more than once on a line (the old
+// strings.Index returned the first occurrence regardless).
 func (pm *PatternManager) FindMatches(text string) []PatternMatch {
 	var matches []PatternMatch
 
 	for _, pattern := range pm.patterns {
-		regexMatches := pattern.Pattern.FindAllStringSubmatch(text, -1)
-		for _, match := range regexMatches {
-			if len(match) > 0 {
-				matches = append(matches, PatternMatch{
-					Text:       match[0],
-					Pattern:    pattern,
-					StartIndex: strings.Index(text, match[0]),
-					EndIndex:   strings.Index(text, match[0]) + len(match[0]),
-				})
+		locs := pattern.Pattern.FindAllStringSubmatchIndex(text, -1)
+		for _, loc := range locs {
+			// loc layout: [g0start, g0end, g1start, g1end, ...]; need group 1.
+			if len(loc) < 4 || loc[2] < 0 || loc[3] < 0 {
+				continue
 			}
+			start, end := loc[2], loc[3]
+			matches = append(matches, PatternMatch{
+				Text:       text[start:end],
+				Pattern:    pattern,
+				StartIndex: start,
+				EndIndex:   end,
+			})
 		}
 	}
 

--- a/internal/validators/personname/technical_terms.go
+++ b/internal/validators/personname/technical_terms.go
@@ -289,6 +289,30 @@ var veryCommonNamesMap = map[string]bool{
 	"operate":   true,
 }
 
+// commonWordNamesMap holds tokens that are BOTH common English words AND present
+// in the first/last name databases (will/read, mark/brown, grace/hill, ...). A
+// Title-Cased bigram whose two tokens are both in this set ("Will Read", "Mark
+// Brown", "Grace Hill") is far more often ordinary prose/headings than a person
+// name, yet the both-names-known path scored it 90-100 (HIGH). When BOTH tokens
+// are in this set and there is no corroborating name signal (formal pattern,
+// title, suffix, comma form, or context keyword), the score is held at MEDIUM
+// instead of HIGH. A real name needs only one distinctive (non-dictionary) token
+// to stay HIGH, so this does not demote names like "John Smith" or "David Brown".
+var commonWordNamesMap = map[string]bool{
+	// first-name-like common words
+	"will": true, "mark": true, "grace": true, "may": true, "june": true,
+	"april": true, "art": true, "bill": true, "rose": true, "hope": true,
+	"joy": true, "frank": true, "rich": true, "guy": true, "drew": true,
+	"chase": true, "reed": true, "robin": true, "jay": true, "dawn": true,
+	"faith": true, "hap": true, "sunny": true,
+	// last-name-like common words
+	"read": true, "brown": true, "hill": true, "young": true, "stone": true,
+	"park": true, "moon": true, "king": true, "long": true, "west": true,
+	"white": true, "wood": true, "day": true, "love": true, "price": true,
+	"bell": true, "cook": true, "fields": true, "banks": true, "rivers": true,
+	"flowers": true, "winter": true, "summers": true, "rain": true,
+}
+
 // emailPatternsMap for efficient email context analysis
 var emailPatternsMap = map[string]bool{
 	"from:":        true,

--- a/internal/validators/personname/validator.go
+++ b/internal/validators/personname/validator.go
@@ -787,6 +787,39 @@ func (v *Validator) isTechnicalTerm(match string) bool {
 	return false
 }
 
+// containsWordKeyword reports whether text contains keyword as a whole word/
+// phrase (case-insensitive, text already lowercased by callers). The previous
+// substring matching let short context keywords fire inside unrelated words
+// ("park" in "parking" -> -35, "inc" in "incident" -> -20, "name" in
+// "username" -> +12), nudging confidence in both directions (L25). A word byte
+// is [a-z0-9]; multi-word phrases are matched with \b on the outer edges.
+func containsWordKeyword(text, keyword string) bool {
+	if keyword == "" {
+		return false
+	}
+	for from := 0; from+len(keyword) <= len(text); {
+		i := strings.Index(text[from:], keyword)
+		if i < 0 {
+			return false
+		}
+		i += from
+		leftOK := i == 0 || !isNameWordByte(text[i-1])
+		right := i + len(keyword)
+		rightOK := right >= len(text) || !isNameWordByte(text[right])
+		if leftOK && rightOK {
+			return true
+		}
+		from = i + 1
+	}
+	return false
+}
+
+// isNameWordByte reports whether b is a word character ([a-z0-9]) for keyword
+// boundary detection. Callers pass already-lowercased text.
+func isNameWordByte(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= '0' && b <= '9')
+}
+
 // AnalyzeContext implements the detector.Validator interface for contextual analysis
 func (v *Validator) AnalyzeContext(match string, context detector.ContextInfo) float64 {
 	adjustment := 0.0
@@ -799,17 +832,18 @@ func (v *Validator) AnalyzeContext(match string, context detector.ContextInfo) f
 		positiveMatches := 0
 		negativeMatches := 0
 
-		// Check for positive keywords (boost confidence)
+		// Check for positive keywords (boost confidence). Whole-word matching so
+		// "name" doesn't fire inside "username"/"filename".
 		for _, keyword := range v.positiveKeywords {
-			if strings.Contains(lowerLine, keyword) {
+			if containsWordKeyword(lowerLine, keyword) {
 				positiveMatches++
 			}
 		}
 
-		// Check for negative keywords (reduce confidence)
-		// Name database validation handles most false positives, so keep this simple
+		// Check for negative keywords (reduce confidence). Whole-word matching so
+		// "inc"/"corp"/"drive" don't fire inside "incident"/"corporate"/"driver".
 		for _, keyword := range v.negativeKeywords {
-			if strings.Contains(lowerLine, keyword) {
+			if containsWordKeyword(lowerLine, keyword) {
 				negativeMatches++
 			}
 		}
@@ -939,25 +973,27 @@ func (v *Validator) analyzeSpecificPatterns(contextLine, match string) float64 {
 		}
 	}
 
-	// Check for business context patterns (strong negative indicators)
+	// Check for business context patterns (strong negative indicators).
+	// Whole-word matching so "inc" doesn't fire inside "incident"/"since" (L25).
 	for _, pattern := range v.getSortedBusinessPatterns() {
-		if strings.Contains(contextLine, pattern) {
+		if containsWordKeyword(contextLine, pattern) {
 			adjustment -= 20.0 // Moderate penalty for technical/business contexts
 			break
 		}
 	}
 
-	// Check for product-specific patterns (very strong negative indicators)
+	// Check for product-specific patterns (very strong negative indicators).
 	for _, pattern := range v.getSortedProductPatterns() {
-		if strings.Contains(contextLine, pattern) {
+		if containsWordKeyword(contextLine, pattern) {
 			adjustment -= 8.0 // Light penalty for product contexts
 			break
 		}
 	}
 
-	// Check for geographic patterns (negative indicators)
+	// Check for geographic patterns (negative indicators). Whole-word matching so
+	// "park" doesn't fire inside "parking"/"sparkle" (L25).
 	for pattern := range geoPatternsMap {
-		if strings.Contains(contextLine, pattern) {
+		if containsWordKeyword(contextLine, pattern) {
 			adjustment -= 35.0 // Strong penalty for geographic contexts
 			break
 		}

--- a/internal/validators/personname/validator.go
+++ b/internal/validators/personname/validator.go
@@ -8,6 +8,8 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/awslabs/ferret-scan/internal/context"
 	"github.com/awslabs/ferret-scan/internal/detector"
@@ -362,6 +364,14 @@ func (v *Validator) CalculateConfidenceWithComponents(match string, components N
 		if v.isTechnicalContext(match, components) {
 			// Technical context: reduce to MEDIUM confidence even with both names
 			baseConfidence = 65.0
+		} else if v.isCommonWordBigram(components) && !v.isFormalNamePattern(components.Pattern) {
+			// Both tokens are ordinary English words that also happen to be in the
+			// name databases ("Will Read", "Grace Hill"). Without a formal pattern
+			// (title/suffix/comma/initial) this is far more likely prose than a
+			// person name, so hold it at MEDIUM rather than jumping to HIGH. A name
+			// with even one distinctive token, or any formal pattern, is unaffected
+			// and still reaches HIGH below.
+			baseConfidence = 65.0
 		} else {
 			// True person name: HIGH confidence for sensitive data detection
 			baseConfidence = 90.0
@@ -603,14 +613,36 @@ func (v *Validator) hasRepeatedCharacters(name string) bool {
 	return false
 }
 
-// isProperlyCapitalized checks if the name has proper capitalization
+// titleAndSuffixTokens are honorifics/suffixes exempt from the leading-capital
+// check in isProperlyCapitalized (they may be lowercased or all-caps).
+var titleAndSuffixTokens = map[string]bool{
+	"mr.": true, "ms.": true, "mrs.": true, "dr.": true, "prof.": true,
+	"mr": true, "ms": true, "mrs": true, "dr": true, "prof": true,
+	"jr.": true, "sr.": true, "jr": true, "sr": true,
+	"ii": true, "iii": true, "iv": true, "v": true,
+}
+
+// isProperlyCapitalized checks if each name word starts with an uppercase letter.
+//
+// Two bugs were fixed here (M20):
+//   - The previous code did strings.Contains("Mr.Ms.Mrs.Dr.Prof.Jr.Sr.III.IV.",
+//     word) — arguments reversed — so any word that was a SUBSTRING of that
+//     concatenation ("M", "I", "V", "Pro", "Sr") skipped the capitalization
+//     check. We now compare against a proper token set.
+//   - It indexed word[0] (a byte), so an accented capital like 'Á' (first byte
+//     0xC3 > 'Z') was wrongly treated as not-capitalized. We now decode the
+//     first rune and use unicode.IsUpper.
 func (v *Validator) isProperlyCapitalized(name string) bool {
-	words := strings.Fields(name)
-	for _, word := range words {
-		if len(word) > 0 && !strings.Contains("Mr.Ms.Mrs.Dr.Prof.Jr.Sr.III.IV.", word) {
-			if word[0] < 'A' || word[0] > 'Z' {
-				return false
-			}
+	for _, word := range strings.Fields(name) {
+		if word == "" {
+			continue
+		}
+		if titleAndSuffixTokens[strings.ToLower(word)] {
+			continue
+		}
+		r, _ := utf8.DecodeRuneInString(word)
+		if !unicode.IsUpper(r) {
+			return false
 		}
 	}
 	return true
@@ -624,6 +656,20 @@ func (v *Validator) isVeryCommonName(name string) bool {
 
 	lowerName := strings.ToLower(name)
 	return veryCommonNamesMap[lowerName]
+}
+
+// isCommonWordBigram reports whether BOTH the first and last name tokens are
+// ordinary English words that merely happen to also be in the name databases
+// (e.g. "Will Read", "Grace Hill"). Such a bigram is usually prose or a heading,
+// not a person name, so it should not reach HIGH confidence on the strength of a
+// bare two-word database match alone.
+func (v *Validator) isCommonWordBigram(components NameComponents) bool {
+	first := strings.ToLower(components.FirstName)
+	last := strings.ToLower(components.LastName)
+	if first == "" || last == "" {
+		return false
+	}
+	return commonWordNamesMap[first] && commonWordNamesMap[last]
 }
 
 // isKnownShortName checks if a short name (< 4 chars) is in the known name databases

--- a/internal/validators/personname/validator_test.go
+++ b/internal/validators/personname/validator_test.go
@@ -1091,3 +1091,22 @@ func TestPersonNameValidator_AllCapsNames(t *testing.T) {
 		}
 	}
 }
+
+// TestPersonNameValidator_ContextKeywordWordBoundary is a regression test for
+// L25: context keywords were matched as substrings, so "park" fired inside
+// "parking" (-35) and "inc" inside "incident" (-20), nudging confidence. They
+// now match on whole words; a real keyword still applies its penalty.
+func TestPersonNameValidator_ContextKeywordWordBoundary(t *testing.T) {
+	v := NewValidator()
+	// Substrings inside unrelated words must not trip the penalty.
+	for _, line := range []string{"Grace Hill parking lot", "Mark Brown incident report"} {
+		if imp := v.AnalyzeContext(strings.Join(strings.Fields(line)[:2], " "),
+			detector.ContextInfo{FullLine: line}); imp < 0 {
+			t.Errorf("L25: %q should not incur a negative keyword penalty, got %.1f", line, imp)
+		}
+	}
+	// A real geographic keyword still penalizes.
+	if imp := v.AnalyzeContext("John Smith", detector.ContextInfo{FullLine: "John Smith visited park today"}); imp >= 0 {
+		t.Errorf("L25: a real 'park' keyword should still penalize, got %.1f", imp)
+	}
+}

--- a/internal/validators/personname/validator_test.go
+++ b/internal/validators/personname/validator_test.go
@@ -4,6 +4,7 @@
 package personname
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/awslabs/ferret-scan/internal/context"
@@ -71,6 +72,102 @@ func TestPersonNameValidator_ValidNames(t *testing.T) {
 				t.Errorf("Expected no match but got %d: %s", len(matches), tt.description)
 			}
 		})
+	}
+}
+
+// TestPersonNameValidator_AccentedNames is a regression test for the ASCII
+// word-boundary bug. The old patterns used [A-ZÀ-ÿ] with a leading/trailing
+// ASCII \b, so:
+//   - names starting with an accented capital (Ángel, Óscar) never matched, and
+//   - names ending in an accent (José, André) were truncated ("Jos", "Andr"),
+//     corrupting the reported Text and the name-DB lookup.
+//
+// The patterns now use Unicode-aware boundaries (wrapNamePattern) and capture
+// the name in group 1.
+func TestPersonNameValidator_AccentedNames(t *testing.T) {
+	pm := NewPatternManager()
+
+	// Each name must be found AND reported in full (no truncation).
+	wantFound := []string{
+		"Ángel Ruiz",
+		"Óscar Núñez",
+		"José André",
+		"María González",
+		"François Dubois",
+	}
+	for _, name := range wantFound {
+		line := "contact " + name + " today"
+		matches := pm.FindMatches(line)
+		found := false
+		for _, m := range matches {
+			if m.Text == name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			got := make([]string, 0, len(matches))
+			for _, m := range matches {
+				got = append(got, m.Text)
+			}
+			t.Errorf("expected to find %q in full, got matches %v", name, got)
+		}
+	}
+
+	// The math symbols × (U+00D7) and ÷ (U+00F7) fall inside the old À-ÿ range
+	// but are NOT letters; they must not be treated as name characters.
+	for _, line := range []string{"5 × 3 equals 15", "A ÷ B ratio"} {
+		for _, m := range pm.FindMatches(line) {
+			if strings.ContainsAny(m.Text, "×÷") {
+				t.Errorf("name match %q in %q wrongly includes a math symbol", m.Text, line)
+			}
+		}
+	}
+}
+
+// TestPersonNameValidator_CommonWordBigram is a regression test for H6: a
+// Title-Cased bigram whose two tokens are both ordinary English words that also
+// appear in the name databases ("Will Read", "Grace Hill") jumped straight to 90
+// (HIGH). Such bigrams must now stay BELOW the HIGH bucket, while real names
+// (with at least one distinctive token) and formal patterns stay HIGH.
+func TestPersonNameValidator_CommonWordBigram(t *testing.T) {
+	v := NewValidator()
+	const highBucket = 90.0
+
+	best := func(line string) float64 {
+		matches, err := v.ValidateContent(line, "test.txt")
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", line, err)
+		}
+		var b float64
+		for _, m := range matches {
+			if m.Confidence > b {
+				b = m.Confidence
+			}
+		}
+		return b
+	}
+
+	// Common-word bigrams: must not reach HIGH on a bare two-word match.
+	for _, line := range []string{"Will Read", "Mark Brown", "Grace Hill", "Bill Young", "Rose Stone"} {
+		if c := best(line); c >= highBucket {
+			t.Errorf("common-word bigram %q should stay below HIGH (%.0f), got %.1f", line, highBucket, c)
+		}
+	}
+
+	// Real names (at least one distinctive token) must still reach HIGH.
+	for _, line := range []string{"John Smith", "Sarah Johnson", "Michael Williams", "David Brown"} {
+		if c := best(line); c < highBucket {
+			t.Errorf("real name %q should reach HIGH (>=%.0f), got %.1f", line, highBucket, c)
+		}
+	}
+
+	// A formal pattern (title / comma form) overrides the gate: a titled or
+	// directory-style entry could be a genuine person, so it stays HIGH.
+	for _, line := range []string{"Dr. Will Read", "Read, Will"} {
+		if c := best(line); c < highBucket {
+			t.Errorf("formal pattern %q should stay HIGH (>=%.0f), got %.1f", line, highBucket, c)
+		}
 	}
 }
 
@@ -919,5 +1016,78 @@ func TestPersonNameValidator_IsFormalNamePattern(t *testing.T) {
 				t.Errorf("isFormalNamePattern(%q) = %v, want %v", tt.pattern, result, tt.isFormal)
 			}
 		})
+	}
+}
+
+// TestPersonNameValidator_IsProperlyCapitalizedUnicode is a regression test for
+// M20: (1) the title/suffix exemption used a reversed strings.Contains so
+// substrings like "M"/"V"/"Pro" skipped the check; (2) word[0] byte-indexing
+// rejected accented capitals like 'Á'.
+func TestPersonNameValidator_IsProperlyCapitalizedUnicode(t *testing.T) {
+	v := NewValidator()
+	proper := []string{"John Smith", "Ángel Ramos", "Óscar Núñez", "Dr. Smith", "Mr. John Doe"}
+	for _, n := range proper {
+		if !v.isProperlyCapitalized(n) {
+			t.Errorf("%q should be considered properly capitalized", n)
+		}
+	}
+	improper := []string{"john smith", "john Smith", "ángel ramos"}
+	for _, n := range improper {
+		if v.isProperlyCapitalized(n) {
+			t.Errorf("%q should NOT be considered properly capitalized", n)
+		}
+	}
+}
+
+// TestPersonNameValidator_SuffixNotInWord is a regression test for M21: the
+// name_with_suffix pattern matched ordinary word triples ("Grace Park Verified")
+// by treating a leading "V"/"IV"/"III" of the third word as a suffix.
+func TestPersonNameValidator_SuffixNotInWord(t *testing.T) {
+	v := NewValidator()
+	for _, line := range []string{
+		"Grace Park Verified today",
+		"Michael Davis IVory tower",
+		"Thomas Anderson IIIumination",
+	} {
+		matches, _ := v.ValidateContent(line, "test.txt")
+		for _, m := range matches {
+			if p, ok := m.Metadata["pattern"]; ok && p == "name_with_suffix" {
+				t.Errorf("%q should not match as name_with_suffix (matched %q)", line, m.Text)
+			}
+		}
+	}
+	// A genuine suffixed name still matches.
+	matches, _ := v.ValidateContent("Grace Park Jr.", "test.txt")
+	if len(matches) == 0 {
+		t.Error("genuine 'Grace Park Jr.' should still be detected")
+	}
+}
+
+// TestPersonNameValidator_AllCapsNames is a regression test for M22: all-caps
+// names (common in forms/spreadsheets) never matched. They now surface when
+// DB-backed, while non-name all-caps prose is rejected (no new false positives).
+func TestPersonNameValidator_AllCapsNames(t *testing.T) {
+	v := NewValidator()
+	best := func(line string) float64 {
+		matches, _ := v.ValidateContent(line, "test.txt")
+		var b float64
+		for _, m := range matches {
+			if m.Confidence > b {
+				b = m.Confidence
+			}
+		}
+		return b
+	}
+	// Real all-caps names must surface.
+	for _, n := range []string{"JOHN SMITH", "SARAH JOHNSON", "MICHAEL WILLIAMS"} {
+		if best(n) < 50 {
+			t.Errorf("all-caps name %q should surface, got %.1f", n, best(n))
+		}
+	}
+	// All-caps prose must NOT surface (not in the name DB).
+	for _, n := range []string{"ERROR CODE", "TODO FIXME", "THE END", "NOT FOUND"} {
+		if best(n) >= 60 {
+			t.Errorf("all-caps prose %q must not reach MEDIUM, got %.1f", n, best(n))
+		}
 	}
 }

--- a/internal/validators/phone/validator.go
+++ b/internal/validators/phone/validator.go
@@ -136,8 +136,12 @@ func NewValidator() *Validator {
 		},
 		// International formats
 		{
-			name:    "International_Plus",
-			regex:   regexp.MustCompile(`(?:^|[\s,;|"'<>])\+\d{1,4}[-.\s]?\d{1,4}[-.\s]?\d{1,4}[-.\s]?\d{1,9}\b`),
+			name: "International_Plus",
+			// Tightened (M10): the middle/last groups now require 2-4 / 3-9 digits
+			// so dotted version tags like "+2024.1.1" or "+1.2.3.4" (groups of 1)
+			// no longer match as international phone numbers, while real numbers
+			// (+44 20 7946 0958, +1 415 555 2671, +12025550173) still do.
+			regex:   regexp.MustCompile(`(?:^|[\s,;|"'<>])\+\d{1,4}[-.\s]?\d{2,4}[-.\s]?\d{2,4}[-.\s]?\d{3,9}\b`),
 			country: "International",
 			format:  "+XX XXXX XXXX XXXX",
 		},
@@ -149,8 +153,11 @@ func NewValidator() *Validator {
 		},
 		// UK formats
 		{
-			name:    "UK_Standard",
-			regex:   regexp.MustCompile(`\b0\d{2,4}[-.\s]?\d{3,8}\b`),
+			name: "UK_Standard",
+			// Allow an optional THIRD group (M9): a real UK national number like
+			// "0161 496 0345" is area + two subscriber groups, which the previous
+			// two-group pattern truncated to "0161 496".
+			regex:   regexp.MustCompile(`\b0\d{2,4}[-.\s]?\d{3,8}([-.\s]\d{3,4})?\b`),
 			country: "UK",
 			format:  "0XXX XXXXXXXX",
 		},
@@ -162,8 +169,11 @@ func NewValidator() *Validator {
 		},
 		// European formats
 		{
-			name:    "European",
-			regex:   regexp.MustCompile(`(?:^|[\s,;|"'<>])\+\d{2}[-.\s]?\d{1,4}[-.\s]?\d{1,4}[-.\s]?\d{1,4}[-.\s]?\d{1,4}\b`),
+			name: "European",
+			// Tightened (M10): last group requires 3-4 digits and inner groups
+			// 2-4, so dotted version tags like "+2024.1.1" / "+1.2.3.4" no longer
+			// match as European phone numbers.
+			regex:   regexp.MustCompile(`(?:^|[\s,;|"'<>])\+\d{2}[-.\s]?\d{2,4}[-.\s]?\d{2,4}[-.\s]?\d{3,4}\b`),
 			country: "Europe",
 			format:  "+XX XXXX XXXX XXXX",
 		},
@@ -357,16 +367,30 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 	return matches, nil
 }
 
-// isDuplicateMatch checks if a match was already found (same number, same line)
+// isDuplicateMatch checks if a match was already found on the same line. Beyond
+// exact cleaned-digit equality, it also treats a match whose cleaned digits are
+// a prefix/substring of an already-found number (or vice versa) as a duplicate
+// (M11): overlapping patterns otherwise emit a truncated partial of the same
+// physical number (e.g. "+44 20 7946" alongside "+44 20 7946 0958"), inflating
+// finding counts with an incorrect partial value.
 func (v *Validator) isDuplicateMatch(existing []detector.Match, newMatch string, lineNum int) bool {
 	cleanNew := v.cleanPhoneNumber(newMatch)
+	if cleanNew == "" {
+		return false
+	}
 
 	for _, match := range existing {
-		if match.LineNumber == lineNum {
-			cleanExisting := v.cleanPhoneNumber(match.Text)
-			if cleanExisting == cleanNew {
-				return true
-			}
+		if match.LineNumber != lineNum {
+			continue
+		}
+		cleanExisting := v.cleanPhoneNumber(match.Text)
+		if cleanExisting == "" {
+			continue
+		}
+		if cleanExisting == cleanNew ||
+			strings.Contains(cleanExisting, cleanNew) ||
+			strings.Contains(cleanNew, cleanExisting) {
+			return true
 		}
 	}
 	return false
@@ -606,6 +630,15 @@ func (v *Validator) cleanPhoneNumber(phone string) string {
 	return cleaned
 }
 
+// hasPhoneSeparators reports whether the raw match is formatted like a phone
+// number — i.e. it contains parentheses, dashes, dots, spaces or a leading "+".
+// A bare run of digits with no separators is what timestamps, IDs and serials
+// look like; the timestamp/date heuristics should only fire on those, not on a
+// number a human clearly formatted as a phone (e.g. "(212) 555-0173").
+func (v *Validator) hasPhoneSeparators(match string) bool {
+	return strings.ContainsAny(match, "()-. ") || strings.HasPrefix(match, "+")
+}
+
 func (v *Validator) isTestPhoneNumber(phone string) bool {
 	lowerPhone := strings.ToLower(phone)
 
@@ -806,8 +839,18 @@ func (v *Validator) looksLikeCreditCard(match string) bool {
 	return false
 }
 
-// looksLikeTimestamp checks if the pattern matches common timestamp formats
+// looksLikeTimestamp checks if the pattern matches common timestamp formats.
+//
+// It only fires on a BARE run of digits with no phone separators: a number a
+// human formatted with parens/dashes/spaces ("(212) 555-0173") is a phone, not
+// a Unix timestamp, even though its 10-digit clean form (2125550173) falls in
+// the 32-bit timestamp range — which is exactly how valid NANP area codes
+// 200-214 (DC 202, NYC 212, 213/214) and the 19xx/20xx-prefixed long forms were
+// being wrongly penalized -60.
 func (v *Validator) looksLikeTimestamp(match string) bool {
+	if v.hasPhoneSeparators(match) {
+		return false
+	}
 	clean := v.cleanPhoneNumber(match)
 
 	// Unix timestamp patterns (10 digits starting with 1 or 2)
@@ -859,10 +902,10 @@ func (v *Validator) looksLikeInvalidNumber(match string) bool {
 		return true
 	}
 
-	// Numbers starting with 0 that aren't international format
-	if strings.HasPrefix(clean, "0") && !strings.HasPrefix(match, "+") && len(clean) < 10 {
-		return true
-	}
+	// Numbers starting with a trunk "0" (UK/EU national format). These are valid
+	// even when shorter than 10 digits, so we no longer reject them on length
+	// alone (M8) — only the <7-digit floor above applies. A genuinely invalid
+	// short leading-0 run is already caught by that floor.
 
 	// All zeros or mostly zeros
 	zeroCount := strings.Count(clean, "0")

--- a/internal/validators/phone/validator.go
+++ b/internal/validators/phone/validator.go
@@ -18,6 +18,10 @@ import (
 var (
 	phoneValidCharsPattern = regexp.MustCompile(`^[\d+\-.\s()]+$`)
 	phoneCleanPattern      = regexp.MustCompile(`[^\d+]`)
+	// reFictional555 matches the NANP reserved fictional exchange 555-0100..0199
+	// in cleaned-digit form ("55501" + two digits), anchored to a 7- or 10/11-digit
+	// number so it doesn't fire on an incidental "55501" run inside other digits.
+	reFictional555         = regexp.MustCompile(`(?:^|[^\d])\+?1?(?:\d{3})?55501\d{2}$`)
 	ssnPattern             = regexp.MustCompile(`^\d{3}[-.\s]\d{2}[-.\s]\d{4}$`)
 	phoneMultiSpacePattern = regexp.MustCompile(`\s{2,}`)
 	namePhonePattern       = regexp.MustCompile(`[A-Z][a-z]+\s+[A-Z][a-z]+\s+\(?\d{3}\)?`)
@@ -76,13 +80,18 @@ func NewValidator() *Validator {
 			"demo", "template", "tutorial", "documentation", "readme",
 			"lorem", "ipsum", "foo", "bar", "baz", "temp", "temporary",
 			"invalid", "nonexistent", "blackhole", "devnull", "null",
-			// SSN-specific keywords to avoid false positives
+			// SSN-specific keywords to avoid false positives. Generic words
+			// "number"/"id"/"name"/"account" were removed (L28): they collide with
+			// legitimate phone context ("phone number", "contact number") and
+			// tabular contact records ("name, phone, id"), demoting real phones out
+			// of HIGH/MEDIUM. The structural SSN/credit-card/timestamp checks (which
+			// don't rely on these words) still suppress those data types.
 			"ssn", "social", "security", "social security", "tax", "identification",
-			"taxpayer", "employee", "id", "number", "federal", "ein", "itin",
+			"taxpayer", "employee", "federal", "ein", "itin",
 			// Credit card and financial data keywords
 			"credit", "card", "visa", "mastercard", "amex", "american express",
-			"discover", "account", "balance", "payment", "transaction", "amount",
-			"first and last name", "last name", "first name", "name",
+			"discover", "balance", "payment", "transaction", "amount",
+			"first and last name", "last name", "first name",
 			// Timestamp and technical keywords
 			"timestamp", "unix", "epoch", "milliseconds", "seconds", "time",
 			"created", "modified", "updated", "generated", "build", "version",
@@ -641,19 +650,30 @@ func (v *Validator) hasPhoneSeparators(match string) bool {
 
 func (v *Validator) isTestPhoneNumber(phone string) bool {
 	lowerPhone := strings.ToLower(phone)
+	cleanDigits := v.cleanPhoneNumber(phone)
 
-	// Check against known test numbers
+	// Match full known test numbers by cleaned-digit equality, not substring
+	// (L29): substring matching on short fragments like "123-456" / "987-654"
+	// penalized real numbers that merely contained those runs.
 	for _, testNumber := range v.testPhoneNumbers {
-		if strings.Contains(phone, testNumber) {
+		if cleanDigits == v.cleanPhoneNumber(testNumber) {
 			return true
 		}
 	}
 
-	// Check against test patterns
-	for _, pattern := range v.knownTestPatterns {
-		if strings.Contains(lowerPhone, strings.ToLower(pattern)) {
+	// Textual placeholder words anywhere in the raw value are still a test signal.
+	for _, word := range []string{"test", "example"} {
+		if strings.Contains(lowerPhone, word) {
 			return true
 		}
+	}
+
+	// The 555-0100..555-0199 exchange is the reserved fictional/test range
+	// (NANP): in cleaned digits that is "55501" + two digits. Match it
+	// structurally rather than via the broad "555-0" fragment, which previously
+	// also flagged real numbers containing that run.
+	if reFictional555.MatchString(cleanDigits) {
+		return true
 	}
 
 	return false
@@ -731,10 +751,15 @@ func (v *Validator) isValidCountryFormat(phone string, pattern phonePattern) boo
 	// Basic validation based on pattern country
 	switch pattern.country {
 	case "US/CA":
-		// US/Canada numbers should be 10 digits (excluding country code)
+		// US/Canada numbers should be 10 digits (excluding country code). Strip a
+		// leading country code whether written "+1" or as a bare "1" (L30): a
+		// toll-free / long-distance number like "1-800-555-1234" cleans to 11
+		// digits, and the previous code only stripped "+1", so it wrongly scored
+		// the bare-1 form as an invalid country format (-10 instead of +5).
 		clean := v.cleanPhoneNumber(phone)
-		if strings.HasPrefix(clean, "+1") {
-			clean = clean[2:]
+		clean = strings.TrimPrefix(clean, "+")
+		if len(clean) == 11 && strings.HasPrefix(clean, "1") {
+			clean = clean[1:]
 		}
 		return len(clean) == 10
 	case "UK":

--- a/internal/validators/phone/validator_test.go
+++ b/internal/validators/phone/validator_test.go
@@ -614,11 +614,15 @@ func TestPhoneValidator_ContextAnalysis(t *testing.T) {
 			expectedImpact: "negative",
 		},
 		{
+			// "number" was removed from negativeKeywords (L28) — it collides with
+			// legitimate phone context and tabular contact data, so it no longer
+			// applies a penalty. A valid-looking number with no real negative
+			// signal now scores high, as it should.
 			name:           "Neutral Context",
-			content:        "The number is 555-123-4567",
+			content:        "The entry is 555-123-4567",
 			expectMatch:    true,
 			minConfidence:  40,
-			maxConfidence:  80,
+			maxConfidence:  100,
 			expectedImpact: "neutral",
 		},
 	}
@@ -773,5 +777,48 @@ func TestPhoneValidator_NoDuplicatePartials(t *testing.T) {
 			got = append(got, m.Text)
 		}
 		t.Errorf("expected a single match for one phone number, got %d: %v", len(matches), got)
+	}
+}
+
+// TestPhoneValidator_LowSeverityFindings covers three LOW-severity fixes:
+// L28 generic words (number/name/id/account) removed from negativeKeywords;
+// L29 test-pattern matching anchored to the full number (not short fragments);
+// L30 a bare leading "1" country code is stripped for US/CA format validation.
+func TestPhoneValidator_LowSeverityFindings(t *testing.T) {
+	v := NewValidator()
+
+	// L28: legitimate "phone number"/contact-record context must not demote.
+	for _, line := range []string{
+		"Phone number: 415-555-2671",
+		"name, id, account, phone 415-555-2671",
+	} {
+		matches, _ := v.ValidateContent(line, "test.txt")
+		var best float64
+		for _, m := range matches {
+			if m.Confidence > best {
+				best = m.Confidence
+			}
+		}
+		if best < 60 {
+			t.Errorf("L28: %q should stay MEDIUM/HIGH, got %.1f", line, best)
+		}
+	}
+
+	// L29: real numbers that merely contain a test fragment are not test numbers;
+	// full known test numbers and the fictional 555-01xx range still are.
+	for _, real := range []string{"415-123-4567", "303-987-6543"} {
+		if v.isTestPhoneNumber(real) {
+			t.Errorf("L29: %s is a real number, not a test number", real)
+		}
+	}
+	for _, test := range []string{"555-0100", "123-456-7890"} {
+		if !v.isTestPhoneNumber(test) {
+			t.Errorf("L29: %s should still be recognized as a test number", test)
+		}
+	}
+
+	// L30: a bare leading "1" must be stripped for US/CA 10-digit validation.
+	if !v.isValidCountryFormat("1-800-555-1234", phonePattern{country: "US/CA"}) {
+		t.Error("L30: bare-1 toll-free number should be a valid US/CA format")
 	}
 }

--- a/internal/validators/phone/validator_test.go
+++ b/internal/validators/phone/validator_test.go
@@ -690,3 +690,88 @@ func TestPhoneValidator_RegressionTests(t *testing.T) {
 		}
 	})
 }
+
+// TestPhoneValidator_NANPAreaCodesNotTimestamps is a regression test for M6/M12:
+// formatted NANP numbers in area codes 200-214 (and 19xx/20xx long forms) were
+// penalized -60 as Unix timestamps/dates. The timestamp heuristic now only fires
+// on a bare digit run with no phone separators.
+func TestPhoneValidator_NANPAreaCodesNotTimestamps(t *testing.T) {
+	v := NewValidator()
+	for _, line := range []string{
+		"call (212) 555-0173 now",
+		"Phone: (202) 555-0173",
+		"contact 213-555-0173",
+		"phone 201-998-7654",
+	} {
+		matches, _ := v.ValidateContent(line, "test.txt")
+		var best float64
+		for _, m := range matches {
+			if m.Confidence > best {
+				best = m.Confidence
+			}
+		}
+		if best < 60 {
+			t.Errorf("formatted NANP number in %q should reach MEDIUM, got %.1f", line, best)
+		}
+	}
+	// A bare 10-digit run with no separators may still be treated as a timestamp.
+	if !v.looksLikeTimestamp("2125550173") {
+		t.Error("a bare 10-digit run should still be eligible as a timestamp")
+	}
+	if v.looksLikeTimestamp("(212) 555-0173") {
+		t.Error("a separator-formatted phone must not be treated as a timestamp")
+	}
+}
+
+// TestPhoneValidator_UKNationalThreeGroup is a regression test for M8/M9: a
+// full UK national number (area + two subscriber groups) was truncated to two
+// groups and the leading-0 form was penalized as invalid.
+func TestPhoneValidator_UKNationalThreeGroup(t *testing.T) {
+	v := NewValidator()
+	matches, _ := v.ValidateContent("ring 0161 496 0345 today", "test.txt")
+	found := false
+	for _, m := range matches {
+		if m.Text == "0161 496 0345" {
+			found = true
+		}
+	}
+	if !found {
+		got := make([]string, 0, len(matches))
+		for _, m := range matches {
+			got = append(got, m.Text)
+		}
+		t.Errorf("full UK number '0161 496 0345' should be captured whole, got %v", got)
+	}
+}
+
+// TestPhoneValidator_VersionStringNotPhone is a regression test for M10: dotted,
+// "+"-prefixed version tags ("+2024.1.1", "+1.2.3.4") matched as international
+// phone numbers.
+func TestPhoneValidator_VersionStringNotPhone(t *testing.T) {
+	v := NewValidator()
+	for _, line := range []string{"git tag +2024.1.1 released", "version +1.2.3.4 here"} {
+		matches, _ := v.ValidateContent(line, "test.txt")
+		if len(matches) > 0 {
+			t.Errorf("version string %q should not match as a phone, got %d", line, len(matches))
+		}
+	}
+	// Real international numbers still match.
+	if m, _ := v.ValidateContent("call +44 20 7946 0958 now", "test.txt"); len(m) == 0 {
+		t.Error("real international number should still be detected")
+	}
+}
+
+// TestPhoneValidator_NoDuplicatePartials is a regression test for M11:
+// overlapping patterns emitted a truncated partial of the same number alongside
+// the full match.
+func TestPhoneValidator_NoDuplicatePartials(t *testing.T) {
+	v := NewValidator()
+	matches, _ := v.ValidateContent("Reach me +44 20 7946 0958 today", "test.txt")
+	if len(matches) != 1 {
+		got := make([]string, 0, len(matches))
+		for _, m := range matches {
+			got = append(got, m.Text)
+		}
+		t.Errorf("expected a single match for one phone number, got %d: %v", len(matches), got)
+	}
+}

--- a/internal/validators/secrets/validator.go
+++ b/internal/validators/secrets/validator.go
@@ -4,6 +4,7 @@
 package secrets
 
 import (
+	"encoding/base64"
 	"math"
 	"regexp"
 	"strings"
@@ -101,15 +102,24 @@ func NewValidator() *Validator {
 		contextAnalyzer: context.NewContextAnalyzer(),
 
 		// Development/staging environment keywords
+		// devKeywords are kept DISJOINT from testKeywords (M25): "test"/"testing"/
+		// "demo" were in both sets, so they incremented both scores equally and
+		// the testScore>devScore tie-break could essentially never fire, misclass-
+		// ifying test content as "development" (-15 instead of -25).
 		devKeywords: []string{
-			"dev", "development", "staging", "stage", "test", "testing",
-			"local", "localhost", "demo", "sandbox", "preview", "beta",
+			"dev", "development", "staging", "stage",
+			"local", "localhost", "sandbox", "preview",
 		},
 
 		// Production environment keywords
+		// prodKeywords use only unambiguous production markers (M25): generic
+		// tokens "main"/"master"/"real"/"actual"/"customer"/"client" were
+		// dropped because they classified ordinary source ("package main",
+		// "func main") as production and applied a spurious +10 boost to every
+		// candidate in the file.
 		prodKeywords: []string{
-			"prod", "production", "live", "release", "deploy", "master",
-			"main", "stable", "customer", "client", "real", "actual",
+			"production", "prod-", "prod_", ".prod", "live", "release",
+			"deploy", "stable", "node_env=production",
 		},
 
 		// Test-specific keywords
@@ -728,11 +738,15 @@ func (v *Validator) CalculateConfidence(match string) (float64, map[string]bool)
 		confidence -= 10 // Very long strings might be less likely to be secrets
 	}
 
-	// Check for common words/patterns
+	// Check for common words/patterns. Only penalize when the word DOMINATES the
+	// token (the match is essentially that word), not when it is an incidental
+	// substring of a long high-entropy value — a 30-char random secret that
+	// merely begins with "test" or contains "secret" is still a real secret
+	// (M26). Require the common word to make up at least half the match.
 	lowerMatch := strings.ToLower(match)
 	commonWords := []string{"password", "secret", "example", "test", "sample", "default"}
 	for _, word := range commonWords {
-		if strings.Contains(lowerMatch, word) {
+		if strings.Contains(lowerMatch, word) && len(word)*2 >= len(lowerMatch) {
 			confidence -= 20
 			checks["not_common_word"] = false
 			break
@@ -749,10 +763,13 @@ func (v *Validator) CalculateConfidence(match string) (float64, map[string]bool)
 		checks["has_entropy"] = false
 	}
 
-	// Test data patterns
+	// Test data patterns. Like the common-word check above, only penalize when the
+	// token IS essentially the test word (delimiter-bounded or dominating the
+	// length), not when "test"/"demo" is an incidental substring of a long
+	// high-entropy secret (M26).
 	testPatterns := []string{"test", "demo", "example", "sample", "fake", "mock"}
 	for _, pattern := range testPatterns {
-		if strings.Contains(lowerMatch, pattern) {
+		if strings.Contains(lowerMatch, pattern) && len(pattern)*3 >= len(lowerMatch) {
 			confidence -= 30
 			checks["not_test_data"] = false
 			break
@@ -832,11 +849,28 @@ func (v *Validator) isCertificate(match string) bool {
 		strings.Contains(match, endMarker)
 }
 
-// isJWTToken checks if the match is a JWT token
+// isJWTToken checks if the match is a JWT token. Beyond the "eyJ" prefix and
+// three dot-separated parts, it requires non-trivial segment lengths AND that
+// the header segment base64url-decodes to JSON containing "alg". The previous
+// prefix-and-dot-count check accepted "eyJ..", minified-JS identifiers
+// ("eyJfile.min.js") and arbitrary "eyJabc.def.ghi" strings as confidence-100
+// JWTs.
 func (v *Validator) isJWTToken(match string) bool {
-	// JWT tokens have 3 parts separated by dots, starting with eyJ
 	parts := strings.Split(match, ".")
-	return len(parts) == 3 && strings.HasPrefix(match, "eyJ")
+	if len(parts) != 3 || !strings.HasPrefix(match, "eyJ") {
+		return false
+	}
+	// Real JWT header/payload are non-trivial; the signature is shorter but
+	// never empty.
+	if len(parts[0]) < 10 || len(parts[1]) < 10 || len(parts[2]) < 5 {
+		return false
+	}
+	// The header must base64url-decode to JSON declaring an algorithm.
+	decoded, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(decoded), `"alg"`)
 }
 
 // isAWSAccessKey checks if the match is an AWS access key
@@ -878,9 +912,19 @@ func (v *Validator) isDockerToken(match string) bool {
 	return strings.HasPrefix(match, "dckr_pat_") && len(match) == 45
 }
 
-// isSlackToken checks if the match is a Slack token
+// slackBotTokenPattern / slackUserTokenPattern validate the full Slack token
+// structure (mirroring the strict compiled patterns used elsewhere), not just
+// the "xoxb-"/"xoxp-" prefix.
+var (
+	slackBotTokenPattern  = regexp.MustCompile(`^xoxb-[0-9]{11,12}-[0-9]{11,12}-[a-zA-Z0-9]{24}$`)
+	slackUserTokenPattern = regexp.MustCompile(`^xoxp-[0-9]{11,12}-[0-9]{11,12}-[0-9]{11,12}-[a-zA-Z0-9]{32}$`)
+)
+
+// isSlackToken checks if the match is a Slack token. It validates the full token
+// structure rather than just the prefix: the previous prefix-only check returned
+// true for any string starting with the bot/user token prefix and scored it 94.
 func (v *Validator) isSlackToken(match string) bool {
-	return strings.HasPrefix(match, "xoxb-") || strings.HasPrefix(match, "xoxp-")
+	return slackBotTokenPattern.MatchString(match) || slackUserTokenPattern.MatchString(match)
 }
 
 // isPGPPrivateKey checks if the match is a PGP private key. Markers are
@@ -1317,6 +1361,18 @@ func (v *Validator) calculateEnhancedConfidenceWithCacheAndEnv(match, fullConten
 		}
 	}
 
+	// Generic high-entropy strings (git SHAs, UUIDs, base64 asset hashes) start at
+	// base 85 and the doc-type boosts above can push them to HIGH with no evidence
+	// they are credentials (M24). When the match is NOT a specific typed pattern
+	// (AWS/JWT/GitHub/...) and there is no corroborating secret keyword nearby,
+	// cap it just below the MEDIUM threshold so it does not surface as MEDIUM/HIGH
+	// on shape alone. A specific pattern, or a nearby secret keyword, lifts it.
+	if !checks["specific_pattern"] && !v.hasNearbySecretKeyword(fullContent, match) {
+		if confidence > 55 {
+			confidence = 55
+		}
+	}
+
 	// Ensure confidence bounds
 	if confidence < 0 {
 		confidence = 0
@@ -1325,6 +1381,30 @@ func (v *Validator) calculateEnhancedConfidenceWithCacheAndEnv(match, fullConten
 	}
 
 	return confidence, checks
+}
+
+// hasNearbySecretKeyword reports whether a positive secret keyword appears on the
+// same line as the match — corroboration that a generic high-entropy string is a
+// credential rather than an incidental hash/UUID/blob.
+func (v *Validator) hasNearbySecretKeyword(fullContent, match string) bool {
+	line := match
+	if idx := strings.Index(fullContent, match); idx >= 0 {
+		start := strings.LastIndexByte(fullContent[:idx], '\n') + 1
+		end := idx + len(match)
+		if nl := strings.IndexByte(fullContent[end:], '\n'); nl >= 0 {
+			end += nl
+		} else {
+			end = len(fullContent)
+		}
+		line = fullContent[start:end]
+	}
+	lower := strings.ToLower(line)
+	for _, kw := range v.positiveKeywords {
+		if strings.Contains(lower, kw) {
+			return true
+		}
+	}
+	return false
 }
 
 // detectEnvironmentType detects if content is from development, test, or production environment

--- a/internal/validators/secrets/validator_test.go
+++ b/internal/validators/secrets/validator_test.go
@@ -7,8 +7,15 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/awslabs/ferret-scan/internal/context"
 	"github.com/awslabs/ferret-scan/internal/detector"
 )
+
+// contextInsightsForTest builds a minimal ContextInsights with the given
+// document type for confidence tests.
+func contextInsightsForTest(docType string) context.ContextInsights {
+	return context.ContextInsights{DocumentType: docType}
+}
 
 // buildTestToken constructs test tokens at runtime to avoid triggering
 // static secret scanners in pre-commit hooks. These are intentional test
@@ -271,9 +278,17 @@ func TestSecretsValidator_JWTTokens(t *testing.T) {
 			wantDetect: true,
 		},
 		{
-			name:       "Minimal JWT structure",
+			// Tightened by M23: short segments whose header does not base64url-
+			// decode to JSON with "alg" are no longer accepted as JWTs (this
+			// rejects minified-JS identifiers and "eyJ.." style false positives).
+			name:       "Too-short non-decoding segments are not a JWT",
 			match:      "eyJhbGci.eyJzdWIi.sig123",
-			wantDetect: true,
+			wantDetect: false,
+		},
+		{
+			name:       "eyJ prefix with empty segments is not a JWT",
+			match:      "eyJ..",
+			wantDetect: false,
 		},
 		{
 			name:       "Missing eyJ prefix",
@@ -1449,5 +1464,94 @@ func TestSecretsValidator_AnalyzeContext_CapsImpact(t *testing.T) {
 	impact = v.AnalyzeContext("match", negativeContext)
 	if impact < -40 {
 		t.Errorf("Negative impact should be capped at -40, got %.1f", impact)
+	}
+}
+
+// TestSecretsValidator_SlackTokenStructure is a regression test for M27: the
+// Slack token check was prefix-only, accepting junk that merely started with the
+// bot/user prefix. It now validates the full token structure. Tokens are built
+// at runtime via buildTestToken to avoid tripping static secret scanners.
+func TestSecretsValidator_SlackTokenStructure(t *testing.T) {
+	v := NewValidator()
+	botPrefix := buildTestToken("xox", "b-")
+	userPrefix := buildTestToken("xox", "p-")
+
+	// Structurally valid tokens.
+	valid := []string{
+		buildTestToken(botPrefix, "123456789012-123456789012-abcdefghijklmnopqrstuvwx"),
+		buildTestToken(userPrefix, "123456789012-123456789012-123456789012-abcdefghijklmnopqrstuvwxyz123456"),
+	}
+	for _, tok := range valid {
+		if !v.isSlackToken(tok) {
+			t.Errorf("structurally valid Slack token %q should be detected", tok)
+		}
+	}
+	// Prefix-only junk must be rejected.
+	junk := []string{
+		buildTestToken(botPrefix, "abc"),
+		buildTestToken(userPrefix, "1"),
+		botPrefix,
+		buildTestToken("xox", "bnotatoken"),
+	}
+	for _, tok := range junk {
+		if v.isSlackToken(tok) {
+			t.Errorf("prefix-only junk %q should not be a Slack token", tok)
+		}
+	}
+}
+
+// TestSecretsValidator_HighEntropyTestSubstring is a regression test for M26: a
+// long high-entropy secret that merely contains "test"/"secret" as a substring
+// was penalized below the MEDIUM threshold. Such tokens keep their base score.
+func TestSecretsValidator_HighEntropyTestSubstring(t *testing.T) {
+	v := NewValidator()
+	for _, tok := range []string{
+		"testkR9wX2mQ7vL4nB8pZ1aT6cF3hJ5", // 30 chars, begins with "test"
+		"kR9secretX2mQ7vL4nB8pZ1aT6cF3hJ5",
+	} {
+		conf, _ := v.CalculateConfidence(tok)
+		if conf < 60 {
+			t.Errorf("high-entropy secret %q should not be gutted by an incidental substring, got %.1f", tok, conf)
+		}
+	}
+	// A token that IS essentially the word must still be penalized.
+	if conf, _ := v.CalculateConfidence("test1234"); conf >= 85 {
+		t.Errorf("token dominated by 'test' should still be penalized, got %.1f", conf)
+	}
+}
+
+// TestSecretsValidator_EnvironmentClassification is a regression test for M25:
+// "package main" / "func main" classified as production (spurious +10 boost),
+// and test content misclassified as development due to dev/test keyword overlap.
+func TestSecretsValidator_EnvironmentClassification(t *testing.T) {
+	v := NewValidator()
+	if env := v.detectEnvironmentType("package main\nfunc main() {}"); env == "production" {
+		t.Errorf("ordinary Go source should not be classified production, got %q", env)
+	}
+	if env := v.detectEnvironmentType("this is example mock fake sample data"); env != "test" {
+		t.Errorf("clear test content should classify as test, got %q", env)
+	}
+}
+
+// TestSecretsValidator_GenericEntropyNotHighWithoutContext is a regression test
+// for M24: a context-free high-entropy string (git SHA, hash, blob) started at
+// base 85 and reached HIGH via doc-type boosts with no evidence it is a secret.
+// It must not reach HIGH without a corroborating secret keyword; with one, it
+// still does.
+func TestSecretsValidator_GenericEntropyNotHighWithoutContext(t *testing.T) {
+	v := NewValidator()
+	full := "checksum: aB3cD4eF5gH6iJ7kL8mN9oP0qR1sT2u"
+	conf, checks := v.calculateEnhancedConfidenceWithCacheAndEnv(
+		"aB3cD4eF5gH6iJ7kL8mN9oP0qR1sT2u", full, contextInsightsForTest("Configuration"), false, "")
+	if !checks["specific_pattern"] && conf >= 60 {
+		t.Errorf("context-free generic entropy string should stay below MEDIUM, got %.1f", conf)
+	}
+
+	// With a secret keyword on the line it should be allowed to reach HIGH.
+	withKw := "api_secret = aB3cD4eF5gH6iJ7kL8mN9oP0qR1sT2u"
+	confKw, _ := v.calculateEnhancedConfidenceWithCacheAndEnv(
+		"aB3cD4eF5gH6iJ7kL8mN9oP0qR1sT2u", withKw, contextInsightsForTest("Configuration"), false, "")
+	if confKw < 60 {
+		t.Errorf("entropy string with a secret keyword should reach MEDIUM/HIGH, got %.1f", confKw)
 	}
 }

--- a/internal/validators/ssn/validator.go
+++ b/internal/validators/ssn/validator.go
@@ -262,11 +262,22 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 				}
 				// Don't cap confidence for tabular data - let the base confidence stand
 			} else if len(contextInfo.PositiveKeywords) == 0 {
-				// For non-tabular data without positive keywords, be more restrictive
+				// For non-tabular data without positive keywords, be more restrictive.
 				if len(contextInfo.NegativeKeywords) > 0 {
 					confidence -= 25 // Stronger penalty for negative context in non-tabular data
-				} else if confidence > 50 {
-					confidence = 50 // Cap at medium confidence without context for non-tabular data
+				} else {
+					// The strongly-formatted hyphenated XXX-XX-XXXX form (which has
+					// already passed all structural checks) is high-quality evidence
+					// on its own, so allow it to reach the 60 MEDIUM threshold even
+					// without a keyword (L45). The riskier separator-less / spaced
+					// forms keep the stricter LOW cap of 50.
+					capValue := 50.0
+					if v.isStrongHyphenatedSSN(match) {
+						capValue = 60.0
+					}
+					if confidence > capValue {
+						confidence = capValue
+					}
 				}
 			}
 
@@ -629,6 +640,18 @@ func (v *Validator) CalculateConfidence(match string) (float64, map[string]bool)
 // Helper methods
 func (v *Validator) cleanSSN(ssn string) string {
 	return strings.ReplaceAll(strings.ReplaceAll(ssn, "-", ""), " ", "")
+}
+
+// isStrongHyphenatedSSN reports whether match is the canonical hyphenated
+// XXX-XX-XXXX form with a valid area number — the highest-quality SSN shape.
+// Such a value is strong enough evidence to reach MEDIUM without a nearby
+// keyword (L45), unlike the riskier bare/space-separated forms.
+func (v *Validator) isStrongHyphenatedSSN(match string) bool {
+	parts := strings.Split(match, "-")
+	if len(parts) != 3 || len(parts[0]) != 3 || len(parts[1]) != 2 || len(parts[2]) != 4 {
+		return false
+	}
+	return v.isValidAreaNumber(parts[0])
 }
 
 func (v *Validator) isValidSSN(ssn string) bool {

--- a/internal/validators/ssn/validator.go
+++ b/internal/validators/ssn/validator.go
@@ -31,6 +31,47 @@ var (
 	reDigitSequences = regexp.MustCompile(`\b\d{18}\b`)
 )
 
+// containsKeyword reports whether text contains keyword as a whole word/phrase,
+// case-insensitively. The previous code used strings.Contains, so short keywords
+// matched inside unrelated words — "hr" in "Christopher" (+45 inflation), "ein"
+// in "Einstein", "ext" in "next", "code" in "barcode" — both fabricating context
+// boosts on non-SSN lines and spuriously penalizing real SSNs.
+//
+// It is implemented as a plain string scan with manual boundary checks rather
+// than a regex: AnalyzeContext/validateSSNByDomain/findKeywords invoke it on the
+// order of a hundred times per matched SSN, and a compiled-regex MatchString per
+// keyword made SSN-dense input ~13x slower. A "word" character here is
+// [a-z0-9_]; a boundary is the string edge or any non-word byte, which also
+// correctly anchors keywords whose own edges are non-word (e.g. "w-2").
+func containsKeyword(text, keyword string) bool {
+	if keyword == "" {
+		return false
+	}
+	lt := strings.ToLower(text)
+	lk := strings.ToLower(keyword)
+	for from := 0; from+len(lk) <= len(lt); {
+		i := strings.Index(lt[from:], lk)
+		if i < 0 {
+			return false
+		}
+		i += from
+		leftOK := i == 0 || !isWordByte(lt[i-1])
+		right := i + len(lk)
+		rightOK := right >= len(lt) || !isWordByte(lt[right])
+		if leftOK && rightOK {
+			return true
+		}
+		from = i + 1
+	}
+	return false
+}
+
+// isWordByte reports whether b is a word character ([a-z0-9_]) for the purpose
+// of keyword boundary detection. text is already lowercased by the caller.
+func isWordByte(b byte) bool {
+	return b == '_' || (b >= 'a' && b <= 'z') || (b >= '0' && b <= '9')
+}
+
 // Validator implements the detector.Validator interface for detecting
 // Social Security Numbers using regex patterns and contextual analysis.
 type Validator struct {
@@ -101,8 +142,12 @@ func NewValidator() *Validator {
 			"medical insurance", "health insurance", "patient id", "medical id",
 		},
 		globalTestPatterns: []string{
+			// Strong test-data indicators. Generic doc/config words
+			// ("documentation", "readme", "template", "default", "tutorial") were
+			// intentionally removed: they commonly appear on legitimate doc/config
+			// lines that may also carry a real SSN, and a -40 penalty on their mere
+			// presence pushed genuine SSNs below the surfacing threshold.
 			"test", "example", "sample", "demo", "placeholder", "mock", "fake",
-			"tutorial", "documentation", "readme", "template", "default",
 			"lorem ipsum", "john doe", "jane smith", "foo bar", "qwerty",
 			"111111111", "222222222", "333333333", "444444444", "555555555",
 			"777777777", "888888888", "999999999", "123456789", "987654321",
@@ -225,6 +270,18 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 				}
 			}
 
+			// Drop known denylisted test SSNs (123-45-6789, 123-45-4321, all-same
+			// digits, etc.). These are not real PII, yet a nearby positive keyword
+			// like "ssn"/"employee" could previously push them to HIGH (100) — a
+			// maximum-confidence false positive on a value the validator itself
+			// flags as test data. The decision is made here, after context
+			// analysis, so it is not defeated by keyword boosts. This is the
+			// false-positive-minimizing behavior and matches the validator's own
+			// denylist intent.
+			if v.isTestSSN(v.cleanSSN(match)) {
+				continue
+			}
+
 			// Ensure confidence stays within bounds
 			if confidence > 100 {
 				confidence = 100
@@ -277,9 +334,9 @@ func (v *Validator) AnalyzeContext(match string, context detector.ContextInfo) f
 
 	// Check for positive keywords (increase confidence)
 	for _, keyword := range v.positiveKeywords {
-		if strings.Contains(fullContext, strings.ToLower(keyword)) {
+		if containsKeyword(fullContext, keyword) {
 			// Give more weight to keywords that are closer to the match
-			if strings.Contains(context.FullLine, strings.ToLower(keyword)) {
+			if containsKeyword(context.FullLine, keyword) {
 				confidenceImpact += 25 // +25% for keywords in the same line
 			} else {
 				confidenceImpact += 10 // +10% for keywords in surrounding context
@@ -289,9 +346,9 @@ func (v *Validator) AnalyzeContext(match string, context detector.ContextInfo) f
 
 	// Check for negative keywords (decrease confidence)
 	for _, keyword := range v.negativeKeywords {
-		if strings.Contains(fullContext, strings.ToLower(keyword)) {
+		if containsKeyword(fullContext, keyword) {
 			// Give more weight to keywords that are closer to the match
-			if strings.Contains(context.FullLine, strings.ToLower(keyword)) {
+			if containsKeyword(context.FullLine, keyword) {
 				confidenceImpact -= 15 // -15% for negative keywords in the same line
 			} else {
 				confidenceImpact -= 8 // -8% for negative keywords in surrounding context
@@ -327,7 +384,7 @@ func (v *Validator) validateSSNByDomain(ssn, context string) float64 {
 
 	// HR/Payroll context
 	for _, keyword := range v.hrKeywords {
-		if strings.Contains(context, keyword) {
+		if containsKeyword(context, keyword) {
 			boost += 20
 			break // Only apply once per domain
 		}
@@ -335,7 +392,7 @@ func (v *Validator) validateSSNByDomain(ssn, context string) float64 {
 
 	// Tax document context
 	for _, keyword := range v.taxKeywords {
-		if strings.Contains(context, keyword) {
+		if containsKeyword(context, keyword) {
 			boost += 25
 			break // Only apply once per domain
 		}
@@ -343,7 +400,7 @@ func (v *Validator) validateSSNByDomain(ssn, context string) float64 {
 
 	// Healthcare context
 	for _, keyword := range v.healthcareKeywords {
-		if strings.Contains(context, keyword) {
+		if containsKeyword(context, keyword) {
 			boost += 18
 			break // Only apply once per domain
 		}
@@ -399,9 +456,20 @@ func (v *Validator) isEnhancedTestPattern(value, context string) bool {
 	lowerValue := strings.ToLower(value)
 	lowerContext := strings.ToLower(context)
 
-	// Check global test patterns
+	// Check global test patterns. The list mixes numeric patterns (e.g.
+	// "111111111") with generic doc/config words ("demo", "default", "readme").
+	// Match numeric/value patterns against the value itself, but match WORD
+	// patterns against the context on whole-word boundaries only — the previous
+	// raw substring scan over the whole line meant an unrelated word like "demo"
+	// inside "demographic" (or simply present on a config line) applied the -40
+	// test penalty and pushed real SSNs under the surfacing threshold.
 	for _, pattern := range v.globalTestPatterns {
-		if strings.Contains(lowerValue, pattern) || strings.Contains(lowerContext, pattern) {
+		// Value match: an actual test value embedded in the candidate.
+		if strings.Contains(lowerValue, pattern) {
+			return true
+		}
+		// Context match: require the pattern to appear as a whole word.
+		if containsKeyword(lowerContext, pattern) {
 			return true
 		}
 	}
@@ -456,11 +524,11 @@ func (v *Validator) isObviousTestSequence(value string) bool {
 // findKeywords returns a list of keywords found in the context
 func (v *Validator) findKeywords(context detector.ContextInfo, keywords []string) []string {
 	// Only check the current line to avoid cross-line contamination
-	fullContext := strings.ToLower(context.FullLine)
+	fullLine := context.FullLine
 
 	var found []string
 	for _, keyword := range keywords {
-		if strings.Contains(fullContext, strings.ToLower(keyword)) {
+		if containsKeyword(fullLine, keyword) {
 			found = append(found, keyword)
 		}
 	}
@@ -508,6 +576,7 @@ func (v *Validator) CalculateConfidence(match string) (float64, map[string]bool)
 	}
 
 	// Boost confidence for properly formatted SSNs (XXX-XX-XXXX pattern)
+	hasSeparator := strings.ContainsAny(match, "- ")
 	if strings.Contains(match, "-") && len(strings.Split(match, "-")) == 3 {
 		parts := strings.Split(match, "-")
 		if len(parts[0]) == 3 && len(parts[1]) == 2 && len(parts[2]) == 4 {
@@ -515,7 +584,19 @@ func (v *Validator) CalculateConfidence(match string) (float64, map[string]bool)
 		}
 	}
 
-	// Check for test numbers
+	// Penalize the separator-less 9-digit form. Any standalone 9-digit token
+	// (order/serial/ZIP9/product IDs) matches \d{9}, so on its own it is much
+	// weaker evidence of an SSN than the dashed/spaced forms. It still surfaces
+	// (lower base + context can lift it), but a bare 9-digit number no longer
+	// reaches HIGH without corroboration. The dashed form is unaffected.
+	if !hasSeparator {
+		confidence -= 15
+	}
+
+	// Check for test numbers. ValidateContent drops known test SSNs outright
+	// (after context analysis); here we record the failed check and apply the
+	// historical penalty so CalculateConfidence remains meaningful for callers
+	// that score a value directly.
 	if v.isTestSSN(cleanMatch) {
 		confidence -= 25
 		checks["not_test_number"] = false
@@ -736,8 +817,20 @@ func (v *Validator) isEncodedData(line, match string) bool {
 		return false
 	}
 
-	// If more than 85% of the line is numbers and spaces (and no tabs), it's likely encoded
+	// If more than 85% of the line is numbers and spaces (and no tabs), it's likely encoded.
 	if totalChars > 0 && float64(numericChars+spaceChars)/float64(totalChars) > 0.85 {
+		// Guard against dropping a line that IS essentially a single SSN. A bare
+		// SSN ("219099999" = 9/9 chars) or a space-separated one ("219 09 9999"
+		// = 11/11) trivially exceeds 85% numeric, so the heuristic was silently
+		// discarding two of the three SSN formats the validator advertises
+		// whenever they appeared alone (CSV cell, log column, one value per line).
+		// The 85% rule is meant to catch dense multi-number blobs; the caller has
+		// already confirmed `match` is a valid SSN on this line, so a line with
+		// only a few distinct number groups is that SSN, not encoded data. A
+		// space-separated SSN tokenizes into 3 groups, so allow up to 3.
+		if len(numbers) <= 3 {
+			return false
+		}
 		return true
 	}
 

--- a/internal/validators/ssn/validator_test.go
+++ b/internal/validators/ssn/validator_test.go
@@ -783,3 +783,150 @@ func TestSSNValidator_NewValidator(t *testing.T) {
 		t.Fatal("NewValidator() has no healthcare keywords")
 	}
 }
+
+// ssnMatchConfidence returns the confidence of the first SSN match on the line,
+// or -1 if none was produced.
+func ssnMatchConfidence(t *testing.T, v *Validator, line string) float64 {
+	t.Helper()
+	matches, err := v.ValidateContent(line, "test.txt")
+	if err != nil {
+		t.Fatalf("unexpected error for %q: %v", line, err)
+	}
+	if len(matches) == 0 {
+		return -1
+	}
+	return matches[0].Confidence
+}
+
+// TestSSNValidator_StandaloneFormatsDetected is a regression test for H1: the
+// isEncodedData 85%-numeric heuristic silently dropped bare ("219099999") and
+// space-separated ("219 09 9999") SSNs — two of the three advertised formats —
+// whenever they appeared alone (CSV cell, log column, one value per line).
+func TestSSNValidator_StandaloneFormatsDetected(t *testing.T) {
+	v := NewValidator()
+	standalone := []string{
+		"219 09 9999", // space-separated, line is just the SSN
+		"219099999",   // bare 9-digit
+		"449874100",   // bare 9-digit, valid area
+	}
+	for _, s := range standalone {
+		matches, err := v.ValidateContent(s, "export.csv")
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", s, err)
+		}
+		if len(matches) == 0 {
+			t.Errorf("standalone SSN %q should be detected, got none", s)
+		}
+	}
+
+	// A genuinely dense numeric blob (many number groups, no SSN structure) must
+	// still be treated as encoded data and dropped.
+	blob := "100 200 300 400 500 600 700 800 900 1000 1100 1200 1300 1400 1500 1600"
+	matches, err := v.ValidateContent(blob, "data.bin")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(matches) > 0 {
+		t.Errorf("dense numeric blob should be treated as encoded, got %d matches", len(matches))
+	}
+}
+
+// TestSSNValidator_KeywordWordBoundary is a regression test for H2: keyword
+// matching used strings.Contains, so short keywords matched inside unrelated
+// words ("hr" in "Christopher", "ein" in "Einstein"), inflating confidence on
+// non-SSN lines. Matching is now on whole words.
+func TestSSNValidator_KeywordWordBoundary(t *testing.T) {
+	v := NewValidator()
+
+	// "Christopher" contains "hr" but is not an HR context: the bare 9-digit
+	// number must NOT be boosted to the HIGH bucket by a phantom keyword.
+	embedded := ssnMatchConfidence(t, v, "Christopher 449874100")
+	// A real "hr" context word legitimately boosts the same number.
+	realKeyword := ssnMatchConfidence(t, v, "hr record 449874100")
+	if embedded < 0 || realKeyword < 0 {
+		t.Fatalf("expected both lines to produce an SSN match (embedded=%.1f, real=%.1f)", embedded, realKeyword)
+	}
+	if embedded >= realKeyword {
+		t.Errorf("phantom 'hr' inside 'Christopher' (%.1f) should not boost as much as a real 'hr' keyword (%.1f)",
+			embedded, realKeyword)
+	}
+	if embedded >= 90 {
+		t.Errorf("number near 'Christopher' (no real SSN keyword) should not reach HIGH, got %.1f", embedded)
+	}
+}
+
+// TestSSNValidator_KnownTestSSNStaysLow is a regression test for H3: the
+// denylisted test SSN 123-45-4321 scored 100 (HIGH) whenever a positive keyword
+// like "SSN"/"employee" was nearby, because the flat -25 test penalty left it at
+// ~60 and context pushed it over. It must now stay below the MEDIUM threshold.
+func TestSSNValidator_KnownTestSSNStaysLow(t *testing.T) {
+	v := NewValidator()
+	const mediumThreshold = 60.0
+
+	for _, line := range []string{
+		"Employee SSN: 123-45-4321",
+		"SSN 123-45-4321 on file",
+		"123-45-4321",
+		"taxpayer id 123454321 payroll",
+	} {
+		conf := ssnMatchConfidence(t, v, line)
+		if conf >= mediumThreshold {
+			t.Errorf("known test SSN in %q should stay below MEDIUM (%.0f), got %.1f", line, mediumThreshold, conf)
+		}
+	}
+
+	// A real, valid SSN with strong context must still reach HIGH (the cap is
+	// scoped to denylisted test numbers only).
+	real := ssnMatchConfidence(t, v, "Employee SSN: 449-87-4100")
+	if real < 90 {
+		t.Errorf("real SSN with strong context should reach HIGH, got %.1f", real)
+	}
+}
+
+// TestSSNValidator_DocWordDoesNotSuppress is a regression test for M1: generic
+// doc/config words ("default", "documentation", "readme", "template") were in
+// the global test-pattern list and applied a -40 penalty on mere presence,
+// pushing real SSNs below the surfacing threshold. They were removed from the
+// strong-indicator list and remaining word matches are whole-word only.
+func TestSSNValidator_DocWordDoesNotSuppress(t *testing.T) {
+	v := NewValidator()
+	const mediumThreshold = 60.0
+	for _, line := range []string{
+		"default config SSN 219-09-9999",
+		"see documentation, SSN 219-09-9999",
+		"demographic record SSN 219-09-9999", // 'demo' must not match inside 'demographic'
+	} {
+		c := ssnMatchConfidence(t, v, line)
+		if c < mediumThreshold {
+			t.Errorf("real SSN should not be suppressed below MEDIUM by a doc word in %q, got %.1f", line, c)
+		}
+	}
+	// A genuine test word still suppresses.
+	if c := ssnMatchConfidence(t, v, "this is a test SSN 219-09-9999"); c >= mediumThreshold {
+		t.Errorf("'test' should still suppress a sample SSN, got %.1f", c)
+	}
+}
+
+// TestSSNValidator_BareNineDigitWeakerThanDashed is a regression test for M2:
+// a separator-less 9-digit token (order/serial/ZIP9 ID) over-matched and could
+// reach HIGH in vaguely positive context. The bare form now scores lower than
+// the dashed form, so it no longer reaches HIGH without strong corroboration,
+// while remaining detectable.
+func TestSSNValidator_BareNineDigitWeakerThanDashed(t *testing.T) {
+	v := NewValidator()
+
+	// Bare numeric ID in a non-SSN context must not reach HIGH.
+	if c := ssnMatchConfidence(t, v, "order number 321074567 shipped"); c >= 90 {
+		t.Errorf("bare 9-digit ID should not reach HIGH, got %.1f", c)
+	}
+
+	// Same digits dashed + SSN keyword must outscore the bare form.
+	bare := ssnMatchConfidence(t, v, "employee ssn 219099999 on file")
+	dashed := ssnMatchConfidence(t, v, "employee ssn 219-09-9999 on file")
+	if bare < 0 || dashed < 0 {
+		t.Fatalf("expected both forms to be detected (bare=%.1f dashed=%.1f)", bare, dashed)
+	}
+	if dashed <= bare {
+		t.Errorf("dashed SSN (%.1f) should outscore the bare 9-digit form (%.1f)", dashed, bare)
+	}
+}

--- a/internal/validators/ssn/validator_test.go
+++ b/internal/validators/ssn/validator_test.go
@@ -930,3 +930,20 @@ func TestSSNValidator_BareNineDigitWeakerThanDashed(t *testing.T) {
 		t.Errorf("dashed SSN (%.1f) should outscore the bare 9-digit form (%.1f)", dashed, bare)
 	}
 }
+
+// TestSSNValidator_StrongHyphenatedReachesMedium is a regression test for L45:
+// a well-formatted XXX-XX-XXXX SSN with no nearby keyword was hard-capped at 50
+// (LOW). The strong hyphenated form now reaches at least MEDIUM, while the
+// riskier bare 9-digit form keeps the stricter LOW cap.
+func TestSSNValidator_StrongHyphenatedReachesMedium(t *testing.T) {
+	v := NewValidator()
+	for _, line := range []string{"449-87-4100", "value: 412-22-5678"} {
+		if c := ssnMatchConfidence(t, v, line); c < 60 {
+			t.Errorf("L45: strong hyphenated SSN %q should reach MEDIUM without a keyword, got %.1f", line, c)
+		}
+	}
+	// The bare 9-digit form (no keyword) stays below MEDIUM.
+	if c := ssnMatchConfidence(t, v, "449874100"); c >= 60 {
+		t.Errorf("L45: bare 9-digit SSN without a keyword should stay below MEDIUM, got %.1f", c)
+	}
+}

--- a/internal/validators/vin/validator.go
+++ b/internal/validators/vin/validator.go
@@ -462,10 +462,12 @@ func (v *Validator) isTestPattern(vin string) bool {
 
 // isEncodedData detects if the match is likely part of encoded data (base64, hex dumps, etc.).
 func (v *Validator) isEncodedData(line, match string) bool {
-	lower := strings.ToLower(line)
-
-	// Hex dump patterns: line contains multiple "0x" prefixes typical of hex dumps
-	if strings.Count(lower, "0x") >= 3 {
+	// Hex dump patterns. The previous `Count(line,"0x") >= 3` rule dropped the
+	// whole line — and the valid VIN on it — whenever it mentioned three hex
+	// literals, e.g. "VIN 1HGBH41JXMN109186 colors 0xFF0000 0x00FF00 0x0000FF"
+	// (L47). A genuine hex dump is DOMINATED by 0x tokens, so we instead require
+	// a strict majority of whitespace tokens to be 0x-prefixed hex words.
+	if looksLikeHexDump(line) {
 		return true
 	}
 	if strings.Count(line, " ") > 10 && isHexDump(line) {
@@ -500,6 +502,26 @@ func isHexDump(line string) bool {
 		}
 	}
 	return len(line) > 0 && float64(hexChars)/float64(len(line)) > 0.85
+}
+
+// looksLikeHexDump reports whether a line is a hex dump — i.e. a strict majority
+// of its whitespace-separated tokens are 0x-prefixed hex words (and there are at
+// least three). This distinguishes a real dump ("0x1A 0x2B 0x3C ...") from a
+// VIN line that merely mentions a few hex literals ("VIN ... 0xFF0000 0x00FF00
+// 0x0000FF"), which should not be discarded.
+func looksLikeHexDump(line string) bool {
+	toks := strings.Fields(line)
+	if len(toks) == 0 {
+		return false
+	}
+	hex := 0
+	for _, t := range toks {
+		lt := strings.ToLower(t)
+		if strings.HasPrefix(lt, "0x") && len(lt) > 2 {
+			hex++
+		}
+	}
+	return hex >= 3 && hex*2 > len(toks)
 }
 
 // buildContext extracts context information around a match within the current line.

--- a/internal/validators/vin/validator.go
+++ b/internal/validators/vin/validator.go
@@ -23,6 +23,41 @@ var transliterationMap = map[byte]int{
 // positionWeights are the weights for each of the 17 VIN positions.
 var positionWeights = [17]int{8, 7, 6, 5, 4, 3, 2, 10, 0, 9, 8, 7, 6, 5, 4, 3, 2}
 
+// containsKeyword reports whether text contains keyword as a whole word,
+// case-insensitively. The previous code used strings.Contains, so short context
+// keywords matched inside unrelated words — positive "car"/"vin" inside
+// "carbon"/"moving" fabricated a +50 boost on a random check-digit-passing
+// token, and negative "sha"/"key"/"api" inside "shall"/"monkey"/"rapid" dropped
+// real VINs. A plain string scan (word byte = [a-z0-9]) keeps this cheap.
+func containsKeyword(text, keyword string) bool {
+	if keyword == "" {
+		return false
+	}
+	lt := strings.ToLower(text)
+	lk := strings.ToLower(keyword)
+	for from := 0; from+len(lk) <= len(lt); {
+		i := strings.Index(lt[from:], lk)
+		if i < 0 {
+			return false
+		}
+		i += from
+		leftOK := i == 0 || !isVINWordByte(lt[i-1])
+		right := i + len(lk)
+		rightOK := right >= len(lt) || !isVINWordByte(lt[right])
+		if leftOK && rightOK {
+			return true
+		}
+		from = i + 1
+	}
+	return false
+}
+
+// isVINWordByte reports whether b is a word character ([a-z0-9]) for keyword
+// boundary detection. text is already lowercased by the caller.
+func isVINWordByte(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= '0' && b <= '9')
+}
+
 // knownWMIs maps common World Manufacturer Identifier prefixes to manufacturer names.
 var knownWMIs = map[string]string{
 	"1G1": "Chevrolet", "1G2": "Pontiac", "1GC": "Chevrolet Truck",
@@ -65,8 +100,12 @@ type Validator struct {
 // NewValidator creates and returns a new VIN Validator instance.
 func NewValidator() *Validator {
 	v := &Validator{
-		// 17 alphanumeric characters excluding I, O, Q
-		pattern: `\b[A-HJ-NPR-Z0-9]{17}\b`,
+		// 17 alphanumeric characters excluding I, O, Q. Case-insensitive: VINs
+		// are commonly stored lowercase or mixed-case in logs/JSON/CSV, and the
+		// uppercase-only class never matched them (ValidateContent ToUppers the
+		// match afterward, so the previous lowercasing was a detection no-op).
+		// The lowercase exclusions (i, o, q) mirror the uppercase ones.
+		pattern: `\b[A-HJ-NPR-Za-hj-npr-z0-9]{17}\b`,
 		positiveKeywords: []string{
 			"vin", "vehicle identification", "vehicle id", "chassis",
 			"title", "registration", "dmv", "odometer", "mileage",
@@ -150,8 +189,25 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 				continue
 			}
 
-			if !v.checkDigitValid(upper) {
-				continue
+			// Check-digit gate. The ISO 3779 position-9 check digit is mandatory
+			// ONLY for North American VINs (WMI region 1-5); manufacturers in
+			// the rest of the world are not required to encode it, so a huge
+			// share of genuine EU/Asian VINs legitimately "fail" this checksum.
+			// Hard-rejecting on failure therefore dropped most non-NA VINs —
+			// including ones whose WMI is in our own knownWMIs table (WVW, WAU,
+			// ZFF, ...). We now only hard-reject when the check digit is
+			// REQUIRED (NA region). For non-NA VINs we keep the candidate but
+			// require a recognized WMI as corroboration so we don't start
+			// surfacing arbitrary 17-char alphanumeric tokens (hashes, base32);
+			// the check-digit status is carried into confidence scoring below.
+			checkDigitOK := v.checkDigitValid(upper)
+			if !checkDigitOK {
+				if v.isNorthAmericanVIN(upper) {
+					continue // NA VIN with a bad check digit is genuinely invalid
+				}
+				if v.detectManufacturer(upper) == "" {
+					continue // no check digit AND no known WMI -> not enough signal
+				}
 			}
 
 			if v.isEncodedData(line, match) {
@@ -160,7 +216,7 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 
 			// --- Passed all gates: score confidence ---
 
-			confidence, checks := v.CalculateConfidence(upper)
+			confidence, checks := v.calculateConfidence(upper, checkDigitOK)
 
 			contextInfo := v.buildContext(line, match)
 			contextImpact := v.AnalyzeContext(match, contextInfo)
@@ -214,10 +270,22 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 }
 
 // CalculateConfidence returns a base confidence and validation checks map.
+// It satisfies the detector.Validator interface; the check-digit status is
+// derived here so external callers get a correct score. The internal scan path
+// uses calculateConfidence directly to avoid recomputing the check digit.
 func (v *Validator) CalculateConfidence(vin string) (float64, map[string]bool) {
+	return v.calculateConfidence(vin, v.checkDigitValid(vin))
+}
+
+// calculateConfidence scores a VIN given the already-computed check-digit
+// result. A valid check digit is a strong signal (+20); an invalid one is only
+// reached here for non-North-American VINs with a recognized WMI (the scan
+// gate rejects NA VINs and unknown-WMI VINs that fail the check digit), so we
+// neither add nor heavily penalize — the known WMI below carries the weight.
+func (v *Validator) calculateConfidence(vin string, checkDigitOK bool) (float64, map[string]bool) {
 	checks := map[string]bool{
 		"format":        true,
-		"check_digit":   true,
+		"check_digit":   checkDigitOK,
 		"known_wmi":     false,
 		"valid_year":    false,
 		"not_test":      true,
@@ -226,9 +294,14 @@ func (v *Validator) CalculateConfidence(vin string) (float64, map[string]bool) {
 
 	confidence := 65.0
 
-	// Check digit already validated in early rejection, so always +20
-	confidence += 20
-	checks["check_digit"] = true
+	if checkDigitOK {
+		confidence += 20
+	} else {
+		// Non-NA VIN without the optional check digit: drop below the +20 a
+		// valid checksum earns, so these surface lower than verified VINs but
+		// remain detectable (a known WMI re-adds signal just below).
+		confidence -= 10
+	}
 
 	// Known manufacturer
 	if v.detectManufacturer(vin) != "" {
@@ -245,6 +318,18 @@ func (v *Validator) CalculateConfidence(vin string) (float64, map[string]bool) {
 	return confidence, checks
 }
 
+// isNorthAmericanVIN reports whether the VIN's WMI region (first character)
+// designates North America (1-5), where the ISO 3779 position-9 check digit is
+// mandatory. For these VINs a failed check digit means the VIN is invalid; for
+// all other regions the check digit is optional and a failure is not
+// disqualifying on its own.
+func (v *Validator) isNorthAmericanVIN(vin string) bool {
+	if len(vin) == 0 {
+		return false
+	}
+	return vin[0] >= '1' && vin[0] <= '5'
+}
+
 // AnalyzeContext adjusts confidence based on surrounding text.
 func (v *Validator) AnalyzeContext(match string, context detector.ContextInfo) float64 {
 	fullContext := strings.ToLower(context.BeforeText + " " + context.FullLine + " " + context.AfterText)
@@ -253,9 +338,8 @@ func (v *Validator) AnalyzeContext(match string, context detector.ContextInfo) f
 	var impact float64
 
 	for _, keyword := range v.positiveKeywords {
-		kw := strings.ToLower(keyword)
-		if strings.Contains(fullContext, kw) {
-			if strings.Contains(fullLine, kw) {
+		if containsKeyword(fullContext, keyword) {
+			if containsKeyword(fullLine, keyword) {
 				impact += 25
 			} else {
 				impact += 10
@@ -264,9 +348,8 @@ func (v *Validator) AnalyzeContext(match string, context detector.ContextInfo) f
 	}
 
 	for _, keyword := range v.negativeKeywords {
-		kw := strings.ToLower(keyword)
-		if strings.Contains(fullContext, kw) {
-			if strings.Contains(fullLine, kw) {
+		if containsKeyword(fullContext, keyword) {
+			if containsKeyword(fullLine, keyword) {
 				impact -= 15
 			} else {
 				impact -= 8
@@ -289,7 +372,7 @@ func (v *Validator) findKeywords(context detector.ContextInfo, keywords []string
 
 	var found []string
 	for _, keyword := range keywords {
-		if strings.Contains(fullContext, strings.ToLower(keyword)) {
+		if containsKeyword(fullContext, keyword) {
 			found = append(found, keyword)
 		}
 	}

--- a/internal/validators/vin/validator_test.go
+++ b/internal/validators/vin/validator_test.go
@@ -5,6 +5,8 @@ package vin
 
 import (
 	"testing"
+
+	"github.com/awslabs/ferret-scan/internal/detector"
 )
 
 func TestVINValidator_ValidVINs(t *testing.T) {
@@ -253,5 +255,118 @@ func TestVINValidator_LegacyValidate(t *testing.T) {
 	}
 	if len(matches) != 0 {
 		t.Errorf("Validate() should return empty matches, got %d", len(matches))
+	}
+}
+
+// TestVINValidator_NonNorthAmericanCheckDigit is a regression test for the
+// mandatory-check-digit gate that silently dropped most non-North-American
+// VINs. The ISO 3779 check digit is required only for WMI region 1-5 (North
+// America); EU/Asian manufacturers commonly do not encode it, so genuine VINs
+// from WVW/WAU/ZFF (all in knownWMIs) were being hard-rejected. We assert those
+// are now detected, while VINs that fail the check digit WITHOUT a corroborating
+// signal (NA region, or unknown WMI) remain rejected so we add no false positives.
+func TestVINValidator_NonNorthAmericanCheckDigit(t *testing.T) {
+	validator := NewValidator()
+
+	// True positives recovered: non-NA VINs with a known WMI that fail the
+	// (optional) NA check digit.
+	detect := []struct {
+		name    string
+		content string
+	}{
+		{"VW Europe", "VIN: WVWZZZ1JZ3W386752"},
+		{"Audi Europe", "vehicle identification number WAUZZZ8K9BA123456"},
+		{"Ferrari Italy", "chassis ZFF67NFA8E0193082 on file"},
+	}
+	for _, tt := range detect {
+		t.Run("detect/"+tt.name, func(t *testing.T) {
+			matches, err := validator.ValidateContent(tt.content, "test.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent() error = %v", err)
+			}
+			if len(matches) == 0 {
+				t.Errorf("%s: expected non-NA VIN to be detected, got none", tt.name)
+			}
+		})
+	}
+
+	// False-positive guards: failing the check digit with no corroboration must
+	// still be rejected.
+	reject := []struct {
+		name    string
+		content string
+	}{
+		// Non-NA shape, unknown WMI, bad check digit -> not enough signal.
+		{"Unknown WMI random token", "ref ABCDEFGH1JKLMNPRS in log"},
+		// North American region (starts with 1) with a wrong check digit is a
+		// genuinely invalid VIN and must stay rejected (unchanged behavior).
+		{"NA VIN bad check digit", "VIN: 1HGBH41JAMN109186"},
+	}
+	for _, tt := range reject {
+		t.Run("reject/"+tt.name, func(t *testing.T) {
+			matches, err := validator.ValidateContent(tt.content, "test.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent() error = %v", err)
+			}
+			if len(matches) > 0 {
+				t.Errorf("%s: expected no match, got %d", tt.name, len(matches))
+			}
+		})
+	}
+
+	// A verified (valid check digit) VIN should still outscore a non-NA VIN that
+	// relies only on its WMI, so ranking still favors fully-validated VINs. We
+	// check the base score directly: in the full pipeline a positive context
+	// keyword ("VIN:") saturates both to 100, masking the (real) base-score gap.
+	verifiedConf, vChecks := validator.CalculateConfidence("1HGBH41JXMN109186")
+	wmiOnlyConf, wChecks := validator.CalculateConfidence("WVWZZZ1JZ3W386752")
+	if !vChecks["check_digit"] {
+		t.Error("expected valid check digit for 1HGBH41JXMN109186")
+	}
+	if wChecks["check_digit"] {
+		t.Error("expected invalid check digit for WVWZZZ1JZ3W386752")
+	}
+	if wmiOnlyConf >= verifiedConf {
+		t.Errorf("check-digit-valid VIN (%.1f) should outscore WMI-only VIN (%.1f)",
+			verifiedConf, wmiOnlyConf)
+	}
+}
+
+// TestVINValidator_LowercaseAndMixedCase is a regression test for M19: the
+// uppercase-only regex never matched lowercase/mixed-case VINs (common in
+// logs/JSON/CSV), and the downstream ToUpper was a detection no-op.
+func TestVINValidator_LowercaseAndMixedCase(t *testing.T) {
+	v := NewValidator()
+	for _, line := range []string{
+		"vin: 1hgbh41jxmn109186",
+		"vin 1HgBh41JxMn109186",
+		"chassis WVWZZZ1JZ3W386752 logged",
+	} {
+		matches, err := v.ValidateContent(line, "test.txt")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(matches) == 0 {
+			t.Errorf("lowercase/mixed-case VIN should be detected for %q, got none", line)
+		}
+	}
+}
+
+// TestVINValidator_KeywordWordBoundary is a regression test for M18: context
+// keywords matched as substrings ("car" in "carbon", negative "sha" in "shall")
+// fabricated or suppressed confidence. Matching is now whole-word.
+func TestVINValidator_KeywordWordBoundary(t *testing.T) {
+	v := NewValidator()
+	// Phantom positives must contribute nothing.
+	if imp := v.AnalyzeContext("X", detector.ContextInfo{FullLine: "carbon moving study"}); imp != 0 {
+		t.Errorf("'carbon'/'moving' should not register as VIN keywords, impact=%.1f", imp)
+	}
+	// Phantom negative must contribute nothing.
+	if imp := v.AnalyzeContext("X", detector.ContextInfo{FullLine: "we shall proceed"}); imp != 0 {
+		t.Errorf("'shall' should not register as negative keyword 'sha', impact=%.1f", imp)
+	}
+	// Real keywords still boost.
+	if imp := v.AnalyzeContext("X", detector.ContextInfo{FullLine: "vehicle vin chassis"}); imp <= 0 {
+		t.Errorf("real VIN keywords should boost, impact=%.1f", imp)
 	}
 }

--- a/internal/validators/vin/validator_test.go
+++ b/internal/validators/vin/validator_test.go
@@ -370,3 +370,22 @@ func TestVINValidator_KeywordWordBoundary(t *testing.T) {
 		t.Errorf("real VIN keywords should boost, impact=%.1f", imp)
 	}
 }
+
+// TestVINValidator_HexDumpHeuristic is a regression test for L47: the 0x>=3
+// count dropped a valid VIN whenever its line mentioned three hex literals
+// (e.g. color values). A real hex dump must still be rejected.
+func TestVINValidator_HexDumpHeuristic(t *testing.T) {
+	v := NewValidator()
+	// Valid VIN with incidental hex color literals must still be detected.
+	m, _ := v.ValidateContent("VIN 1HGBH41JXMN109186 colors 0xFF0000 0x00FF00 0x0000FF", "test.txt")
+	if len(m) == 0 {
+		t.Error("L47: valid VIN with incidental hex literals should be detected")
+	}
+	// A genuine hex dump (majority 0x tokens) is still recognized as encoded.
+	if !looksLikeHexDump("0x1A 0x2B 0x3C 0x4D 0x5E 0x6F") {
+		t.Error("L47: a real hex dump should be recognized")
+	}
+	if looksLikeHexDump("VIN 1HGBH41JXMN109186 colors 0xFF0000 0x00FF00 0x0000FF") {
+		t.Error("L47: a VIN line with a few hex literals is not a hex dump")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes **59 verified detection-quality findings** across 10 validators, surfaced by an adversarial review of the validator suite. Every change targets the same goal: **recover true positives and reduce false positives** without regressing the other direction.

Each commit is scoped to one validator and pairs the fix with regression tests asserting both the recovered/kept true positive **and** the no-new-false-positive guard.

Findings addressed: **15 high + 36 medium + 13 low** (the remaining low findings were verified as no-runtime-effect dead code / metadata labels and are intentionally skipped; passport findings are owned by PR #85).

## High-impact fixes (by validator)

- **creditcard** — adjacent PANs sharing a delimiter; 13/19-digit PANs; `=`/`:` delimiters; whole-word negative keywords; relaxed identical-digit cap.
- **email** — delegated gTLDs no longer zeroed; whole-word keywords; per-occurrence context; pseudo-TLD (.local/.localhost/.test) gating.
- **ipaddress** — compressed IPv6 matched in full; zero-padded doc range filtered; bare IPv4 / MAC-like hex tuples gated; 5+-octet leak fixed; CGNAT/benchmark ranges filtered; exact test-IP match; whole-word keywords.
- **vin** — lowercase/mixed-case VINs; whole-word keywords; hex-dump heuristic no longer discards valid VINs.
- **ssn** — standalone SSNs detected; denylisted test SSNs dropped; whole-word keywords; doc-words removed from suppression; bare 9-digit ranked below dashed; strong hyphenated form reaches MEDIUM without a keyword.
- **intellectualproperty** — trademark symbol markers detected; case-sensitive patents; copyright footer variants; inline-flag detection; open-source license caps trade-secret findings.
- **personname** — Unicode-aware boundaries; DB-gated all-caps names; common-word bigram gate; capitalization/suffix bug fixes; whole-word context keywords.
- **metadata** — real GPS coordinate check; no duplicate field emission; phoneBasic separator; GPS-combine validation (0/0 + range); numeric IDs no longer hidden as versions.
- **secrets** — JWT/Slack structural validation; generic high-entropy gated; disjoint env keyword sets; test-substring penalty scoped.
- **phone** — timestamp/date heuristics gated on separators; UK 3-group capture; version-string false matches rejected; duplicate-partial dedup; generic negatives removed; anchored test-number match; bare-1 country code.

## Verification

- All 25 packages pass, including `-race` on every changed validator and `gofmt`.
- Old-vs-new timing benchmarked on ~10k-line mixed files at each stage; all changes are linear-time (no algorithmic regressions). Increases are small constant-factor costs of doing correct work (whole-word matching, all-caps name scanning, lowercase VIN matching).
- A few pre-existing test fixtures that encoded the old buggy behavior were updated, documented inline as deliberate corrections.

## Scope notes

- Branched off `main`; no file overlap with open PRs #84 (redactors) or #85 (explain + passport).
- Passport findings are owned by PR #85 and intentionally excluded.
