### PR TITLE
docs(v2): measured performance baseline (pre-v2 vs v2)

### DIFF
--- a/docs/proposals/V2_ARCHITECTURE.md
+++ b/docs/proposals/V2_ARCHITECTURE.md
@@ -303,6 +303,46 @@ the shared `LineScan` primitive (4.1); structured provenance (5.1); `Descriptor(
 
 ---
 
+## Performance Baseline (measured)
+
+Empirical comparison of a **pre-v2 binary** (commit `75be0e6`, before PR #98) vs a **v2 binary**
+(post #98–#104), built from the same toolchain and run on the same machine (macOS, `--checks all`,
+output to `/dev/null`). This grounds the phase plan: it shows the landed orchestration work is
+behavior-neutral-to-faster, and it isolates exactly what Phase 3 still has to fix.
+
+| Workload | pre-v2 | v2 | Read |
+|---|---|---|---|
+| 3.9 MB normal text file | 4.85s | **3.20s** | v2 ~34% faster (collapsed bridge/cleaner path) |
+| 200-file directory | 0.35s | 0.35s | identical — the concurrency governor (#102) adds no measurable overhead |
+| 256 KB **single dense line** | 9.71s | 9.56s | **identical** — per-validator O(n²) cost is unchanged |
+| 2 MB single dense line | did not finish (killed >90s) | did not finish (killed >90s) | both runaway |
+| Peak RSS (3.9 MB file, v2) | — | ~65 MB | — |
+
+**What this confirms about the design boundary (important):**
+
+- The merged v2 work made a runaway validator **terminable and bounded at the ORCHESTRATION layer** —
+  Phase 1's context-cancellable join, the configurable per-file `JobTimeout` (default 5 min), and #102's
+  process-wide concurrency governor — so the *scan* can no longer hang forever and one pathological file
+  cannot starve the worker pool. On normal inputs the consolidation is a net speedup.
+- It did **not** touch the **per-validator O(n²) inner scanning cost** on a single very long line. The
+  256 KB-single-line case is ~9.6s on *both* binaries, and 2 MB single-line runs away on both. This is the
+  exact hot path **Phase 3** targets (ctx-polling in the validator loops + the Move-C shared `LineScan`
+  primitive that removes the per-match full-line rescan). The complexity guard in `internal/goldencorpus`
+  measures *linear* scaling on multi-line dense input; the single-very-long-line pathology is a distinct
+  hot path still pending.
+
+**Phase 3 success criteria, anchored to these numbers:** after Phase 3, the 256 KB single-line scan should
+drop from ~9.6s toward sub-second (linear, not quadratic), and the 2 MB single-line scan should complete
+within the per-file budget (today it must be killed). Detection output on normal inputs must remain
+byte-identical (golden net), with the only behavioral change being bounded-partial + an explicit incomplete
+signal on inputs that exceed the budget.
+
+> Method caveat: macOS lacks `timeout`/`gtimeout`; "did not finish" runs were wall-clock-capped and killed
+> manually. Numbers are best-of-small-N on one machine — directional, not a benchmark suite. A repeatable
+> Go benchmark for the single-long-line path is worth adding alongside Phase 3.
+
+---
+
 ## Phase 1 Prototype (landed)
 
 This branch (`feat/v2-phase1-bounded-execution`) implements the behavior-preserving slice of Move A. It


### PR DESCRIPTION
## docs(v2): empirical performance baseline

Part of the **v2 architecture overhaul** (`v2-refactor`). Docs-only — adds a *Performance Baseline (measured)* section to [`docs/proposals/V2_ARCHITECTURE.md`](docs/proposals/V2_ARCHITECTURE.md). No code change.

Captures a real pre-v2 (`75be0e6`) vs v2 (post #98–#104) binary comparison run during testing:

| Workload | pre-v2 | v2 |
|---|---|---|
| 3.9 MB normal file | 4.85s | **3.20s** (~34% faster) |
| 200-file directory | 0.35s | 0.35s (governor adds no overhead) |
| 256 KB single dense line | 9.71s | 9.56s (**unchanged** — O(n²) intact) |
| 2 MB single dense line | killed >90s | killed >90s |

**Why capture this:** it documents the v2 design boundary with evidence — landed work bounds runaway validators at the *orchestration* layer (cancellable join, per-file `JobTimeout`, #102 concurrency governor) and is a net speedup on normal inputs, but the *per-validator* O(n²) single-long-line cost is unchanged. That single-long-line hot path is precisely what **Phase 3** (ctx-polling + the Move-C shared `LineScan` primitive) targets. The section adds Phase-3 success criteria anchored to the 9.6s number and an honest method caveat (macOS lacks `timeout`; directional numbers, not a benchmark suite — a repeatable Go benchmark is worth adding with Phase 3).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)