### PR TITLE
feat(v2): surface degraded validator coverage on the file path (Phase 4)

### DIFF
--- a/internal/core/scanner.go
+++ b/internal/core/scanner.go
@@ -76,11 +76,11 @@ type ScanResult struct {
 	// from "did not finish scanning", which must never look the same.
 	// IncompleteReason carries a short, payload-free explanation when set.
 	//
-	// NOTE (v2 Phase 1 scope): this is currently populated only on the
-	// ScanContent (stdin / in-memory / library) path, which calls the validator
-	// runner directly. The file/worker-pool path (ScanFile) does not yet thread
-	// per-file diagnostics through to ScanResult — that is Phase 4
-	// (ScanResult.Diagnostics in docs/proposals/V2_ARCHITECTURE.md).
+	// Populated on BOTH the in-memory path (ScanContent) and the file/worker-pool
+	// path (ScanFile): ScanFile aggregates per-file validator-completion status
+	// from ProcessingStats.IncompleteFiles (v2 Phase 4). On the file path,
+	// IncompleteReason names the single offending file or counts them when more
+	// than one did not complete.
 	Incomplete       bool
 	IncompleteReason string
 }
@@ -179,11 +179,31 @@ func ScanFile(scanConfig ScanConfig) (*ScanResult, error) {
 		explain.Annotate(unsuppressed, explain.NewSignalSynthesizer())
 	}
 
+	// Surface degraded validator coverage (v2 Phase 4): if any file's validation
+	// did not complete (timeout/cancel/validator error), flag the result as
+	// Incomplete so a partially-scanned run is never mistaken for a clean one.
+	// Matches are still returned (the worker pool keeps the partial results);
+	// this only adds the signal. Defaults false when every file completed.
+	incomplete := false
+	incompleteReason := ""
+	if stats != nil && len(stats.IncompleteFiles) > 0 {
+		incomplete = true
+		if len(stats.IncompleteFiles) == 1 {
+			incompleteReason = fmt.Sprintf("validation did not complete for %s: %s",
+				stats.IncompleteFiles[0].FilePath, stats.IncompleteFiles[0].Reason)
+		} else {
+			incompleteReason = fmt.Sprintf("validation did not complete for %d of %d files",
+				len(stats.IncompleteFiles), stats.TotalFiles)
+		}
+	}
+
 	return &ScanResult{
 		Matches:           unsuppressed,
 		SuppressedMatches: suppressed,
 		SuppressedCount:   len(suppressed),
 		ProcessedFiles:    stats.ProcessedFiles,
+		Incomplete:        incomplete,
+		IncompleteReason:  incompleteReason,
 	}, nil
 }
 

