### PR TITLE
feat(v2-refactor): cooperative cancellation in the remaining 7 line-loop validators (Phase 3, slice 3)

### DIFF
--- a/docs/proposals/V2_ARCHITECTURE.md
+++ b/docs/proposals/V2_ARCHITECTURE.md
@@ -297,6 +297,19 @@ polling inside validators, the concurrency limiter, the per-validator budget, an
 (Moves A, C). Behavior changes *only* on over-deadline/over-budget inputs (today: hang or crash; v2:
 bounded partial + explicit incomplete signal).
 
+> **Phase 3, slice 1 — per-line ctx polling in the three worst offenders — LANDED (PR #107).** The
+> audit-measured worst offenders (SSN, IP, phone) now implement `execguard.ContextAwareValidator` via a
+> new `ValidateContentCtx` that polls a shared `execguard.LineLoopCancelled(ctx, i)` primitive (reads
+> `ctx.Err()` every 256 lines, and on `i==0`) once per line; on deadline/cancel each returns the matches
+> gathered so far plus `ctx.Err()`. `ValidateContent` becomes a `context.Background()` shim, so the common
+> uncancelled path is byte-identical (golden corpus passes with zero `UPDATE_GOLDEN`). Because
+> `execguard.ValidateContent` already dispatches to `ContextAwareValidator` when implemented, the live scan
+> path routes through the ctx-aware form automatically: a runaway **multi-line** scan is reclaimed
+> promptly (SSN 0.01s vs 53.68s; IP 0.01s vs 5.18s; phone 0.01s vs 16.16s — negative-controlled).
+> **Still open in Phase 3:** the O(n²) **single-long-line** case (fixed by the shared `LineScan` primitive,
+> 4.1 — slice 2); adopting the ctx-poll in the remaining line-loop validators; and the concurrency
+> limiter + per-validator/extraction budgets (Move C).
+
 **Phase 4 — Surface and consolidate.** Add `ScanResult.Diagnostics` + opt-in degraded-coverage exit (1.4);
 the shared `LineScan` primitive (4.1); structured provenance (5.1); `Descriptor()` + data-driven routing
 (3.3, 5.3); the `Observer` seam and typed config schema (6.2, 6.4).

--- a/internal/execguard/linebudget.go
+++ b/internal/execguard/linebudget.go
@@ -1,0 +1,46 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package execguard
+
+import "context"
+
+// ctxCheckStride is how often (in loop iterations) a validator's line loop
+// consults the context. Checking ctx.Err() on every iteration would add a
+// (cheap but non-zero) atomic load to the hot path for no benefit; a stride of
+// 256 bounds the worst-case over-run to at most 255 extra lines after a deadline
+// fires — negligible against a multi-million-line runaway — while keeping the
+// per-line cost effectively free.
+const ctxCheckStride = 256
+
+// LineLoopCancelled reports whether a validator's per-line loop should stop
+// because its context is done (deadline exceeded or cancelled). It is the
+// v2 Phase 3 cooperative-cancellation primitive: validators that implement
+// execguard.ContextAwareValidator call this once per line so a runaway scan of a
+// large multi-line input is reclaimed promptly instead of running to completion.
+//
+// It only actually reads ctx.Err() every ctxCheckStride iterations (and always
+// on the first, i==0, so an already-expired budget skips the work entirely), so
+// the common case is a single integer-modulo test. A nil ctx never cancels.
+//
+// Usage in a validator's ValidateContentCtx:
+//
+//	for i, line := range lines {
+//	    if execguard.LineLoopCancelled(ctx, i) {
+//	        return matches, ctx.Err() // return partial matches + why we stopped
+//	    }
+//	    // ... scan line ...
+//	}
+//
+// Returning the partial matches gathered so far (rather than discarding them) is
+// deliberate: a timed-out DLP scan should surface what it found, and the caller
+// records ctx.Err() as an incomplete-coverage signal (see ScanResult.Incomplete).
+func LineLoopCancelled(ctx context.Context, i int) bool {
+	if ctx == nil {
+		return false
+	}
+	if i%ctxCheckStride != 0 {
+		return false
+	}
+	return ctx.Err() != nil
+}

--- a/internal/validators/creditcard/ctx_cancel_test.go
+++ b/internal/validators/creditcard/ctx_cancel_test.go
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package creditcard
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestValidateContentCtx_ReclaimsRunawayMultiLineScan: a cancelled context stops a
+// large multi-line scan promptly (v2 Phase 3 per-line ctx polling).
+func TestValidateContentCtx_ReclaimsRunawayMultiLineScan(t *testing.T) {
+	v := NewValidator()
+	content := strings.Repeat("visa 4532015112830366 mc 5425233430109903\n", 500000)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_, err := v.ValidateContentCtx(ctx, content, "<stdin>")
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Errorf("cancelled scan took %v; expected prompt return", elapsed)
+	}
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestValidateContent_BackgroundShimEqualsCtx: the non-ctx shim must produce the
+// same result as ValidateContentCtx with a never-cancelling context.
+func TestValidateContent_BackgroundShimEqualsCtx(t *testing.T) {
+	const content = "visa 4532015112830366\nmc 5425233430109903\n"
+	shim, err1 := NewValidator().ValidateContent(content, "<stdin>")
+	ctxRes, err2 := NewValidator().ValidateContentCtx(context.Background(), content, "<stdin>")
+	if err1 != nil || err2 != nil {
+		t.Fatalf("unexpected errors: shim=%v ctx=%v", err1, err2)
+	}
+	if len(shim) != len(ctxRes) {
+		t.Errorf("shim vs ctx match count differ: %d != %d", len(shim), len(ctxRes))
+	}
+}

--- a/internal/validators/creditcard/validator.go
+++ b/internal/validators/creditcard/validator.go
@@ -4,6 +4,7 @@
 package creditcard
 
 import (
+	stdctx "context"
 	"fmt"
 	"os"
 	"regexp"
@@ -11,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/awslabs/ferret-scan/internal/detector"
+	"github.com/awslabs/ferret-scan/internal/execguard"
 	"github.com/awslabs/ferret-scan/internal/observability"
 )
 
@@ -168,6 +170,15 @@ func (v *Validator) Validate(filePath string) ([]detector.Match, error) {
 
 // ValidateContent validates preprocessed content with optimized performance
 func (v *Validator) ValidateContent(content string, originalPath string) ([]detector.Match, error) {
+	// Backward-compatible shim: run with a background context (never cancels).
+	return v.ValidateContentCtx(stdctx.Background(), content, originalPath)
+}
+
+// ValidateContentCtx implements execguard.ContextAwareValidator: the context-aware
+// form of ValidateContent, polling ctx once per line so a runaway multi-line scan
+// is reclaimed promptly (v2 Phase 3). Returns partial matches + ctx.Err() on
+// cancellation.
+func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, originalPath string) ([]detector.Match, error) {
 	var finishTiming func(bool, map[string]interface{})
 	if v.observer != nil {
 		finishTiming = v.observer.StartTiming("creditcard_validator_optimized", "validate_content", originalPath)
@@ -177,6 +188,13 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 	lines := strings.Split(content, "\n")
 
 	for lineNum, line := range lines {
+		// Cooperative cancellation (v2 Phase 3): bail promptly on deadline/cancel.
+		if execguard.LineLoopCancelled(ctx, lineNum) {
+			if finishTiming != nil {
+				finishTiming(false, map[string]interface{}{"cancelled": true, "match_count": len(matches)})
+			}
+			return matches, ctx.Err()
+		}
 		// PERFORMANCE: several context operations are a function of the LINE
 		// (not the individual match), so a single very long line packed with N
 		// PANs previously recomputed each of them O(N) times, giving O(N * len)

--- a/internal/validators/email/ctx_cancel_test.go
+++ b/internal/validators/email/ctx_cancel_test.go
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package email
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestValidateContentCtx_ReclaimsRunawayMultiLineScan: a cancelled context stops a
+// large multi-line scan promptly (v2 Phase 3 per-line ctx polling).
+func TestValidateContentCtx_ReclaimsRunawayMultiLineScan(t *testing.T) {
+	v := NewValidator()
+	content := strings.Repeat("contact john.doe@example.com or admin@acme-corp.com today\n", 500000)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_, err := v.ValidateContentCtx(ctx, content, "<stdin>")
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Errorf("cancelled scan took %v; expected prompt return", elapsed)
+	}
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestValidateContent_BackgroundShimEqualsCtx: the non-ctx shim must produce the
+// same result as ValidateContentCtx with a never-cancelling context.
+func TestValidateContent_BackgroundShimEqualsCtx(t *testing.T) {
+	const content = "contact john.doe@example.com or admin@acme-corp.com\nsupport@business.io\n"
+	shim, err1 := NewValidator().ValidateContent(content, "<stdin>")
+	ctxRes, err2 := NewValidator().ValidateContentCtx(context.Background(), content, "<stdin>")
+	if err1 != nil || err2 != nil {
+		t.Fatalf("unexpected errors: shim=%v ctx=%v", err1, err2)
+	}
+	if len(shim) != len(ctxRes) {
+		t.Errorf("shim vs ctx match count differ: %d != %d", len(shim), len(ctxRes))
+	}
+}

--- a/internal/validators/email/validator.go
+++ b/internal/validators/email/validator.go
@@ -4,11 +4,13 @@
 package email
 
 import (
+	stdctx "context"
 	"os"
 	"regexp"
 	"strings"
 
 	"github.com/awslabs/ferret-scan/internal/detector"
+	"github.com/awslabs/ferret-scan/internal/execguard"
 	"github.com/awslabs/ferret-scan/internal/observability"
 )
 
@@ -215,6 +217,15 @@ func (v *Validator) Validate(filePath string) ([]detector.Match, error) {
 
 // ValidateContent validates preprocessed content for email addresses
 func (v *Validator) ValidateContent(content string, originalPath string) ([]detector.Match, error) {
+	// Backward-compatible shim: run with a background context (never cancels).
+	return v.ValidateContentCtx(stdctx.Background(), content, originalPath)
+}
+
+// ValidateContentCtx implements execguard.ContextAwareValidator: the context-aware
+// form of ValidateContent, polling ctx once per line so a runaway multi-line scan
+// is reclaimed promptly (v2 Phase 3). Returns partial matches + ctx.Err() on
+// cancellation.
+func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, originalPath string) ([]detector.Match, error) {
 	var finishTiming func(bool, map[string]interface{})
 	if v.observer != nil {
 		finishTiming = v.observer.StartTiming("email_validator", "validate_content", originalPath)
@@ -229,6 +240,13 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 	re := v.regex
 
 	for lineNum, line := range lines {
+		// Cooperative cancellation (v2 Phase 3): bail promptly on deadline/cancel.
+		if execguard.LineLoopCancelled(ctx, lineNum) {
+			if finishTiming != nil {
+				finishTiming(false, map[string]interface{}{"cancelled": true, "match_count": len(matches)})
+			}
+			return matches, ctx.Err()
+		}
 		// Use match offsets (not just the strings) so that when the same email
 		// text appears more than once on a line, each occurrence is analyzed with
 		// ITS OWN surrounding context. The previous code re-ran strings.Index,

--- a/internal/validators/intellectualproperty/ctx_cancel_test.go
+++ b/internal/validators/intellectualproperty/ctx_cancel_test.go
@@ -1,0 +1,46 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package intellectualproperty
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestValidateContentCtx_ReclaimsRunawayMultiLineScan: a cancelled context stops a
+// large multi-line scan promptly (v2 Phase 3 per-line ctx polling, threaded into
+// detectPatternsByLine). The partial per-line matches are still reconstructed and
+// returned with ctx.Err().
+func TestValidateContentCtx_ReclaimsRunawayMultiLineScan(t *testing.T) {
+	v := NewValidator()
+	content := strings.Repeat("Copyright (c) 2024 Acme Corp. All rights reserved. Patent US1234567B2\n", 500000)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_, err := v.ValidateContentCtx(ctx, content, "<stdin>")
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Errorf("cancelled scan took %v; expected prompt return", elapsed)
+	}
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestValidateContent_BackgroundShimEqualsCtx: the non-ctx shim must produce the
+// same result as ValidateContentCtx with a never-cancelling context.
+func TestValidateContent_BackgroundShimEqualsCtx(t *testing.T) {
+	const content = "Copyright (c) 2024 Acme Corp. All rights reserved.\nPatent US1234567B2\n"
+	shim, err1 := NewValidator().ValidateContent(content, "<stdin>")
+	ctxRes, err2 := NewValidator().ValidateContentCtx(context.Background(), content, "<stdin>")
+	if err1 != nil || err2 != nil {
+		t.Fatalf("unexpected errors: shim=%v ctx=%v", err1, err2)
+	}
+	if len(shim) != len(ctxRes) {
+		t.Errorf("shim vs ctx match count differ: %d != %d", len(shim), len(ctxRes))
+	}
+}

--- a/internal/validators/intellectualproperty/validator.go
+++ b/internal/validators/intellectualproperty/validator.go
@@ -4,6 +4,7 @@
 package intellectualproperty
 
 import (
+	stdctx "context"
 	"fmt"
 	"os"
 	"regexp"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/awslabs/ferret-scan/internal/config"
 	"github.com/awslabs/ferret-scan/internal/detector"
+	"github.com/awslabs/ferret-scan/internal/execguard"
 	"github.com/awslabs/ferret-scan/internal/observability"
 )
 
@@ -697,12 +699,25 @@ func (v *Validator) Validate(filePath string) ([]detector.Match, error) {
 
 // ValidateContent validates preprocessed content for intellectual property references
 func (v *Validator) ValidateContent(content string, originalPath string) ([]detector.Match, error) {
+	// Backward-compatible shim: run with a background context (never cancels).
+	return v.ValidateContentCtx(stdctx.Background(), content, originalPath)
+}
+
+// ValidateContentCtx implements execguard.ContextAwareValidator: the context-aware
+// form of ValidateContent, polling ctx once per line (inside detectPatternsByLine)
+// so a runaway multi-line scan is reclaimed promptly (v2 Phase 3). On cancellation
+// the line loop stops; the partial per-line matches gathered so far are still run
+// through legal-notice reconstruction and returned along with ctx.Err().
+func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, originalPath string) ([]detector.Match, error) {
 	// Use line-based grouping for legal notice reconstruction
-	lineMatches := v.detectPatternsByLine(content, originalPath)
+	lineMatches := v.detectPatternsByLine(ctx, content, originalPath)
 
 	// Process line matches with legal notice reconstruction logic
 	processedMatches := v.processLineMatches(lineMatches)
 
+	if ctx.Err() != nil {
+		return processedMatches, ctx.Err()
+	}
 	return processedMatches, nil
 }
 
@@ -841,13 +856,18 @@ func (v *Validator) processLineMatches(lineMatches map[int][]detector.Match) []d
 }
 
 // detectPatternsByLine detects IP patterns and groups matches by line number
-func (v *Validator) detectPatternsByLine(content string, originalPath string) map[int][]detector.Match {
+func (v *Validator) detectPatternsByLine(ctx stdctx.Context, content string, originalPath string) map[int][]detector.Match {
 	lineMatches := make(map[int][]detector.Match)
 
 	// Split content into lines for processing
 	lines := strings.Split(content, "\n")
 
 	for lineNum, line := range lines {
+		// Cooperative cancellation (v2 Phase 3): stop promptly on deadline/cancel,
+		// returning the per-line matches gathered so far.
+		if execguard.LineLoopCancelled(ctx, lineNum) {
+			return lineMatches
+		}
 		// PERFORMANCE: keyword context impact and the open-source-license check
 		// are LINE-GLOBAL — they depend only on the line text, not on the
 		// individual match or its position. The previous code recomputed them

--- a/internal/validators/ipaddress/ctx_cancel_test.go
+++ b/internal/validators/ipaddress/ctx_cancel_test.go
@@ -1,0 +1,48 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ipaddress
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestValidateContentCtx_ReclaimsRunawayMultiLineScan: a cancelled context stops
+// a large multi-line IP scan promptly (v2 Phase 3 per-line ctx polling).
+func TestValidateContentCtx_ReclaimsRunawayMultiLineScan(t *testing.T) {
+	v := NewValidator()
+	content := strings.Repeat("host 203.0.113.42 gw 192.168.1.1 dns 8.8.8.8\n", 500000)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_, err := v.ValidateContentCtx(ctx, content, "<stdin>")
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Errorf("cancelled scan took %v; expected prompt return", elapsed)
+	}
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestValidateContent_BackgroundShimEqualsCtx: the non-ctx shim must produce the
+// exact same result as ValidateContentCtx with a never-cancelling context — that
+// is the behavior-preserving invariant (the shim just supplies context.Background).
+// Asserting equality avoids coupling the test to IP-scoring specifics.
+func TestValidateContent_BackgroundShimEqualsCtx(t *testing.T) {
+	v := NewValidator()
+	const content = "server address 203.0.113.50 for access\nprivate 10.0.0.5 internal\n"
+
+	shim, err1 := v.ValidateContent(content, "<stdin>")
+	ctxRes, err2 := v.ValidateContentCtx(context.Background(), content, "<stdin>")
+	if err1 != nil || err2 != nil {
+		t.Fatalf("unexpected errors: shim=%v ctx=%v", err1, err2)
+	}
+	if len(shim) != len(ctxRes) {
+		t.Errorf("shim vs ctx match count differ: %d != %d", len(shim), len(ctxRes))
+	}
+}

--- a/internal/validators/ipaddress/validator.go
+++ b/internal/validators/ipaddress/validator.go
@@ -4,12 +4,14 @@
 package ipaddress
 
 import (
+	stdctx "context"
 	"net"
 	"os"
 	"regexp"
 	"strings"
 
 	"github.com/awslabs/ferret-scan/internal/detector"
+	"github.com/awslabs/ferret-scan/internal/execguard"
 	"github.com/awslabs/ferret-scan/internal/observability"
 )
 
@@ -264,6 +266,15 @@ func (v *Validator) Validate(filePath string) ([]detector.Match, error) {
 
 // ValidateContent validates preprocessed content for IP addresses
 func (v *Validator) ValidateContent(content string, originalPath string) ([]detector.Match, error) {
+	// Backward-compatible shim: run with a background context (never cancels).
+	return v.ValidateContentCtx(stdctx.Background(), content, originalPath)
+}
+
+// ValidateContentCtx implements execguard.ContextAwareValidator: the context-aware
+// form of ValidateContent, polling ctx once per line so a runaway multi-line scan
+// is reclaimed promptly (v2 Phase 3). Returns partial matches + ctx.Err() on
+// cancellation.
+func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, originalPath string) ([]detector.Match, error) {
 	var finishTiming func(bool, map[string]interface{})
 	if v.observer != nil {
 		finishTiming = v.observer.StartTiming("ipaddress_validator", "validate_content", originalPath)
@@ -276,6 +287,13 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 
 	// Process each pattern type
 	for lineNum, line := range lines {
+		// Cooperative cancellation (v2 Phase 3): bail promptly on deadline/cancel.
+		if execguard.LineLoopCancelled(ctx, lineNum) {
+			if finishTiming != nil {
+				finishTiming(false, map[string]interface{}{"cancelled": true, "match_count": len(matches)})
+			}
+			return matches, ctx.Err()
+		}
 		// Cheap per-line fast paths: every IPv6 form needs a ":" and the
 		// compressed form additionally needs a "::". Skipping the (multi-branch)
 		// IPv6 regexes on lines that cannot possibly contain such an address

--- a/internal/validators/passport/ctx_cancel_test.go
+++ b/internal/validators/passport/ctx_cancel_test.go
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package passport
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestValidateContentCtx_ReclaimsRunawayMultiLineScan: a cancelled context stops a
+// large multi-line scan promptly (v2 Phase 3 per-line ctx polling).
+func TestValidateContentCtx_ReclaimsRunawayMultiLineScan(t *testing.T) {
+	v := NewValidator()
+	content := strings.Repeat("passport number 123456789 issued to traveler\n", 500000)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_, err := v.ValidateContentCtx(ctx, content, "<stdin>")
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Errorf("cancelled scan took %v; expected prompt return", elapsed)
+	}
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestValidateContent_BackgroundShimEqualsCtx: the non-ctx shim must produce the
+// same result as ValidateContentCtx with a never-cancelling context.
+func TestValidateContent_BackgroundShimEqualsCtx(t *testing.T) {
+	const content = "passport number 123456789 issued to traveler\nsecond line 987654321\n"
+	shim, err1 := NewValidator().ValidateContent(content, "<stdin>")
+	ctxRes, err2 := NewValidator().ValidateContentCtx(context.Background(), content, "<stdin>")
+	if err1 != nil || err2 != nil {
+		t.Fatalf("unexpected errors: shim=%v ctx=%v", err1, err2)
+	}
+	if len(shim) != len(ctxRes) {
+		t.Errorf("shim vs ctx match count differ: %d != %d", len(shim), len(ctxRes))
+	}
+}

--- a/internal/validators/passport/validator.go
+++ b/internal/validators/passport/validator.go
@@ -4,12 +4,14 @@
 package passport
 
 import (
+	stdctx "context"
 	"regexp"
 	"strings"
 	"unicode"
 
 	"github.com/awslabs/ferret-scan/internal/context"
 	"github.com/awslabs/ferret-scan/internal/detector"
+	"github.com/awslabs/ferret-scan/internal/execguard"
 	"github.com/awslabs/ferret-scan/internal/observability"
 )
 
@@ -346,12 +348,25 @@ const maxMatchesPerLinePerPattern = 2000
 
 // ValidateContent validates preprocessed content for passport numbers
 func (v *Validator) ValidateContent(content string, originalPath string) ([]detector.Match, error) {
+	// Backward-compatible shim: run with a background context (never cancels).
+	return v.ValidateContentCtx(stdctx.Background(), content, originalPath)
+}
+
+// ValidateContentCtx implements execguard.ContextAwareValidator: the context-aware
+// form of ValidateContent, polling ctx once per line so a runaway multi-line scan
+// is reclaimed promptly (v2 Phase 3). On cancellation it returns the matches
+// gathered so far plus ctx.Err().
+func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, originalPath string) ([]detector.Match, error) {
 	var matches []detector.Match
 
 	// Split content into lines for processing
 	lines := strings.Split(content, "\n")
 
 	for lineNum, line := range lines {
+		// Cooperative cancellation (v2 Phase 3): bail promptly on deadline/cancel.
+		if execguard.LineLoopCancelled(ctx, lineNum) {
+			return matches, ctx.Err()
+		}
 		// Per-LINE work hoisted OUT of the per-match loop. These values depend
 		// only on the line (not on the individual match), so computing them once
 		// per line instead of once per match removes the dominant

--- a/internal/validators/personname/ctx_cancel_test.go
+++ b/internal/validators/personname/ctx_cancel_test.go
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package personname
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestValidateContentCtx_ReclaimsRunawayMultiLineScan: a cancelled context stops a
+// large multi-line scan promptly (v2 Phase 3 per-line ctx polling). personname
+// returns the pre-dedup partial matches plus ctx.Err() on cancel.
+func TestValidateContentCtx_ReclaimsRunawayMultiLineScan(t *testing.T) {
+	v := NewValidator()
+	content := strings.Repeat("John Smith and Jane Doe met Robert Brown today\n", 500000)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_, err := v.ValidateContentCtx(ctx, content, "<stdin>")
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Errorf("cancelled scan took %v; expected prompt return", elapsed)
+	}
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestValidateContent_BackgroundShimEqualsCtx: the non-ctx shim must produce the
+// same result as ValidateContentCtx with a never-cancelling context.
+func TestValidateContent_BackgroundShimEqualsCtx(t *testing.T) {
+	const content = "John Smith and Jane Doe met Robert Brown today\nAlice Johnson called\n"
+	shim, err1 := NewValidator().ValidateContent(content, "<stdin>")
+	ctxRes, err2 := NewValidator().ValidateContentCtx(context.Background(), content, "<stdin>")
+	if err1 != nil || err2 != nil {
+		t.Fatalf("unexpected errors: shim=%v ctx=%v", err1, err2)
+	}
+	if len(shim) != len(ctxRes) {
+		t.Errorf("shim vs ctx match count differ: %d != %d", len(shim), len(ctxRes))
+	}
+}

--- a/internal/validators/personname/validator.go
+++ b/internal/validators/personname/validator.go
@@ -4,6 +4,7 @@
 package personname
 
 import (
+	stdctx "context"
 	"regexp"
 	"slices"
 	"strings"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/awslabs/ferret-scan/internal/context"
 	"github.com/awslabs/ferret-scan/internal/detector"
+	"github.com/awslabs/ferret-scan/internal/execguard"
 	"github.com/awslabs/ferret-scan/internal/observability"
 )
 
@@ -105,6 +107,15 @@ func (v *Validator) Validate(filePath string) ([]detector.Match, error) {
 
 // ValidateContent implements the detector.Validator interface for preprocessed content
 func (v *Validator) ValidateContent(content string, originalPath string) ([]detector.Match, error) {
+	// Backward-compatible shim: run with a background context (never cancels).
+	return v.ValidateContentCtx(stdctx.Background(), content, originalPath)
+}
+
+// ValidateContentCtx implements execguard.ContextAwareValidator: the context-aware
+// form of ValidateContent, polling ctx once per line so a runaway multi-line scan
+// is reclaimed promptly (v2 Phase 3). On cancellation it returns the (pre-dedup)
+// matches gathered so far plus ctx.Err().
+func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, originalPath string) ([]detector.Match, error) {
 	var matches []detector.Match
 
 	// Ensure name databases are loaded
@@ -112,6 +123,10 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 
 	lines := strings.Split(content, "\n")
 	for lineNum, line := range lines {
+		// Cooperative cancellation (v2 Phase 3): bail promptly on deadline/cancel.
+		if execguard.LineLoopCancelled(ctx, lineNum) {
+			return matches, ctx.Err()
+		}
 		lineMatches := v.findNamesInLine(line, lineNum+1, originalPath)
 		matches = append(matches, lineMatches...)
 	}

--- a/internal/validators/phone/ctx_cancel_test.go
+++ b/internal/validators/phone/ctx_cancel_test.go
@@ -1,0 +1,42 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package phone
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestValidateContentCtx_ReclaimsRunawayMultiLineScan: a cancelled context stops
+// a large multi-line phone scan promptly (v2 Phase 3 per-line ctx polling).
+func TestValidateContentCtx_ReclaimsRunawayMultiLineScan(t *testing.T) {
+	v := NewValidator()
+	content := strings.Repeat("call 212-555-0142 or 415-555-0199 or 312-555-0123\n", 500000)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_, err := v.ValidateContentCtx(ctx, content, "<stdin>")
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Errorf("cancelled scan took %v; expected prompt return", elapsed)
+	}
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestValidateContent_BackgroundShimUnaffected: the non-ctx shim still detects.
+func TestValidateContent_BackgroundShimUnaffected(t *testing.T) {
+	v := NewValidator()
+	matches, err := v.ValidateContent("call me at 212-555-0142 tomorrow", "<stdin>")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Error("expected the phone number to be detected via the background shim")
+	}
+}

--- a/internal/validators/phone/validator.go
+++ b/internal/validators/phone/validator.go
@@ -4,6 +4,7 @@
 package phone
 
 import (
+	stdctx "context"
 	"os"
 	"regexp"
 	"sort"
@@ -11,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/awslabs/ferret-scan/internal/detector"
+	"github.com/awslabs/ferret-scan/internal/execguard"
 	"github.com/awslabs/ferret-scan/internal/observability"
 )
 
@@ -286,6 +288,15 @@ func (v *Validator) Validate(filePath string) ([]detector.Match, error) {
 
 // ValidateContent validates preprocessed content for phone numbers
 func (v *Validator) ValidateContent(content string, originalPath string) ([]detector.Match, error) {
+	// Backward-compatible shim: run with a background context (never cancels).
+	return v.ValidateContentCtx(stdctx.Background(), content, originalPath)
+}
+
+// ValidateContentCtx implements execguard.ContextAwareValidator: the context-aware
+// form of ValidateContent, polling ctx once per line so a runaway multi-line scan
+// is reclaimed promptly (v2 Phase 3). Returns partial matches + ctx.Err() on
+// cancellation.
+func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, originalPath string) ([]detector.Match, error) {
 	var finishTiming func(bool, map[string]interface{})
 	if v.observer != nil {
 		finishTiming = v.observer.StartTiming("phone_validator", "validate_content", originalPath)
@@ -298,6 +309,13 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 
 	// Process each pattern type
 	for lineNum, line := range lines {
+		// Cooperative cancellation (v2 Phase 3): bail promptly on deadline/cancel.
+		if execguard.LineLoopCancelled(ctx, lineNum) {
+			if finishTiming != nil {
+				finishTiming(false, map[string]interface{}{"cancelled": true, "match_count": len(matches)})
+			}
+			return matches, ctx.Err()
+		}
 		// Per-line state hoisted out of the per-match loop:
 		//   - dedup indexes the cleaned-digit form of every match already accepted
 		//     on THIS line so duplicate detection is O(1)-amortized per candidate

--- a/internal/validators/socialmedia/ctx_cancel_test.go
+++ b/internal/validators/socialmedia/ctx_cancel_test.go
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package socialmedia
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestValidateContentCtx_ReclaimsRunawayMultiLineScan: a cancelled context stops a
+// large multi-line scan promptly (v2 Phase 3 per-line ctx polling, threaded into
+// detectPatternsByLine). Uses newConfiguredValidator so patterns are compiled and
+// the per-line loop actually runs (the unconfigured validator returns early,
+// before the loop).
+func TestValidateContentCtx_ReclaimsRunawayMultiLineScan(t *testing.T) {
+	v := newConfiguredValidator()
+	content := strings.Repeat("follow https://twitter.com/johndoe and https://github.com/johndoe\n", 500000)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_, err := v.ValidateContentCtx(ctx, content, "<stdin>")
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Errorf("cancelled scan took %v; expected prompt return", elapsed)
+	}
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestValidateContent_BackgroundShimEqualsCtx: the non-ctx shim must produce the
+// same result as ValidateContentCtx with a never-cancelling context.
+func TestValidateContent_BackgroundShimEqualsCtx(t *testing.T) {
+	const content = "follow https://twitter.com/johndoe\nhttps://github.com/johndoe\n"
+	shim, err1 := newConfiguredValidator().ValidateContent(content, "<stdin>")
+	ctxRes, err2 := newConfiguredValidator().ValidateContentCtx(context.Background(), content, "<stdin>")
+	if err1 != nil || err2 != nil {
+		t.Fatalf("unexpected errors: shim=%v ctx=%v", err1, err2)
+	}
+	if len(shim) != len(ctxRes) {
+		t.Errorf("shim vs ctx match count differ: %d != %d", len(shim), len(ctxRes))
+	}
+}

--- a/internal/validators/socialmedia/validator.go
+++ b/internal/validators/socialmedia/validator.go
@@ -4,6 +4,7 @@
 package socialmedia
 
 import (
+	stdctx "context"
 	"fmt"
 	"os"
 	"regexp"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/awslabs/ferret-scan/internal/config"
 	"github.com/awslabs/ferret-scan/internal/detector"
+	"github.com/awslabs/ferret-scan/internal/execguard"
 	"github.com/awslabs/ferret-scan/internal/observability"
 )
 
@@ -558,6 +560,16 @@ func (v *Validator) Validate(filePath string) ([]detector.Match, error) {
 
 // ValidateContent validates preprocessed content for social media references
 func (v *Validator) ValidateContent(content string, originalPath string) ([]detector.Match, error) {
+	// Backward-compatible shim: run with a background context (never cancels).
+	return v.ValidateContentCtx(stdctx.Background(), content, originalPath)
+}
+
+// ValidateContentCtx implements execguard.ContextAwareValidator: the context-aware
+// form of ValidateContent, polling ctx once per line (inside detectPatternsByLine)
+// so a runaway multi-line scan is reclaimed promptly (v2 Phase 3). On cancellation
+// the line loop stops and the partial per-line matches gathered so far are
+// clustered and returned along with ctx.Err().
+func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, originalPath string) ([]detector.Match, error) {
 	var finishTiming func(bool, map[string]any)
 	if v.observer != nil {
 		finishTiming = v.observer.StartTiming("social_media_validator", "validate_content", originalPath)
@@ -605,7 +617,7 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 	}
 
 	// Use line-based processing for social media pattern detection with error handling
-	lineMatches, err := v.detectPatternsByLineWithErrorHandling(content, originalPath)
+	lineMatches, err := v.detectPatternsByLineWithErrorHandling(ctx, content, originalPath)
 	if err != nil {
 		// Log error but continue with empty results for graceful degradation
 		if v.observer != nil && v.observer.DebugObserver != nil {
@@ -656,11 +668,19 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 		}
 	}
 
+	// If the scan was cancelled/timed out mid-line-loop, the detection above
+	// returned only the lines processed before the deadline. Surface ctx.Err() so
+	// the caller records incomplete coverage (v2 Phase 3); the clustered partial
+	// matches are still returned.
+	if ctx.Err() != nil {
+		return processedMatches, ctx.Err()
+	}
+
 	return processedMatches, nil
 }
 
 // detectPatternsByLineWithErrorHandling wraps detectPatternsByLine with comprehensive error handling
-func (v *Validator) detectPatternsByLineWithErrorHandling(content string, originalPath string) (map[int][]detector.Match, error) {
+func (v *Validator) detectPatternsByLineWithErrorHandling(ctx stdctx.Context, content string, originalPath string) (map[int][]detector.Match, error) {
 	defer func() {
 		if r := recover(); r != nil {
 			// Log panic recovery for debugging
@@ -690,7 +710,7 @@ func (v *Validator) detectPatternsByLineWithErrorHandling(content string, origin
 	}
 
 	// Call the original method with error handling
-	lineMatches := v.detectPatternsByLine(content, originalPath)
+	lineMatches := v.detectPatternsByLine(ctx, content, originalPath)
 	return lineMatches, nil
 }
 
@@ -2521,7 +2541,7 @@ func (v *Validator) compileWhitelistPatterns() {
 
 // detectPatternsByLine detects social media patterns and groups matches by line number
 // with platform categorization, metadata tagging, and batch processing optimizations
-func (v *Validator) detectPatternsByLine(content string, originalPath string) map[int][]detector.Match {
+func (v *Validator) detectPatternsByLine(ctx stdctx.Context, content string, originalPath string) map[int][]detector.Match {
 	lineMatches := make(map[int][]detector.Match)
 
 	// If no patterns are configured, return empty results
@@ -2537,7 +2557,7 @@ func (v *Validator) detectPatternsByLine(content string, originalPath string) ma
 	useBatchProcessing := contentLength > 1024*1024 // 1MB threshold
 
 	if useBatchProcessing {
-		return v.detectPatternsByLineBatch(content, originalPath)
+		return v.detectPatternsByLineBatch(ctx, content, originalPath)
 	}
 
 	// Split content into lines for processing
@@ -2548,6 +2568,11 @@ func (v *Validator) detectPatternsByLine(content string, originalPath string) ma
 
 	// Process each line for social media patterns with optimizations
 	for lineNum, line := range lines {
+		// Cooperative cancellation (v2 Phase 3): stop promptly on deadline/cancel,
+		// returning the per-line matches gathered so far.
+		if execguard.LineLoopCancelled(ctx, lineNum) {
+			return lineMatches
+		}
 		// Skip empty lines early
 		if len(strings.TrimSpace(line)) == 0 {
 			continue
@@ -2561,7 +2586,7 @@ func (v *Validator) detectPatternsByLine(content string, originalPath string) ma
 }
 
 // detectPatternsByLineBatch processes large files using batch processing for better performance
-func (v *Validator) detectPatternsByLineBatch(content string, originalPath string) map[int][]detector.Match {
+func (v *Validator) detectPatternsByLineBatch(ctx stdctx.Context, content string, originalPath string) map[int][]detector.Match {
 	lineMatches := make(map[int][]detector.Match)
 
 	// Split content into lines
@@ -2576,6 +2601,11 @@ func (v *Validator) detectPatternsByLineBatch(content string, originalPath strin
 
 		// Process batch
 		for lineNum := i; lineNum < end; lineNum++ {
+			// Cooperative cancellation (v2 Phase 3): stop promptly on
+			// deadline/cancel, returning the per-line matches gathered so far.
+			if execguard.LineLoopCancelled(ctx, lineNum) {
+				return lineMatches
+			}
 			line := lines[lineNum]
 
 			// Skip empty lines early

--- a/internal/validators/ssn/ctx_cancel_test.go
+++ b/internal/validators/ssn/ctx_cancel_test.go
@@ -1,0 +1,106 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ssn
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/awslabs/ferret-scan/internal/execguard"
+)
+
+// TestValidateContentCtx_ReclaimsRunawayMultiLineScan is the v2 Phase 3
+// regression test: a large multi-line input that would otherwise run to
+// completion is reclaimed promptly when the context is already cancelled — the
+// validator polls ctx per line and returns ctx.Err() instead of scanning every
+// line.
+func TestValidateContentCtx_ReclaimsRunawayMultiLineScan(t *testing.T) {
+	v := NewValidator()
+
+	// Many lines of dense near-SSN tokens — enough that a full scan is clearly
+	// measurable, so an early return is unambiguous.
+	line := "ssn 449-87-4100 and 555-12-3456 and 111-22-3333"
+	content := strings.Repeat(line+"\n", 500000)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled: the loop must bail on (or before) the first check
+
+	start := time.Now()
+	matches, err := v.ValidateContentCtx(ctx, content, "<stdin>")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Error("expected a context error from a cancelled scan, got nil")
+	}
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+	// Reclaimed promptly: must not scan all 500k lines. Generous ceiling guards
+	// against a regression where the poll is missing (which would take seconds).
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("cancelled scan took %v; expected prompt return (per-line ctx poll missing?)", elapsed)
+	}
+	// Partial matches are acceptable (<= the first ctxCheckStride lines' worth);
+	// the point is we did NOT scan the whole input.
+	_ = matches
+}
+
+// TestValidateContentCtx_DeadlineWhileScanning verifies a deadline that fires
+// mid-scan also reclaims the loop (not just an already-cancelled context).
+func TestValidateContentCtx_DeadlineWhileScanning(t *testing.T) {
+	v := NewValidator()
+	content := strings.Repeat("ssn 449-87-4100 more text here\n", 2000000)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := v.ValidateContentCtx(ctx, content, "<stdin>")
+	elapsed := time.Since(start)
+
+	if err != context.DeadlineExceeded {
+		t.Errorf("expected context.DeadlineExceeded, got %v", err)
+	}
+	// Should stop within a small multiple of the 50ms budget, not scan 2M lines.
+	if elapsed > 5*time.Second {
+		t.Errorf("scan ran %v past a 50ms deadline; ctx polling not effective", elapsed)
+	}
+}
+
+// TestValidateContent_BackgroundShimUnaffected confirms the non-ctx shim behaves
+// exactly as before: a normal scan completes and finds the SSN.
+func TestValidateContent_BackgroundShimUnaffected(t *testing.T) {
+	v := NewValidator()
+	matches, err := v.ValidateContent("employee ssn: 449-87-4100 on record", "<stdin>")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Error("expected the SSN to be detected via the background shim")
+	}
+}
+
+// TestLineLoopCancelled_StrideBehavior locks the helper's cheap-check contract:
+// it reads ctx only on stride boundaries, and an already-done ctx is caught at
+// i==0.
+func TestLineLoopCancelled_StrideBehavior(t *testing.T) {
+	done, cancel := context.WithCancel(context.Background())
+	cancel()
+	if !execguard.LineLoopCancelled(done, 0) {
+		t.Error("expected cancellation to be detected at i=0")
+	}
+	// A live context never reports cancelled regardless of index.
+	live := context.Background()
+	for _, i := range []int{0, 1, 255, 256, 512} {
+		if execguard.LineLoopCancelled(live, i) {
+			t.Errorf("live context reported cancelled at i=%d", i)
+		}
+	}
+	// nil context never cancels.
+	if execguard.LineLoopCancelled(nil, 0) {
+		t.Error("nil context must not report cancelled")
+	}
+}

--- a/internal/validators/ssn/validator.go
+++ b/internal/validators/ssn/validator.go
@@ -4,11 +4,13 @@
 package ssn
 
 import (
+	stdctx "context"
 	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/awslabs/ferret-scan/internal/detector"
+	"github.com/awslabs/ferret-scan/internal/execguard"
 	"github.com/awslabs/ferret-scan/internal/observability"
 )
 
@@ -234,6 +236,16 @@ func (v *Validator) newLineContext(line string) *lineContext {
 
 // ValidateContent validates preprocessed content for SSNs
 func (v *Validator) ValidateContent(content string, originalPath string) ([]detector.Match, error) {
+	// Backward-compatible shim: run with a background context (never cancels).
+	return v.ValidateContentCtx(stdctx.Background(), content, originalPath)
+}
+
+// ValidateContentCtx implements execguard.ContextAwareValidator: it is the
+// context-aware form of ValidateContent, polling ctx once per line so a runaway
+// scan of a large multi-line input is reclaimed promptly (v2 Phase 3). On
+// cancellation it returns the matches gathered so far plus ctx.Err(), so a
+// timed-out scan surfaces partial findings rather than discarding them.
+func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, originalPath string) ([]detector.Match, error) {
 	var matches []detector.Match
 
 	// Split content into lines for processing
@@ -242,6 +254,11 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 	isDocx := strings.Contains(originalPath, ".docx")
 
 	for lineNum, line := range lines {
+		// Cooperative cancellation: stop promptly if the scan's deadline fired
+		// or it was cancelled, returning what we have plus the reason.
+		if execguard.LineLoopCancelled(ctx, lineNum) {
+			return matches, ctx.Err()
+		}
 		// Use FindAllStringIndex so we enumerate matches with their byte offsets in a
 		// single regex pass (FindAllString already did one pass; this is equivalent).
 		// We deliberately compute the context window from the FIRST occurrence of each

--- a/internal/validators/vin/ctx_cancel_test.go
+++ b/internal/validators/vin/ctx_cancel_test.go
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package vin
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestValidateContentCtx_ReclaimsRunawayMultiLineScan: a cancelled context stops a
+// large multi-line scan promptly (v2 Phase 3 per-line ctx polling).
+func TestValidateContentCtx_ReclaimsRunawayMultiLineScan(t *testing.T) {
+	v := NewValidator()
+	content := strings.Repeat("vehicle 1HGBH41JXMN109186 and JH4TB2H26CC000000 logged\n", 500000)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_, err := v.ValidateContentCtx(ctx, content, "<stdin>")
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Errorf("cancelled scan took %v; expected prompt return", elapsed)
+	}
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestValidateContent_BackgroundShimEqualsCtx: the non-ctx shim must produce the
+// same result as ValidateContentCtx with a never-cancelling context.
+func TestValidateContent_BackgroundShimEqualsCtx(t *testing.T) {
+	const content = "vehicle 1HGBH41JXMN109186\nJH4TB2H26CC000000\n"
+	shim, err1 := NewValidator().ValidateContent(content, "<stdin>")
+	ctxRes, err2 := NewValidator().ValidateContentCtx(context.Background(), content, "<stdin>")
+	if err1 != nil || err2 != nil {
+		t.Fatalf("unexpected errors: shim=%v ctx=%v", err1, err2)
+	}
+	if len(shim) != len(ctxRes) {
+		t.Errorf("shim vs ctx match count differ: %d != %d", len(shim), len(ctxRes))
+	}
+}

--- a/internal/validators/vin/validator.go
+++ b/internal/validators/vin/validator.go
@@ -4,10 +4,12 @@
 package vin
 
 import (
+	stdctx "context"
 	"regexp"
 	"strings"
 
 	"github.com/awslabs/ferret-scan/internal/detector"
+	"github.com/awslabs/ferret-scan/internal/execguard"
 	"github.com/awslabs/ferret-scan/internal/observability"
 )
 
@@ -193,6 +195,15 @@ func (v *Validator) Validate(filePath string) ([]detector.Match, error) {
 // boundary check reproduce the original fullContext/fullLine distinction
 // exactly (see analyzeContextHoisted).
 func (v *Validator) ValidateContent(content string, originalPath string) ([]detector.Match, error) {
+	// Backward-compatible shim: run with a background context (never cancels).
+	return v.ValidateContentCtx(stdctx.Background(), content, originalPath)
+}
+
+// ValidateContentCtx implements execguard.ContextAwareValidator: the context-aware
+// form of ValidateContent, polling ctx once per line so a runaway multi-line scan
+// is reclaimed promptly (v2 Phase 3). Returns partial matches + ctx.Err() on
+// cancellation.
+func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, originalPath string) ([]detector.Match, error) {
 	var finishTiming func(bool, map[string]interface{})
 	if v.observer != nil {
 		finishTiming = v.observer.StartTiming("vin_validator", "validate_content", originalPath)
@@ -202,6 +213,13 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 	lines := strings.Split(content, "\n")
 
 	for lineNum, line := range lines {
+		// Cooperative cancellation (v2 Phase 3): bail promptly on deadline/cancel.
+		if execguard.LineLoopCancelled(ctx, lineNum) {
+			if finishTiming != nil {
+				finishTiming(false, map[string]interface{}{"cancelled": true, "match_count": len(matches)})
+			}
+			return matches, ctx.Err()
+		}
 		locs := v.regex.FindAllStringIndex(line, -1)
 		if len(locs) == 0 {
 			continue


### PR DESCRIPTION
> ⚠️ **Stacked on #107.** This PR targets `main` so CI runs, but its first two commits belong to #107 and will drop out of the diff once #107 merges. **Review only the third commit here** ("…remaining 7 line-loop validators"), or review it on top of #107.

## What

Phase 3, slice 3 — completes the ctx-polling coverage started in #107 (SSN/IP/phone). The **remaining seven** line-loop validators now implement `execguard.ContextAwareValidator`, so a runaway **multi-line** scan in **any** of the 13 validators is reclaimed promptly instead of running to the 5-minute job deadline.

> **Stacked on #107** (base = `feat/v2-phase3-ctx-polling`, which introduces `execguard.LineLoopCancelled`). Review/merge #107 first.

Each validator gains a `ValidateContentCtx` that polls `execguard.LineLoopCancelled` once per line; `ValidateContent` becomes a `context.Background()` shim. Since `execguard.ValidateContent` (from #98) dispatches to `ContextAwareValidator` when implemented, the live path routes through the ctx-aware form with **no wiring change**.

| shape | validators | notes |
|---|---|---|
| direct loop in `ValidateContent` | email, creditcard, vin | preserve `finishTiming` observer, record `{cancelled, match_count}` on cancel |
| direct loop, no observer | passport, personname | personname returns pre-dedup partials |
| loop in a helper | socialmedia, intellectualproperty | ctx threaded into `detectPatternsByLine` (socialmedia also its batch variant + `*WithErrorHandling` wrapper); partial per-line matches still clustered/reconstructed; `ValidateContentCtx` surfaces `ctx.Err()` |

## Behavior-preserving

- Common uncancelled path **byte-identical** — golden corpus passes with zero `UPDATE_GOLDEN`.
- Public `ValidateContent` contract unchanged.

## Tests

Per-validator `ctx_cancel_test.go`: (a) a cancelled context reclaims a 500k-line scan in **<500ms** returning `context.Canceled`; (b) the background shim equals `ValidateContentCtx(Background)`. socialmedia uses `newConfiguredValidator` so the loop actually runs (the unconfigured validator returns before it).

**Negative control**: neutralizing `LineLoopCancelled` made all 7 reclaim tests fail — email 18s, socialmedia 35s, personname 20s, vin 15s, IP 15s, creditcard 6s, passport 4s to completion vs ≤0.02s with the poll — proving each validator's poll is wired to the live path.

Full suite + `-race` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)