### PR TITLE
fix(show-match): honor --show-match in 3 reveal paths it silently ignored

### DIFF
--- a/internal/formatters/gitlab-sast/leak_test.go
+++ b/internal/formatters/gitlab-sast/leak_test.go
@@ -55,3 +55,35 @@ func TestGitLabSAST_NoLeakWhenHidden(t *testing.T) {
 		t.Errorf("gitlab-sast should include the value when ShowMatch=true")
 	}
 }
+
+// TestGitLabSAST_RevealsValueWithoutFullLine is a regression test for the
+// reveal gap: gitlab-sast hardcodes "[HIDDEN]" in the message, so the only
+// surface that can reveal the matched value was the Context block sourced from
+// Context.FullLine. Validators that never populate FullLine (e.g. secrets/AWS
+// keys) therefore revealed nothing even with --show-match. The description must
+// fall back to the matched value itself when FullLine is empty and ShowMatch is
+// set — and still reveal nothing when it is not.
+func TestGitLabSAST_RevealsValueWithoutFullLine(t *testing.T) {
+	const awsKey = "AKIAIOSFODNN7EXAMPLE"
+	// Secrets-style finding: no Context.FullLine populated.
+	match := detector.Match{
+		Text:       awsKey,
+		LineNumber: 1,
+		Type:       "AWS_ACCESS_KEY",
+		Confidence: 90,
+		Filename:   "config.env",
+		Validator:  "secrets",
+	}
+	s := NewDataSanitizer()
+
+	hidden := s.SanitizeDescription(match, false)
+	if strings.Contains(hidden, awsKey) {
+		t.Errorf("gitlab-sast revealed the value without --show-match:\n%s", hidden)
+	}
+
+	shown := s.SanitizeDescription(match, true)
+	if !strings.Contains(shown, awsKey) {
+		t.Errorf("gitlab-sast should reveal the matched value with --show-match even when "+
+			"Context.FullLine is empty (secrets-style finding):\n%s", shown)
+	}
+}

--- a/internal/formatters/gitlab-sast/sanitizer.go
+++ b/internal/formatters/gitlab-sast/sanitizer.go
@@ -72,6 +72,15 @@ func (s *DataSanitizer) SanitizeDescription(match detector.Match, showMatch bool
 		} else {
 			description.WriteString("\n**Context:** [HIDDEN] (use --show-match to include the surrounding line)\n")
 		}
+	} else if showMatch && match.Text != "" {
+		// Validator-independent reveal path. SanitizeMessage always emits
+		// "[HIDDEN]", so the Context line above is normally the only place the
+		// matched value can surface — but some validators (e.g. secrets/AWS
+		// keys) never populate Context.FullLine, so --show-match would reveal
+		// nothing for them, contradicting the flag's contract. Fall back to the
+		// matched value itself so every validator honors --show-match, while the
+		// deny-by-default branch (no --show-match) still emits nothing here.
+		description.WriteString(fmt.Sprintf("\n**Matched value:**\n```\n%s\n```\n", match.Text))
 	}
 
 	// Add metadata information if available