--- a/internal/parallel/diagnostics_test.go
+++ b/internal/parallel/diagnostics_test.go
@@ -1,0 +1,98 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package parallel
+
+import (
+	"io"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/awslabs/ferret-scan/internal/detector"
+	"github.com/awslabs/ferret-scan/internal/observability"
+)
+
+// TestDiagnostics_IncompleteFileSurfacedButMatchesKept verifies the v2 Phase 4
+// contract: when a validator does not complete for a file (here, a stall that
+// trips the per-file timeout), that file is reported in
+// ProcessingStats.IncompleteFiles, yet the partial/clean matches from ALL files
+// — including the stalled one's siblings — are still returned. Degraded coverage
+// is surfaced, not silently dropped, and it does not suppress other findings.
+func TestDiagnostics_IncompleteFileSurfacedButMatchesKept(t *testing.T) {
+	dir := t.TempDir()
+	good := writeTxt(t, dir, "good.txt", "alpha content")
+	stall := writeTxt(t, dir, "STALLME.txt", "beta content")
+
+	v := &batchStubValidator{stallMarker: "STALLME", release: make(chan struct{})}
+	defer close(v.release)
+
+	observer := observability.NewStandardObserver(observability.ObservabilityMetrics, io.Discard)
+	pp := NewParallelProcessor(observer)
+	fr := newTestFileRouter(t)
+	cfg := &JobConfig{JobTimeout: 300 * time.Millisecond}
+
+	done := make(chan struct{})
+	var matches []detector.Match
+	var stats *ProcessingStats
+	go func() {
+		matches, stats, _ = pp.ProcessFilesWithProgress(
+			[]string{good, stall},
+			[]detector.Validator{v},
+			fr, cfg, nil, nil,
+		)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("scan did not complete within 10s")
+	}
+
+	// The stalled file must be reported as incomplete...
+	if len(stats.IncompleteFiles) != 1 {
+		t.Fatalf("expected 1 incomplete file, got %d: %+v", len(stats.IncompleteFiles), stats.IncompleteFiles)
+	}
+	if filepath.Base(stats.IncompleteFiles[0].FilePath) != "STALLME.txt" {
+		t.Errorf("wrong incomplete file: %q", stats.IncompleteFiles[0].FilePath)
+	}
+	if stats.IncompleteFiles[0].Reason == "" {
+		t.Error("incomplete file diagnostic has no reason")
+	}
+
+	// ...but the good file's match must still be present (not discarded).
+	foundGood := false
+	for _, m := range matches {
+		if filepath.Base(m.Filename) == "good.txt" {
+			foundGood = true
+		}
+	}
+	if !foundGood {
+		t.Errorf("good file's match was dropped; matches=%v", matches)
+	}
+}
+
+// TestDiagnostics_CleanScanHasNoIncompleteFiles confirms the happy-path default:
+// when every file's validation completes, IncompleteFiles is empty (so
+// ScanResult.Incomplete stays false and clean scans see no behavior change).
+func TestDiagnostics_CleanScanHasNoIncompleteFiles(t *testing.T) {
+	dir := t.TempDir()
+	f1 := writeTxt(t, dir, "a.txt", "alpha")
+	f2 := writeTxt(t, dir, "b.txt", "beta")
+
+	v := &batchStubValidator{} // no stall, no error
+	observer := observability.NewStandardObserver(observability.ObservabilityMetrics, io.Discard)
+	pp := NewParallelProcessor(observer)
+	fr := newTestFileRouter(t)
+
+	_, stats, err := pp.ProcessFilesWithProgress(
+		[]string{f1, f2}, []detector.Validator{v}, fr, &JobConfig{}, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(stats.IncompleteFiles) != 0 {
+		t.Errorf("clean scan should have no incomplete files, got %+v", stats.IncompleteFiles)
+	}
+}

--- a/internal/parallel/parallel_processor.go
+++ b/internal/parallel/parallel_processor.go
@@ -29,6 +29,21 @@ type ProcessingStats struct {
 	TotalDuration  time.Duration `json:"total_duration_ms"`
 	WorkerCount    int           `json:"worker_count"`
 	AvgFileTime    time.Duration `json:"avg_file_time_ms"`
+
+	// IncompleteFiles lists files whose validator coverage was cut short (a
+	// validator errored or the scan was cancelled/timed out). It is populated
+	// from each Result.ValidationError and is empty on a fully-clean run, so
+	// callers that ignore it see no behavior change (v2 Phase 4). Callers use it
+	// to set ScanResult.Incomplete — distinguishing "scanned clean" from "did
+	// not finish scanning".
+	IncompleteFiles []FileDiagnostic `json:"incomplete_files,omitempty"`
+}
+
+// FileDiagnostic records that a single file's validation did not complete
+// cleanly. It carries no payload bytes — only the path and a short reason.
+type FileDiagnostic struct {
+	FilePath string `json:"file_path"`
+	Reason   string `json:"reason"`
 }
 
 // NewParallelProcessor creates a new parallel processor
@@ -87,11 +102,21 @@ func (pp *ParallelProcessor) ProcessFilesWithProgress(filePaths []string, valida
 	var mu sync.Mutex
 	processedCount := 0
 	totalDuration := time.Duration(0)
+	var incompleteFiles []FileDiagnostic
 
 	for i := 0; i < jobCount; i++ {
 		result := <-pp.workerPool.Results()
 
 		mu.Lock()
+		// Record degraded validator coverage (timeout/cancel/validator error)
+		// independently of the fatal-error path below, so a partially-scanned
+		// file still contributes its matches AND is flagged as incomplete.
+		if result.ValidationError != nil {
+			incompleteFiles = append(incompleteFiles, FileDiagnostic{
+				FilePath: result.FilePath,
+				Reason:   result.ValidationError.Error(),
+			})
+		}
 		if result.Error != nil {
 			if pp.observer != nil {
 				pp.observer.LogOperation(observability.StandardObservabilityData{
@@ -118,12 +143,13 @@ func (pp *ParallelProcessor) ProcessFilesWithProgress(filePaths []string, valida
 	overallDuration := time.Since(start)
 
 	stats := &ProcessingStats{
-		TotalFiles:     jobCount,
-		ProcessedFiles: processedCount,
-		TotalMatches:   len(allMatches),
-		TotalDuration:  overallDuration,
-		WorkerCount:    pp.workerPool.workers,
-		AvgFileTime:    totalDuration / time.Duration(max(processedCount, 1)),
+		TotalFiles:      jobCount,
+		ProcessedFiles:  processedCount,
+		TotalMatches:    len(allMatches),
+		TotalDuration:   overallDuration,
+		WorkerCount:     pp.workerPool.workers,
+		AvgFileTime:     totalDuration / time.Duration(max(processedCount, 1)),
+		IncompleteFiles: incompleteFiles,
 	}
 
 	if finishTiming != nil {

--- a/internal/parallel/worker_pool.go
+++ b/internal/parallel/worker_pool.go
@@ -76,6 +76,16 @@ type Result struct {
 	Error    error
 	Duration time.Duration
 
+	// ValidationError is the error returned by the validator run for this file,
+	// if any (e.g. a validator timed out or the scan context was cancelled). It
+	// is ALWAYS captured — unlike the historical behavior where the validator
+	// error was only retained under --debug — so callers can report degraded
+	// coverage on every run (v2 Phase 4). It is kept SEPARATE from Error: a
+	// validator error does not make the file's matches invalid (the file was
+	// read and partially scanned), so it must not trip the matches-discard path
+	// that Error drives in parallel_processor. Nil when validation completed.
+	ValidationError error
+
 	// Redaction results
 	RedactionResult *redactors.RedactionResult
 	RedactedPath    string
@@ -177,6 +187,7 @@ func (wp *WorkerPool) processJob(job *Job, workerID int) *Result {
 
 	var allMatches []detector.Match
 	var lastError error
+	var validationErr error // captured for Result.ValidationError, always (not just --debug)
 	var processedContent *preprocessors.ProcessedContent
 
 	// Wrap file processing with resilience
@@ -221,13 +232,15 @@ func (wp *WorkerPool) processJob(job *Job, workerID int) *Result {
 			return resilience.NewTransientError("no content processed", nil)
 		}
 
-		// Run validators with error isolation
-		matches, validationErr := RunValidators(ctx, job.Validators, processedContent, DefaultValidatorRetryStrategy())
-		if validationErr != nil {
-			// Don't fail entire job for validator errors, just log them
-			if job.Config.Debug {
-				lastError = validationErr
-			}
+		// Run validators with error isolation. Capture the validator error
+		// unconditionally into validationErr (surfaced via Result.ValidationError
+		// regardless of --debug) so callers can report degraded coverage. We do
+		// NOT promote it to lastError: a validator error/timeout does not make
+		// this file's already-gathered matches invalid, so it must not trip the
+		// fatal-error path (which discards the file's matches downstream).
+		matches, verr := RunValidators(ctx, job.Validators, processedContent, DefaultValidatorRetryStrategy())
+		if verr != nil {
+			validationErr = verr
 		}
 
 		allMatches = matches
@@ -288,6 +301,7 @@ func (wp *WorkerPool) processJob(job *Job, workerID int) *Result {
 		FilePath:        job.FilePath,
 		Matches:         allMatches,
 		Error:           lastError,
+		ValidationError: validationErr,
 		Duration:        duration,
 		RedactionResult: redactionResult,
 		RedactedPath:    redactedPath,


### PR DESCRIPTION
## feat(v2): ScanResult.Incomplete on the file/worker-pool path

Part of the **v2 architecture overhaul** (`v2-refactor`; Phase 4 in [`docs/proposals/V2_ARCHITECTURE.md`](docs/proposals/V2_ARCHITECTURE.md)). Branches off current `main` (no overlap with open #102/#103).

### Problem
Phase 1 added `ScanResult.Incomplete` but populated it **only** on the in-memory `ScanContent` path. The file/worker-pool path (`ScanFile`) **swallowed validator errors unless `--debug`**, so a timed-out or partially-scanned directory scan looked indistinguishable from a clean one — the dangerous silent-incomplete failure mode for a DLP tool.

### Fix (thread per-file validator status through to ScanResult)
- **worker_pool**: capture the validator-run error **unconditionally** into a new `Result.ValidationError` (was retained only under `--debug`). Kept **separate** from `Result.Error` so it does **not** trip the fatal-error path that discards a file's matches — a validator timeout doesn't invalidate matches already gathered.
- **parallel_processor**: collect each `ValidationError` into `ProcessingStats.IncompleteFiles` (`[]FileDiagnostic{path, reason}`); empty on a fully-clean run.
- **ScanFile**: set `ScanResult.Incomplete` / `IncompleteReason` from `IncompleteFiles` (names the single offending file, or counts when >1), mirroring `ScanContent`.

### Behavior-preserving
Additive fields, default false/empty. Golden net **byte-identical** (zero `UPDATE_GOLDEN`); full `go test ./...` + `-race` clean.

### Tests (negative-control verified)
- `TestDiagnostics_IncompleteFileSurfacedButMatchesKept`: a stalled file (300ms `JobTimeout`) is reported in `IncompleteFiles` **while its sibling's match is still returned** — degraded coverage surfaced, findings not dropped. Verified to fail if the collection is neutralized.
- `TestDiagnostics_CleanScanHasNoIncompleteFiles`: clean scan → empty.

### Scope (honest)
This makes the signal **available** on the `ScanFile`/library surface — closing the Phase 4 plumbing gap. **CLI exit-code and web-response consumption** of `Incomplete` are a separate, behavior-changing decision (they'd alter exit semantics) and are intentionally **not** wired here.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)