### PR TITLE
fix(build): correct ldflags symbol path so version is injected at build time

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,9 +23,9 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X ferret-scan/internal/version.Version={{.Version}}
-      - -X ferret-scan/internal/version.GitCommit={{.Commit}}
-      - -X ferret-scan/internal/version.BuildDate={{.Date}}
+      - -X github.com/awslabs/ferret-scan/internal/version.Version={{.Version}}
+      - -X github.com/awslabs/ferret-scan/internal/version.GitCommit={{.Commit}}
+      - -X github.com/awslabs/ferret-scan/internal/version.BuildDate={{.Date}}
 
 # Note: Web UI functionality is now integrated into the main ferret-scan binary
 # Use: ferret-scan --web to start web server mode

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,9 +52,9 @@ ARG BUILD_DATE=unknown
 RUN CGO_ENABLED=0 GOOS=linux GOMAXPROCS=2 go build \
     -a -installsuffix cgo -p 2 \
     -ldflags="-s -w -extldflags '-static' \
-              -X 'ferret-scan/internal/version.Version=${VERSION}' \
-              -X 'ferret-scan/internal/version.GitCommit=${GIT_COMMIT}' \
-              -X 'ferret-scan/internal/version.BuildDate=${BUILD_DATE}'" \
+              -X 'github.com/awslabs/ferret-scan/internal/version.Version=${VERSION}' \
+              -X 'github.com/awslabs/ferret-scan/internal/version.GitCommit=${GIT_COMMIT}' \
+              -X 'github.com/awslabs/ferret-scan/internal/version.BuildDate=${BUILD_DATE}'" \
     -o ferret-scan ./cmd && \
     go clean -cache -testcache -modcache
 

--- a/Makefile
+++ b/Makefile
@@ -65,21 +65,21 @@ build:
 	@echo "Building..."
 	@go env -w GOPROXY=direct
 	@VERSION=$$(git describe --tags --exact-match 2>/dev/null || git describe --tags 2>/dev/null || echo "0.0.0-development"); \
-	go build -ldflags="-s -w -X 'ferret-scan/internal/version.Version=$$VERSION' -X 'ferret-scan/internal/version.GitCommit=$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)' -X 'ferret-scan/internal/version.BuildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)'" -o bin/ferret-scan ./cmd
+	go build -ldflags="-s -w -X 'github.com/awslabs/ferret-scan/internal/version.Version=$$VERSION' -X 'github.com/awslabs/ferret-scan/internal/version.GitCommit=$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)' -X 'github.com/awslabs/ferret-scan/internal/version.BuildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)'" -o bin/ferret-scan ./cmd
 
 # Build for Windows (amd64)
 build-windows:
 	@echo "Building for Windows (amd64)..."
 	@go env -w GOPROXY=direct
 	@VERSION=$$(git describe --tags --exact-match 2>/dev/null || git describe --tags 2>/dev/null || echo "0.0.0-development"); \
-	GOOS=windows GOARCH=amd64 go build -ldflags="-s -w -X 'ferret-scan/internal/version.Version=$$VERSION' -X 'ferret-scan/internal/version.GitCommit=$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)' -X 'ferret-scan/internal/version.BuildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)'" -o bin/ferret-scan-win-amd64.exe ./cmd
+	GOOS=windows GOARCH=amd64 go build -ldflags="-s -w -X 'github.com/awslabs/ferret-scan/internal/version.Version=$$VERSION' -X 'github.com/awslabs/ferret-scan/internal/version.GitCommit=$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)' -X 'github.com/awslabs/ferret-scan/internal/version.BuildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)'" -o bin/ferret-scan-win-amd64.exe ./cmd
 
 # Build for Windows (arm64)
 build-windows-arm64:
 	@echo "Building for Windows (arm64)..."
 	@go env -w GOPROXY=direct
 	@VERSION=$$(git describe --tags --exact-match 2>/dev/null || git describe --tags 2>/dev/null || echo "0.0.0-development"); \