--- a/internal/formatters/junit/formatter.go
+++ b/internal/formatters/junit/formatter.go
@@ -40,6 +40,10 @@ type TestCase struct {
 	ClassName string   `xml:"classname,attr"`
 	Time      string   `xml:"time,attr"`
 	Failure   *Failure `xml:"failure,omitempty"`
+	// SystemOut carries informational, non-failing detail (the standard JUnit
+	// <system-out> element). Suppressed findings use it so they convey their
+	// detail without being reported as failures.
+	SystemOut string `xml:"system-out,omitempty"`
 }
 
 type Failure struct {
@@ -201,11 +205,37 @@ func (f *Formatter) createTestCaseForFile(filename string, matches []detector.Ma
 func (f *Formatter) createTestCaseForSuppressedFile(filename string, suppressedMatches []detector.SuppressedMatch, options formatters.FormatterOptions) TestCase {
 	basename := filepath.Base(filename)
 
+	// Suppressed findings don't create failures - they're informational - so
+	// their detail goes in <system-out> rather than <failure>. We still honor
+	// --show-match here so the matched value surfaces exactly when the operator
+	// opts in, matching the active-finding path and every other formatter; the
+	// default (no --show-match) emits type/line/confidence only, never the value.
+	var out strings.Builder
+	for i, suppressed := range suppressedMatches {
+		if i > 0 {
+			out.WriteString("\n")
+		}
+		match := suppressed.Match
+		out.WriteString(fmt.Sprintf("Line %d: %s suppressed by %s (%.1f%%)",
+			match.LineNumber, match.Type, suppressed.SuppressedBy, match.Confidence))
+		if suppressed.RuleReason != "" {
+			out.WriteString(fmt.Sprintf(" - %s", suppressed.RuleReason))
+		}
+		if options.ShowMatch {
+			out.WriteString(fmt.Sprintf("\nMatch: %s", match.Text))
+			// FullLine carries the raw value; gate on ShowMatch too (consistent
+			// with the active path) so --verbose never re-leaks when hidden.
+			if options.Verbose && match.Context.FullLine != "" {
+				out.WriteString(fmt.Sprintf("\nContext: %s", match.Context.FullLine))
+			}
+		}
+	}
+
 	return TestCase{
 		Name:      basename + " (suppressed)",
 		ClassName: "suppressed-findings",
 		Time:      "0.001",
-		// Suppressed findings don't create failures - they're informational
+		SystemOut: out.String(),
 	}
 }
 

--- a/internal/formatters/junit/formatter_test.go
+++ b/internal/formatters/junit/formatter_test.go
@@ -52,3 +52,60 @@ func TestJUnitFormatter_VerboseDoesNotLeakWhenHidden(t *testing.T) {
 		t.Errorf("JUnit output should include the value when ShowMatch=true")
 	}
 }
+
+// TestJUnitFormatter_SuppressedHonorsShowMatch is a regression test for the
+// reveal gap where createTestCaseForSuppressedFile emitted an empty <testcase>
+// and ignored ShowMatch entirely — so --show-match was a silent no-op for
+// suppressed findings, inconsistent with every other formatter. The suppressed
+// value must surface in <system-out> when ShowMatch is set, stay hidden when it
+// is not, and never be reported as a <failure>.
+func TestJUnitFormatter_SuppressedHonorsShowMatch(t *testing.T) {
+	const secret = "4929-3813-3266-4295"
+	suppressed := []detector.SuppressedMatch{{
+		Match: detector.Match{
+			Text:       secret,
+			LineNumber: 2,
+			Type:       "VISA",
+			Confidence: 100,
+			Filename:   "cards.tsv",
+			Validator:  "creditcard",
+			Context:    detector.ContextInfo{FullLine: "Robert Aragon\t" + secret},
+		},
+		SuppressedBy: "SUP-00000001",
+		RuleReason:   "known test card",
+	}}
+	allLevels := map[string]bool{"high": true, "medium": true, "low": true}
+
+	// Hidden: the value must not appear, but the suppressed finding's structural
+	// detail should still be present (so the entry is informative).
+	hidden, err := NewFormatter().Format(nil, suppressed, formatters.FormatterOptions{
+		ShowMatch: false, Verbose: true, ConfidenceLevel: allLevels,
+	})
+	if err != nil {
+		t.Fatalf("Format error: %v", err)
+	}
+	if strings.Contains(hidden, secret) {
+		t.Errorf("JUnit suppressed output leaked the value with ShowMatch=false:\n%s", hidden)
+	}
+	if !strings.Contains(hidden, "SUP-00000001") {
+		t.Errorf("JUnit suppressed output should still show the suppressing rule id:\n%s", hidden)
+	}
+	// Suppressed findings are informational, not failures.
+	if strings.Contains(hidden, "<failure") {
+		t.Errorf("suppressed findings must not be reported as <failure>:\n%s", hidden)
+	}
+
+	// Revealed: --show-match surfaces the value in <system-out>.
+	shown, err := NewFormatter().Format(nil, suppressed, formatters.FormatterOptions{
+		ShowMatch: true, Verbose: true, ConfidenceLevel: allLevels,
+	})
+	if err != nil {
+		t.Fatalf("Format error: %v", err)
+	}
+	if !strings.Contains(shown, secret) {
+		t.Errorf("JUnit suppressed output should reveal the value when ShowMatch=true:\n%s", shown)
+	}
+	if strings.Contains(shown, "<failure") {
+		t.Errorf("suppressed findings must not be reported as <failure> even when revealed:\n%s", shown)
+	}
+}

--- a/internal/formatters/text/formatter.go
+++ b/internal/formatters/text/formatter.go
@@ -774,6 +774,13 @@ func (f *Formatter) formatPrecommitOutput(matches []detector.Match, suppressedMa
 					f.getPrecommitIssueDescription(match),
 					strings.ToLower(confidenceLevel))
 
+				// Honor --show-match here too, so the resolution hint below
+				// ("Use --show-match flag to see exact matches") is truthful in
+				// pre-commit mode. displayMatchText returns "[HIDDEN]" by default
+				// and the raw value only when ShowMatch is set, so the default
+				// pre-commit output still never prints the matched value.
+				fmt.Fprintf(&builder, "    match: %s\n", displayMatchText(match, options))
+
 				// Per-finding explanation when scanned with --explain: promote
 				// the "why" and a verdict to the pre-commit gate, the highest-
 				// friction moment, instead of leaving it in verbose-only output.

--- a/internal/formatters/text/formatter_test.go
+++ b/internal/formatters/text/formatter_test.go
@@ -90,3 +90,48 @@ func TestTextFormatter_VerboseDetailedViewDoesNotLeak(t *testing.T) {
 		t.Errorf("--show-match should reveal the value in verbose output")
 	}
 }
