### PR TITLE
fix(ci): prevent script injection in GitHub Actions workflows

### DIFF
--- a/.github/workflows/docker-multiarch.yml
+++ b/.github/workflows/docker-multiarch.yml
@@ -101,14 +101,16 @@ jobs:
 
       - name: Verify GHCR access
         if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
+        env:
+          ACTOR: ${{ github.actor }}
         run: |
           echo "🔍 Verifying GHCR access..."
-          echo "Actor: ${{ github.actor }}"
+          echo "Actor: $ACTOR"
           echo "Repository: ${{ github.repository }}"
           echo "Repository owner: ${{ github.repository_owner }}"
 
           # Test if we can access the repository
-          if docker manifest inspect ghcr.io/${{ env.GHCR_REPOSITORY }}:latest >/dev/null 2>&1; then
+          if docker manifest inspect "ghcr.io/${GHCR_REPOSITORY}:latest" >/dev/null 2>&1; then
             echo "✅ Can access existing images"
           else
             echo "ℹ️ No existing images found (this is normal for first push)"
@@ -139,15 +141,21 @@ jobs:
 
       - name: Determine platforms
         id: platforms
+        # The platforms input is free-text workflow_dispatch input; pass via env
+        # and reference as "$VAR" so it cannot inject shell commands (GitHub
+        # Actions script-injection hardening).
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_PLATFORMS: ${{ github.event.inputs.platforms }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "platforms=${{ github.event.inputs.platforms }}" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "platforms=$INPUT_PLATFORMS" >> "$GITHUB_OUTPUT"
+          elif [ "$EVENT_NAME" = "pull_request" ]; then
             # Only build for amd64 on PRs for faster feedback
-            echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
+            echo "platforms=linux/amd64" >> "$GITHUB_OUTPUT"
           else
             # Full multi-arch build for main branch and tags
-            echo "platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
+            echo "platforms=linux/amd64,linux/arm64" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build and push Docker image
@@ -204,55 +212,68 @@ jobs:
 
       - name: Test multi-arch images
         if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
+        # PLATFORMS derives from the untrusted platforms input and IMAGE_VERSION
+        # from the metadata action; pass via env and reference as "$VAR" so
+        # neither can inject shell commands.
+        env:
+          PLATFORMS: ${{ steps.platforms.outputs.platforms }}
+          IMAGE_VERSION: ${{ steps.meta.outputs.version }}
         run: |
           echo "🧪 Testing built images..."
 
           # Test each platform
-          for platform in $(echo "${{ steps.platforms.outputs.platforms }}" | tr ',' ' '); do
+          for platform in $(echo "$PLATFORMS" | tr ',' ' '); do
             echo "Testing $platform..."
 
             # Test GHCR image
-            docker run --rm --platform=$platform \
-              ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPOSITORY }}:${{ steps.meta.outputs.version }} \
+            docker run --rm --platform="$platform" \
+              "${GHCR_REGISTRY}/${GHCR_REPOSITORY}:${IMAGE_VERSION}" \
               --version || echo "⚠️ GHCR version check failed for $platform"
 
-            docker run --rm --platform=$platform \
-              ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPOSITORY }}:${{ steps.meta.outputs.version }} \
+            docker run --rm --platform="$platform" \
+              "${GHCR_REGISTRY}/${GHCR_REPOSITORY}:${IMAGE_VERSION}" \
               --help | head -5 || echo "⚠️ GHCR help check failed for $platform"
           done
 
       - name: Create release summary
         if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
+        # IMAGE_TAGS/PLATFORMS derive from the metadata action and the untrusted
+        # platforms input; pass via env and reference as "$VAR" so they cannot
+        # inject shell commands. The registry/repository names are workflow-level
+        # env constants, referenced directly as shell vars.
+        env:
+          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
+          PLATFORMS: ${{ steps.platforms.outputs.platforms }}
         run: |
