### PR TITLE
fix(test): deterministic TestSafeRun_ExpiredDeadlineReturnsFast (Windows CI flake on main)

### DIFF
--- a/internal/execguard/execguard_test.go
+++ b/internal/execguard/execguard_test.go
@@ -150,22 +150,29 @@ func TestValidateContent_PrefersContextAwarePath(t *testing.T) {
 	}
 }
 
-// Guards the timing claim: SafeRun returns immediately on an already-expired
-// deadline rather than invoking work.
+// Guards the claim: when the context is already done, SafeRun returns its work
+// function WITHOUT invoking it (so an expired budget never starts new work).
+//
+// Determinism note: this used a time.Nanosecond timeout + a 1ms sleep to force
+// an "expired" deadline, which is flaky on Windows — its timer granularity
+// (~15ms) means the deadline may not have fired when SafeRun checks ctx.Err(),
+// so the work runs and the test sees the full sleep. We instead use a
+// pre-cancelled context: ctx.Err() is non-nil immediately on every OS, with no
+// clock-granularity race. A bool flag (not wall-clock time) proves fn never ran.
 func TestSafeRun_ExpiredDeadlineReturnsFast(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
-	defer cancel()
-	time.Sleep(time.Millisecond) // ensure the deadline has passed
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // deadline/cancellation already tripped, deterministically
 
-	start := time.Now()
+	ran := false
 	_, err := SafeRun(ctx, "ok", func() ([]detector.Match, error) {
-		time.Sleep(2 * time.Second) // would dominate if it ran
+		ran = true
+		time.Sleep(2 * time.Second) // would dominate if SafeRun wrongly invoked fn
 		return nil, nil
 	})
-	if time.Since(start) > 500*time.Millisecond {
-		t.Errorf("SafeRun should skip work on an expired deadline, took %v", time.Since(start))
+	if ran {
+		t.Error("SafeRun must NOT invoke fn when the context is already done")
 	}
 	if err == nil {
-		t.Error("expected a context deadline error")
+		t.Error("expected a context cancellation error")
 	}
 }


### PR DESCRIPTION
## Fixes the red Windows `Go Tests` run on `main`

After #98–#100 merged, `main`'s post-merge `windows-latest / Go` run failed ([run 28475228602](https://github.com/awslabs/ferret-scan/actions/runs/28475228602/job/84398044975)) on `TestSafeRun_ExpiredDeadlineReturnsFast` — a flaky test introduced in #98, **not a product defect**.

### Root cause
The test forced an 'expired deadline' with `context.WithTimeout(..., time.Nanosecond)` + `time.Sleep(time.Millisecond)`, then used **wall-clock time** to assert `SafeRun` skipped its 2-second work function. On Windows the timer granularity is ~15ms, so the 1ms sleep can return *before* the nanosecond deadline actually fires → `ctx.Err()` is still nil → `SafeRun` correctly runs the fn → the test sees the full 2s and fails. Passes on macOS/Linux (fine-grained timers); genuinely flaky on Windows.

### Fix
Use a **pre-cancelled** context (`WithCancel` + immediate `cancel()`) so `ctx.Err()` is non-nil immediately on every OS — no clock-granularity race — and assert the work fn was skipped via a **bool flag**, not wall-clock time. The `SafeRun` logic is unchanged; only the test's timing assumption is corrected.

### Verification
- Stress-passes `-count=20`; `gofmt`/`vet` clean; full `go test ./...` green.
- Confirmed this was the only test in the tree using the fragile `time.Nanosecond` timing pattern.
- No product code change.

Part of the v2 refactor series (follow-up to #98).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)