### PR TITLE
feat(v2): global concurrency governor for validator fan-out (gap 2.1)

### DIFF
--- a/internal/execguard/limiter.go
+++ b/internal/execguard/limiter.go
@@ -1,0 +1,73 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package execguard
+
+import (
+	"context"
+	"runtime"
+)
+
+// Limiter is a counting semaphore that bounds how many validator invocations run
+// concurrently across the WHOLE process. It exists to close v2 gap 2.1: file
+// workers (capped at min(NumCPU, 8)) each fan out one goroutine per document
+// validator (~12), so without a shared cap the live goroutine count is
+// workers × validators ≈ 100 CPU-bound goroutines on an 8-core box — oversubscription
+// that hurts throughput and memory under directory scans. A single shared Limiter
+// keeps total in-flight validator work proportional to CPU count regardless of how
+// the file/validator layers multiply.
+//
+// It is a thin, dependency-free counting semaphore (buffered channel), not
+// golang.org/x/sync/semaphore — the project avoids adding that dependency for a
+// primitive this small.
+type Limiter struct {
+	tokens chan struct{}
+}
+
+// NewLimiter returns a Limiter allowing n concurrent holders. n <= 0 is treated
+// as 1 (a Limiter must permit at least one holder or it would deadlock).
+func NewLimiter(n int) *Limiter {
+	if n < 1 {
+		n = 1
+	}
+	return &Limiter{tokens: make(chan struct{}, n)}
+}
+
+// Acquire blocks until a token is available or ctx is done. It returns ctx.Err()
+// if the context is cancelled/expired before a token is obtained, in which case
+// the caller MUST NOT call Release. On success it returns nil and the caller must
+// Release exactly once.
+func (l *Limiter) Acquire(ctx context.Context) error {
+	// Honor an already-cancelled context promptly (don't race the select).
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	select {
+	case l.tokens <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Release returns a token. Call exactly once per successful Acquire.
+func (l *Limiter) Release() {
+	select {
+	case <-l.tokens:
+	default:
+		// No token held — calling Release without a matching Acquire is a bug;
+		// the default branch keeps it non-blocking rather than panicking, since a
+		// stray Release must never wedge a scan.
+	}
+}
+
+// DefaultLimiter is the process-wide validator-concurrency limiter. It is sized
+// to GOMAXPROCS so total concurrent validator work tracks available CPU rather
+// than the (file workers × validators) product. Validator dispatch acquires from
+// it; see the document fan-out in internal/validators.
+//
+// Sizing rationale: validator work is CPU-bound regex scanning, so GOMAXPROCS is
+// the natural ceiling. It is deliberately NOT min(NumCPU,8)-capped like the file
+// worker pool — the file pool already bounds I/O-bound preprocessing breadth;
+// this bounds CPU-bound validation depth.
+var DefaultLimiter = NewLimiter(runtime.GOMAXPROCS(0))

--- a/internal/execguard/limiter_test.go
+++ b/internal/execguard/limiter_test.go
@@ -1,0 +1,141 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package execguard
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestLimiter_BoundsConcurrency verifies the semaphore never lets more than n
+// holders run at once, under heavy contention. Run with -race for full value.
+func TestLimiter_BoundsConcurrency(t *testing.T) {
+	const n = 4
+	const goroutines = 50
+	lim := NewLimiter(n)
+
+	var inFlight int64
+	var maxSeen int64
+	var wg sync.WaitGroup
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := lim.Acquire(context.Background()); err != nil {
+				t.Errorf("Acquire failed: %v", err)
+				return
+			}
+			cur := atomic.AddInt64(&inFlight, 1)
+			// Track the high-water mark of concurrent holders.
+			for {
+				old := atomic.LoadInt64(&maxSeen)
+				if cur <= old || atomic.CompareAndSwapInt64(&maxSeen, old, cur) {
+					break
+				}
+			}
+			time.Sleep(time.Millisecond) // hold the slot briefly to force contention
+			atomic.AddInt64(&inFlight, -1)
+			lim.Release()
+		}()
+	}
+	wg.Wait()
+
+	if maxSeen > n {
+		t.Errorf("limiter allowed %d concurrent holders; cap is %d", maxSeen, n)
+	}
+	if maxSeen == 0 {
+		t.Error("no holders observed — test did not exercise the limiter")
+	}
+}
+
+// TestLimiter_AcquireRespectsCancelledContext verifies Acquire returns the
+// context error (and grants no token) when the limiter is full and ctx is
+// cancelled — so a cancelled scan never blocks forever waiting for a slot.
+func TestLimiter_AcquireRespectsCancelledContext(t *testing.T) {
+	lim := NewLimiter(1)
+	// Fill the single slot.
+	if err := lim.Acquire(context.Background()); err != nil {
+		t.Fatalf("first Acquire: %v", err)
+	}
+	defer lim.Release()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled
+
+	start := time.Now()
+	err := lim.Acquire(ctx)
+	if err == nil {
+		t.Fatal("expected Acquire to fail on a cancelled context while full")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+	if time.Since(start) > time.Second {
+		t.Errorf("Acquire on a cancelled context should return promptly, took %v", time.Since(start))
+	}
+}
+
+// TestLimiter_AcquireUnblocksOnRelease verifies a waiter proceeds once a slot is
+// freed (the happy path under contention).
+func TestLimiter_AcquireUnblocksOnRelease(t *testing.T) {
+	lim := NewLimiter(1)
+	if err := lim.Acquire(context.Background()); err != nil {
+		t.Fatalf("first Acquire: %v", err)
+	}
+
+	acquired := make(chan struct{})
+	go func() {
+		_ = lim.Acquire(context.Background()) // blocks until Release below
+		close(acquired)
+	}()
+
+	select {
+	case <-acquired:
+		t.Fatal("second Acquire returned before the slot was released")
+	case <-time.After(50 * time.Millisecond):
+		// expected: still blocked
+	}
+
+	lim.Release()
+	select {
+	case <-acquired:
+		// expected: unblocked
+	case <-time.After(time.Second):
+		t.Fatal("second Acquire did not proceed after Release")
+	}
+	lim.Release()
+}
+
+// TestLimiter_ZeroOrNegativeBecomesOne guards the floor: a non-positive size
+// must not produce a deadlocking zero-capacity limiter.
+func TestLimiter_ZeroOrNegativeBecomesOne(t *testing.T) {
+	for _, n := range []int{0, -5} {
+		lim := NewLimiter(n)
+		if err := lim.Acquire(context.Background()); err != nil {
+			t.Errorf("NewLimiter(%d): Acquire blocked/failed: %v", n, err)
+		}
+		lim.Release()
+	}
+}
+
+// TestLimiter_StrayReleaseIsSafe verifies Release without a matching Acquire
+// does not block or panic (a stray Release must never wedge a scan).
+func TestLimiter_StrayReleaseIsSafe(t *testing.T) {
+	lim := NewLimiter(2)
+	lim.Release() // no token held
+	// The limiter must still grant its full capacity afterward.
+	if err := lim.Acquire(context.Background()); err != nil {
+		t.Fatalf("Acquire after stray Release: %v", err)
+	}
+	if err := lim.Acquire(context.Background()); err != nil {
+		t.Fatalf("second Acquire after stray Release: %v", err)
+	}
+	lim.Release()
+	lim.Release()
+}

--- a/internal/validators/dual_path_bridge.go
+++ b/internal/validators/dual_path_bridge.go
@@ -799,12 +799,28 @@ func (dvb *DocumentValidatorBridge) ProcessDocumentContentCtx(ctx stdctx.Context
 		go func(v detector.Validator) {
 			defer wg.Done()
 
+			// Bound process-wide concurrent validator work (v2 gap 2.1): file
+			// workers each fan out here, so without a shared cap the live
+			// goroutine count is workers × validators. Acquire a token before
+			// running; if ctx is cancelled while waiting, skip this validator
+			// (no Release) and record the error — same outcome as the execguard
+			// skip-on-cancel path. The token is held only for the validate call,
+			// then released, so a stalled validator holds at most one slot.
+			if lerr := execguard.DefaultLimiter.Acquire(ctx); lerr != nil {
+				errorsMu.Lock()
+				validationErrors = append(validationErrors, lerr)
+				errorsMu.Unlock()
+				resultsChan <- validatorResult{matches: nil, err: lerr}
+				return
+			}
+
 			// Dispatch through the execguard chokepoint: recovers panics
 			// (so one validator cannot crash the whole process — v2 gap 1.3)
 			// and threads ctx to context-aware validators / skips launch once
 			// ctx is cancelled (v2 gap 1.1). Behavior is unchanged for the
 			// common success path.
 			matches, err := execguard.ValidateContent(ctx, validatorName(v), v, content, filePath)
+			execguard.DefaultLimiter.Release()
 			if err != nil {
 				errorsMu.Lock()
 				validationErrors = append(validationErrors, err)


### PR DESCRIPTION
## feat(v2): bound process-wide concurrent validator work

Part of the **v2 architecture overhaul** (`v2-refactor`; closes the live half of Theme 2 — gap 2.1 in [`docs/proposals/V2_ARCHITECTURE.md`](docs/proposals/V2_ARCHITECTURE.md)). Branches off current `main` (post #98–#101).

### Problem
File workers (capped at `min(NumCPU, 8)`) each fan out one goroutine **per document validator** (~12) in `DocumentValidatorBridge`. With no shared cap, live goroutines = workers × validators ≈ **100 CPU-bound goroutines** on an 8-core box — oversubscription that degrades throughput and memory under directory scans. The companion dead-code half (the never-wired adaptive processor) was already removed in #100; this adds the **real** governor.

### Fix
- New `execguard.Limiter`: a dependency-free counting semaphore (buffered channel — deliberately **not** `golang.org/x/sync/semaphore`, too small to justify a new dependency).
- Process-wide `execguard.DefaultLimiter`, sized to `GOMAXPROCS`, so total in-flight validator work tracks CPU count regardless of how the file/validator layers multiply. (Bounds CPU-bound validation *depth*; the file worker pool already bounds I/O-bound preprocessing *breadth*.)
- The document leaf fan-out acquires a token before each validator runs, releases after.

### Safety / design
- **ctx-aware Acquire**: a cancelled scan never blocks waiting for a slot — returns `ctx.Err()` and grants no token, mirroring the existing execguard skip-on-cancel path.
- **Token held only across the validate call** → a stalled validator holds at most one slot and never starves the metadata path (which doesn't acquire).
- **No deadlock**: the leaf fan-out is the only acquiring site; no goroutine holds a token while waiting to acquire another (verified), so even capacity 1 is safe.

### Behavior-preserving
Matches are unioned order-independently, so bounding concurrency **cannot change which matches are produced** — proven by the golden net passing **byte-identical (zero `UPDATE_GOLDEN`)**, including `mixed_pii_basic` which runs 5 validators concurrently through the limiter.

### Verification
- Limiter unit tests: bound-concurrency (under `-race`), ctx-cancel, unblock-on-release, size floor, stray-release safety — all green.
- Full `go test ./...` clean; `-race` clean end-to-end on the scan path (no deadlock/race under the limiter); golden net byte-identical; `gofmt`/`vet` clean.

### Follow-ups (not in scope)
Phase 3 (ctx-polling inside validator hot-loops, so a stalled validator is *reclaimed* immediately rather than holding its one slot until timeout) and gap 3.3 NAME-tier registry remain.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)