-          echo "## 🐳 Multi-Architecture Docker Build Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Container Registries" >> $GITHUB_STEP_SUMMARY
-          echo "#### Amazon ECR Public" >> $GITHUB_STEP_SUMMARY
-          echo "**Image:** \`${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Gallery:** https://gallery.ecr.aws/g4m5x5s3/ferret-scan" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "#### GitHub Container Registry" >> $GITHUB_STEP_SUMMARY
-          echo "**Image:** \`${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPOSITORY }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Packages:** https://github.com/awslabs/ferret-scan/pkgs/container/ferret-scan" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Tags:** ${{ steps.meta.outputs.tags }}" | tr ',' '\n' | sed 's/^/- `/' | sed 's/$/`/' >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Platforms:** ${{ steps.platforms.outputs.platforms }}" | tr ',' '\n' | sed 's/^/- /' >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Usage Examples:" >> $GITHUB_STEP_SUMMARY
-          echo '```bash' >> $GITHUB_STEP_SUMMARY
-          echo "# Pull from GitHub Container Registry" >> $GITHUB_STEP_SUMMARY
-          echo "docker pull ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPOSITORY }}:latest" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "# Pull from Amazon ECR Public" >> $GITHUB_STEP_SUMMARY
-          echo "docker pull ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:latest" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "# Run CLI mode" >> $GITHUB_STEP_SUMMARY
-          echo "docker run --rm -v \$(pwd):/data ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPOSITORY }}:latest --file /data/sample.txt" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "# Run web mode" >> $GITHUB_STEP_SUMMARY
-          echo "docker run --rm -p 8080:8080 ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPOSITORY }}:latest --web --port 8080" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "## 🐳 Multi-Architecture Docker Build Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Container Registries" >> "$GITHUB_STEP_SUMMARY"
+          echo "#### Amazon ECR Public" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Image:** \`${ECR_REGISTRY}/${ECR_REPOSITORY}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Gallery:** https://gallery.ecr.aws/g4m5x5s3/ferret-scan" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "#### GitHub Container Registry" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Image:** \`${GHCR_REGISTRY}/${GHCR_REPOSITORY}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Packages:** https://github.com/awslabs/ferret-scan/pkgs/container/ferret-scan" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Tags:** $IMAGE_TAGS" | tr ',' '\n' | sed 's/^/- `/' | sed 's/$/`/' >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Platforms:** $PLATFORMS" | tr ',' '\n' | sed 's/^/- /' >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Usage Examples:" >> "$GITHUB_STEP_SUMMARY"
+          echo '```bash' >> "$GITHUB_STEP_SUMMARY"
+          echo "# Pull from GitHub Container Registry" >> "$GITHUB_STEP_SUMMARY"
+          echo "docker pull ${GHCR_REGISTRY}/${GHCR_REPOSITORY}:latest" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "# Pull from Amazon ECR Public" >> "$GITHUB_STEP_SUMMARY"
+          echo "docker pull ${ECR_REGISTRY}/${ECR_REPOSITORY}:latest" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "# Run CLI mode" >> "$GITHUB_STEP_SUMMARY"
+          echo "docker run --rm -v \$(pwd):/data ${GHCR_REGISTRY}/${GHCR_REPOSITORY}:latest --file /data/sample.txt" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "# Run web mode" >> "$GITHUB_STEP_SUMMARY"
+          echo "docker run --rm -p 8080:8080 ${GHCR_REGISTRY}/${GHCR_REPOSITORY}:latest --web --port 8080" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
 
   security-scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/ferret-scan.yml
+++ b/.github/workflows/ferret-scan.yml
@@ -87,27 +87,40 @@ jobs:
 
       - name: Determine scan scope
         id: scope
+        # Event/input context is passed via env and referenced as "$VAR" so a
+        # crafted input value cannot inject shell commands (GitHub Actions
+        # script-injection hardening).
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_SCAN_SCOPE: ${{ github.event.inputs.scan_scope }}
+          INPUT_CONFIDENCE_LEVEL: ${{ github.event.inputs.confidence_level }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "scope=${{ github.event.inputs.scan_scope }}" >> $GITHUB_OUTPUT
-            echo "confidence=${{ github.event.inputs.confidence_level }}" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "scope=changed-files" >> $GITHUB_OUTPUT
-            echo "confidence=high,medium" >> $GITHUB_OUTPUT
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "scope=$INPUT_SCAN_SCOPE" >> "$GITHUB_OUTPUT"
+            echo "confidence=$INPUT_CONFIDENCE_LEVEL" >> "$GITHUB_OUTPUT"
+          elif [ "$EVENT_NAME" = "pull_request" ]; then
+            echo "scope=changed-files" >> "$GITHUB_OUTPUT"
+            echo "confidence=high,medium" >> "$GITHUB_OUTPUT"
           else
-            echo "scope=full-repository" >> $GITHUB_OUTPUT
-            echo "confidence=high,medium" >> $GITHUB_OUTPUT
+            echo "scope=full-repository" >> "$GITHUB_OUTPUT"
+            echo "confidence=high,medium" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Get changed files (PR only)
         if: steps.scope.outputs.scope == 'changed-files'
         id: changed-files
+        # SHAs come from the (untrusted) pull_request event; pass via env and
+        # reference as "$VAR" so they cannot inject shell commands.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           # Get list of changed files in the PR
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          if [ "$EVENT_NAME" = "pull_request" ]; then
             # For pull requests, compare against the base branch
             git diff --name-only --diff-filter=ACM \
-              ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} \
+              "$BASE_SHA".."$HEAD_SHA" \
               | grep -E '\.(py|js|ts|go|java|json|yaml|yml|env|conf|config)$' \
               | grep -v -E '(test_|_test\.|spec_|_spec\.|mock_|_mock\.)' \
               > changed_files.txt || true
