### PR TITLE
feat(v2-refactor): cooperative cancellation in SSN/IP/phone validator line loops (Phase 3, slice 1)

### DIFF
--- a/docs/proposals/V2_ARCHITECTURE.md
+++ b/docs/proposals/V2_ARCHITECTURE.md
@@ -297,6 +297,19 @@ polling inside validators, the concurrency limiter, the per-validator budget, an
 (Moves A, C). Behavior changes *only* on over-deadline/over-budget inputs (today: hang or crash; v2:
 bounded partial + explicit incomplete signal).
 
+> **Phase 3, slice 1 — per-line ctx polling in the three worst offenders — LANDED (PR #107).** The
+> audit-measured worst offenders (SSN, IP, phone) now implement `execguard.ContextAwareValidator` via a
+> new `ValidateContentCtx` that polls a shared `execguard.LineLoopCancelled(ctx, i)` primitive (reads
+> `ctx.Err()` every 256 lines, and on `i==0`) once per line; on deadline/cancel each returns the matches
+> gathered so far plus `ctx.Err()`. `ValidateContent` becomes a `context.Background()` shim, so the common
+> uncancelled path is byte-identical (golden corpus passes with zero `UPDATE_GOLDEN`). Because
+> `execguard.ValidateContent` already dispatches to `ContextAwareValidator` when implemented, the live scan
+> path routes through the ctx-aware form automatically: a runaway **multi-line** scan is reclaimed
+> promptly (SSN 0.01s vs 53.68s; IP 0.01s vs 5.18s; phone 0.01s vs 16.16s — negative-controlled).
+> **Still open in Phase 3:** the O(n²) **single-long-line** case (fixed by the shared `LineScan` primitive,
+> 4.1 — slice 2); adopting the ctx-poll in the remaining line-loop validators; and the concurrency
+> limiter + per-validator/extraction budgets (Move C).
+
 **Phase 4 — Surface and consolidate.** Add `ScanResult.Diagnostics` + opt-in degraded-coverage exit (1.4);
 the shared `LineScan` primitive (4.1); structured provenance (5.1); `Descriptor()` + data-driven routing
 (3.3, 5.3); the `Observer` seam and typed config schema (6.2, 6.4).

--- a/internal/execguard/linebudget.go
+++ b/internal/execguard/linebudget.go
@@ -1,0 +1,46 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package execguard
+
+import "context"
+
+// ctxCheckStride is how often (in loop iterations) a validator's line loop
+// consults the context. Checking ctx.Err() on every iteration would add a
+// (cheap but non-zero) atomic load to the hot path for no benefit; a stride of
+// 256 bounds the worst-case over-run to at most 255 extra lines after a deadline
+// fires — negligible against a multi-million-line runaway — while keeping the
+// per-line cost effectively free.
+const ctxCheckStride = 256
+
+// LineLoopCancelled reports whether a validator's per-line loop should stop
+// because its context is done (deadline exceeded or cancelled). It is the
+// v2 Phase 3 cooperative-cancellation primitive: validators that implement
+// execguard.ContextAwareValidator call this once per line so a runaway scan of a
+// large multi-line input is reclaimed promptly instead of running to completion.
+//
+// It only actually reads ctx.Err() every ctxCheckStride iterations (and always
+// on the first, i==0, so an already-expired budget skips the work entirely), so
+// the common case is a single integer-modulo test. A nil ctx never cancels.
+//
+// Usage in a validator's ValidateContentCtx:
+//
+//	for i, line := range lines {
+//	    if execguard.LineLoopCancelled(ctx, i) {
+//	        return matches, ctx.Err() // return partial matches + why we stopped
+//	    }
+//	    // ... scan line ...
+//	}
+//
+// Returning the partial matches gathered so far (rather than discarding them) is
+// deliberate: a timed-out DLP scan should surface what it found, and the caller
+// records ctx.Err() as an incomplete-coverage signal (see ScanResult.Incomplete).
+func LineLoopCancelled(ctx context.Context, i int) bool {
+	if ctx == nil {
+		return false
+	}
+	if i%ctxCheckStride != 0 {
+		return false
+	}
+	return ctx.Err() != nil
+}

--- a/internal/validators/ipaddress/ctx_cancel_test.go
+++ b/internal/validators/ipaddress/ctx_cancel_test.go
@@ -1,0 +1,48 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ipaddress
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestValidateContentCtx_ReclaimsRunawayMultiLineScan: a cancelled context stops
+// a large multi-line IP scan promptly (v2 Phase 3 per-line ctx polling).
+func TestValidateContentCtx_ReclaimsRunawayMultiLineScan(t *testing.T) {
+	v := NewValidator()
+	content := strings.Repeat("host 203.0.113.42 gw 192.168.1.1 dns 8.8.8.8\n", 500000)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_, err := v.ValidateContentCtx(ctx, content, "<stdin>")
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Errorf("cancelled scan took %v; expected prompt return", elapsed)
+	}
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestValidateContent_BackgroundShimEqualsCtx: the non-ctx shim must produce the
+// exact same result as ValidateContentCtx with a never-cancelling context — that
+// is the behavior-preserving invariant (the shim just supplies context.Background).
+// Asserting equality avoids coupling the test to IP-scoring specifics.
+func TestValidateContent_BackgroundShimEqualsCtx(t *testing.T) {
+	v := NewValidator()
+	const content = "server address 203.0.113.50 for access\nprivate 10.0.0.5 internal\n"
+
+	shim, err1 := v.ValidateContent(content, "<stdin>")
+	ctxRes, err2 := v.ValidateContentCtx(context.Background(), content, "<stdin>")
+	if err1 != nil || err2 != nil {
+		t.Fatalf("unexpected errors: shim=%v ctx=%v", err1, err2)
+	}
+	if len(shim) != len(ctxRes) {
+		t.Errorf("shim vs ctx match count differ: %d != %d", len(shim), len(ctxRes))
+	}
+}

--- a/internal/validators/ipaddress/validator.go
+++ b/internal/validators/ipaddress/validator.go
@@ -4,12 +4,14 @@
 package ipaddress
 
 import (
+	stdctx "context"
 	"net"
 	"os"
 	"regexp"
 	"strings"
 
 	"github.com/awslabs/ferret-scan/internal/detector"
+	"github.com/awslabs/ferret-scan/internal/execguard"
 	"github.com/awslabs/ferret-scan/internal/observability"
 )
 
@@ -264,6 +266,15 @@ func (v *Validator) Validate(filePath string) ([]detector.Match, error) {
 
 // ValidateContent validates preprocessed content for IP addresses
 func (v *Validator) ValidateContent(content string, originalPath string) ([]detector.Match, error) {
+	// Backward-compatible shim: run with a background context (never cancels).
+	return v.ValidateContentCtx(stdctx.Background(), content, originalPath)
+}
+
+// ValidateContentCtx implements execguard.ContextAwareValidator: the context-aware
+// form of ValidateContent, polling ctx once per line so a runaway multi-line scan
+// is reclaimed promptly (v2 Phase 3). Returns partial matches + ctx.Err() on
+// cancellation.
+func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, originalPath string) ([]detector.Match, error) {
 	var finishTiming func(bool, map[string]interface{})
 	if v.observer != nil {
 		finishTiming = v.observer.StartTiming("ipaddress_validator", "validate_content", originalPath)
@@ -276,6 +287,13 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 
 	// Process each pattern type
 	for lineNum, line := range lines {
+		// Cooperative cancellation (v2 Phase 3): bail promptly on deadline/cancel.
+		if execguard.LineLoopCancelled(ctx, lineNum) {
+			if finishTiming != nil {
+				finishTiming(false, map[string]interface{}{"cancelled": true, "match_count": len(matches)})
+			}
+			return matches, ctx.Err()
+		}
 		// Cheap per-line fast paths: every IPv6 form needs a ":" and the
 		// compressed form additionally needs a "::". Skipping the (multi-branch)
 		// IPv6 regexes on lines that cannot possibly contain such an address

--- a/internal/validators/phone/ctx_cancel_test.go
+++ b/internal/validators/phone/ctx_cancel_test.go
@@ -1,0 +1,42 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package phone
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestValidateContentCtx_ReclaimsRunawayMultiLineScan: a cancelled context stops
+// a large multi-line phone scan promptly (v2 Phase 3 per-line ctx polling).
+func TestValidateContentCtx_ReclaimsRunawayMultiLineScan(t *testing.T) {
+	v := NewValidator()
+	content := strings.Repeat("call 212-555-0142 or 415-555-0199 or 312-555-0123\n", 500000)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_, err := v.ValidateContentCtx(ctx, content, "<stdin>")
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Errorf("cancelled scan took %v; expected prompt return", elapsed)
+	}
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestValidateContent_BackgroundShimUnaffected: the non-ctx shim still detects.
+func TestValidateContent_BackgroundShimUnaffected(t *testing.T) {
+	v := NewValidator()
+	matches, err := v.ValidateContent("call me at 212-555-0142 tomorrow", "<stdin>")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Error("expected the phone number to be detected via the background shim")
+	}
+}

--- a/internal/validators/phone/validator.go
+++ b/internal/validators/phone/validator.go
@@ -4,6 +4,7 @@
 package phone
 
 import (
+	stdctx "context"
 	"os"
 	"regexp"
 	"sort"
@@ -11,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/awslabs/ferret-scan/internal/detector"
+	"github.com/awslabs/ferret-scan/internal/execguard"
 	"github.com/awslabs/ferret-scan/internal/observability"
 )
 
@@ -286,6 +288,15 @@ func (v *Validator) Validate(filePath string) ([]detector.Match, error) {
 
 // ValidateContent validates preprocessed content for phone numbers
 func (v *Validator) ValidateContent(content string, originalPath string) ([]detector.Match, error) {
+	// Backward-compatible shim: run with a background context (never cancels).
+	return v.ValidateContentCtx(stdctx.Background(), content, originalPath)
+}
+
+// ValidateContentCtx implements execguard.ContextAwareValidator: the context-aware
+// form of ValidateContent, polling ctx once per line so a runaway multi-line scan
+// is reclaimed promptly (v2 Phase 3). Returns partial matches + ctx.Err() on
+// cancellation.
+func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, originalPath string) ([]detector.Match, error) {
 	var finishTiming func(bool, map[string]interface{})
 	if v.observer != nil {
 		finishTiming = v.observer.StartTiming("phone_validator", "validate_content", originalPath)
@@ -298,6 +309,13 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 
 	// Process each pattern type
 	for lineNum, line := range lines {
+		// Cooperative cancellation (v2 Phase 3): bail promptly on deadline/cancel.
+		if execguard.LineLoopCancelled(ctx, lineNum) {
+			if finishTiming != nil {
+				finishTiming(false, map[string]interface{}{"cancelled": true, "match_count": len(matches)})
+			}
+			return matches, ctx.Err()
+		}
 		// Per-line state hoisted out of the per-match loop:
 		//   - dedup indexes the cleaned-digit form of every match already accepted
 		//     on THIS line so duplicate detection is O(1)-amortized per candidate

--- a/internal/validators/ssn/ctx_cancel_test.go
+++ b/internal/validators/ssn/ctx_cancel_test.go
@@ -1,0 +1,106 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ssn
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/awslabs/ferret-scan/internal/execguard"
+)
+
+// TestValidateContentCtx_ReclaimsRunawayMultiLineScan is the v2 Phase 3
+// regression test: a large multi-line input that would otherwise run to
+// completion is reclaimed promptly when the context is already cancelled — the
+// validator polls ctx per line and returns ctx.Err() instead of scanning every
+// line.
+func TestValidateContentCtx_ReclaimsRunawayMultiLineScan(t *testing.T) {
+	v := NewValidator()
+
+	// Many lines of dense near-SSN tokens — enough that a full scan is clearly
+	// measurable, so an early return is unambiguous.
+	line := "ssn 449-87-4100 and 555-12-3456 and 111-22-3333"
+	content := strings.Repeat(line+"\n", 500000)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled: the loop must bail on (or before) the first check
+
+	start := time.Now()
+	matches, err := v.ValidateContentCtx(ctx, content, "<stdin>")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Error("expected a context error from a cancelled scan, got nil")
+	}
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+	// Reclaimed promptly: must not scan all 500k lines. Generous ceiling guards
+	// against a regression where the poll is missing (which would take seconds).
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("cancelled scan took %v; expected prompt return (per-line ctx poll missing?)", elapsed)
+	}
+	// Partial matches are acceptable (<= the first ctxCheckStride lines' worth);
+	// the point is we did NOT scan the whole input.
+	_ = matches
+}
+
+// TestValidateContentCtx_DeadlineWhileScanning verifies a deadline that fires
+// mid-scan also reclaims the loop (not just an already-cancelled context).
+func TestValidateContentCtx_DeadlineWhileScanning(t *testing.T) {
+	v := NewValidator()
+	content := strings.Repeat("ssn 449-87-4100 more text here\n", 2000000)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := v.ValidateContentCtx(ctx, content, "<stdin>")
+	elapsed := time.Since(start)
+
+	if err != context.DeadlineExceeded {
+		t.Errorf("expected context.DeadlineExceeded, got %v", err)
+	}
+	// Should stop within a small multiple of the 50ms budget, not scan 2M lines.
+	if elapsed > 5*time.Second {
+		t.Errorf("scan ran %v past a 50ms deadline; ctx polling not effective", elapsed)
+	}
+}
+
+// TestValidateContent_BackgroundShimUnaffected confirms the non-ctx shim behaves
+// exactly as before: a normal scan completes and finds the SSN.
+func TestValidateContent_BackgroundShimUnaffected(t *testing.T) {
+	v := NewValidator()
+	matches, err := v.ValidateContent("employee ssn: 449-87-4100 on record", "<stdin>")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Error("expected the SSN to be detected via the background shim")
+	}
+}
+
+// TestLineLoopCancelled_StrideBehavior locks the helper's cheap-check contract:
+// it reads ctx only on stride boundaries, and an already-done ctx is caught at
+// i==0.
+func TestLineLoopCancelled_StrideBehavior(t *testing.T) {
+	done, cancel := context.WithCancel(context.Background())
+	cancel()
+	if !execguard.LineLoopCancelled(done, 0) {
+		t.Error("expected cancellation to be detected at i=0")
+	}
+	// A live context never reports cancelled regardless of index.
+	live := context.Background()
+	for _, i := range []int{0, 1, 255, 256, 512} {
+		if execguard.LineLoopCancelled(live, i) {
+			t.Errorf("live context reported cancelled at i=%d", i)
+		}
+	}
+	// nil context never cancels.
+	if execguard.LineLoopCancelled(nil, 0) {
+		t.Error("nil context must not report cancelled")
+	}
+}

--- a/internal/validators/ssn/validator.go
+++ b/internal/validators/ssn/validator.go
@@ -4,11 +4,13 @@
 package ssn
 
 import (
+	stdctx "context"
 	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/awslabs/ferret-scan/internal/detector"
+	"github.com/awslabs/ferret-scan/internal/execguard"
 	"github.com/awslabs/ferret-scan/internal/observability"
 )
 
@@ -234,6 +236,16 @@ func (v *Validator) newLineContext(line string) *lineContext {
 
 // ValidateContent validates preprocessed content for SSNs
 func (v *Validator) ValidateContent(content string, originalPath string) ([]detector.Match, error) {
+	// Backward-compatible shim: run with a background context (never cancels).
+	return v.ValidateContentCtx(stdctx.Background(), content, originalPath)
+}
+
+// ValidateContentCtx implements execguard.ContextAwareValidator: it is the
+// context-aware form of ValidateContent, polling ctx once per line so a runaway
+// scan of a large multi-line input is reclaimed promptly (v2 Phase 3). On
+// cancellation it returns the matches gathered so far plus ctx.Err(), so a
+// timed-out scan surfaces partial findings rather than discarding them.
+func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, originalPath string) ([]detector.Match, error) {
 	var matches []detector.Match
 
 	// Split content into lines for processing
@@ -242,6 +254,11 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 	isDocx := strings.Contains(originalPath, ".docx")
 
 	for lineNum, line := range lines {
+		// Cooperative cancellation: stop promptly if the scan's deadline fired
+		// or it was cancelled, returning what we have plus the reason.
+		if execguard.LineLoopCancelled(ctx, lineNum) {
+			return matches, ctx.Err()
+		}
 		// Use FindAllStringIndex so we enumerate matches with their byte offsets in a
 		// single regex pass (FindAllString already did one pass; this is equivalent).
 		// We deliberately compute the context window from the FIRST occurrence of each


### PR DESCRIPTION
## What

Phase 3, slice 1 of the [v2 architecture consolidation](docs/proposals/V2_ARCHITECTURE.md): make the three audit-measured worst-offender validators (**SSN, IP, phone**) reclaimable mid-scan.

Each validator now implements `execguard.ContextAwareValidator` via a new `ValidateContentCtx` that **polls the context once per line** and, on deadline/cancel, returns the matches gathered so far plus `ctx.Err()`. The existing `ValidateContent` becomes a backward-compatible shim over `ValidateContentCtx(context.Background(), ...)`.

Because `execguard.ValidateContent` already dispatches to `ContextAwareValidator` when implemented (#98), the live scan path routes through the ctx-aware form **automatically** — a runaway *multi-line* scan is now reclaimed promptly instead of running to completion.

| validator | reclaim (cancelled ctx, 500k lines) | before (no poll, neg-control) |
|---|---|---|
| SSN | 0.01s | 53.68s |
| IP | 0.01s | 5.18s |
| phone | 0.01s | 16.16s |

## New primitive

`execguard.LineLoopCancelled(ctx, i)` polls `ctx.Err()` every 256 iterations (and on `i==0`), keeping the per-line cost effectively free while bounding worst-case over-run to <256 lines after a budget fires.

## Behavior-preserving

- Public `ValidateContent` contract unchanged; common (uncancelled) path is byte-identical.
- Observer timing (`finishTiming`) preserved on the IP/phone path; on cancel it records `{cancelled: true, match_count}`.
- **Golden corpus byte-identical** (zero `UPDATE_GOLDEN`).

## Scope note

This fixes runaway **multi-line** scans. The O(n²) **single-long-line** case is Phase 3 slice 2 (shared `LineScan` primitive) and is **unchanged** here.

## Tests

- Per-validator `ctx_cancel_test.go`: (a) cancelled-context reclaim returns <500ms with `context.Canceled` on 500k-line input; (b) background shim behavior-preserving; SSN adds a deadline-while-scanning case + stride-behavior unit test.
- **Negative controls** confirmed the reclaim tests genuinely fail without the poll (IP 5.18s, phone 16.16s, SSN 53.68s, all returning `nil` err).
- Full suite + `-race` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)