### PR TITLE
refactor(v2): migrate gitlab name-tier metadata to core.TypeMeta (gap 3.3 remainder)

### DIFF
--- a/internal/core/typemeta.go
+++ b/internal/core/typemeta.go
@@ -35,6 +35,15 @@ type TypeDescriptor struct {
 	GitLabCheckDesc string
 	// Empty GitLabRemediation → gitlab generic "Review the detected…" fallback.
 	GitLabRemediation string
+
+	// GitLabName is the gitlab-sast vulnerability display name (origin:
+	// gitlab-sast/mapper.go generateVulnerabilityName/nameMap). It is keyed by
+	// VALIDATOR NAME (e.g. CREDIT_CARD), not sub-type, so sub-types like VISA
+	// have no entry and fall back to the mapper's strings.Title("…")+" Detected"
+	// rule. Empty GitLabName → that fallback. Note this is NOT always equal to
+	// SARIFShort (e.g. SECRETS differs: "Secret/API Key Detected" vs "Secret or
+	// API Key Detected"), so it is a distinct field.
+	GitLabName string
 }
 
 // sarifCloudDesc is the shared SARIF rule description for every cloud-provider
@@ -183,6 +192,31 @@ var typeDescriptors = func() map[string]TypeDescriptor {
 	m["DOCUMENT_COMMENTS"] = TypeDescriptor{GitLabCheckDesc: "Document comments"}
 	m["AUTHOR_INFO"] = TypeDescriptor{GitLabCheckDesc: "Author information"}
 	m["COMPANY_INFO"] = TypeDescriptor{GitLabCheckDesc: "Company information"}
+
+	// --- gitlab-sast vulnerability display names (name tier, gap 3.3) ---
+	// Verbatim from gitlab-sast/mapper.go generateVulnerabilityName's nameMap,
+	// keyed by validator name. Applied as an overlay so a key can carry both a
+	// GitLabCheckDesc (above) and a GitLabName without re-listing. Keys absent
+	// here (incl. all sub-types) keep the mapper's strings.Title fallback.
+	gitlabNames := map[string]string{
+		"CREDIT_CARD":           "Credit Card Number Detected",
+		"SSN":                   "Social Security Number Detected",
+		"PASSPORT":              "Passport Number Detected",
+		"EMAIL":                 "Email Address Detected",
+		"PHONE":                 "Phone Number Detected",
+		"IP_ADDRESS":            "IP Address Detected",
+		"SECRETS":               "Secret/API Key Detected",
+		"INTELLECTUAL_PROPERTY": "Intellectual Property Detected",
+		"SOCIAL_MEDIA":          "Social Media Handle Detected",
+		"VIN":                   "Vehicle Identification Number Detected",
+		"METADATA":              "Sensitive Metadata Detected",
+		"COMPREHEND":            "AWS Comprehend PII Detected",
+	}
+	for k, name := range gitlabNames {
+		d := m[k] // zero value if k had no SARIF/sensitivity entry (e.g. COMPREHEND)
+		d.GitLabName = name
+		m[k] = d
+	}
 
 	return m
 }()

--- a/internal/core/typemeta_test.go
+++ b/internal/core/typemeta_test.go
@@ -76,3 +76,33 @@ func TestTypeMeta_CloudSubTypesShareDescriptionDistinctWeight(t *testing.T) {
 		}
 	}
 }