@@ -120,16 +133,18 @@ jobs:
           fi
 
           if [ -s changed_files.txt ]; then
-            echo "has_files=true" >> $GITHUB_OUTPUT
+            echo "has_files=true" >> "$GITHUB_OUTPUT"
             echo "Changed files to scan:"
             cat changed_files.txt
           else
-            echo "has_files=false" >> $GITHUB_OUTPUT
+            echo "has_files=false" >> "$GITHUB_OUTPUT"
             echo "No relevant files changed"
           fi
 
       - name: Run Ferret Scan on changed files
         if: steps.scope.outputs.scope == 'changed-files' && steps.changed-files.outputs.has_files == 'true'
+        env:
+          CONFIDENCE: ${{ steps.scope.outputs.confidence }}
         run: |
           echo "🔍 Scanning changed files for sensitive data..."
 
@@ -148,7 +163,7 @@ jobs:
               # Run scan and capture results in JSON (for PR comments)
               if ./bin/ferret-scan \
                 --file "$file" \
-                --confidence "${{ steps.scope.outputs.confidence }}" \
+                --confidence "$CONFIDENCE" \
                 --format json \
                 --no-color \
                 --quiet > "results/${file//\//_}.json" 2>/dev/null; then
@@ -194,9 +209,9 @@ jobs:
           # CodeQL (actual vulnerability scanners).
 
           # Generate summary
-          echo "high_findings=$high_findings" >> $GITHUB_ENV
-          echo "medium_findings=$medium_findings" >> $GITHUB_ENV
-          echo "scan_exit_code=$exit_code" >> $GITHUB_ENV
+          echo "high_findings=$high_findings" >> "$GITHUB_ENV"
+          echo "medium_findings=$medium_findings" >> "$GITHUB_ENV"
+          echo "scan_exit_code=$exit_code" >> "$GITHUB_ENV"
 
           echo "📊 Scan Summary:"
           echo "   High confidence findings: $high_findings"
@@ -204,6 +219,8 @@ jobs:
 
       - name: Run Ferret Scan on full repository
         if: steps.scope.outputs.scope == 'full-repository'
+        env:
+          CONFIDENCE: ${{ steps.scope.outputs.confidence }}
         run: |
           echo "🔍 Scanning full repository for sensitive data..."
 
@@ -221,7 +238,7 @@ jobs:
             "--exclude" "results/**"
             "--exclude" ".git/**"
             "--exclude" "node_modules/**"
-            "--confidence" "${{ steps.scope.outputs.confidence }}"
+            "--confidence" "$CONFIDENCE"
             "--format" "json"
             "--output" "results/full-scan.json"
             "--no-color"
@@ -242,15 +259,15 @@ jobs:
             high_findings=$(jq -r 'if type == "array" then .[] else .results[]? end | select(.confidence == "HIGH") | .confidence' results/full-scan.json 2>/dev/null | wc -l || echo "0")
             medium_findings=$(jq -r 'if type == "array" then .[] else .results[]? end | select(.confidence == "MEDIUM") | .confidence' results/full-scan.json 2>/dev/null | wc -l || echo "0")
 