+
+// TestTextFormatter_PrecommitHonorsShowMatch is a regression test for the
+// pre-commit reveal gap: formatPrecommitOutput never printed match.Text, so
+// --show-match was a silent no-op there even though the resolution guidance
+// told users to "Use --show-match flag to see exact matches." The matched
+// value must surface in pre-commit output when ShowMatch is set, and stay
+// [HIDDEN] when it is not (so the hint is truthful in both directions).
+func TestTextFormatter_PrecommitHonorsShowMatch(t *testing.T) {
+	const secret = "4929-3813-3266-4295"
+	matches := []detector.Match{{
+		Text:       secret,
+		LineNumber: 2,
+		Type:       "CREDIT_CARD",
+		Confidence: 100,
+		Filename:   "cards.tsv",
+		Validator:  "creditcard",
+		Context:    detector.ContextInfo{FullLine: "Robert Aragon\t" + secret},
+	}}
+	levels := map[string]bool{"high": true, "medium": true, "low": true}
+
+	// Hidden: pre-commit output must not print the value; it shows [HIDDEN].
+	hidden, err := NewFormatter().Format(matches, nil, formatters.FormatterOptions{
+		PrecommitMode: true, ShowMatch: false, NoColor: true, ConfidenceLevel: levels,
+	})
+	if err != nil {
+		t.Fatalf("Format error: %v", err)
+	}
+	if strings.Contains(hidden, secret) {
+		t.Errorf("pre-commit output leaked the value with ShowMatch=false:\n%s", hidden)
+	}
+	if !strings.Contains(hidden, "[HIDDEN]") {
+		t.Errorf("pre-commit output should show [HIDDEN] for the match when ShowMatch=false:\n%s", hidden)
+	}
+
+	// Revealed: --show-match surfaces the value (makes the resolution hint honest).
+	shown, err := NewFormatter().Format(matches, nil, formatters.FormatterOptions{
+		PrecommitMode: true, ShowMatch: true, NoColor: true, ConfidenceLevel: levels,
+	})
+	if err != nil {
+		t.Fatalf("Format error: %v", err)
+	}
+	if !strings.Contains(shown, secret) {
+		t.Errorf("pre-commit --show-match should reveal the matched value:\n%s", shown)
+	}
+}


### PR DESCRIPTION
## Summary

Stacked on #88. A `--show-match` **reveal** audit (all 7 formats + stdin + web-export × full flag matrix, with adversarial verification) confirmed the **hide** direction is solid everywhere, but found **3 pre-existing paths where `--show-match` was a silent no-op** — the value was never surfaced even when the operator explicitly opted in.

**None are security leaks** — the dangerous direction (leaking *without* the flag) was always safe. These are "reveal-too-little" / misleading-contract bugs. All three are fixed and gated on `ShowMatch`, so deny-by-default behavior is unchanged.

## Fixes

1. **pre-commit (text)** — `formatPrecommitOutput` never printed `match.Text`, yet the resolution guidance told users *"Use --show-match flag to see exact matches."* Now prints `match: <value>` per finding — `[HIDDEN]` by default, the real value with `--show-match` — making the hint truthful.
2. **JUnit suppressed findings** — `createTestCaseForSuppressedFile` emitted an empty `<testcase>` and ignored `ShowMatch` entirely (every other formatter reveals suppressed values). Now emits detail in `<system-out>` (informational, **not** a `<failure>`), revealing the value only under `--show-match`. Added a `SystemOut` field to `TestCase`.
3. **gitlab-sast** — `SanitizeMessage` hardcodes `[HIDDEN]`, so the value could only surface via the Context block sourced from `Context.FullLine` — which the `secrets`/AWS-key validator never populates, so `--show-match` revealed nothing for it. Added a validator-independent fallback that emits the matched value when `FullLine` is empty and `ShowMatch` is set.

## Verification

- Both directions confirmed with the binary: value revealed under `--show-match`, `[HIDDEN]` without — for all three paths (AWS key, card, SSN fixtures; junit needs an enabled suppression).
- **Re-ran the full deny-by-default leak check**: 0 leaks across all 7 formats in default and `--verbose` modes (the new gitlab-sast reveal path is correctly gated). Bulk gitlab-sast docx scan: 0 structured-PII leaks.
- `go test ./...` green; `-race` clean on formatters; `gofmt` clean.
- Regression tests added for each gap (`text`, `junit`, `gitlab-sast`).

## Notes

- Base is #88's branch (stacked) because GAP 3 edits `gitlab-sast/sanitizer.go`, which #88 already touched. **Retarget to `main` once #88 merges.**
- Decision taken on GAP 1: chose to *reveal* (Option A) over *never-reveal* (Option B) for consistency with `displayMatchText` and every other format. Easy to flip if the team prefers pre-commit never print values.