### PR TITLE
fix(dos): cloudresources O(n²) per-match negative-keyword rescan on single-line input

### DIFF
--- a/internal/goldencorpus/corpus.go
+++ b/internal/goldencorpus/corpus.go
@@ -129,6 +129,13 @@ var Cases = []Case{
 		Checks:      []string{"EMAIL"},
 		Input:       manyEmails(12),
 	},
+	{
+		Name:        "cloud_resources_test_context",
+		Description: "Same AWS IAM-role ARN on two lines: one clean, one carrying a same-line test-context keyword (\"example\"). Locks the CLOUD_RESOURCES negative-keyword penalty (-20, per-line/local), the behavior the per-line hasKeywordToken hoist must preserve.",
+		Checks:      []string{"CLOUD_RESOURCES"},
+		Input: "prod arn:aws:iam::123456789012:role/PaymentsAdmin\n" +
+			"example arn:aws:iam::123456789012:role/PaymentsAdmin\n",
+	},
 }
 
 // FileCase is one file-based corpus entry. Unlike Case (which scans an in-memory

--- a/internal/goldencorpus/testdata/golden/cloud_resources_test_context.csv
+++ b/internal/goldencorpus/testdata/golden/cloud_resources_test_context.csv
@@ -1,0 +1,3 @@
+Filename,Type,Confidence Level,Confidence %,Line Number,Text
+<golden:cloud_resources_test_context>,AWS_ARN,HIGH,95.0,1,arn:aws:iam::123456789012:role/PaymentsAdmin
+<golden:cloud_resources_test_context>,AWS_ARN,MEDIUM,75.0,2,arn:aws:iam::123456789012:role/PaymentsAdmin