-            echo "high_findings=$high_findings" >> $GITHUB_ENV
-            echo "medium_findings=$medium_findings" >> $GITHUB_ENV
-            echo "scan_exit_code=0" >> $GITHUB_ENV
+            echo "high_findings=$high_findings" >> "$GITHUB_ENV"
+            echo "medium_findings=$medium_findings" >> "$GITHUB_ENV"
+            echo "scan_exit_code=0" >> "$GITHUB_ENV"
 
             echo "📊 Full Repository Scan Summary:"
             echo "   High confidence findings: $high_findings"
             echo "   Medium confidence findings: $medium_findings"
           else
-            echo "scan_exit_code=1" >> $GITHUB_ENV
+            echo "scan_exit_code=1" >> "$GITHUB_ENV"
             echo "❌ Full repository scan failed"
           fi
 
@@ -342,7 +359,9 @@ jobs:
 
       - name: Fail on high confidence findings
         if: env.high_findings != '0'
+        env:
+          HIGH_FINDINGS: ${{ env.high_findings }}
         run: |
-          echo "❌ Blocking merge: ${{ env.high_findings }} high confidence sensitive data findings detected"
+          echo "❌ Blocking merge: $HIGH_FINDINGS high confidence sensitive data findings detected"
           echo "Please review and address the findings before merging this PR"
           exit 1

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -80,54 +80,73 @@ jobs:
           pip install build twine setuptools_scm
 
       - name: Validate context
+        # Untrusted/event context values are passed via env vars and referenced
+        # as "$VAR" rather than interpolated directly into the script, so a value
+        # containing shell metacharacters cannot inject commands (GitHub Actions
+        # script-injection hardening).
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          ACTOR: ${{ github.actor }}
+          INPUT_ACTION: ${{ github.event.inputs.action }}
+          INPUT_REASON: ${{ github.event.inputs.reason }}
         run: |
-          echo "## Build & Publish Context" >> $GITHUB_STEP_SUMMARY
-          echo "- **Event**: ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Actor**: ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
+          echo "## Build & Publish Context" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Event**: $EVENT_NAME" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Actor**: $ACTOR" >> "$GITHUB_STEP_SUMMARY"
 
-          if [[ "${{ github.event_name }}" == "release" ]]; then
-            echo "- **Action**: Automatic production release" >> $GITHUB_STEP_SUMMARY
-            echo "- **Target**: Production PyPI" >> $GITHUB_STEP_SUMMARY
-            echo "- **Version Source**: GitHub release tag" >> $GITHUB_STEP_SUMMARY
+          if [[ "$EVENT_NAME" == "release" ]]; then
+            echo "- **Action**: Automatic production release" >> "$GITHUB_STEP_SUMMARY"
+            echo "- **Target**: Production PyPI" >> "$GITHUB_STEP_SUMMARY"
+            echo "- **Version Source**: GitHub release tag" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "- **Action**: ${{ github.event.inputs.action }}" >> $GITHUB_STEP_SUMMARY
-            echo "- **Reason**: ${{ github.event.inputs.reason || 'Manual action' }}" >> $GITHUB_STEP_SUMMARY
+            echo "- **Action**: $INPUT_ACTION" >> "$GITHUB_STEP_SUMMARY"
+            echo "- **Reason**: ${INPUT_REASON:-Manual action}" >> "$GITHUB_STEP_SUMMARY"
 
-            case "${{ github.event.inputs.action }}" in
+            case "$INPUT_ACTION" in
               "test-only")
-                echo "- **Target**: Build and test only (no publishing)" >> $GITHUB_STEP_SUMMARY
+                echo "- **Target**: Build and test only (no publishing)" >> "$GITHUB_STEP_SUMMARY"
                 ;;
               "publish-testpypi")
-                echo "- **Target**: Test PyPI" >> $GITHUB_STEP_SUMMARY
+                echo "- **Target**: Test PyPI" >> "$GITHUB_STEP_SUMMARY"
                 ;;
               "publish-pypi")
-                echo "- **Target**: Production PyPI" >> $GITHUB_STEP_SUMMARY
-                echo "⚠️ **WARNING**: Manual production PyPI publishing!" >> $GITHUB_STEP_SUMMARY
+                echo "- **Target**: Production PyPI" >> "$GITHUB_STEP_SUMMARY"
+                echo "⚠️ **WARNING**: Manual production PyPI publishing!" >> "$GITHUB_STEP_SUMMARY"
                 ;;
             esac
           fi
-          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Determine version
         id: version