+
+// TestTypeMeta_GitLabName locks the name-tier (gap 3.3 remainder): gitlab-sast
+// vulnerability display names, keyed by validator name. Captures the nuances
+// that (a) GitLabName is NOT always == SARIFShort (SECRETS differs), (b)
+// sub-types like VISA have no GitLabName so the mapper's title-case fallback
+// applies, and (c) COMPREHEND carries a GitLabName despite having no SARIF entry.
+func TestTypeMeta_GitLabName(t *testing.T) {
+	cases := []struct {
+		typ  string
+		want string // expected GitLabName ("" = none → mapper fallback)
+	}{
+		{"CREDIT_CARD", "Credit Card Number Detected"},
+		{"SECRETS", "Secret/API Key Detected"}, // differs from SARIFShort "Secret or API Key Detected"
+		{"COMPREHEND", "AWS Comprehend PII Detected"},
+		{"VIN", "Vehicle Identification Number Detected"},
+		{"VISA", ""},           // sub-type: no name-tier entry → mapper title-case fallback
+		{"AWS_ACCESS_KEY", ""}, // sub-type
+	}
+	for _, c := range cases {
+		d, _ := TypeMeta(c.typ)
+		if d.GitLabName != c.want {
+			t.Errorf("TypeMeta(%q).GitLabName = %q, want %q", c.typ, d.GitLabName, c.want)
+		}
+	}
+	// Guard the SECRETS != SARIFShort invariant explicitly (the reason GitLabName
+	// is a distinct field, not an alias of SARIFShort).
+	if d, _ := TypeMeta("SECRETS"); d.GitLabName == d.SARIFShort {
+		t.Errorf("SECRETS GitLabName and SARIFShort must differ; both = %q", d.GitLabName)
+	}
+}

--- a/internal/formatters/gitlab-sast/mapper.go
+++ b/internal/formatters/gitlab-sast/mapper.go
@@ -9,36 +9,16 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/awslabs/ferret-scan/internal/core"
 	"github.com/awslabs/ferret-scan/internal/detector"
 )
 
 // VulnerabilityMapper handles mapping Ferret Scan matches to GitLab vulnerabilities
-type VulnerabilityMapper struct {
-	// Configuration for mapping behavior
-	categoryMappings map[string]string
-}
+type VulnerabilityMapper struct{}
 
-// NewVulnerabilityMapper creates a new vulnerability mapper with default configuration
+// NewVulnerabilityMapper creates a new vulnerability mapper.
 func NewVulnerabilityMapper() *VulnerabilityMapper {
-	return &VulnerabilityMapper{
-		categoryMappings: map[string]string{
-			// All Ferret Scan check types map to SAST category
-			"CREDIT_CARD":           "sast",
-			"SSN":                   "sast",
-			"PASSPORT":              "sast",
-			"EMAIL":                 "sast",
-			"PHONE":                 "sast",
-			"IP_ADDRESS":            "sast",
-			"SECRETS":               "sast",
-			"INTELLECTUAL_PROPERTY": "sast",
-			"SOCIAL_MEDIA":          "sast",
-			"VIN":                   "sast",
-			"METADATA":              "sast",
-			"COMPREHEND":            "sast",
-			// Default fallback
-			"DEFAULT": "sast",
-		},
-	}
+	return &VulnerabilityMapper{}
 }
 
 // MapToGitLabVulnerability converts a Ferret Scan match to GitLab vulnerability format