--- a/internal/goldencorpus/testdata/golden/cloud_resources_test_context.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/cloud_resources_test_context.gitlab-sast.json
@@ -1,0 +1,82 @@
+{
+  "remediations": [],
+  "scan": {
+    "analyzer": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "end_time": "<TIMESTAMP>",
+    "scanner": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "start_time": "<TIMESTAMP>",
+    "status": "success",
+    "type": "sast"
+  },
+  "version": "15.0.4",
+  "vulnerabilities": [
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected sensitive data (aws arn) in this file.\n\n**Location:** <golden:cloud_resources_test_context> (line 1)\n**Confidence:** HIGH (95.0%)\n**Detected by:** cloud_resources validator\n\n**Matched value:**\n```\narn:aws:iam::123456789012:role/PaymentsAdmin\n```\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "AWS_ARN"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "cloud_resources"
+        }
+      ],
+      "location": {
+        "end_line": 1,
+        "file": "<golden:cloud_resources_test_context>",
+        "start_line": 1
+      },
+      "message": "Sensitive data (aws arn) detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Aws Arn Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected sensitive data (aws arn) in this file.\n\n**Location:** <golden:cloud_resources_test_context> (line 2)\n**Confidence:** MEDIUM (75.0%)\n**Detected by:** cloud_resources validator\n\n**Matched value:**\n```\narn:aws:iam::123456789012:role/PaymentsAdmin\n```\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "AWS_ARN"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "cloud_resources"
+        }
+      ],
+      "location": {
+        "end_line": 2,
+        "file": "<golden:cloud_resources_test_context>",
+        "start_line": 2
+      },
+      "message": "Sensitive data (aws arn) detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Aws Arn Detected",
+      "severity": "High"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/cloud_resources_test_context.json.json
+++ b/internal/goldencorpus/testdata/golden/cloud_resources_test_context.json.json
@@ -1,0 +1,69 @@
+{
+  "results": [
+    {
+      "confidence": 95,
+      "confidence_level": "HIGH",
+      "filename": "<golden:cloud_resources_test_context>",
+      "line_number": 1,
+      "metadata": {
+        "account_id": "123456789012",
+        "confidence_adjustment": 0,
+        "confidence_factors": [
+          "base_match:+85",
+          "valid_account_id:+10"
+        ],
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "Financial",
+        "original_confidence": 95,
+        "provider": "aws",
+        "resource_type": "AWS_ARN",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0.125
+        },
+        "service": "iam",
+        "validation_path": "document"
+      },
+      "text": "arn:aws:iam::123456789012:role/PaymentsAdmin",
+      "type": "AWS_ARN",
+      "validator": "cloud_resources"
+    },
+    {
+      "confidence": 75,
+      "confidence_level": "MEDIUM",
+      "filename": "<golden:cloud_resources_test_context>",
+      "line_number": 2,
+      "metadata": {
+        "account_id": "123456789012",
+        "confidence_adjustment": 0,
+        "confidence_factors": [
+          "base_match:+85",
+          "valid_account_id:+10",
+          "test_context:-20"
+        ],
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "Financial",
+        "original_confidence": 75,
+        "provider": "aws",
+        "resource_type": "AWS_ARN",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0.125
+        },
+        "service": "iam",
+        "validation_path": "document"
+      },
+      "text": "arn:aws:iam::123456789012:role/PaymentsAdmin",
+      "type": "AWS_ARN",
+      "validator": "cloud_resources"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/cloud_resources_test_context.junit.xml
+++ b/internal/goldencorpus/testdata/golden/cloud_resources_test_context.junit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
+  <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
+    <testcase name="&lt;golden:cloud_resources_test_context&gt;" classname="security-scan" time="0.001">
+      <failure message="2 security findings detected" type="SECURITY_FINDINGS">Line 1: AWS_ARN detected with 95.0% confidence (HIGH)&#xA;Match: arn:aws:iam::123456789012:role/PaymentsAdmin&#xA;Validator: cloud_resources&#xA;Line 2: AWS_ARN detected with 75.0% confidence (MEDIUM)&#xA;Match: arn:aws:iam::123456789012:role/PaymentsAdmin&#xA;Validator: cloud_resources</failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/internal/goldencorpus/testdata/golden/cloud_resources_test_context.redact_format_preserving.txt
+++ b/internal/goldencorpus/testdata/golden/cloud_resources_test_context.redact_format_preserving.txt
@@ -1,0 +1,6 @@
+=== REDACTED ===
+prod ********************************************
+example ********************************************
+=== FINDINGS (sorted) ===
+type=AWS_ARN line=1 conf=high match=arn:aws:iam::123456789012:role/PaymentsAdmin
+type=AWS_ARN line=2 conf=medium match=arn:aws:iam::123456789012:role/PaymentsAdmin

--- a/internal/goldencorpus/testdata/golden/cloud_resources_test_context.redact_simple.txt
+++ b/internal/goldencorpus/testdata/golden/cloud_resources_test_context.redact_simple.txt
@@ -1,0 +1,6 @@
+=== REDACTED ===
+prod [AWS_ARN-REDACTED]
+example [AWS_ARN-REDACTED]
+=== FINDINGS (sorted) ===
+type=AWS_ARN line=1 conf=high match=arn:aws:iam::123456789012:role/PaymentsAdmin
+type=AWS_ARN line=2 conf=medium match=arn:aws:iam::123456789012:role/PaymentsAdmin

--- a/internal/goldencorpus/testdata/golden/cloud_resources_test_context.sarif.json
+++ b/internal/goldencorpus/testdata/golden/cloud_resources_test_context.sarif.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/refs/heads/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:cloud_resources_test_context>"
+                },
+                "region": {
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Cloud Resource Identifier Detected in <golden:cloud_resources_test_context> at line 1 (confidence: 95.0% - HIGH). Matched text: 'arn:aws:iam::123456789012:role/PaymentsAdmin'"
+          },
+          "properties": {
+            "confidence": 95,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "account_id": "123456789012",
+              "confidence_adjustment": 0,
+              "confidence_factors": [
+                "base_match:+85",
+                "valid_account_id:+10"
+              ],
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "Financial",
+              "original_confidence": 95,
+              "provider": "aws",
+              "resource_type": "AWS_ARN",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0.1
+              },
+              "service": "iam",
+              "validation_path": "document"
+            },
+            "validator": "cloud_resources"
+          },
+          "rank": 82.5,
+          "ruleId": "AWS_ARN"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:cloud_resources_test_context>"
+                },
+                "region": {
+                  "startLine": 2
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Cloud Resource Identifier Detected in <golden:cloud_resources_test_context> at line 2 (confidence: 75.0% - MEDIUM). Matched text: 'arn:aws:iam::123456789012:role/PaymentsAdmin'"
+          },
+          "properties": {
+            "confidence": 75,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "account_id": "123456789012",
+              "confidence_adjustment": 0,
+              "confidence_factors": [
+                "base_match:+85",
+                "valid_account_id:+10",
+                "test_context:-20"
+              ],
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "Financial",
+              "original_confidence": 75,
+              "provider": "aws",
+              "resource_type": "AWS_ARN",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0.1
+              },
+              "service": "iam",
+              "validation_path": "document"
+            },
+            "validator": "cloud_resources"
+          },
+          "rank": 72.5,
+          "ruleId": "AWS_ARN"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/awslabs/ferret-scan",
+          "name": "Ferret Scan",
+          "rules": [
+            {
+              "fullDescription": {
+                "text": "A cloud provider resource identifier (e.g. AWS ARN, Azure resource ID, GCP resource name, OCI OCID, IBM CRN, or Alibaba ARN) was detected in the scanned content. These identifiers can expose account, subscription, project, or tenant identity and infrastructure layout."
+              },
+              "help": {
+                "text": "Cloud resource identifiers embed account/subscription/project anchors that reveal ownership and infrastructure topology. Avoid hardcoding them in source, logs, or shared documents. Use variables, parameters, or service discovery instead, and scrub identifiers from artifacts shared outside your organization."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/AWS_ARN.md",
+              "id": "AWS_ARN",
+              "shortDescription": {
+                "text": "Cloud Resource Identifier Detected"
+              }
+            }
+          ],
+          "semanticVersion": "0.0.0-development",
+          "version": "0.0.0-development"
+        }
+      },
+      "versionControlProvenance": [
+        {
+          "mappedTo": {
+            "uriBaseId": "%SRCROOT%"
+          },
+          "repositoryUri": "https://github.com/awslabs/ferret-scan",
+          "revisionId": "0.0.0-development"
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/internal/goldencorpus/testdata/golden/cloud_resources_test_context.txt
+++ b/internal/goldencorpus/testdata/golden/cloud_resources_test_context.txt
@@ -1,0 +1,4 @@
+LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH                          FILE
+--------------------------------------------------------------------------------------------------------
+[HIGH  ] cloud_res... AWS_ARN                95.00% line     1 arn:aws:iam::123456789012:r... <golden:cloud_resources_test_context>
+[MEDIUM] cloud_res... AWS_ARN                75.00% line     2 arn:aws:iam::123456789012:r... <golden:cloud_resources_test_context>

--- a/internal/goldencorpus/testdata/golden/cloud_resources_test_context.yaml
+++ b/internal/goldencorpus/testdata/golden/cloud_resources_test_context.yaml
@@ -1,0 +1,56 @@
+results:
+    - text: arn:aws:iam::123456789012:role/PaymentsAdmin
+      line_number: 1
+      type: AWS_ARN
+      confidence: 95
+      confidence_level: HIGH
+      filename: <golden:cloud_resources_test_context>
+      validator: cloud_resources
+      metadata:
+        account_id: "123456789012"
+        confidence_adjustment: 0
+        confidence_factors:
+            - base_match:+85
+            - valid_account_id:+10
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: Financial
+        original_confidence: 95
+        provider: aws
+        resource_type: AWS_ARN
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0.125
+        service: iam
+        validation_path: document
+    - text: arn:aws:iam::123456789012:role/PaymentsAdmin
+      line_number: 2
+      type: AWS_ARN
+      confidence: 75
+      confidence_level: MEDIUM
+      filename: <golden:cloud_resources_test_context>
+      validator: cloud_resources
+      metadata:
+        account_id: "123456789012"
+        confidence_adjustment: 0
+        confidence_factors:
+            - base_match:+85
+            - valid_account_id:+10
+            - test_context:-20
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: Financial
+        original_confidence: 75
+        provider: aws
+        resource_type: AWS_ARN
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0.125
+        service: iam
+        validation_path: document

--- a/internal/validators/cloudresources/cloudresources.go
+++ b/internal/validators/cloudresources/cloudresources.go
@@ -196,12 +196,16 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 	providerCounts := make(map[string]int)
 	var suppressedKeyword, suppressedLowConf int
 
-	// Per-line cache: matches on the same line share the same line text and its
-	// lowercase, so compute each once per distinct line-start offset rather than
-	// per match. On single-line input every match shares one line, so this turns
-	// the per-match O(content) ToLower/line-extraction into O(content) total.
+	// Per-line cache: matches on the same line share the same line text, its
+	// lowercase, AND whether that line carries a negative (test-context) keyword,
+	// so compute each once per distinct line-start offset rather than per match.
+	// The negative-keyword scan in particular is O(lineLen × keywords); hoisting
+	// it here turns the per-match O(content) work into O(content) total. On
+	// single-line input every match shares one line, so all of this is computed
+	// exactly once instead of once per (potentially tens of thousands of) matches.
 	cachedLineStart := -1
 	var cachedLine, cachedLineLower string
+	var cachedLineHasNegKw bool
 
 	for i := range raws {
 		if containedFlag[i] {
@@ -229,14 +233,15 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 			cachedLineStart = lineStart
 			cachedLine = content[lineStart:lineEnd]
 			cachedLineLower = strings.ToLower(cachedLine)
+			cachedLineHasNegKw = hasKeywordToken(cachedLineLower, v.negativeKeywords)
 		}
 		lineNo := lineIndex.lineAt(start)
 
-		confidence, factors := v.scoreMatch(text, resourceType, cachedLineLower, isCustom)
+		confidence, factors := v.scoreMatch(text, resourceType, cachedLineHasNegKw, isCustom)
 
 		// Below the sanity floor: too weak to surface at any confidence level.
 		if confidence < acceptThreshold {
-			if hasKeywordToken(cachedLineLower, v.negativeKeywords) {
+			if cachedLineHasNegKw {
 				suppressedKeyword++
 			} else {
 				suppressedLowConf++
@@ -416,9 +421,11 @@ func typeBaseConfidence(resourceType, match string) float64 {
 
 // scoreMatch computes the confidence and the list of contributing factors for a
 // match, using only the match text and its OWN line (never the whole document).
-// lineLower is the match's line, already lowercased by the caller (cached per
-// line) so this is not re-lowercased per match.
-func (v *Validator) scoreMatch(match, resourceType, lineLower string, isCustom bool) (float64, []string) {
+// lineHasNegKeyword reports whether the match's line carries a negative
+// (test-context) keyword; the caller computes it once per line (cached) so the
+// scan is not repeated per match. The public CalculateConfidence path, which has
+// no line context, passes false.
+func (v *Validator) scoreMatch(match, resourceType string, lineHasNegKeyword, isCustom bool) (float64, []string) {
 	base := typeBaseConfidence(resourceType, match)
 	if isCustom {
 		base = 75.0
@@ -447,8 +454,11 @@ func (v *Validator) scoreMatch(match, resourceType, lineLower string, isCustom b
 
 	// LOCAL test-context penalty: only the match's own line is considered, so a
 	// stray "example" elsewhere in the document cannot suppress a real finding.
-	// Whole-token match avoids dropping names like "company-templates".
-	if hasKeywordToken(lineLower, v.negativeKeywords) {
+	// Whole-token match avoids dropping names like "company-templates". The scan
+	// is hoisted to the caller (computed once per line) so this stays O(1) even
+	// when thousands of matches share one line — see ValidateContent's per-line
+	// cache. The public CalculateConfidence path passes false (no line context).
+	if lineHasNegKeyword {
 		confidence -= 20.0
 		factors = append(factors, "test_context:-20")
 	}
@@ -498,7 +508,7 @@ func isWordByte(b byte) bool {
 // which requires surrounding text) so the two paths do not diverge.
 func (v *Validator) CalculateConfidence(match string) (float64, map[string]bool) {
 	resourceType := getCloudResourceType(match)
-	confidence, _ := v.scoreMatch(match, resourceType, "", false)
+	confidence, _ := v.scoreMatch(match, resourceType, false, false)
 	checks := map[string]bool{
 		"valid_format":      true,
 		"valid_account_id":  extractAccountID(match) != "",

--- a/internal/validators/cloudresources/race_off_test.go
+++ b/internal/validators/cloudresources/race_off_test.go
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !race
+
+package cloudresources
+
+// raceEnabled reports whether the binary was built with the race detector. The
+// race detector adds large (5-20x), variable wall-clock overhead, so timing-based
+// regression tests use it to relax their wall-clock ceiling (the scan still runs,
+// so -race can still detect data races in the per-line cached state).
+const raceEnabled = false

--- a/internal/validators/cloudresources/race_on_test.go
+++ b/internal/validators/cloudresources/race_on_test.go
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build race
+
+package cloudresources
+
+// raceEnabled reports whether the binary was built with the race detector. The
+// race detector adds large (5-20x), variable wall-clock overhead, so timing-based
+// regression tests use it to relax their wall-clock ceiling (the scan still runs,
+// so -race can still detect data races in the per-line cached state).
+const raceEnabled = true

--- a/internal/validators/cloudresources/validator_timing_test.go
+++ b/internal/validators/cloudresources/validator_timing_test.go
@@ -1,0 +1,59 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudresources
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestCloudResources_SingleLineDoSGuard is a regression guard for the residual
+// O(n^2) blowup fixed alongside this test: scoreMatch re-ran hasKeywordToken
+// (a full-line, per-negative-keyword scan) for EVERY match, so a single line
+// packed with thousands of distinct ARNs cost O(matches x lineLen). On a ~1MB
+// single line the pre-fix cost was ~4.7s; after hoisting the negative-keyword
+// scan into the per-line cache it is well under 200ms.
+//
+// The trigger SHAPE matters: the input must be a single line of many DISTINCT,
+// matchable cloud-resource identifiers (minified-JSON/one-line-log shape). A
+// synthetic input that does not match cloud-resource patterns exercises none of
+// the per-match loop and would not reproduce the quadratic (the lesson from the
+// personname residual that earlier synthetic worst cases missed).
+func TestCloudResources_SingleLineDoSGuard(t *testing.T) {
+	const targetBytes = 1 << 20 // ~1MB single line, no newlines
+
+	var b strings.Builder
+	for i := 0; b.Len() < targetBytes; i++ {
+		// Distinct account id + role name each iteration so the containment
+		// dedup and match cap behave as they would on real dense input.
+		fmt.Fprintf(&b, "arn:aws:iam::%012d:role/Role%d ", i, i)
+	}
+	line := b.String()
+
+	// -race inflates wall-clock 5-20x, so relax the ceiling under the race
+	// detector. The scan still runs (so -race exercises the per-line cached
+	// state); only the timing bound is relaxed.
+	ceiling := 3 * time.Second
+	if raceEnabled {
+		ceiling = 30 * time.Second
+	}
+
+	v := NewValidator()
+	start := time.Now()
+	matches, err := v.ValidateContent(line, "worstcase.txt")
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("ValidateContent returned error: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Fatalf("expected matches on the worst-case line, got 0 (perf guard must not disable detection)")
+	}
+	if elapsed > ceiling {
+		t.Fatalf("ValidateContent on a %d-byte single line took %v (> %v ceiling); "+
+			"the O(n^2) per-match negative-keyword rescan may have regressed", len(line), elapsed, ceiling)
+	}
+	t.Logf("1MB single line: %d matches in %v (ceiling %v)", len(matches), elapsed, ceiling)
+}


### PR DESCRIPTION
## What

Part of the [v2 consolidation](docs/proposals/V2_ARCHITECTURE.md) Phase 3 (bounded execution). While re-grounding the single-long-line O(n²) work — most of which already landed in #9f81d93/#2b72961 — an adversarial re-audit found **one residual quadratic** that the earlier round missed: the **cloud-resources** validator.

The validator correctly hoists the per-line `ToLower` into a cache (`cachedLineLower`, computed once per distinct line-start), but the **negative-keyword scan was not hoisted**: `scoreMatch` ran `hasKeywordToken` over the whole cached line, and it is called **once per match**. On a single line packed with thousands of distinct cloud-resource identifiers (minified-JSON / one-line-log shape) that is `O(matches × lineLen × keywords)` = quadratic. The below-threshold branch made a *second* identical per-match scan.

cloudresources landed **after** the systemic DoS fix and reintroduced a per-match full-line scan behind the (correctly hoisted) `ToLower` cache — and, unlike the other 11 validators, it had **no timing regression guard**.

## Fix (behavior-preserving; performance only)

- Compute `hasKeywordToken` **once per line** into `cachedLineHasNegKw`, alongside the existing per-line `ToLower` cache.
- `scoreMatch` now takes a precomputed `lineHasNegKeyword bool` instead of the line text; the below-threshold branch reuses the same cached bool. `CalculateConfidence` (no line context) passes `false`, exactly equivalent to its prior `hasKeywordToken("", …) == false`.

## Measured (single line of distinct ARNs)

| input | before | after |
|---|---|---|
| 77 KB (2000 ARNs) | 164 ms | **6 ms** |
| 155 KB (4000 ARNs) | 638 ms | **14 ms** |
| 1 MB single line | 4.74 s | **55 ms** (86× faster) |

Before: ~4× time per 2× input (quadratic). After: ~2× (linear). The `maxMatchesPerPattern=5000` cap only dampened the floor, not the complexity class.

## Detection unchanged

- **Golden corpus byte-identical**, zero `UPDATE_GOLDEN`.
- Added golden case `cloud_resources_test_context` that locks the −20 test-context penalty: the same ARN scores **HIGH 95%** on a clean line and **MEDIUM 75%** on a line carrying `example` — the exact behavior the hoist must preserve.

## Regression guard

- Added `TestCloudResources_SingleLineDoSGuard` (1 MB single line must finish < 3s; relaxed under `-race` via the standard `raceEnabled` helper pair).
- **Negative control**: confirmed the test fails (4.57s) when the per-match rescan is reintroduced.
- Full suite + `-race` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)