-	GOOS=windows GOARCH=arm64 go build -ldflags="-s -w -X 'ferret-scan/internal/version.Version=$$VERSION' -X 'ferret-scan/internal/version.GitCommit=$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)' -X 'ferret-scan/internal/version.BuildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)'" -o bin/ferret-scan-win-arm64.exe ./cmd
+	GOOS=windows GOARCH=arm64 go build -ldflags="-s -w -X 'github.com/awslabs/ferret-scan/internal/version.Version=$$VERSION' -X 'github.com/awslabs/ferret-scan/internal/version.GitCommit=$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)' -X 'github.com/awslabs/ferret-scan/internal/version.BuildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)'" -o bin/ferret-scan-win-arm64.exe ./cmd
 
 # Build for all platforms
 build-all-platforms:
@@ -87,10 +87,10 @@ build-all-platforms:
 	@go env -w GOPROXY=direct
 	@VERSION=$$(git describe --tags --exact-match 2>/dev/null || git describe --tags 2>/dev/null || echo "0.0.0-development"); \
 	echo "Building for current platform..." && make build && \
-	echo "Building for Linux (amd64)..." && GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -X 'ferret-scan/internal/version.Version=$$VERSION' -X 'ferret-scan/internal/version.GitCommit=$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)' -X 'ferret-scan/internal/version.BuildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)'" -o bin/ferret-scan-linux-amd64 ./cmd && \
-	echo "Building for Linux (arm64)..." && GOOS=linux GOARCH=arm64 go build -ldflags="-s -w -X 'ferret-scan/internal/version.Version=$$VERSION' -X 'ferret-scan/internal/version.GitCommit=$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)' -X 'ferret-scan/internal/version.BuildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)'" -o bin/ferret-scan-linux-arm64 ./cmd && \
-	echo "Building for macOS (amd64)..." && GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w -X 'ferret-scan/internal/version.Version=$$VERSION' -X 'ferret-scan/internal/version.GitCommit=$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)' -X 'ferret-scan/internal/version.BuildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)'" -o bin/ferret-scan-darwin-amd64 ./cmd && \
-	echo "Building for macOS (arm64)..." && GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w -X 'ferret-scan/internal/version.Version=$$VERSION' -X 'ferret-scan/internal/version.GitCommit=$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)' -X 'ferret-scan/internal/version.BuildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)'" -o bin/ferret-scan-darwin-arm64 ./cmd
+	echo "Building for Linux (amd64)..." && GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -X 'github.com/awslabs/ferret-scan/internal/version.Version=$$VERSION' -X 'github.com/awslabs/ferret-scan/internal/version.GitCommit=$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)' -X 'github.com/awslabs/ferret-scan/internal/version.BuildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)'" -o bin/ferret-scan-linux-amd64 ./cmd && \
+	echo "Building for Linux (arm64)..." && GOOS=linux GOARCH=arm64 go build -ldflags="-s -w -X 'github.com/awslabs/ferret-scan/internal/version.Version=$$VERSION' -X 'github.com/awslabs/ferret-scan/internal/version.GitCommit=$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)' -X 'github.com/awslabs/ferret-scan/internal/version.BuildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)'" -o bin/ferret-scan-linux-arm64 ./cmd && \
+	echo "Building for macOS (amd64)..." && GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w -X 'github.com/awslabs/ferret-scan/internal/version.Version=$$VERSION' -X 'github.com/awslabs/ferret-scan/internal/version.GitCommit=$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)' -X 'github.com/awslabs/ferret-scan/internal/version.BuildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)'" -o bin/ferret-scan-darwin-amd64 ./cmd && \
+	echo "Building for macOS (arm64)..." && GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w -X 'github.com/awslabs/ferret-scan/internal/version.Version=$$VERSION' -X 'github.com/awslabs/ferret-scan/internal/version.GitCommit=$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)' -X 'github.com/awslabs/ferret-scan/internal/version.BuildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)'" -o bin/ferret-scan-darwin-arm64 ./cmd
 	@make build-windows
 	@make build-windows-arm64
 	@echo "✓ All platform binaries built in bin/ directory"
@@ -102,7 +102,7 @@ build-all-platforms:
 build-release:
 	@echo "Building release version $(VERSION)..."
 	@go env -w GOPROXY=direct