@@ -143,38 +123,20 @@ func (m *VulnerabilityMapper) MapConfidenceLevelToSeverity(confidenceLevel strin
 
 // mapCheckTypeToCategory maps Ferret Scan check types to GitLab categories
 func (m *VulnerabilityMapper) mapCheckTypeToCategory(checkType string) string {
-	// Normalize check type to uppercase
-	normalizedType := strings.ToUpper(checkType)
-
-	if category, exists := m.categoryMappings[normalizedType]; exists {
-		return category
-	}
-
-	// Default to SAST category for all Ferret Scan findings
-	return m.categoryMappings["DEFAULT"]
+	// Every Ferret Scan finding is a SAST-category vulnerability in GitLab. The
+	// former per-type categoryMappings map (and its DEFAULT) mapped every key to
+	// "sast", so this is byte-identical and removes a redundant table (gap 3.3).
+	return "sast"
 }
 
 // generateVulnerabilityName creates a human-readable name for the vulnerability
 func (m *VulnerabilityMapper) generateVulnerabilityName(checkType string) string {
-	// #nosec G101 -- display-name dictionary for finding categories. No credentials.
-	nameMap := map[string]string{
-		"CREDIT_CARD":           "Credit Card Number Detected",
-		"SSN":                   "Social Security Number Detected",
-		"PASSPORT":              "Passport Number Detected",
-		"EMAIL":                 "Email Address Detected",
-		"PHONE":                 "Phone Number Detected",
-		"IP_ADDRESS":            "IP Address Detected",
-		"SECRETS":               "Secret/API Key Detected",
-		"INTELLECTUAL_PROPERTY": "Intellectual Property Detected",
-		"SOCIAL_MEDIA":          "Social Media Handle Detected",
-		"VIN":                   "Vehicle Identification Number Detected",
-		"METADATA":              "Sensitive Metadata Detected",
-		"COMPREHEND":            "AWS Comprehend PII Detected",
-	}
-
-	normalizedType := strings.ToUpper(checkType)
-	if name, exists := nameMap[normalizedType]; exists {
-		return name
+	// Display name from the central type-metadata registry (core.TypeMeta — gap
+	// 3.3, name tier). Keyed by validator name (CREDIT_CARD, …); sub-types like
+	// VISA have no GitLabName entry and hit the title-case fallback below,
+	// byte-identical to the former local nameMap behavior.
+	if d, ok := core.TypeMeta(strings.ToUpper(checkType)); ok && d.GitLabName != "" {
+		return d.GitLabName
 	}
 
 	// Fallback: convert underscores to spaces and title case
@@ -313,9 +275,4 @@ func (m *VulnerabilityMapper) ValidateMapping(match detector.Match) error {
 	}
 
 	return nil
-}
-
-// AddCategoryMapping adds or updates a check type to category mapping
-func (m *VulnerabilityMapper) AddCategoryMapping(checkType, category string) {
-	m.categoryMappings[strings.ToUpper(checkType)] = category
 }


### PR DESCRIPTION
## refactor(v2): finish the type-metadata source-of-truth (gap 3.3)

Part of the **v2 architecture overhaul** (`v2-refactor`). Completes gap 3.3 — #98 migrated the *sub-type-keyed* metadata (SARIF descriptions/weights, gitlab check-desc/remediation) into `core.TypeMeta`; this migrates the remaining **validator-NAME-keyed** gitlab tables, leaving no scattered per-type metadata in the gitlab-sast formatter. Branches off current `main`.

### Changes
- **gitlab `nameMap` → `core.TypeMeta.GitLabName`** (new field, verbatim values). Keyed by validator name (CREDIT_CARD, …); sub-types (VISA, AWS_ACCESS_KEY) have no entry and keep the mapper's `strings.Title` fallback — byte-identical. `GitLabName` is a **distinct field**, not an alias of `SARIFShort`, because SECRETS differs (`Secret/API Key Detected` vs `Secret or API Key Detected`).
- **gitlab `categoryMappings` removed**: it mapped every key (and DEFAULT) to `"sast"`, so `mapCheckTypeToCategory` now returns `"sast"` directly. Also removed the dead `AddCategoryMapping` (zero callers).

### Behavior-preserving
Golden net **byte-identical** (zero `UPDATE_GOLDEN`). Negative-control verified: changing SSN's `GitLabName` (a name that IS emitted in the gitlab goldens) breaks the snapshot; CREDIT_CARD wouldn't, since the validator emits VISA/MASTERCARD sub-types that hit the fallback — confirming the name-tier path is genuinely golden-covered. New `TestTypeMeta_GitLabName` locks the invariants (SECRETS≠SARIFShort; sub-types have no name).

### Deliberately out of scope (documented in code)
- **text/csv `getPrecommitIssueDescription` switches**: their strings AND default-branch fallbacks differ per formatter (`API key or secret detected` vs `API key/secret`; text has a metadata-field special case). Consolidating yields little and risks byte-divergence, so they stay local.
- The mapper's dead `messageMap`/`generateDescription` (overwritten by the sanitizer) — a separate dead-code cleanup, not behavior.

### Verification
`go build ./...`, full `go test ./...`, `gofmt`/`vet` clean; golden deterministic ×3.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)