+        # Event/input context (ref name, inputs.version, action) is passed via env
+        # and referenced as "$VAR" so a crafted tag name or input value cannot
+        # inject shell commands. Git metadata such as a tag/branch name is
+        # attacker-influenceable and must be treated as untrusted.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          CALL_VERSION: ${{ inputs.version }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          INPUT_ACTION: ${{ github.event.inputs.action }}
         run: |
           echo "🔍 Git repository state:"
           echo "Current HEAD: $(git rev-parse HEAD)"
-          echo "Current branch/tag: ${{ github.ref_name }}"
+          echo "Current branch/tag: $REF_NAME"
           echo "Git describe: $(git describe --tags 2>/dev/null || echo 'no tags found')"
           echo "Available tags: $(git tag --sort=-version:refname | head -5 | tr '\n' ' ')"
           echo ""
 
-          if [[ "${{ github.event_name }}" == "workflow_call" && -n "${{ inputs.version }}" ]]; then
+          if [[ "$EVENT_NAME" == "workflow_call" && -n "$CALL_VERSION" ]]; then
             # Use version passed from calling workflow
-            VERSION="${{ inputs.version }}"
+            VERSION="$CALL_VERSION"
             echo "✅ Using workflow_call version: $VERSION"
-            echo "version=$VERSION" >> $GITHUB_OUTPUT
-            echo "source=workflow-call" >> $GITHUB_OUTPUT
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "source=workflow-call" >> "$GITHUB_OUTPUT"
 
-          elif [[ "${{ github.event_name }}" == "release" ]]; then
+          elif [[ "$EVENT_NAME" == "release" ]]; then
             # Use GitHub release tag, remove 'v' prefix if present
-            VERSION="${{ github.ref_name }}"
+            VERSION="$REF_NAME"
             VERSION="${VERSION#v}"
 
             # Validate it's a proper release version (no dev/alpha/beta for production)
@@ -138,26 +157,26 @@ jobs:
             fi
 
             echo "✅ Using GitHub release version: $VERSION"
-            echo "version=$VERSION" >> $GITHUB_OUTPUT
-            echo "source=github-release" >> $GITHUB_OUTPUT
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "source=github-release" >> "$GITHUB_OUTPUT"
 
             # Verify Git tag exists and matches
             ACTUAL_VERSION=$(git describe --tags --exact-match HEAD 2>/dev/null || echo "no-exact-match")
-            if [[ "$ACTUAL_VERSION" != "${{ github.ref_name }}" ]]; then
+            if [[ "$ACTUAL_VERSION" != "$REF_NAME" ]]; then
               echo "⚠️ Warning: Git tag mismatch"
-              echo "Expected: ${{ github.ref_name }}"
+              echo "Expected: $REF_NAME"
               echo "Actual: $ACTUAL_VERSION"
               echo "This may indicate a workflow trigger issue"
             else
               echo "✅ Git tag matches release: $ACTUAL_VERSION"
             fi
 
-          elif [[ -n "${{ github.event.inputs.version }}" ]]; then
+          elif [[ -n "$INPUT_VERSION" ]]; then
             # Use manually specified version
-            VERSION="${{ github.event.inputs.version }}"
+            VERSION="$INPUT_VERSION"
             echo "✅ Using manual version: $VERSION"
-            echo "version=$VERSION" >> $GITHUB_OUTPUT
-            echo "source=manual-input" >> $GITHUB_OUTPUT
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "source=manual-input" >> "$GITHUB_OUTPUT"
           else
             # Use setuptools_scm for development versions
             cd python-package
@@ -167,13 +186,13 @@ jobs:
 
             VERSION=$(python -m setuptools_scm)
             echo "✅ Setuptools_scm result: $VERSION"
-            echo "version=$VERSION" >> $GITHUB_OUTPUT
-            echo "source=setuptools_scm" >> $GITHUB_OUTPUT
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "source=setuptools_scm" >> "$GITHUB_OUTPUT"
             cd ..
           fi
 
           # Additional validation for production PyPI
-          if [[ "${{ github.event_name }}" == "release" || "${{ github.event.inputs.action }}" == "publish-pypi" ]]; then
+          if [[ "$EVENT_NAME" == "release" || "$INPUT_ACTION" == "publish-pypi" ]]; then
             # Ensure version doesn't contain local identifiers
             if [[ "$VERSION" == *"+"* ]]; then
               echo "❌ Error: Production versions cannot contain local identifiers (+)"