-	@go build -ldflags="-s -w -X 'ferret-scan/internal/version.Version=$(VERSION)' -X 'ferret-scan/internal/version.GitCommit=$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)' -X 'ferret-scan/internal/version.BuildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)'" -o bin/ferret-scan ./cmd
+	@go build -ldflags="-s -w -X 'github.com/awslabs/ferret-scan/internal/version.Version=$(VERSION)' -X 'github.com/awslabs/ferret-scan/internal/version.GitCommit=$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)' -X 'github.com/awslabs/ferret-scan/internal/version.BuildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)'" -o bin/ferret-scan ./cmd
 
 # Note: Web UI release functionality is now integrated into build-release target
 # The single ferret-scan binary includes both CLI and web modes

--- a/docs/development/WINDOWS_CROSS_COMPILATION.md
+++ b/docs/development/WINDOWS_CROSS_COMPILATION.md
@@ -103,9 +103,9 @@ BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 # Build flags
 LDFLAGS="-s -w"
-LDFLAGS="$LDFLAGS -X ferret-scan/internal/version.Version=$VERSION"
-LDFLAGS="$LDFLAGS -X ferret-scan/internal/version.GitCommit=$COMMIT"
-LDFLAGS="$LDFLAGS -X ferret-scan/internal/version.BuildDate=$BUILD_DATE"
+LDFLAGS="$LDFLAGS -X github.com/awslabs/ferret-scan/internal/version.Version=$VERSION"
+LDFLAGS="$LDFLAGS -X github.com/awslabs/ferret-scan/internal/version.GitCommit=$COMMIT"
+LDFLAGS="$LDFLAGS -X github.com/awslabs/ferret-scan/internal/version.BuildDate=$BUILD_DATE"
 
 # Build for different Windows architectures
 build_windows() {
@@ -175,9 +175,9 @@ build_target() {
 
     # Build flags
     local ldflags="-s -w"
-    ldflags="$ldflags -X ferret-scan/internal/version.Version=$VERSION"
-    ldflags="$ldflags -X ferret-scan/internal/version.GitCommit=$(git rev-parse HEAD)"
-    ldflags="$ldflags -X ferret-scan/internal/version.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    ldflags="$ldflags -X github.com/awslabs/ferret-scan/internal/version.Version=$VERSION"
+    ldflags="$ldflags -X github.com/awslabs/ferret-scan/internal/version.GitCommit=$(git rev-parse HEAD)"
+    ldflags="$ldflags -X github.com/awslabs/ferret-scan/internal/version.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
     # Build command
     GOOS=$goos GOARCH=$goarch CGO_ENABLED=0 go build \
@@ -383,7 +383,7 @@ const (
 PROJECT_NAME := ferret-scan
 VERSION := $(shell git describe --tags --always --dirty)
 BUILD_DIR := dist
-LDFLAGS := -s -w -X ferret-scan/internal/version.Version=$(VERSION)
+LDFLAGS := -s -w -X github.com/awslabs/ferret-scan/internal/version.Version=$(VERSION)
 
 # Windows targets
 WINDOWS_TARGETS := windows/amd64 windows/arm64 windows/386
@@ -495,9 +495,9 @@ jobs:
 
         # Build flags
         LDFLAGS="-s -w"
-        LDFLAGS="$LDFLAGS -X ferret-scan/internal/version.Version=${{ steps.version.outputs.version }}"
-        LDFLAGS="$LDFLAGS -X ferret-scan/internal/version.GitCommit=${{ github.sha }}"
-        LDFLAGS="$LDFLAGS -X ferret-scan/internal/version.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        LDFLAGS="$LDFLAGS -X github.com/awslabs/ferret-scan/internal/version.Version=${{ steps.version.outputs.version }}"
+        LDFLAGS="$LDFLAGS -X github.com/awslabs/ferret-scan/internal/version.GitCommit=${{ github.sha }}"
+        LDFLAGS="$LDFLAGS -X github.com/awslabs/ferret-scan/internal/version.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
         # Build
         go build -ldflags "$LDFLAGS" -trimpath -o "$OUTPUT" ./cmd
@@ -563,9 +563,9 @@ builds:
         goarch: "386"
     ldflags:
       - -s -w
-      - -X ferret-scan/internal/version.Version={{.Version}}
-      - -X ferret-scan/internal/version.GitCommit={{.Commit}}
-      - -X ferret-scan/internal/version.BuildDate={{.Date}}
+      - -X github.com/awslabs/ferret-scan/internal/version.Version={{.Version}}
+      - -X github.com/awslabs/ferret-scan/internal/version.GitCommit={{.Commit}}
+      - -X github.com/awslabs/ferret-scan/internal/version.BuildDate={{.Date}}
 
 archives:
   - id: default

--- a/docs/development/WINDOWS_DEVELOPMENT.md
+++ b/docs/development/WINDOWS_DEVELOPMENT.md
@@ -204,7 +204,7 @@ $Version = "v1.0.0-dev"
 $Commit = git rev-parse HEAD
 $BuildDate = Get-Date -Format "2006-01-02T15:04:05Z"
 
-go build -ldflags "-X ferret-scan/internal/version.Version=$Version -X ferret-scan/internal/version.GitCommit=$Commit -X ferret-scan/internal/version.BuildDate=$BuildDate" -o ferret-scan.exe ./cmd
+go build -ldflags "-X github.com/awslabs/ferret-scan/internal/version.Version=$Version -X github.com/awslabs/ferret-scan/internal/version.GitCommit=$Commit -X github.com/awslabs/ferret-scan/internal/version.BuildDate=$BuildDate" -o ferret-scan.exe ./cmd
 ```
 
 ### Cross-Platform Building
@@ -266,9 +266,9 @@ $BuildDate = Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ"
 # Build flags
 $BuildFlags = @()
 $LdFlags = @(
-    "-X ferret-scan/internal/version.Version=$Version",
-    "-X ferret-scan/internal/version.GitCommit=$GitCommit",
-    "-X ferret-scan/internal/version.BuildDate=$BuildDate"
+    "-X github.com/awslabs/ferret-scan/internal/version.Version=$Version",
+    "-X github.com/awslabs/ferret-scan/internal/version.GitCommit=$GitCommit",
+    "-X github.com/awslabs/ferret-scan/internal/version.BuildDate=$BuildDate"
 )
 
 if (-not $Debug) {

--- a/python-package/build-package.sh
+++ b/python-package/build-package.sh
@@ -45,7 +45,7 @@ echo "Git commit: $GIT_COMMIT"
 echo "Build date: $BUILD_DATE"
 
 # Set up ldflags with version information
-LDFLAGS="-s -w -X 'ferret-scan/internal/version.Version=$VERSION' -X 'ferret-scan/internal/version.GitCommit=$GIT_COMMIT' -X 'ferret-scan/internal/version.BuildDate=$BUILD_DATE'"
+LDFLAGS="-s -w -X 'github.com/awslabs/ferret-scan/internal/version.Version=$VERSION' -X 'github.com/awslabs/ferret-scan/internal/version.GitCommit=$GIT_COMMIT' -X 'github.com/awslabs/ferret-scan/internal/version.BuildDate=$BUILD_DATE'"
 
 # Linux AMD64
 GOOS=linux GOARCH=amd64 go build -ldflags="$LDFLAGS" -o "$BINARY_DIR/ferret-scan-linux-amd64" ./cmd


### PR DESCRIPTION
The -X ldflags used the bare path `ferret-scan/internal/version.Version` instead of the full module path `github.com/awslabs/ferret-scan/internal/ version.Version`. Go's linker silently ignores -X when the symbol path doesn't resolve, so released binaries kept the compiled-in default and reported `0.0.0-development` (e.g. v1.8.4 from PyPI and the --version / --web /health output).

Fix the path in every build entrypoint:
- .goreleaser.yml          (GitHub Actions release / tag builds)
- Makefile                 (build, build-release, all-platforms targets)
- python-package/build-package.sh (PyPI bundled binaries)
- Dockerfile               (container image builds)
- docs/development/WINDOWS_{DEVELOPMENT,CROSS_COMPILATION}.md (reference snippets)

Verified: a build with the corrected ldflags reports the injected version on both `ferret-scan --version` and the web UI /health endpoint (both read the same internal/version package). No Go source changes.