### PR TITLE
fix(redaction): deny-by-default across metadata, suppressed findings, SARIF/CSV/gitlab-sast, and web

### DIFF
--- a/internal/formatters/csv/formatter.go
+++ b/internal/formatters/csv/formatter.go
@@ -109,13 +109,19 @@ func (f *Formatter) createCSVRow(match detector.Match, options formatters.Format
 			f.escapeCSVField(displayText),
 		}
 
-		// Add metadata if verbose mode is enabled
-		if options.Verbose && match.Metadata != nil {
-			metadataJSON, err := json.Marshal(match.Metadata)
-			if err != nil {
-				row = append(row, f.escapeCSVField("Error serializing metadata"))
-			} else {
-				row = append(row, f.escapeCSVField(string(metadataJSON)))
+		// Add metadata if verbose mode is enabled. Run it through the shared
+		// sanitizer first: when ShowMatch is false this redacts any metadata
+		// value that embeds the raw matched text (e.g. name_components,
+		// full_field), so --verbose CSV can't leak what displayText hid.
+		if options.Verbose {
+			sanitized := shared.SanitizeMetadata(match.Metadata, match.Text, options.ShowMatch)
+			if sanitized != nil {
+				metadataJSON, err := json.Marshal(sanitized)
+				if err != nil {
+					row = append(row, f.escapeCSVField("Error serializing metadata"))
+				} else {
+					row = append(row, f.escapeCSVField(string(metadataJSON)))
+				}
 			}
 		}
 	}

--- a/internal/formatters/gitlab-sast/explanation_test.go
+++ b/internal/formatters/gitlab-sast/explanation_test.go
@@ -19,7 +19,7 @@ func TestSanitizeDescription_IncludesExplanation(t *testing.T) {
 	}}
 	explain.Annotate(s, explain.NewSignalSynthesizer())
 