@@ -185,14 +204,17 @@ jobs:
           fi
 
       - name: Build Python package with Go binaries
+        env:
+          VERSION_SOURCE: ${{ steps.version.outputs.source }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           echo "🔨 Building Python package with embedded Go binaries"
           cd python-package
 
           # Set the version explicitly if we have one
-          if [[ "${{ steps.version.outputs.source }}" != "setuptools_scm" ]]; then
-            export SETUPTOOLS_SCM_PRETEND_VERSION="${{ steps.version.outputs.version }}"
-            echo "Building with explicit version: ${{ steps.version.outputs.version }}"
+          if [[ "$VERSION_SOURCE" != "setuptools_scm" ]]; then
+            export SETUPTOOLS_SCM_PRETEND_VERSION="$VERSION"
+            echo "Building with explicit version: $VERSION"
           else
             echo "Building with setuptools_scm auto-detection"
           fi
@@ -209,6 +231,8 @@ jobs:
           ls -la python-package/ferret_scan/binaries/ || echo "No binaries directory found"
 
       - name: Test package installation
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           cd python-package
           echo "🧪 Testing package installation..."
@@ -216,7 +240,7 @@ jobs:
 
           # Test version matches expected
           INSTALLED_VERSION=$(ferret-scan --version | head -1)
-          EXPECTED_VERSION="${{ steps.version.outputs.version }}"
+          EXPECTED_VERSION="$VERSION"
 
           echo "Expected version: $EXPECTED_VERSION"
           echo "Installed version: $INSTALLED_VERSION"
@@ -270,26 +294,30 @@ jobs:
 
       - name: Check if should publish to PyPI
         id: should_publish
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          IS_TAG_PUSH: ${{ inputs.is_tag_push }}
+          INPUT_ACTION: ${{ github.event.inputs.action }}
         run: |
           SHOULD_PUBLISH="false"
 
-          if [[ "${{ github.event_name }}" == "release" ]]; then
+          if [[ "$EVENT_NAME" == "release" ]]; then
             echo "✅ Should publish: GitHub release event"
             SHOULD_PUBLISH="true"
-          elif [[ "${{ inputs.is_tag_push }}" == "true" ]]; then
+          elif [[ "$IS_TAG_PUSH" == "true" ]]; then
             echo "✅ Should publish: Tag push detected (is_tag_push=true)"
             SHOULD_PUBLISH="true"
-          elif [[ "${{ github.event.inputs.action }}" == "publish-pypi" ]]; then
+          elif [[ "$INPUT_ACTION" == "publish-pypi" ]]; then
             echo "✅ Should publish: Manual publish action"
             SHOULD_PUBLISH="true"
           else
             echo "❌ Should NOT publish: Conditions not met"
-            echo "  - Event: ${{ github.event_name }}"
-            echo "  - is_tag_push: ${{ inputs.is_tag_push }}"
-            echo "  - Manual action: ${{ github.event.inputs.action }}"
+            echo "  - Event: $EVENT_NAME"
+            echo "  - is_tag_push: $IS_TAG_PUSH"
+            echo "  - Manual action: $INPUT_ACTION"
           fi
 
-          echo "should_publish=$SHOULD_PUBLISH" >> $GITHUB_OUTPUT
+          echo "should_publish=$SHOULD_PUBLISH" >> "$GITHUB_OUTPUT"
 
       - name: Publish to PyPI
         if: steps.should_publish.outputs.should_publish == 'true'
@@ -299,37 +327,43 @@ jobs:
           verbose: true
 
       - name: Create summary
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_ACTION: ${{ github.event.inputs.action }}
+          IS_TAG_PUSH: ${{ inputs.is_tag_push }}
+          VERSION: ${{ steps.version.outputs.version }}
+          VERSION_SOURCE: ${{ steps.version.outputs.source }}
         run: |
-          echo "## 📦 Build & Publish Results" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Version**: ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Version Source**: ${{ steps.version.outputs.source }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "✅ Package built successfully" >> $GITHUB_STEP_SUMMARY
-          echo "✅ Installation test passed" >> $GITHUB_STEP_SUMMARY
-          echo "✅ Package validation passed" >> $GITHUB_STEP_SUMMARY
-          echo "✅ Build artifacts uploaded" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## 📦 Build & Publish Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Version**: $VERSION" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Version Source**: $VERSION_SOURCE" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "✅ Package built successfully" >> "$GITHUB_STEP_SUMMARY"
+          echo "✅ Installation test passed" >> "$GITHUB_STEP_SUMMARY"
+          echo "✅ Package validation passed" >> "$GITHUB_STEP_SUMMARY"
+          echo "✅ Build artifacts uploaded" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
 
           # Publishing results
-          if [[ "${{ github.event_name }}" == "release" || "${{ github.event.inputs.action }}" == "publish-pypi" || ("${{ github.event_name }}" == "workflow_call" && "${{ inputs.is_tag_push }}" == "true") ]]; then
-            echo "✅ **Published to PyPI**: https://pypi.org/p/ferret-scan" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "### Installation" >> $GITHUB_STEP_SUMMARY
-            echo '```bash' >> $GITHUB_STEP_SUMMARY
-            echo 'pip install ferret-scan' >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-          elif [[ "${{ github.event.inputs.action }}" == "publish-testpypi" ]]; then
-            echo "✅ **Published to Test PyPI**: https://test.pypi.org/p/ferret-scan" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "### Test Installation" >> $GITHUB_STEP_SUMMARY
-            echo '```bash' >> $GITHUB_STEP_SUMMARY
-            echo 'pip install --index-url https://test.pypi.org/simple/ ferret-scan' >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
+          if [[ "$EVENT_NAME" == "release" || "$INPUT_ACTION" == "publish-pypi" || ("$EVENT_NAME" == "workflow_call" && "$IS_TAG_PUSH" == "true") ]]; then
+            echo "✅ **Published to PyPI**: https://pypi.org/p/ferret-scan" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "### Installation" >> "$GITHUB_STEP_SUMMARY"
+            echo '```bash' >> "$GITHUB_STEP_SUMMARY"
+            echo 'pip install ferret-scan' >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          elif [[ "$INPUT_ACTION" == "publish-testpypi" ]]; then
+            echo "✅ **Published to Test PyPI**: https://test.pypi.org/p/ferret-scan" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "### Test Installation" >> "$GITHUB_STEP_SUMMARY"
+            echo '```bash' >> "$GITHUB_STEP_SUMMARY"
+            echo 'pip install --index-url https://test.pypi.org/simple/ ferret-scan' >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "📦 **Test build completed** (not published)" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "Ready for publishing:" >> $GITHUB_STEP_SUMMARY
-            echo "- Create a GitHub release for automatic PyPI publishing" >> $GITHUB_STEP_SUMMARY
-            echo "- Or use workflow dispatch for manual publishing" >> $GITHUB_STEP_SUMMARY
+            echo "📦 **Test build completed** (not published)" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "Ready for publishing:" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Create a GitHub release for automatic PyPI publishing" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Or use workflow dispatch for manual publishing" >> "$GITHUB_STEP_SUMMARY"
           fi


### PR DESCRIPTION
Script Injection in GitHub Actions workflows: several run: steps interpolated ${{ ... }} event/input context directly into the shell script. GitHub substitutes the raw value into the script before execution, so a value containing shell metacharacters could inject commands with the runner's token — a high-impact path on the publish/release workflows (id-token: write, PyPI/GHCR/ECR reach), even though every sink is behind maintainer-triggered events (workflow_dispatch/release/workflow_call), not pull_request.

Remediation follows the GitHub hardening guidance ("use an intermediate environment variable"): move each untrusted context value into a step-level env: var and reference it as "$VAR" in the script, so the value is passed as a real environment variable instead of being spliced into the script text. Covered the free-text inputs (pypi action/reason/version, docker platforms, ferret scan_scope/confidence_level), attacker-influenceable git metadata (ref_name, pull_request base/head SHAs, actor), and step outputs derived from them. Expression-context interpolations (if:/with:/uses:/name:/ url:) are evaluated by the Actions runtime, not a shell, and are left as-is; workflow-level env constants (registry/repo names) are referenced as shell vars.

Also quoted $GITHUB_OUTPUT/$GITHUB_ENV/$GITHUB_STEP_SUMMARY redirect targets in the touched steps. Verified with actionlint: no errors (only pre-existing shellcheck SC2129/SC2086 style notes), and a sweep confirms zero untrusted ${{ }} interpolations remain inside any run: block across the three workflows.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