-	desc := NewDataSanitizer().SanitizeDescription(s[0])
+	desc := NewDataSanitizer().SanitizeDescription(s[0], false)
 	for _, want := range []string{"**Why:**", "**Verdict:**", "**Suggested suppression reason:**"} {
 		if !strings.Contains(desc, want) {
 			t.Errorf("description missing %q:\n%s", want, desc)
@@ -31,7 +31,7 @@ func TestSanitizeDescription_NoExplanationWhenAbsent(t *testing.T) {
 	m := detector.Match{
 		Text: "x", Type: "EMAIL", Confidence: 50, Filename: "a.go", LineNumber: 1,
 	}
-	desc := NewDataSanitizer().SanitizeDescription(m)
+	desc := NewDataSanitizer().SanitizeDescription(m, false)
 	if strings.Contains(desc, "**Why:**") {
 		t.Errorf("description should not contain explanation when unannotated:\n%s", desc)
 	}

--- a/internal/formatters/gitlab-sast/formatter.go
+++ b/internal/formatters/gitlab-sast/formatter.go
@@ -31,7 +31,7 @@ type VulnerabilityMapperInterface interface {
 // DataSanitizerInterface defines the contract for data sanitization
 type DataSanitizerInterface interface {
 	SanitizeMessage(match detector.Match) string
-	SanitizeDescription(match detector.Match) string
+	SanitizeDescription(match detector.Match, showMatch bool) string
 	EnsureNoSensitiveData(text string) string
 }
 
@@ -155,7 +155,7 @@ func (f *Formatter) Format(matches []detector.Match, suppressedMatches []detecto
 
 		// Sanitize the vulnerability data to ensure no sensitive information is exposed
 		vuln.Message = f.sanitizer.SanitizeMessage(match)
-		vuln.Description = f.sanitizer.SanitizeDescription(match)
+		vuln.Description = f.sanitizer.SanitizeDescription(match, options.ShowMatch)
 
 		// Validate the vulnerability before adding
 		if err := f.validator.ValidateVulnerability(vuln); err != nil {

--- a/internal/formatters/gitlab-sast/leak_test.go
+++ b/internal/formatters/gitlab-sast/leak_test.go
@@ -1,0 +1,57 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package gitlabsast
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/internal/detector"
+	"github.com/awslabs/ferret-scan/internal/formatters"
+)
+
+// TestGitLabSAST_NoLeakWhenHidden is a regression test for the gitlab-sast PII
+// leak: the vulnerability description embedded the surrounding line via a
+// pattern-based scrub that masked card-shaped substrings but left names and
+// SSN-shaped values intact. With ShowMatch=false the raw line must be withheld
+// entirely.
+func TestGitLabSAST_NoLeakWhenHidden(t *testing.T) {
+	const secret = "4929-3813-3266-4295"
+	const name = "Robert Aragon"
+	const ssn = "489-36-8350"
+	matches := []detector.Match{{
+		Text:       secret,
+		LineNumber: 5,
+		Type:       "CREDIT_CARD",
+		Confidence: 100,
+		Filename:   "cards.tsv",
+		Validator:  "creditcard",
+		Context: detector.ContextInfo{
+			FullLine: name + "\t" + ssn + "\t" + secret,
+		},
+		Metadata: map[string]interface{}{"card_type": "VISA"},
+	}}
+
+	allLevels := map[string]bool{"high": true, "medium": true, "low": true}
+
+	f := NewFormatter()
+	hidden, err := f.Format(matches, nil, formatters.FormatterOptions{ShowMatch: false, Verbose: true, ConfidenceLevel: allLevels})
+	if err != nil {
+		t.Fatalf("Format error: %v", err)
+	}
+	for _, leak := range []string{secret, name, ssn} {
+		if strings.Contains(hidden, leak) {
+			t.Errorf("gitlab-sast leaked %q with ShowMatch=false", leak)
+		}
+	}
+
+	// With ShowMatch the surrounding line (and value) may appear.
+	shown, err := f.Format(matches, nil, formatters.FormatterOptions{ShowMatch: true, Verbose: true, ConfidenceLevel: allLevels})
+	if err != nil {
+		t.Fatalf("Format error: %v", err)
+	}
+	if !strings.Contains(shown, secret) {
+		t.Errorf("gitlab-sast should include the value when ShowMatch=true")
+	}
+}

--- a/internal/formatters/gitlab-sast/sanitizer.go
+++ b/internal/formatters/gitlab-sast/sanitizer.go
@@ -42,7 +42,7 @@ func (s *DataSanitizer) SanitizeMessage(match detector.Match) string {
 }
 
 // SanitizeDescription creates a detailed but safe description for GitLab vulnerability reports
-func (s *DataSanitizer) SanitizeDescription(match detector.Match) string {
+func (s *DataSanitizer) SanitizeDescription(match detector.Match, showMatch bool) string {
 	var description strings.Builder
 
 	// Start with check type description
@@ -61,11 +61,17 @@ func (s *DataSanitizer) SanitizeDescription(match detector.Match) string {
 		description.WriteString(fmt.Sprintf("**Detected by:** %s validator\n", match.Validator))
 	}
 
-	// Add context information if available and safe
+	// Add the raw context line ONLY when the operator opted in with --show-match.
+	// The previous code always embedded EnsureNoSensitiveData(FullLine), but that
+	// pattern-based scrub is fail-open: it masked the card-shaped substring yet
+	// left names and SSN-shaped values in the line. Deny-by-default: omit the
+	// surrounding line entirely unless ShowMatch, so no unrecognized PII leaks.
 	if match.Context.FullLine != "" {
-		// Always sanitize the full line context
-		sanitizedLine := s.EnsureNoSensitiveData(match.Context.FullLine)
-		description.WriteString(fmt.Sprintf("\n**Context:**\n```\n%s\n```\n", sanitizedLine))
+		if showMatch {
+			description.WriteString(fmt.Sprintf("\n**Context:**\n```\n%s\n```\n", match.Context.FullLine))
+		} else {
+			description.WriteString("\n**Context:** [HIDDEN] (use --show-match to include the surrounding line)\n")
+		}
 	}
 
 	// Add metadata information if available

--- a/internal/formatters/sarif/leak_test.go
+++ b/internal/formatters/sarif/leak_test.go
@@ -1,0 +1,65 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package sarif
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/internal/detector"
+	"github.com/awslabs/ferret-scan/internal/formatters"
+)
+
+// TestSARIF_NoLeakWhenHidden is a regression test for the SARIF PII leak: the
+// context region snippet embedded the raw surrounding line (FullLine), and the
+// metadata properties dumped value-bearing keys, both regardless of ShowMatch.
+// With ShowMatch=false the matched value and the surrounding line must never
+// appear anywhere in the SARIF document.
+func TestSARIF_NoLeakWhenHidden(t *testing.T) {
+	const secret = "4929-3813-3266-4295"
+	const name = "Robert Aragon"
+	matches := []detector.Match{{
+		Text:       secret,
+		LineNumber: 5,
+		Type:       "VISA",
+		Confidence: 100,
+		Filename:   "cards.tsv",
+		Validator:  "creditcard",
+		Context: detector.ContextInfo{
+			FullLine:   name + "\t" + secret + "\t",
+			BeforeText: name + "\t",
+			AfterText:  "\t",
+		},
+		Metadata: map[string]interface{}{
+			"card_type":       "VISA",
+			"name_components": map[string]interface{}{"FullName": name},
+			"full_field":      "Author: " + name,
+			"clean_number":    "4929381332664295",
+		},
+	}}
+
+	// HIGH confidence (100) — include the high bucket so the match is not
+	// filtered out before it reaches the mapper.
+	allLevels := map[string]bool{"high": true, "medium": true, "low": true}
+
+	f := NewFormatter()
+	hidden, err := f.Format(matches, nil, formatters.FormatterOptions{ShowMatch: false, Verbose: true, ConfidenceLevel: allLevels})
+	if err != nil {
+		t.Fatalf("Format error: %v", err)
+	}
+	for _, leak := range []string{secret, name, "4929381332664295"} {
+		if strings.Contains(hidden, leak) {
+			t.Errorf("SARIF leaked %q with ShowMatch=false", leak)
+		}
+	}
+
+	// With ShowMatch the value is allowed to appear.
+	shown, err := f.Format(matches, nil, formatters.FormatterOptions{ShowMatch: true, Verbose: true, ConfidenceLevel: allLevels})
+	if err != nil {
+		t.Fatalf("Format error: %v", err)
+	}
+	if !strings.Contains(shown, secret) {
+		t.Errorf("SARIF should include the value when ShowMatch=true")
+	}
+}

--- a/internal/formatters/sarif/mapper.go
+++ b/internal/formatters/sarif/mapper.go
@@ -82,7 +82,7 @@ func (m *VulnerabilityMapper) MapToSARIFResult(match detector.Match, options for
 		Level:      LevelError, // All sensitive data findings are errors
 		Message:    m.buildMessage(match, options),
 		Locations:  []SARIFLocation{m.buildLocation(match, options)},
-		Properties: m.buildProperties(match),
+		Properties: m.buildProperties(match, options),
 		Rank:       m.calculateRank(match),
 	}
 
@@ -100,7 +100,7 @@ func (m *VulnerabilityMapper) MapSuppressedMatch(suppressed detector.SuppressedM
 		Level:      LevelNone, // Suppressed results use "none" level
 		Message:    m.buildMessage(suppressed.Match, options),
 		Locations:  []SARIFLocation{m.buildLocation(suppressed.Match, options)},
-		Properties: m.buildPropertiesForSuppressed(suppressed),
+		Properties: m.buildPropertiesForSuppressed(suppressed, options),
 		Suppressions: []SARIFSuppression{
 			{
 				Kind:          SuppressionKindInSource,
@@ -122,9 +122,13 @@ func (m *VulnerabilityMapper) buildLocation(match detector.Match, options format
 		},
 	}
 
-	// Add context region if available
-	if contextRegion := m.buildContextRegion(match); contextRegion != nil {
-		location.PhysicalLocation.ContextRegion = contextRegion
+	// Add context region only when ShowMatch is set: its snippet embeds the raw
+	// surrounding line(s) (BeforeText/FullLine/AfterText), which contain the
+	// matched value, so emitting it while the value is hidden would leak it.
+	if options.ShowMatch {
+		if contextRegion := m.buildContextRegion(match); contextRegion != nil {
+			location.PhysicalLocation.ContextRegion = contextRegion
+		}
 	}
 
 	return location
@@ -237,7 +241,7 @@ func (m *VulnerabilityMapper) buildContextRegion(match detector.Match) *SARIFReg
 }
 
 // buildProperties includes confidence, confidenceLevel, validator, and metadata in result properties
-func (m *VulnerabilityMapper) buildProperties(match detector.Match) map[string]interface{} {
+func (m *VulnerabilityMapper) buildProperties(match detector.Match, options formatters.FormatterOptions) map[string]interface{} {
 	properties := make(map[string]interface{})
 
 	// Add confidence information (rounded to 1 decimal place)
@@ -249,20 +253,17 @@ func (m *VulnerabilityMapper) buildProperties(match detector.Match) map[string]i
 		properties["validator"] = match.Validator
 	}
 
-	// Add metadata if available (with rounded floats). Skip the explanation
-	// key here — it is surfaced as a first-class "explanation" property below
-	// (and in the message), so it gets exactly one representation.
-	if len(match.Metadata) > 0 {
-		roundedMetadata := make(map[string]interface{})
-		for key, value := range match.Metadata {
-			if key == explain.MetadataKey {
-				continue
-			}
+	// Add metadata if available (with rounded floats). The shared sanitizer
+	// drops the explanation key (surfaced as a first-class property below) and,
+	// when ShowMatch is false, redacts any value that embeds the raw matched
+	// text so metadata cannot leak what the snippet/message redaction hides.
+	sanitized := shared.SanitizeMetadata(match.Metadata, match.Text, options.ShowMatch)
+	if len(sanitized) > 0 {
+		roundedMetadata := make(map[string]interface{}, len(sanitized))
+		for key, value := range sanitized {
 			roundedMetadata[key] = roundMetadataFloats(value)
 		}
-		if len(roundedMetadata) > 0 {
-			properties["metadata"] = roundedMetadata
-		}
+		properties["metadata"] = roundedMetadata
 	}
 
 	// Add the advisory explanation as a structured, first-class property.
@@ -287,8 +288,8 @@ func (m *VulnerabilityMapper) buildProperties(match detector.Match) map[string]i
 
 // buildPropertiesForSuppressed builds properties for suppressed matches
 // including expiration information
-func (m *VulnerabilityMapper) buildPropertiesForSuppressed(suppressed detector.SuppressedMatch) map[string]interface{} {
-	properties := m.buildProperties(suppressed.Match)
+func (m *VulnerabilityMapper) buildPropertiesForSuppressed(suppressed detector.SuppressedMatch, options formatters.FormatterOptions) map[string]interface{} {
+	properties := m.buildProperties(suppressed.Match, options)
 
 	// Add suppression-specific properties
 	properties["suppressedBy"] = suppressed.SuppressedBy

--- a/internal/formatters/shared/structures.go
+++ b/internal/formatters/shared/structures.go
@@ -9,6 +9,182 @@ import (
 	"github.com/awslabs/ferret-scan/internal/formatters"
 )
 
+// redactionPlaceholder is the single token used everywhere a sensitive value is
+// withheld, so output is consistent across formatters and fields.
+const redactionPlaceholder = "[HIDDEN]"
+
+// safeMetadataKeys is an ALLOWLIST of metadata keys that are known to carry only
+// non-sensitive, analytical/structural data and are therefore safe to serialize
+// when the matched value is hidden (ShowMatch=false).
+//
+// Redaction here is deny-by-default (fail-safe): the raw value must NEVER be in
+// the output unless the operator explicitly opts in with --show-match. So rather
+// than enumerate the keys that DO leak (a denylist that fails open the moment a
+// validator adds a new value-bearing key), we enumerate the keys that are proven
+// safe and withhold everything else. Anything not in this set — including any
+// future key — is dropped when ShowMatch is false.
+//
+// Adding a key here is a deliberate security decision: it asserts the key's
+// value can never contain matched content or other PII. Keys that echo the
+// matched value or document content (e.g. name_components, full_field, clean_ip,
+// clean_number, username, field_name, description, message) are intentionally
+// absent and are withheld until --show-match.
+var safeMetadataKeys = map[string]bool{
+	// Classification / type labels
+	"card_type":       true,
+	"vendor":          true,
+	"metadata_type":   true,
+	"ip_type":         true,
+	"pii_type":        true,
+	"secret_type":     true,
+	"pattern_type":    true,
+	"platform":        true,
+	"type":            true,
+	"document_type":   true,
+	"coordinate_type": true,
+	"email_provider":  true,
+	"language":        true,
+	"format":          true,
+
+	// Confidence / scoring / correlation (numeric or structured, no content)
+	"confidence_adjustment":   true,
+	"original_confidence":     true,
+	"context_impact":          true,
+	"enhanced_context_impact": true,
+	"context_confidence":      true,
+	"confidence_factors":      true,
+	"correlation_boost":       true,
+	"cross_path_correlation":  true,
+	"cross_validator_signals": true,
+	"cross_validator_impact":  true,
+	"total_adjustment":        true,
+	"preprocessor_adjustment": true,
+	"semantic_context":        true,
+	"analysis_confidence":     true,
+
+	// Context classification (labels/scores, not raw text)
+	"context_domain":   true,
+	"context_doctype":  true,
+	"context_doc_type": true,
+	"context_keywords": true,
+	"cultural_context": true,
+	"environment_type": true,
+
+	// Validation results / detection bookkeeping.
+	// NOTE: validation_details is intentionally NOT allowlisted. Unlike
+	// validation_checks (booleans) and validation_path (a "document"/"metadata"
+	// label), some validators populate validation_details with value-derived
+	// sub-fields — e.g. the social-media validator embeds the raw matched
+	// LinkedIn URL/username (actual_path, extracted_username, domain). Echoing
+	// it would re-leak the value the Text field redacts. Withheld until
+	// --show-match. (Caught by scanning real documents, not synthetic fixtures.)
+	"validation_checks": true,
+	"validation_path":   true,
+	"detection_method":  true,
+	"detection_reason":  true,
+	"is_private":        true,
+	"is_reserved":       true,
+	"not_test":          true,
+	"first_names_count": true,
+	"last_names_count":  true,
+
+	// Pattern bookkeeping (names of internal patterns, not matched content)
+	"pattern":             true,
+	"pattern_name":        true,
+	"pattern_priority":    true,
+	"pattern_index":       true,
+	"reconstruction_type": true,
+	"consolidated_count":  true,
+	"cluster_type":        true,
+
+	// Risk classification (levels/factors, not content)
+	"custom_prop_risk_level":   true,
+	"custom_prop_risk_factors": true,
+	"template_risk_level":      true,
+	"template_risk_factors":    true,
+
+	// Provenance — the scanned file path / preprocessor, already exposed via the
+	// top-level filename field; not match content.
+	"source":              true,
+	"source_file":         true,
+	"original_file":       true,
+	"source_preprocessor": true,
+	"preprocessor_name":   true,
+	"preprocessor_type":   true,
+	"validator_version":   true,
+	"check_type":          true,
+}
+
+// SanitizeMetadata returns a copy of a finding's metadata that is safe to
+// serialize given the ShowMatch setting. It is the single, canonical path shared
+// by every formatter that emits the metadata map (JSON, YAML, SARIF, CSV), so
+// the matched value can never reach output through metadata when it is hidden in
+// the Text field.
+//
+//   - ShowMatch=true: all metadata is returned (only the explain key is dropped,
+//     since it is surfaced separately as a first-class field).
+//   - ShowMatch=false: ONLY allowlisted, known-safe keys are returned
+//     (deny-by-default). Every other key — including any new/unknown one — is
+//     withheld so raw values can never leak.
+//
+// Returns nil when nothing remains, so callers can omit an empty map.
+func SanitizeMetadata(meta map[string]interface{}, matchText string, showMatch bool) map[string]interface{} {
+	if len(meta) == 0 {
+		return nil
+	}
+
+	out := make(map[string]interface{}, len(meta))
+	for k, v := range meta {
+		// The explanation is surfaced as a first-class field; never dump it raw.
+		if k == explain.MetadataKey {
+			continue
+		}
+		// Deny-by-default: when the value is hidden, emit only proven-safe keys.
+		if !showMatch && !safeMetadataKeys[k] {
+			continue
+		}
+		out[k] = v
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// SanitizeSuppressedMatches returns suppressed matches that are safe to
+// serialize given the ShowMatch setting. The JSON/YAML formatters embed the
+// raw detector.SuppressedMatch (its finding's Text, Metadata, and Context all
+// carry the matched value and surrounding line), so without this the
+// `suppressed` block re-leaks exactly what the active-results redaction hides —
+// e.g. `--show-suppressed` without `--show-match` would dump raw cards/SSNs.
+//
+//   - ShowMatch=true: returned unchanged (the web UI relies on the real value
+//     to power its client-side click-to-reveal of suppressed findings).
+//   - ShowMatch=false: a copy is returned with the finding's value-bearing
+//     fields redacted, while the structural/suppression fields (type, line,
+//     confidence, filename, validator, suppressed_by, rule_reason, expiry) are
+//     preserved so the entry is still useful.
+func SanitizeSuppressedMatches(suppressed []detector.SuppressedMatch, showMatch bool) []detector.SuppressedMatch {
+	if showMatch || len(suppressed) == 0 {
+		return suppressed
+	}
+	out := make([]detector.SuppressedMatch, len(suppressed))
+	for i, s := range suppressed {
+		sanitized := s // copy the suppression envelope (SuppressedBy, RuleReason, ...)
+		m := s.Match   // copy the finding so we don't mutate the caller's slice
+		m.Metadata = SanitizeMetadata(m.Metadata, s.Match.Text, false)
+		m.Text = redactionPlaceholder
+		m.SecureText = nil
+		// Context holds the raw surrounding line and before/after text.
+		m.Context.FullLine = ""
+		m.Context.BeforeText = ""
+		m.Context.AfterText = ""
+		sanitized.Match = m
+		out[i] = sanitized
+	}
+	return out
+}
+
 // JSONResponse represents the top-level response structure for JSON/YAML output
 type JSONResponse struct {
 	Results    []JSONMatch                `json:"results" yaml:"results"`
@@ -70,25 +246,17 @@ func GetConfidenceLevel(confidence float64) string {
 func ConvertMatchesToJSONFormat(matches []detector.Match, suppressedMatches []detector.SuppressedMatch, options formatters.FormatterOptions) JSONResponse {
 	var jsonMatches []JSONMatch
 	for _, match := range matches {
-		metadata := make(map[string]interface{})
-		for k, v := range match.Metadata {
-			// The explanation is surfaced as a first-class field below; don't
-			// also dump it as a raw blob in metadata (one representation only).
-			if k == explain.MetadataKey {
-				continue
-			}
-			metadata[k] = v
-		}
-		if len(metadata) == 0 {
-			metadata = nil // keep `metadata` omitted rather than emitting {}
-		}
+		// Sanitize metadata through the single shared path so a value duplicated
+		// inside metadata (e.g. name_components, full_field) cannot defeat the
+		// Text-field redaction below.
+		metadata := SanitizeMetadata(match.Metadata, match.Text, options.ShowMatch)
 
 		confidenceLevel := GetConfidenceLevel(match.Confidence)
 
 		// Determine display text based on ShowMatch option. When ShowMatch is
 		// false, substitute "[HIDDEN]" so raw sensitive data is never serialized
 		// into JSON/YAML output, matching the text, CSV, SARIF, and JUnit formatters.
-		displayText := "[HIDDEN]"
+		displayText := redactionPlaceholder
 		if options.ShowMatch {
 			displayText = match.Text
 		}
@@ -132,7 +300,10 @@ func ConvertMatchesToJSONFormat(matches []detector.Match, suppressedMatches []de
 	}
 
 	return JSONResponse{
-		Results:    jsonMatches,
-		Suppressed: suppressedMatches,
+		Results: jsonMatches,
+		// Suppressed matches embed the raw finding, so route them through the
+		// same deny-by-default redaction as active results: without --show-match
+		// the value, metadata, and surrounding context are withheld.
+		Suppressed: SanitizeSuppressedMatches(suppressedMatches, options.ShowMatch),
 	}
 }

--- a/internal/formatters/shared/structures_test.go
+++ b/internal/formatters/shared/structures_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/awslabs/ferret-scan/internal/detector"
+	"github.com/awslabs/ferret-scan/internal/explain"
 	"github.com/awslabs/ferret-scan/internal/formatters"
 )
 
@@ -73,5 +74,147 @@ func TestConvertMatchesToJSONFormat_ShowMatchTrueRevealsText(t *testing.T) {
 	}
 	if !strings.Contains(r.FullLine, sensitiveValue) {
 		t.Errorf("FullLine should contain the matched value when ShowMatch is true, got %q", r.FullLine)
+	}
+}
+
+// TestSanitizeMetadata_DenyByDefault verifies the fail-safe allowlist model:
+// when ShowMatch is false, only known-safe keys survive and every other key
+// (including unknown/future ones and value-bearing ones like name_components /
+// full_field) is withheld; when ShowMatch is true, everything is returned
+// (except the explain key, which is surfaced separately).
+func TestSanitizeMetadata_DenyByDefault(t *testing.T) {
+	meta := map[string]interface{}{
+		// safe, allowlisted
+		"card_type":         "VISA",
+		"vendor":            "Visa",
+		"validation_checks": map[string]bool{"luhn": true},
+		"context_impact":    0,
+		// value-bearing / PII — must be withheld when hidden
+		"name_components": map[string]interface{}{"FullName": "Robert Aragon", "FirstName": "Robert"},
+		"full_field":      "Author: Brian Hileman",
+		"clean_number":    "4929381332664295",
+		"username":        "secretuser",
+		// unknown future key — must be withheld by default
+		"some_new_key": "anything could be here",
+	}
+
+	// Hidden: only allowlisted keys remain.
+	hidden := SanitizeMetadata(meta, "Robert Aragon", false)
+	allowed := map[string]bool{"card_type": true, "vendor": true, "validation_checks": true, "context_impact": true}
+	for k := range hidden {
+		if !allowed[k] {
+			t.Errorf("key %q leaked through deny-by-default sanitizer", k)
+		}
+	}
+	for k := range allowed {
+		if _, ok := hidden[k]; !ok {
+			t.Errorf("safe key %q should be retained when hidden", k)
+		}
+	}
+	// Explicitly confirm the PII/unknown keys are gone.
+	for _, k := range []string{"name_components", "full_field", "clean_number", "username", "some_new_key"} {
+		if _, ok := hidden[k]; ok {
+			t.Errorf("PII/unknown key %q must be withheld when ShowMatch=false", k)
+		}
+	}
+
+	// Shown: everything is returned.
+	shown := SanitizeMetadata(meta, "Robert Aragon", true)
+	for k := range meta {
+		if _, ok := shown[k]; !ok {
+			t.Errorf("key %q should be present when ShowMatch=true", k)
+		}
+	}
+}
+
+// TestSanitizeMetadata_DropsExplainKey confirms the explain key is never dumped
+// raw (it is surfaced as a first-class field), regardless of ShowMatch.
+func TestSanitizeMetadata_DropsExplainKey(t *testing.T) {
+	meta := map[string]interface{}{"card_type": "VISA"}
+	meta[explain.MetadataKey] = "raw explain blob"
+	for _, show := range []bool{true, false} {
+		out := SanitizeMetadata(meta, "x", show)
+		if _, ok := out[explain.MetadataKey]; ok {
+			t.Errorf("explain key must never be in sanitized metadata (showMatch=%v)", show)
+		}
+	}
+}
+
+// sampleSuppressed builds a suppressed match whose finding carries the matched
+// value in Text, Metadata, and Context — the three places the JSON/YAML
+// `suppressed` block would otherwise re-leak.
+func sampleSuppressed() []detector.SuppressedMatch {
+	return []detector.SuppressedMatch{{
+		Match: detector.Match{
+			Text:       sensitiveValue,
+			LineNumber: 12,
+			Type:       "STRIPE_KEY",
+			Confidence: 95,
+			Filename:   "config.go",
+			Validator:  "secrets",
+			Metadata: map[string]interface{}{
+				"secret_type": "stripe",                // allowlisted, structural
+				"full_field":  "key=" + sensitiveValue, // value-bearing, must drop
+			},
+			Context: detector.ContextInfo{
+				FullLine:   "apiKey := \"" + sensitiveValue + "\"",
+				BeforeText: "apiKey := \"",
+				AfterText:  "\"",
+			},
+		},
+		SuppressedBy: "SUP-00000001",
+		RuleReason:   "known test key",
+	}}
+}
+
+// TestSanitizeSuppressedMatches_HidesValueByDefault is a regression test for the
+// `--show-suppressed` (without `--show-match`) leak: the JSON/YAML suppressed
+// block embedded the raw finding. The value, metadata, and context must be
+// withheld by default, while the structural and suppression fields are kept.
+func TestSanitizeSuppressedMatches_HidesValueByDefault(t *testing.T) {
+	out := SanitizeSuppressedMatches(sampleSuppressed(), false)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 suppressed match, got %d", len(out))
+	}
+	f := out[0].Match
+	if f.Text != redactionPlaceholder {
+		t.Errorf("suppressed Text = %q, want %q", f.Text, redactionPlaceholder)
+	}
+	if f.Context.FullLine != "" || f.Context.BeforeText != "" || f.Context.AfterText != "" {
+		t.Errorf("suppressed Context must be cleared when hidden: %+v", f.Context)
+	}
+	if _, ok := f.Metadata["full_field"]; ok {
+		t.Error("value-bearing metadata key full_field leaked in suppressed block")
+	}
+	if _, ok := f.Metadata["secret_type"]; !ok {
+		t.Error("allowlisted metadata key secret_type should be retained")
+	}
+	// Structural + suppression fields must survive so the entry stays useful.
+	if f.Type != "STRIPE_KEY" || f.LineNumber != 12 || f.Confidence != 95 || f.Validator != "secrets" {
+		t.Errorf("structural fields not preserved: %+v", f)
+	}
+	if out[0].SuppressedBy != "SUP-00000001" || out[0].RuleReason != "known test key" {
+		t.Errorf("suppression envelope not preserved: by=%q reason=%q", out[0].SuppressedBy, out[0].RuleReason)
+	}
+
+	// The original input must not be mutated (we operate on copies).
+	orig := sampleSuppressed()[0]
+	_ = SanitizeSuppressedMatches([]detector.SuppressedMatch{orig}, false)
+	if orig.Match.Text != sensitiveValue {
+		t.Error("SanitizeSuppressedMatches mutated the caller's input")
+	}
+}
+
+// TestSanitizeSuppressedMatches_RevealsWithShowMatch verifies the web UI path:
+// with ShowMatch the suppressed finding is returned intact so the client-side
+// reveal of suppressed findings still works.
+func TestSanitizeSuppressedMatches_RevealsWithShowMatch(t *testing.T) {
+	out := SanitizeSuppressedMatches(sampleSuppressed(), true)
+	f := out[0].Match
+	if f.Text != sensitiveValue {
+		t.Errorf("suppressed Text = %q, want real value when ShowMatch=true", f.Text)
+	}
+	if f.Context.FullLine == "" {
+		t.Error("suppressed Context.FullLine should be present when ShowMatch=true")
 	}
 }

--- a/internal/web/scan_redaction_test.go
+++ b/internal/web/scan_redaction_test.go
@@ -1,0 +1,143 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package web
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/internal/detector"
+	"github.com/awslabs/ferret-scan/internal/formatters"
+	formatterShared "github.com/awslabs/ferret-scan/internal/formatters/shared"
+	"github.com/awslabs/ferret-scan/internal/suppressions"
+)
+
+// scanFormatterOptions mirrors the options the /scan handler uses to render the
+// JSON that is delivered to the operator's browser. Keep this in lockstep with
+// handleScan: the web UI redacts client-side, so /scan must receive the real
+// value (ShowMatch) and the context fields (Verbose) the suppression hash
+// depends on. This test exists because a deny-by-default change to the shared
+// JSON formatter once silently broke this contract.
+func scanFormatterOptions() formatters.FormatterOptions {
+	return formatters.FormatterOptions{
+		ConfidenceLevel: map[string]bool{"high": true, "medium": true, "low": true},
+		Verbose:         true,
+		ShowMatch:       true,
+	}
+}
+
+// TestScanJSON_DeliversRealDataForClientSideRedaction asserts that the JSON the
+// /scan endpoint sends to the browser carries the real matched value and the
+// raw context fields. The web UI hides them client-side (🔒 click-to-reveal),
+// so redacting them server-side would blank the reveal toggle.
+func TestScanJSON_DeliversRealDataForClientSideRedaction(t *testing.T) {
+	const secret = "4929-3813-3266-4295"
+	const fullLine = "Robert Aragon\t" + secret + "\t489-36-8350"
+	matches := []detector.Match{{
+		Text:       secret,
+		LineNumber: 5,
+		Type:       "CREDIT_CARD",
+		Confidence: 100,
+		Filename:   "cards.tsv",
+		Validator:  "creditcard",
+		Context: detector.ContextInfo{
+			FullLine:   fullLine,
+			BeforeText: "header row",
+			AfterText:  "footer row",
+		},
+		Metadata: map[string]interface{}{"card_type": "VISA"},
+	}}
+
+	out, err := formatters.Export("json", matches, nil, scanFormatterOptions())
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	var resp formatterShared.JSONResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(resp.Results))
+	}
+	r := resp.Results[0]
+	if r.Text != secret {
+		t.Errorf("scan JSON Text = %q, want real value %q (UI redacts client-side)", r.Text, secret)
+	}
+	if r.FullLine != fullLine {
+		t.Errorf("scan JSON full_line = %q, want %q (suppression hash depends on it)", r.FullLine, fullLine)
+	}
+	if r.BeforeText != "header row" || r.AfterText != "footer row" {
+		t.Errorf("scan JSON dropped before/after context: before=%q after=%q", r.BeforeText, r.AfterText)
+	}
+}
+
+// TestScanJSON_SuppressionHashRoundTrips is the load-bearing regression test:
+// the hash computed at scan time (from the real detector.Match) must equal the
+// hash the web UI recomputes from the fields it parsed out of the /scan JSON.
+// If /scan redacts text/context, the browser feeds [HIDDEN]/"" into
+// GenerateFindingHashFromData and the resulting suppression rule never matches
+// the finding it was created for.
+func TestScanJSON_SuppressionHashRoundTrips(t *testing.T) {
+	const secret = "4929-3813-3266-4295"
+	match := detector.Match{
+		Text:       secret,
+		LineNumber: 5,
+		Type:       "CREDIT_CARD",
+		Confidence: 100,
+		Filename:   "cards.tsv",
+		Validator:  "creditcard",
+		Context: detector.ContextInfo{
+			FullLine:   "Robert Aragon\t" + secret,
+			BeforeText: "before",
+			AfterText:  "after",
+		},
+	}
+
+	// Scan-time hash: the manager hashes the real match (IsSuppressed path).
+	mgr := suppressions.NewSuppressionManager("")
+	scanHash, err := mgr.GenerateFindingHashFromData(map[string]interface{}{
+		"type":        match.Type,
+		"text":        match.Text,
+		"filename":    match.Filename,
+		"line_number": float64(match.LineNumber),
+		"confidence":  match.Confidence,
+		"full_line":   match.Context.FullLine,
+		"before_text": match.Context.BeforeText,
+		"after_text":  match.Context.AfterText,
+	})
+	if err != nil {
+		t.Fatalf("scan hash: %v", err)
+	}
+
+	// Render the /scan JSON, parse it the way the browser does, then recompute
+	// the hash from the parsed fields (the /suppressions/create path).
+	out, err := formatters.Export("json", []detector.Match{match}, nil, scanFormatterOptions())
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	var resp formatterShared.JSONResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	r := resp.Results[0]
+	uiHash, err := mgr.GenerateFindingHashFromData(map[string]interface{}{
+		"type":        r.Type,
+		"text":        r.Text,
+		"filename":    r.Filename,
+		"line_number": float64(r.LineNumber),
+		"confidence":  r.Confidence,
+		"full_line":   r.FullLine,
+		"before_text": r.BeforeText,
+		"after_text":  r.AfterText,
+	})
+	if err != nil {
+		t.Fatalf("ui hash: %v", err)
+	}
+
+	if scanHash != uiHash {
+		t.Errorf("suppression hash mismatch:\n scan-time = %s\n web-ui    = %s\n"+
+			"the /scan JSON must carry real text+context so the UI recomputes the same hash", scanHash, uiHash)
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -462,11 +462,22 @@ func (ws *WebServer) handleScan(responseWriter http.ResponseWriter, request *htt
 		suppressedCount += suppCount
 	}
 
-	// Use CLI's JSON formatter with CLI's confidence parsing
-	// Always use verbose for web UI to include context fields needed for suppression creation
+	// Use CLI's JSON formatter with CLI's confidence parsing.
+	//
+	// The web UI does redaction CLIENT-SIDE: this /scan response is delivered to
+	// the operator's own browser, which stores the real value, displays a
+	// "🔒 [HIDDEN]" placeholder, and reveals it only on click. It also recomputes
+	// the suppression hash from the real text + context (full_line/before/after),
+	// which must match the scan-time hash. So this call MUST receive the real
+	// data: ShowMatch:true defeats the formatter's deny-by-default redaction
+	// (which is meant for file/stdout output, not the interactive UI), and
+	// Verbose:true includes the context fields the hash depends on. The file
+	// download path (/export) still honors the user's --show-match choice
+	// server-side, so exported artifacts remain redacted by default.
 	formatterOptions := formatters.FormatterOptions{
 		ConfidenceLevel: core.ParseConfidenceLevels(confidence),
-		Verbose:         true, // Always verbose for web UI to include context fields
+		Verbose:         true, // Include context fields (needed for suppression creation)
+		ShowMatch:       true, // Deliver real data to the browser; UI redacts client-side
 	}
 
 	// Use CLI's exact JSON formatting


### PR DESCRIPTION
## Summary

Follow-up to #87. Extends the deny-by-default redaction model so a raw matched value can only reach output when the operator passes `--show-match`. #87 gated the active-result `Text` and verbose context fields; this PR closes the remaining side channels found by scanning the full `~/Downloads` corpus (275 docx, 74 jpg/jpeg).

## What leaked (and is now fixed)

- **Metadata map** — JSON/YAML/SARIF/CSV dumped the raw `Metadata` map. Now routed through a single `SanitizeMetadata` **allowlist**: when hidden, only proven-safe structural keys survive; any value-bearing or unknown/future key is withheld. Notably **removed `validation_details`** from the allowlist — the social-media validator embeds the raw matched LinkedIn URL/username in it. *(Caught by scanning real documents, not synthetic fixtures.)*
- **Suppressed findings** — the JSON/YAML `suppressed` block embedded the raw `detector.SuppressedMatch`, so `--show-suppressed` without `--show-match` dumped raw cards/SSNs/names. `SanitizeSuppressedMatches` now redacts the finding's `Text`, `Context`, and value-bearing metadata while preserving structural + suppression fields.
- **SARIF** — gated the `contextRegion` snippet (raw surrounding line) on `ShowMatch`.
- **gitlab-sast** — withhold the surrounding line in the description unless `ShowMatch`. The old `EnsureNoSensitiveData` scrub was fail-open (masked card-shaped substrings but left names and SSN-shaped values).
- **CSV** — verbose metadata routed through `SanitizeMetadata`.

## Web UI fix (important)

The `/scan` endpoint renders JSON for the operator's **own browser**, which redacts **client-side** (🔒 click-to-reveal) and recomputes the suppression hash from the real `text` + context. The deny-by-default change broke that contract, so `/scan` now opts into `ShowMatch`+`Verbose` to receive real data. The `/export` download path still honors the user's `--show-match` choice server-side, so exported artifacts remain redacted by default.

## Verification

- **Bulk real-data scan** — full `~/Downloads`: **0 genuine PII leaks** across all 7 formats in default and `--verbose` modes; values correctly revealed with `--show-match`.
- **Images** — GPS EXIF coordinate redacts by default, reveals with `--show-match`.
- **End-to-end suppression on real data** — CLI 75→0 after enabling generated rules; web create+rescan suppresses the finding, and the web-computed hash matches the engine's scan-time hash exactly.
- `go test ./...` green; `-race` clean on touched packages; `gofmt` clean.

## Tests added

- `sarif/leak_test.go`, `gitlab-sast/leak_test.go` — no-leak-when-hidden / reveal-when-shown.
- `shared` — suppressed-match sanitizer (hide + reveal + no-mutation of caller input).
- `web/scan_redaction_test.go` — `/scan` delivers real data; suppression-hash round-trip (scan-time hash == web-recomputed hash).