### PR TITLE
feat(v2-refactor): per-validator time + match budgets (Move C) + secrets/cloudresources ctx

### DIFF
--- a/docs/proposals/V2_ARCHITECTURE.md
+++ b/docs/proposals/V2_ARCHITECTURE.md
@@ -356,6 +356,19 @@ polling inside validators, the concurrency limiter, the per-validator budget, an
 (Moves A, C). Behavior changes *only* on over-deadline/over-budget inputs (today: hang or crash; v2:
 bounded partial + explicit incomplete signal).
 
+> **Phase 3, slice 1 — per-line ctx polling in the three worst offenders — LANDED (PR #107).** The
+> audit-measured worst offenders (SSN, IP, phone) now implement `execguard.ContextAwareValidator` via a
+> new `ValidateContentCtx` that polls a shared `execguard.LineLoopCancelled(ctx, i)` primitive (reads
+> `ctx.Err()` every 256 lines, and on `i==0`) once per line; on deadline/cancel each returns the matches
+> gathered so far plus `ctx.Err()`. `ValidateContent` becomes a `context.Background()` shim, so the common
+> uncancelled path is byte-identical (golden corpus passes with zero `UPDATE_GOLDEN`). Because
+> `execguard.ValidateContent` already dispatches to `ContextAwareValidator` when implemented, the live scan
+> path routes through the ctx-aware form automatically: a runaway **multi-line** scan is reclaimed
+> promptly (SSN 0.01s vs 53.68s; IP 0.01s vs 5.18s; phone 0.01s vs 16.16s — negative-controlled).
+> **Still open in Phase 3:** the O(n²) **single-long-line** case (fixed by the shared `LineScan` primitive,
+> 4.1 — slice 2); adopting the ctx-poll in the remaining line-loop validators; and the concurrency
+> limiter + per-validator/extraction budgets (Move C).
+
 **Phase 4 — Surface and consolidate.** Add `ScanResult.Diagnostics` + opt-in degraded-coverage exit (1.4);
 the shared `LineScan` primitive (4.1); structured provenance (5.1); `Descriptor()` + data-driven routing
 (3.3, 5.3); the `Observer` seam and typed config schema (6.2, 6.4).

--- a/internal/core/scanner.go
+++ b/internal/core/scanner.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/awslabs/ferret-scan/internal/config"
 	"github.com/awslabs/ferret-scan/internal/detector"
+	"github.com/awslabs/ferret-scan/internal/execguard"
 	"github.com/awslabs/ferret-scan/internal/explain"
 	"github.com/awslabs/ferret-scan/internal/observability"
 	"github.com/awslabs/ferret-scan/internal/parallel"
@@ -241,6 +242,13 @@ type ContentScanConfig struct {
 	// writer to route the internal observer through a structured logger.
 	// See ScanConfig.LogWriter for the no-payload-bytes contract.
 	LogWriter io.Writer
+
+	// ValidatorBudgets optionally bounds per-validator execution (time and/or
+	// match count), keyed by validator name (e.g. "SSN", "IP_ADDRESS"). Nil/empty
+	// = disabled = historical behavior (byte-identical). When a budget fires, the
+	// scan returns partial matches and ScanResult.Incomplete is set. See
+	// execguard.ValidatorBudget.
+	ValidatorBudgets map[string]execguard.ValidatorBudget
 }
 
 // ScanContent scans an in-memory content buffer using the same validator
@@ -303,6 +311,8 @@ func ScanContent(content string, cfg ContentScanConfig) (*ScanResult, error) {
 	// transient failure mode worth retrying for.
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
+	// Attach per-validator budgets (no-op when nil/empty — byte-identical path).
+	ctx = execguard.WithBudgets(ctx, cfg.ValidatorBudgets)
 
 	matches, validationErr := parallel.RunValidators(ctx, validatorsList, processed, nil)
 	if validationErr != nil && cfg.Debug {
@@ -320,6 +330,11 @@ func ScanContent(content string, cfg ContentScanConfig) (*ScanResult, error) {
 	if validationErr != nil && (errors.Is(validationErr, context.DeadlineExceeded) || errors.Is(validationErr, context.Canceled)) {
 		incomplete = true
 		incompleteReason = "validator execution did not complete: " + validationErr.Error()
+	} else if validationErr != nil && errors.Is(validationErr, execguard.ErrMatchBudgetExceeded) {
+		// A per-validator match cap fired: results are truncated, so coverage is
+		// partial in the same load-bearing way as a timeout.
+		incomplete = true
+		incompleteReason = "validator match budget exceeded: " + validationErr.Error()
 	}
 
 	// Stamp every match as virtual and ensure the filename is the synthetic

--- a/internal/execguard/budget.go
+++ b/internal/execguard/budget.go
@@ -1,0 +1,58 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package execguard
+
+import (
+	"context"
+	"time"
+)
+
+// ValidatorBudget bounds a single validator's work on one scan. Both fields are
+// opt-in: the zero value (TimeLimit<=0, MatchLimit<=0) is DISABLED and preserves
+// historical behavior exactly. Budgets are carried on the context (see
+// WithBudgets) so no fan-out signature changes are needed — the single dispatch
+// chokepoint (ValidateContent) reads the budget for the validator it is about to
+// run.
+type ValidatorBudget struct {
+	// TimeLimit is a per-validator wall-clock ceiling. When > 0, ValidateContent
+	// derives a child context.WithTimeout(ctx, TimeLimit) so the validator gets
+	// its own deadline, tighter than the per-file/job deadline. It only has teeth
+	// on validators that poll the context (execguard.ContextAwareValidator); a
+	// legacy validator still gets the tighter deadline for the SafeRun entry check
+	// but cannot be interrupted mid-run.
+	TimeLimit time.Duration
+
+	// MatchLimit caps how many matches a validator may emit on one scan. When > 0
+	// and the validator returns more, the slice is truncated (keeping emission
+	// order) and ErrMatchBudgetExceeded is returned alongside the capped matches.
+	MatchLimit int
+}
+
+// budgetKey is the unexported context key type for the per-validator budget map,
+// collision-proof against any other context value.
+type budgetKey struct{}
+
+// WithBudgets attaches per-validator budgets (keyed by the same validator name
+// passed to ValidateContent) to ctx. An empty/nil map is a no-op: the parent ctx
+// is returned unchanged, so the context-value chain is identical to today when no
+// budgets are configured (preserving byte-identical behavior).
+func WithBudgets(ctx context.Context, budgets map[string]ValidatorBudget) context.Context {
+	if len(budgets) == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, budgetKey{}, budgets)
+}
+
+// budgetFor returns the budget configured for validator name, or the zero
+// (disabled) ValidatorBudget when none is set. A nil ctx or a ctx without budgets
+// yields the disabled zero value.
+func budgetFor(ctx context.Context, name string) ValidatorBudget {
+	if ctx == nil {
+		return ValidatorBudget{}
+	}
+	if m, ok := ctx.Value(budgetKey{}).(map[string]ValidatorBudget); ok {
+		return m[name] // absent key => zero value => disabled
+	}
+	return ValidatorBudget{}
+}

--- a/internal/execguard/budget_test.go
+++ b/internal/execguard/budget_test.go
@@ -1,0 +1,173 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package execguard
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/awslabs/ferret-scan/internal/detector"
+)
+
+// blockingCtxValidator implements ContextAwareValidator by blocking on ctx.Done()
+// and then returning a partial match + ctx.Err(). It waits for the deadline
+// rather than racing a sleep against it — the anti-flake pattern the codebase
+// relies on (see execguard_test.go / validator_runner_cancel_test.go).
+type blockingCtxValidator struct{ started chan struct{} }
+
+func (b *blockingCtxValidator) Validate(string) ([]detector.Match, error)             { return nil, nil }
+func (b *blockingCtxValidator) CalculateConfidence(string) (float64, map[string]bool) { return 0, nil }
+func (b *blockingCtxValidator) AnalyzeContext(string, detector.ContextInfo) float64   { return 0 }
+func (b *blockingCtxValidator) ValidateContent(string, string) ([]detector.Match, error) {
+	return nil, errors.New("legacy path must not be used")
+}
+func (b *blockingCtxValidator) ValidateContentCtx(ctx context.Context, _, _ string) ([]detector.Match, error) {
+	if b.started != nil {
+		close(b.started)
+	}
+	<-ctx.Done()
+	return []detector.Match{{Type: "PARTIAL", Text: "x"}}, ctx.Err()
+}
+
+// manyMatchValidator returns n matches, no error, ignoring ctx.
+type manyMatchValidator struct{ n int }
+
+func (m manyMatchValidator) Validate(string) ([]detector.Match, error)             { return nil, nil }
+func (m manyMatchValidator) CalculateConfidence(string) (float64, map[string]bool) { return 0, nil }
+func (m manyMatchValidator) AnalyzeContext(string, detector.ContextInfo) float64   { return 0 }
+func (m manyMatchValidator) ValidateContent(string, string) ([]detector.Match, error) {
+	out := make([]detector.Match, m.n)
+	for i := range out {
+		out[i] = detector.Match{Type: "T", Text: string(rune('a' + i%26))}
+	}
+	return out, nil
+}
+
+// --- TIME budget ---
+
+func TestTimeBudget_FiresAndReturnsCtxErr(t *testing.T) {
+	v := &blockingCtxValidator{started: make(chan struct{})}
+	ctx := WithBudgets(context.Background(), map[string]ValidatorBudget{
+		"STUB": {TimeLimit: 20 * time.Millisecond},
+	})
+
+	matches, err := ValidateContent(ctx, "STUB", v, "content", "p")
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("want DeadlineExceeded from per-validator budget, got %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("want partial matches preserved, got %d", len(matches))
+	}
+}
+
+func TestTimeBudget_AlreadyExpiredParentSkipsLaunch(t *testing.T) {
+	// A pre-cancelled parent must skip launching the validator entirely — no
+	// wall-clock involved (deterministic; the Windows-safe pattern).
+	parent, cancel := context.WithCancel(context.Background())
+	cancel()
+	v := &blockingCtxValidator{started: make(chan struct{})}
+	ctx := WithBudgets(parent, map[string]ValidatorBudget{"STUB": {TimeLimit: time.Hour}})
+
+	_, err := ValidateContent(ctx, "STUB", v, "content", "p")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want Canceled, got %v", err)
+	}
+	select {
+	case <-v.started:
+		t.Fatal("validator was launched despite an already-cancelled context")
+	default:
+	}
+}
+
+func TestTimeBudget_DisabledDoesNotDeriveDeadline(t *testing.T) {
+	// With no budget, a background context has no deadline: the validator must see
+	// exactly the parent ctx (no child WithTimeout). We assert by having the stub
+	// report whether its ctx had a deadline.
+	var sawDeadline bool
+	v := deadlineProbe{report: func(has bool) { sawDeadline = has }}
+	_, err := ValidateContent(context.Background(), "PROBE", v, "c", "p")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sawDeadline {
+		t.Error("disabled budget must not derive a deadline; validator saw one")
+	}
+}
+
+// deadlineProbe reports whether the ctx it received carries a deadline.
+type deadlineProbe struct{ report func(bool) }
+
+func (deadlineProbe) Validate(string) ([]detector.Match, error)             { return nil, nil }
+func (deadlineProbe) CalculateConfidence(string) (float64, map[string]bool) { return 0, nil }
+func (deadlineProbe) AnalyzeContext(string, detector.ContextInfo) float64   { return 0 }
+func (deadlineProbe) ValidateContent(string, string) ([]detector.Match, error) {
+	return nil, errors.New("legacy path must not be used")
+}
+func (d deadlineProbe) ValidateContentCtx(ctx context.Context, _, _ string) ([]detector.Match, error) {
+	_, has := ctx.Deadline()
+	d.report(has)
+	return nil, nil
+}
+
+// --- MATCH budget ---
+
+func TestMatchBudget_TruncatesAndSignals(t *testing.T) {
+	ctx := WithBudgets(context.Background(), map[string]ValidatorBudget{
+		"MANY": {MatchLimit: 3},
+	})
+	matches, err := ValidateContent(ctx, "MANY", manyMatchValidator{n: 10}, "c", "p")
+	if !errors.Is(err, ErrMatchBudgetExceeded) {
+		t.Fatalf("want ErrMatchBudgetExceeded, got %v", err)
+	}
+	if len(matches) != 3 {
+		t.Fatalf("want matches truncated to 3, got %d", len(matches))
+	}
+}
+
+func TestMatchBudget_UnderCapIsUnmutated(t *testing.T) {
+	ctx := WithBudgets(context.Background(), map[string]ValidatorBudget{
+		"MANY": {MatchLimit: 100},
+	})
+	matches, err := ValidateContent(ctx, "MANY", manyMatchValidator{n: 10}, "c", "p")
+	if err != nil {
+		t.Fatalf("under-cap must not error, got %v", err)
+	}
+	if len(matches) != 10 {
+		t.Fatalf("under-cap must return all matches, got %d", len(matches))
+	}
+}
+
+func TestMatchBudget_DisabledReturnsAll(t *testing.T) {
+	matches, err := ValidateContent(context.Background(), "MANY", manyMatchValidator{n: 10}, "c", "p")
+	if err != nil {
+		t.Fatalf("disabled must not error, got %v", err)
+	}
+	if len(matches) != 10 {
+		t.Fatalf("disabled must return all matches, got %d", len(matches))
+	}
+}
+
+// --- WithBudgets / budgetFor semantics ---
+
+func TestWithBudgets_EmptyMapIsNoOp(t *testing.T) {
+	parent := context.Background()
+	if got := WithBudgets(parent, nil); got != parent {
+		t.Error("WithBudgets(nil) must return the parent ctx unchanged")
+	}
+	if got := WithBudgets(parent, map[string]ValidatorBudget{}); got != parent {
+		t.Error("WithBudgets(empty) must return the parent ctx unchanged")
+	}
+}
+
+func TestBudgetFor_AbsentAndNilAreDisabled(t *testing.T) {
+	if b := budgetFor(nil, "X"); b.TimeLimit != 0 || b.MatchLimit != 0 {
+		t.Errorf("nil ctx must yield disabled budget, got %+v", b)
+	}
+	ctx := WithBudgets(context.Background(), map[string]ValidatorBudget{"A": {TimeLimit: time.Second}})
+	if b := budgetFor(ctx, "B"); b.TimeLimit != 0 || b.MatchLimit != 0 {
+		t.Errorf("absent key must yield disabled budget, got %+v", b)
+	}
+}

--- a/internal/execguard/execguard.go
+++ b/internal/execguard/execguard.go
@@ -28,11 +28,19 @@ package execguard
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/awslabs/ferret-scan/internal/detector"
 	"github.com/awslabs/ferret-scan/internal/resilience"
 )
+
+// ErrMatchBudgetExceeded is returned (alongside the truncated, capped matches) by
+// ValidateContent when a validator emits more matches than its ValidatorBudget
+// MatchLimit allows. Callers can errors.Is-check it to record incomplete coverage
+// (see internal/core/scanner.go). It is distinct from context errors: a match-cap
+// hit is not a deadline/cancellation.
+var ErrMatchBudgetExceeded = errors.New("validator match budget exceeded")
 
 // ContextAwareValidator is an OPTIONAL extension of detector.Validator. A
 // validator that implements it receives the active context and is expected to
@@ -85,10 +93,36 @@ func SafeRun(ctx context.Context, name string, fn func() ([]detector.Match, erro
 // ContextAwareValidator, otherwise it calls the legacy ValidateContent. Either
 // way the call is wrapped by SafeRun (panic recovery + boundary cancellation).
 func ValidateContent(ctx context.Context, name string, v detector.Validator, content, originalPath string) ([]detector.Match, error) {
-	return SafeRun(ctx, name, func() ([]detector.Match, error) {
+	b := budgetFor(ctx, name)
+
+	// Per-validator TIME budget: derive a child deadline tighter than the parent
+	// (per-file/job) deadline. context.WithTimeout never extends a parent deadline,
+	// so the tighter of {parent, TimeLimit} always wins. The derived ctx is the one
+	// handed to a ContextAwareValidator, which polls it via LineLoopCancelled — so
+	// a runaway validator self-terminates at its own budget. Disabled (<=0) leaves
+	// ctx untouched: byte-identical to the no-budget path.
+	if b.TimeLimit > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, b.TimeLimit)
+		defer cancel()
+	}
+
+	matches, err := SafeRun(ctx, name, func() ([]detector.Match, error) {
 		if cav, ok := v.(ContextAwareValidator); ok {
 			return cav.ValidateContentCtx(ctx, content, originalPath)
 		}
 		return v.ValidateContent(content, originalPath)
 	})
+
+	// Per-validator MATCH budget: cap only a SUCCESSFUL result. Never truncate a
+	// partial slice returned alongside an error (e.g. ctx.Err() from a timed-out
+	// scan) — that path already carries its own incompleteness meaning, and
+	// dropping matches a timed-out scan did find would double-signal. When the
+	// count is at/under the cap (or the cap is disabled), matches is returned
+	// completely unmutated: byte-identical to the no-budget path.
+	if err == nil && b.MatchLimit > 0 && len(matches) > b.MatchLimit {
+		matches = matches[:b.MatchLimit]
+		err = fmt.Errorf("%w: validator %q emitted more than %d matches", ErrMatchBudgetExceeded, name, b.MatchLimit)
+	}
+	return matches, err
 }

--- a/internal/execguard/linebudget.go
+++ b/internal/execguard/linebudget.go
@@ -1,0 +1,46 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package execguard
+
+import "context"
+
+// ctxCheckStride is how often (in loop iterations) a validator's line loop
+// consults the context. Checking ctx.Err() on every iteration would add a
+// (cheap but non-zero) atomic load to the hot path for no benefit; a stride of
+// 256 bounds the worst-case over-run to at most 255 extra lines after a deadline
+// fires — negligible against a multi-million-line runaway — while keeping the
+// per-line cost effectively free.
+const ctxCheckStride = 256
+
+// LineLoopCancelled reports whether a validator's per-line loop should stop
+// because its context is done (deadline exceeded or cancelled). It is the
+// v2 Phase 3 cooperative-cancellation primitive: validators that implement
+// execguard.ContextAwareValidator call this once per line so a runaway scan of a
+// large multi-line input is reclaimed promptly instead of running to completion.
+//
+// It only actually reads ctx.Err() every ctxCheckStride iterations (and always
+// on the first, i==0, so an already-expired budget skips the work entirely), so
+// the common case is a single integer-modulo test. A nil ctx never cancels.
+//
+// Usage in a validator's ValidateContentCtx:
+//
+//	for i, line := range lines {
+//	    if execguard.LineLoopCancelled(ctx, i) {
+//	        return matches, ctx.Err() // return partial matches + why we stopped
+//	    }
+//	    // ... scan line ...
+//	}
+//
+// Returning the partial matches gathered so far (rather than discarding them) is
+// deliberate: a timed-out DLP scan should surface what it found, and the caller
+// records ctx.Err() as an incomplete-coverage signal (see ScanResult.Incomplete).
+func LineLoopCancelled(ctx context.Context, i int) bool {
+	if ctx == nil {
+		return false
+	}
+	if i%ctxCheckStride != 0 {
+		return false
+	}
+	return ctx.Err() != nil
+}

--- a/internal/parallel/validator_runner.go
+++ b/internal/parallel/validator_runner.go
@@ -5,14 +5,28 @@ package parallel
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
 	"github.com/awslabs/ferret-scan/internal/detector"
+	"github.com/awslabs/ferret-scan/internal/execguard"
 	"github.com/awslabs/ferret-scan/internal/preprocessors"
 	"github.com/awslabs/ferret-scan/internal/resilience"
 	"github.com/awslabs/ferret-scan/internal/validators/metadata"
 )
+
+// partialMatchesSurvive reports whether an error is a per-validator BUDGET or
+// DEADLINE outcome (v2 Move C / Phase 3) rather than a hard validator failure.
+// For these, the matches gathered before the budget fired are genuine findings
+// and must be preserved (the error is still propagated so the scan is flagged
+// incomplete). A hard error keeps the historical behavior of discarding its
+// partial slice.
+func partialMatchesSurvive(err error) bool {
+	return errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, context.Canceled) ||
+		errors.Is(err, execguard.ErrMatchBudgetExceeded)
+}
 
 // ValidatorStrategy controls how a single validator invocation is executed.
 // A nil strategy invokes the operation once with no wrapping; the worker pool
@@ -102,7 +116,13 @@ func RunValidators(
 				}
 
 				if err := runOne(ctx, op); err != nil {
-					matchesChan <- []detector.Match{}
+					// Preserve partial matches on a budget/deadline outcome; drop
+					// them on a hard error (historical behavior).
+					if partialMatchesSurvive(err) {
+						matchesChan <- matches
+					} else {
+						matchesChan <- []detector.Match{}
+					}
 					errorChan <- err
 					return
 				}
@@ -130,7 +150,11 @@ func RunValidators(
 				}
 
 				if err := runOne(ctx, op); err != nil {
-					matchesChan <- []detector.Match{}
+					if partialMatchesSurvive(err) {
+						matchesChan <- matches
+					} else {
+						matchesChan <- []detector.Match{}
+					}
 					errorChan <- err
 					return
 				}
@@ -168,7 +192,11 @@ func RunValidators(
 				}
 
 				if err := runOne(ctx, op); err != nil {
-					matchesChan <- []detector.Match{}
+					if partialMatchesSurvive(err) {
+						matchesChan <- matches
+					} else {
+						matchesChan <- []detector.Match{}
+					}
 					errorChan <- err
 					return
 				}

--- a/internal/parallel/worker_pool.go
+++ b/internal/parallel/worker_pool.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/awslabs/ferret-scan/internal/detector"
+	"github.com/awslabs/ferret-scan/internal/execguard"
 	"github.com/awslabs/ferret-scan/internal/observability"
 	"github.com/awslabs/ferret-scan/internal/preprocessors"
 	"github.com/awslabs/ferret-scan/internal/redactors"
@@ -61,6 +62,12 @@ type JobConfig struct {
 	// server) can tighten this so a single pathological file cannot delay batch
 	// completion for the full default window.
 	JobTimeout time.Duration
+
+	// ValidatorBudgets optionally bounds per-validator execution (time and/or
+	// match count), keyed by validator name. Nil/empty = disabled = historical
+	// behavior. Attached to the per-file job context so the dispatch chokepoint
+	// (execguard.ValidateContent) can enforce each validator's budget.
+	ValidatorBudgets map[string]execguard.ValidatorBudget
 }
 
 // DefaultJobTimeout is the per-file processing ceiling used when
@@ -255,6 +262,10 @@ func (wp *WorkerPool) processJob(job *Job, workerID int) *Result {
 	}
 	jobCtx, cancel := context.WithTimeout(wp.ctx, jobTimeout)
 	defer cancel()
+	// Attach per-validator budgets (no-op when nil/empty — byte-identical path).
+	if job.Config != nil {
+		jobCtx = execguard.WithBudgets(jobCtx, job.Config.ValidatorBudgets)
+	}
 
 	err := processWithResilience(jobCtx)
 	if err != nil {

--- a/internal/validators/cloudresources/cloudresources.go
+++ b/internal/validators/cloudresources/cloudresources.go
@@ -14,6 +14,7 @@
 package cloudresources
 
 import (
+	stdctx "context"
 	"fmt"
 	"regexp"
 	"sort"
@@ -21,6 +22,7 @@ import (
 
 	"github.com/awslabs/ferret-scan/internal/config"
 	"github.com/awslabs/ferret-scan/internal/detector"
+	"github.com/awslabs/ferret-scan/internal/execguard"
 	"github.com/awslabs/ferret-scan/internal/observability"
 )
 
@@ -110,6 +112,15 @@ func (v *Validator) SetObserver(observer *observability.StandardObserver) {
 // per-match full-content ToLower + strings.Index made it O(matches × content),
 // which took ~84s on an 800 KB file.
 func (v *Validator) ValidateContent(content string, originalPath string) ([]detector.Match, error) {
+	// Backward-compatible shim: run with a background context (never cancels).
+	return v.ValidateContentCtx(stdctx.Background(), content, originalPath)
+}
+
+// ValidateContentCtx implements execguard.ContextAwareValidator: the context-aware
+// form of ValidateContent, polling ctx once per candidate span in the scoring loop
+// so a runaway scan over tens of thousands of matches is reclaimed promptly (v2
+// Phase 3). On cancellation it returns the matches gathered so far plus ctx.Err().
+func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, originalPath string) ([]detector.Match, error) {
 	var finishTiming func(bool, map[string]interface{})
 	if v.observer != nil {
 		finishTiming = v.observer.StartTiming("cloud_resources", "validate_content", originalPath)
@@ -122,6 +133,16 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 			finishTiming(true, map[string]interface{}{"match_count": 0, "skipped_oversize": true})
 		}
 		return nil, nil
+	}
+
+	// Entry-level cancellation check (v2 Phase 3): the whole-content regex pass and
+	// containment dedup below run before the polled scoring loop, so an
+	// already-cancelled/expired scan bails here rather than paying for them.
+	if execguard.LineLoopCancelled(ctx, 0) {
+		if finishTiming != nil {
+			finishTiming(false, map[string]interface{}{"cancelled": true, "match_count": 0})
+		}
+		return nil, ctx.Err()
 	}
 
 	// Precompute document-level signals once.
@@ -204,6 +225,14 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 	var cachedLine, cachedLineLower string
 
 	for i := range raws {
+		// Cooperative cancellation (v2 Phase 3): bail promptly on deadline/cancel,
+		// returning the matches gathered so far plus the reason.
+		if execguard.LineLoopCancelled(ctx, i) {
+			if finishTiming != nil {
+				finishTiming(false, map[string]interface{}{"cancelled": true, "match_count": len(matches)})
+			}
+			return matches, ctx.Err()
+		}
 		if containedFlag[i] {
 			continue
 		}

--- a/internal/validators/cloudresources/ctx_cancel_test.go
+++ b/internal/validators/cloudresources/ctx_cancel_test.go
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudresources
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// buildManyARNs returns n lines each carrying a distinct AWS IAM-role ARN, so the
+// scoring loop over deduped spans has n iterations to poll.
+func buildManyARNs(n int) string {
+	var b strings.Builder
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&b, "arn:aws:iam::%012d:role/Role%d\n", i, i)
+	}
+	return b.String()
+}
+
+// TestValidateContentCtx_ReclaimsRunawayScan: a cancelled context stops a large
+// scan promptly (v2 Phase 3 per-span ctx polling in the scoring loop).
+func TestValidateContentCtx_ReclaimsRunawayScan(t *testing.T) {
+	v := NewValidator()
+	// Keep the input under maxContentBytes (5MB); ~100k ARNs (~3.9MB) still gives
+	// the scoring loop plenty of iterations for the pre-cancelled poll to catch.
+	content := buildManyARNs(100000)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// An already-cancelled scan bails at the entry check before the whole-content
+	// regex pass, so this is near-instant. -race inflates wall-clock 5-20x, so
+	// relax the ceiling under the race detector (the scan still runs; only the
+	// timing bound is relaxed). The ctx.Err() assertion below is the real guard.
+	ceiling := 500 * time.Millisecond
+	if raceEnabled {
+		ceiling = 5 * time.Second
+	}
+
+	start := time.Now()
+	_, err := v.ValidateContentCtx(ctx, content, "<stdin>")
+	if elapsed := time.Since(start); elapsed > ceiling {
+		t.Errorf("cancelled scan took %v; expected prompt return", elapsed)
+	}
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestValidateContent_BackgroundShimEqualsCtx: the non-ctx shim must produce the
+// same result as ValidateContentCtx with a never-cancelling context.
+func TestValidateContent_BackgroundShimEqualsCtx(t *testing.T) {
+	const content = "prod arn:aws:iam::123456789012:role/PaymentsAdmin\nexample arn:aws:iam::123456789012:role/PaymentsAdmin\n"
+	shim, err1 := NewValidator().ValidateContent(content, "<stdin>")
+	ctxRes, err2 := NewValidator().ValidateContentCtx(context.Background(), content, "<stdin>")
+	if err1 != nil || err2 != nil {
+		t.Fatalf("unexpected errors: shim=%v ctx=%v", err1, err2)
+	}
+	if len(shim) != len(ctxRes) {
+		t.Errorf("shim vs ctx match count differ: %d != %d", len(shim), len(ctxRes))
+	}
+}

--- a/internal/validators/cloudresources/race_off_test.go
+++ b/internal/validators/cloudresources/race_off_test.go
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !race
+
+package cloudresources
+
+// raceEnabled reports whether the binary was built with the race detector. The
+// race detector adds large (5-20x), variable wall-clock overhead, so timing-based
+// regression tests use it to relax their wall-clock ceiling (the scan still runs,
+// so -race can still detect data races in the per-line cached state).
+const raceEnabled = false

--- a/internal/validators/cloudresources/race_on_test.go
+++ b/internal/validators/cloudresources/race_on_test.go
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build race
+
+package cloudresources
+
+// raceEnabled reports whether the binary was built with the race detector. The
+// race detector adds large (5-20x), variable wall-clock overhead, so timing-based
+// regression tests use it to relax their wall-clock ceiling (the scan still runs,
+// so -race can still detect data races in the per-line cached state).
+const raceEnabled = true

--- a/internal/validators/creditcard/ctx_cancel_test.go
+++ b/internal/validators/creditcard/ctx_cancel_test.go
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package creditcard
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestValidateContentCtx_ReclaimsRunawayMultiLineScan: a cancelled context stops a
+// large multi-line scan promptly (v2 Phase 3 per-line ctx polling).
+func TestValidateContentCtx_ReclaimsRunawayMultiLineScan(t *testing.T) {
+	v := NewValidator()
+	content := strings.Repeat("visa 4532015112830366 mc 5425233430109903\n", 500000)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_, err := v.ValidateContentCtx(ctx, content, "<stdin>")
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Errorf("cancelled scan took %v; expected prompt return", elapsed)
+	}
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestValidateContent_BackgroundShimEqualsCtx: the non-ctx shim must produce the
+// same result as ValidateContentCtx with a never-cancelling context.
+func TestValidateContent_BackgroundShimEqualsCtx(t *testing.T) {
+	const content = "visa 4532015112830366\nmc 5425233430109903\n"
+	shim, err1 := NewValidator().ValidateContent(content, "<stdin>")
+	ctxRes, err2 := NewValidator().ValidateContentCtx(context.Background(), content, "<stdin>")
+	if err1 != nil || err2 != nil {
+		t.Fatalf("unexpected errors: shim=%v ctx=%v", err1, err2)
+	}
+	if len(shim) != len(ctxRes) {
+		t.Errorf("shim vs ctx match count differ: %d != %d", len(shim), len(ctxRes))
+	}
+}

--- a/internal/validators/creditcard/validator.go
+++ b/internal/validators/creditcard/validator.go
@@ -4,6 +4,7 @@
 package creditcard
 
 import (
+	stdctx "context"
 	"fmt"
 	"os"
 	"regexp"
@@ -11,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/awslabs/ferret-scan/internal/detector"
+	"github.com/awslabs/ferret-scan/internal/execguard"
 	"github.com/awslabs/ferret-scan/internal/observability"
 )
 
@@ -168,6 +170,15 @@ func (v *Validator) Validate(filePath string) ([]detector.Match, error) {
 
 // ValidateContent validates preprocessed content with optimized performance
 func (v *Validator) ValidateContent(content string, originalPath string) ([]detector.Match, error) {
+	// Backward-compatible shim: run with a background context (never cancels).
+	return v.ValidateContentCtx(stdctx.Background(), content, originalPath)
+}
+
+// ValidateContentCtx implements execguard.ContextAwareValidator: the context-aware
+// form of ValidateContent, polling ctx once per line so a runaway multi-line scan
+// is reclaimed promptly (v2 Phase 3). Returns partial matches + ctx.Err() on
+// cancellation.
+func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, originalPath string) ([]detector.Match, error) {
 	var finishTiming func(bool, map[string]interface{})
 	if v.observer != nil {
 		finishTiming = v.observer.StartTiming("creditcard_validator_optimized", "validate_content", originalPath)
@@ -177,6 +188,13 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 	lines := strings.Split(content, "\n")
 
 	for lineNum, line := range lines {
+		// Cooperative cancellation (v2 Phase 3): bail promptly on deadline/cancel.
+		if execguard.LineLoopCancelled(ctx, lineNum) {
+			if finishTiming != nil {
+				finishTiming(false, map[string]interface{}{"cancelled": true, "match_count": len(matches)})
+			}
+			return matches, ctx.Err()
+		}
 		// PERFORMANCE: several context operations are a function of the LINE
 		// (not the individual match), so a single very long line packed with N
 		// PANs previously recomputed each of them O(N) times, giving O(N * len)

--- a/internal/validators/detector.go
+++ b/internal/validators/detector.go
@@ -79,7 +79,7 @@ func (d *Detector) SetupValidators(validators map[string]detector.Validator) err
 		if name == "METADATA" {
 			continue // handled separately below
 		}
-		d.bridge.RegisterDocumentValidator(v)
+		d.bridge.RegisterDocumentValidator(name, v)
 	}
 
 	if mv, exists := validators["METADATA"]; exists {

--- a/internal/validators/dual_path_bridge.go
+++ b/internal/validators/dual_path_bridge.go
@@ -5,6 +5,7 @@ package validators
 
 import (
 	stdctx "context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -41,9 +42,17 @@ type EnhancedValidatorBridge struct {
 	mu sync.RWMutex
 }
 
+// namedValidator pairs a document validator with its logical check name (e.g.
+// "SSN", "IP_ADDRESS") so the dispatch chokepoint can key per-validator budgets
+// and diagnostics by the operator-facing name rather than the Go type.
+type namedValidator struct {
+	name string
+	v    detector.Validator
+}
+
 // DocumentValidatorBridge routes document body content to non-metadata validators
 type DocumentValidatorBridge struct {
-	validators      []detector.Validator
+	validators      []namedValidator
 	contextAnalyzer *context.ContextAnalyzer
 	observer        *observability.StandardObserver
 	metrics         *DocumentValidationMetrics
@@ -172,7 +181,7 @@ func NewEnhancedValidatorBridge(config *DualPathConfig) *EnhancedValidatorBridge
 // NewDocumentValidatorBridge creates a new document validator bridge
 func NewDocumentValidatorBridge() *DocumentValidatorBridge {
 	return &DocumentValidatorBridge{
-		validators:      make([]detector.Validator, 0),
+		validators:      make([]namedValidator, 0),
 		contextAnalyzer: context.NewContextAnalyzer(),
 		metrics:         &DocumentValidationMetrics{},
 	}
@@ -207,9 +216,11 @@ func (evb *EnhancedValidatorBridge) SetObservabilityHooks(hooks *performance.Obs
 	evb.observabilityHooks = hooks
 }
 
-// RegisterDocumentValidator registers a validator for document body content
-func (evb *EnhancedValidatorBridge) RegisterDocumentValidator(validator detector.Validator) {
-	evb.documentBridge.RegisterValidator(validator)
+// RegisterDocumentValidator registers a validator for document body content under
+// its logical check name (e.g. "SSN"), used for per-validator budget keying and
+// diagnostics at the dispatch chokepoint.
+func (evb *EnhancedValidatorBridge) RegisterDocumentValidator(name string, validator detector.Validator) {
+	evb.documentBridge.RegisterValidator(name, validator)
 }
 
 // SetMetadataValidator sets the metadata validator
@@ -338,11 +349,13 @@ func (evb *EnhancedValidatorBridge) ProcessContentCtx(ctx stdctx.Context, conten
 	// Process content through dual paths
 	result, err := evb.processDualPath(ctx, routedContent, contextInsights)
 	if err != nil {
-		// A context cancellation/timeout is terminal: do NOT fall back to a
-		// legacy re-run (it would re-invoke the same runaway validator and
-		// stall again). Return the partial matches gathered so far along with
-		// the context error so callers can report incomplete coverage.
-		if ctxErr := ctx.Err(); ctxErr != nil {
+		// A context cancellation/timeout OR a per-validator budget outcome (v2 Move
+		// C: time/match budget) is terminal: do NOT fall back to a legacy re-run —
+		// for a cancel it would re-invoke the same runaway validator and stall
+		// again; for a budget it would wastefully re-scan and double-count. Return
+		// the partial matches gathered so far with the error so callers can report
+		// incomplete coverage.
+		if ctxErr := ctx.Err(); ctxErr != nil || firstBudgetError([]error{err}) != nil {
 			var partial []detector.Match
 			if result != nil {
 				partial = result.AllMatches
@@ -467,6 +480,14 @@ func (evb *EnhancedValidatorBridge) processDualPath(ctx stdctx.Context, routedCo
 						Error:     err.Error(),
 					})
 				}
+				// A per-validator budget outcome (v2 Move C: match cap or time
+				// budget) still carries the genuine matches gathered before the
+				// budget fired — keep them (the error is recorded in documentErr so
+				// the scan is flagged incomplete). Other errors discard the slice,
+				// preserving historical behavior.
+				if firstBudgetError([]error{err}) != nil {
+					result.DocumentMatches = matches
+				}
 				return
 			}
 			result.DocumentMatches = matches
@@ -581,6 +602,16 @@ func (evb *EnhancedValidatorBridge) processDualPath(ctx stdctx.Context, routedCo
 	}
 
 	result.ProcessingTime = time.Since(startTime)
+
+	// Surface a per-validator BUDGET outcome (v2 Move C) that occurred on a single
+	// path: the matches gathered so far are complete and returned in result, but the
+	// caller must flag ScanResult.Incomplete because a validator's time/match budget
+	// cut its coverage short. (Full cancellation is handled at ctx.Err() above; both
+	// paths failing is handled earlier.) No budgets configured => budgetErr nil =>
+	// byte-identical return.
+	if budgetErr := firstBudgetError([]error{documentErr, metadataErr}); budgetErr != nil {
+		return result, budgetErr
+	}
 	return result, nil
 }
 
@@ -727,11 +758,12 @@ func (evb *EnhancedValidatorBridge) processContentLegacy(ctx stdctx.Context, con
 	return allMatches, nil
 }
 
-// RegisterValidator registers a validator for document body content (legacy compatibility)
-func (dvb *DocumentValidatorBridge) RegisterValidator(validator detector.Validator) {
+// RegisterValidator registers a validator for document body content under its
+// logical check name (e.g. "SSN"), preserved for budget keying and diagnostics.
+func (dvb *DocumentValidatorBridge) RegisterValidator(name string, validator detector.Validator) {
 	dvb.mu.Lock()
 	defer dvb.mu.Unlock()
-	dvb.validators = append(dvb.validators, validator)
+	dvb.validators = append(dvb.validators, namedValidator{name: name, v: validator})
 }
 
 // SetObserver sets the observability component
@@ -751,6 +783,22 @@ type validatorResult struct {
 // stable identifier available without changing the interface in Phase 1.
 func validatorName(v detector.Validator) string {
 	return fmt.Sprintf("%T", v)
+}
+
+// firstBudgetError returns the first error that represents a per-validator budget
+// outcome — a time budget (context.DeadlineExceeded/Canceled) or a match-count cap
+// (execguard.ErrMatchBudgetExceeded) — or nil if none. These are the errors that
+// mean "coverage was cut short" and should surface as ScanResult.Incomplete;
+// ordinary validator errors are deliberately excluded (historical behavior).
+func firstBudgetError(errs []error) error {
+	for _, err := range errs {
+		if errors.Is(err, stdctx.DeadlineExceeded) ||
+			errors.Is(err, stdctx.Canceled) ||
+			errors.Is(err, execguard.ErrMatchBudgetExceeded) {
+			return err
+		}
+	}
+	return nil
 }
 
 // ProcessDocumentContent processes document body content with non-metadata
@@ -776,7 +824,7 @@ func (dvb *DocumentValidatorBridge) ProcessDocumentContentCtx(ctx stdctx.Context
 	startTime := time.Now()
 
 	dvb.mu.RLock()
-	validators := make([]detector.Validator, len(dvb.validators))
+	validators := make([]namedValidator, len(dvb.validators))
 	copy(validators, dvb.validators)
 	dvb.mu.RUnlock()
 
@@ -796,7 +844,7 @@ func (dvb *DocumentValidatorBridge) ProcessDocumentContentCtx(ctx stdctx.Context
 	// Launch goroutines for each validator
 	for _, validator := range validators {
 		wg.Add(1)
-		go func(v detector.Validator) {
+		go func(nv namedValidator) {
 			defer wg.Done()
 
 			// Bound process-wide concurrent validator work (v2 gap 2.1): file
@@ -815,11 +863,16 @@ func (dvb *DocumentValidatorBridge) ProcessDocumentContentCtx(ctx stdctx.Context
 			}
 
 			// Dispatch through the execguard chokepoint: recovers panics
-			// (so one validator cannot crash the whole process — v2 gap 1.3)
-			// and threads ctx to context-aware validators / skips launch once
-			// ctx is cancelled (v2 gap 1.1). Behavior is unchanged for the
+			// (so one validator cannot crash the whole process — v2 gap 1.3),
+			// threads ctx to context-aware validators / skips launch once ctx is
+			// cancelled (v2 gap 1.1), and enforces the per-validator budget keyed
+			// by the logical check name (v2 Move C). Behavior is unchanged for the
 			// common success path.
-			matches, err := execguard.ValidateContent(ctx, validatorName(v), v, content, filePath)
+			name := nv.name
+			if name == "" {
+				name = validatorName(nv.v) // fallback: Go type (unnamed registration)
+			}
+			matches, err := execguard.ValidateContent(ctx, name, nv.v, content, filePath)
 			execguard.DefaultLimiter.Release()
 			if err != nil {
 				errorsMu.Lock()
@@ -834,6 +887,14 @@ func (dvb *DocumentValidatorBridge) ProcessDocumentContentCtx(ctx stdctx.Context
 						Success:   false,
 						Error:     err.Error(),
 					})
+				}
+				// A match-budget hit is a "soft" outcome (v2 Move C): the truncated
+				// matches are genuine findings and must be kept, unlike a real
+				// validator error (which discards its partial slice). The error is
+				// still recorded above so the scan is flagged incomplete.
+				if errors.Is(err, execguard.ErrMatchBudgetExceeded) {
+					resultsChan <- validatorResult{matches: matches, err: err}
+					return
 				}
 				resultsChan <- validatorResult{matches: nil, err: err}
 				return
@@ -904,11 +965,18 @@ func (dvb *DocumentValidatorBridge) ProcessDocumentContentCtx(ctx stdctx.Context
 		close(done)
 	}()
 
+	// keepMatches reports whether a validator result's matches should be collected:
+	// on success, or on a match-budget hit (the truncated matches are real findings
+	// — v2 Move C). A real validator error still discards its partial slice.
+	keepMatches := func(r validatorResult) bool {
+		return r.matches != nil && (r.err == nil || errors.Is(r.err, execguard.ErrMatchBudgetExceeded))
+	}
+
 	select {
 	case <-done:
 		close(resultsChan)
 		for result := range resultsChan {
-			if result.err == nil && result.matches != nil {
+			if keepMatches(result) {
 				allMatches = append(allMatches, result.matches...)
 			}
 		}
@@ -916,7 +984,7 @@ func (dvb *DocumentValidatorBridge) ProcessDocumentContentCtx(ctx stdctx.Context
 		for draining := true; draining; {
 			select {
 			case result := <-resultsChan:
-				if result.err == nil && result.matches != nil {
+				if keepMatches(result) {
 					allMatches = append(allMatches, result.matches...)
 				}
 			default:
@@ -937,6 +1005,17 @@ func (dvb *DocumentValidatorBridge) ProcessDocumentContentCtx(ctx stdctx.Context
 	if len(validationErrors) > 0 && dvb.observer != nil && dvb.observer.DebugObserver != nil {
 		dvb.observer.DebugObserver.LogDetail("document_validation_errors",
 			fmt.Sprintf("%d out of %d validators failed", len(validationErrors), len(validators)))
+	}
+
+	// Surface a per-validator BUDGET or DEADLINE outcome (v2 Move C) so the caller
+	// can flag ScanResult.Incomplete: a validator's own time budget (child
+	// context.DeadlineExceeded) or match-count cap (ErrMatchBudgetExceeded) means
+	// coverage was cut short even though the overall scan completed. Ordinary
+	// validator errors keep the historical behavior (logged, not surfaced) so a
+	// single failing validator does not by itself mark the scan incomplete. When
+	// no budgets are configured there are no such errors — byte-identical path.
+	if budgetErr := firstBudgetError(validationErrors); budgetErr != nil {
+		return allMatches, budgetErr
 	}
 
 	// Update metrics

--- a/internal/validators/email/ctx_cancel_test.go
+++ b/internal/validators/email/ctx_cancel_test.go
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package email
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestValidateContentCtx_ReclaimsRunawayMultiLineScan: a cancelled context stops a
+// large multi-line scan promptly (v2 Phase 3 per-line ctx polling).
+func TestValidateContentCtx_ReclaimsRunawayMultiLineScan(t *testing.T) {
+	v := NewValidator()
+	content := strings.Repeat("contact john.doe@example.com or admin@acme-corp.com today\n", 500000)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_, err := v.ValidateContentCtx(ctx, content, "<stdin>")
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Errorf("cancelled scan took %v; expected prompt return", elapsed)
+	}
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestValidateContent_BackgroundShimEqualsCtx: the non-ctx shim must produce the
+// same result as ValidateContentCtx with a never-cancelling context.
+func TestValidateContent_BackgroundShimEqualsCtx(t *testing.T) {
+	const content = "contact john.doe@example.com or admin@acme-corp.com\nsupport@business.io\n"
+	shim, err1 := NewValidator().ValidateContent(content, "<stdin>")
+	ctxRes, err2 := NewValidator().ValidateContentCtx(context.Background(), content, "<stdin>")
+	if err1 != nil || err2 != nil {
+		t.Fatalf("unexpected errors: shim=%v ctx=%v", err1, err2)
+	}
+	if len(shim) != len(ctxRes) {
+		t.Errorf("shim vs ctx match count differ: %d != %d", len(shim), len(ctxRes))
+	}
+}

--- a/internal/validators/email/validator.go
+++ b/internal/validators/email/validator.go
@@ -4,11 +4,13 @@
 package email
 
 import (
+	stdctx "context"
 	"os"
 	"regexp"
 	"strings"
 
 	"github.com/awslabs/ferret-scan/internal/detector"
+	"github.com/awslabs/ferret-scan/internal/execguard"
 	"github.com/awslabs/ferret-scan/internal/observability"
 )
 
@@ -215,6 +217,15 @@ func (v *Validator) Validate(filePath string) ([]detector.Match, error) {
 
 // ValidateContent validates preprocessed content for email addresses
 func (v *Validator) ValidateContent(content string, originalPath string) ([]detector.Match, error) {
+	// Backward-compatible shim: run with a background context (never cancels).
+	return v.ValidateContentCtx(stdctx.Background(), content, originalPath)
+}
+
+// ValidateContentCtx implements execguard.ContextAwareValidator: the context-aware
+// form of ValidateContent, polling ctx once per line so a runaway multi-line scan
+// is reclaimed promptly (v2 Phase 3). Returns partial matches + ctx.Err() on
+// cancellation.
+func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, originalPath string) ([]detector.Match, error) {
 	var finishTiming func(bool, map[string]interface{})
 	if v.observer != nil {
 		finishTiming = v.observer.StartTiming("email_validator", "validate_content", originalPath)
@@ -229,6 +240,13 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 	re := v.regex
 
 	for lineNum, line := range lines {
+		// Cooperative cancellation (v2 Phase 3): bail promptly on deadline/cancel.
+		if execguard.LineLoopCancelled(ctx, lineNum) {
+			if finishTiming != nil {
+				finishTiming(false, map[string]interface{}{"cancelled": true, "match_count": len(matches)})
+			}
+			return matches, ctx.Err()
+		}
 		// Use match offsets (not just the strings) so that when the same email
 		// text appears more than once on a line, each occurrence is analyzed with
 		// ITS OWN surrounding context. The previous code re-ran strings.Index,

--- a/internal/validators/execguard_e2e_test.go
+++ b/internal/validators/execguard_e2e_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/awslabs/ferret-scan/internal/detector"
+	"github.com/awslabs/ferret-scan/internal/execguard"
 	"github.com/awslabs/ferret-scan/internal/observability"
 	"github.com/awslabs/ferret-scan/internal/preprocessors"
 )
@@ -153,4 +154,87 @@ func (okDocValidator) CalculateConfidence(string) (float64, map[string]bool) { r
 func (okDocValidator) AnalyzeContext(string, detector.ContextInfo) float64   { return 0 }
 func (okDocValidator) ValidateContent(_, path string) ([]detector.Match, error) {
 	return []detector.Match{{Type: "OKTYPE", Text: "x", Validator: "OK", Filename: path}}, nil
+}
+
+// nMatchDocValidator emits n matches, ignoring ctx — for the match-budget e2e.
+type nMatchDocValidator struct{ n int }
+
+func (nMatchDocValidator) Validate(string) ([]detector.Match, error)             { return nil, nil }
+func (nMatchDocValidator) CalculateConfidence(string) (float64, map[string]bool) { return 0, nil }
+func (nMatchDocValidator) AnalyzeContext(string, detector.ContextInfo) float64   { return 0 }
+func (m nMatchDocValidator) ValidateContent(_, path string) ([]detector.Match, error) {
+	out := make([]detector.Match, m.n)
+	for i := range out {
+		out[i] = detector.Match{Type: "MANY", Text: "m", Validator: "MANY", Filename: path}
+	}
+	return out, nil
+}
+
+// TestE2E_MatchBudgetTruncatesThroughStack proves a per-validator MATCH budget
+// (Move C), attached via execguard.WithBudgets, is enforced at the dispatch
+// chokepoint inside the REAL nested stack — the emitting validator's result is
+// capped. Deterministic (no wall-clock).
+func TestE2E_MatchBudgetTruncatesThroughStack(t *testing.T) {
+	wrapper := buildWrapper(t, map[string]detector.Validator{"MANY": nMatchDocValidator{n: 50}})
+	ctx := execguard.WithBudgets(stdctx.Background(), map[string]execguard.ValidatorBudget{
+		"MANY": {MatchLimit: 5},
+	})
+
+	matches, _ := wrapper.ValidateProcessedContentCtx(ctx, processed("content"))
+	if len(matches) != 5 {
+		t.Fatalf("expected match budget to cap output at 5 through the full stack, got %d", len(matches))
+	}
+}
+
+// TestE2E_MatchBudgetUnderCapUnaffected confirms a generous budget leaves output
+// untouched through the stack (byte-identical behavior when under the cap).
+func TestE2E_MatchBudgetUnderCapUnaffected(t *testing.T) {
+	wrapper := buildWrapper(t, map[string]detector.Validator{"MANY": nMatchDocValidator{n: 3}})
+	ctx := execguard.WithBudgets(stdctx.Background(), map[string]execguard.ValidatorBudget{
+		"MANY": {MatchLimit: 100},
+	})
+
+	matches, err := wrapper.ValidateProcessedContentCtx(ctx, processed("content"))
+	if err != nil {
+		t.Fatalf("under-cap must not error through the stack: %v", err)
+	}
+	if len(matches) != 3 {
+		t.Fatalf("under-cap must return all 3 matches, got %d", len(matches))
+	}
+}
+
+// budgetBlockValidator is ctx-aware and blocks until its (per-validator) deadline
+// fires, then returns ctx.Err() — a runaway validator that a TIME budget must
+// reclaim. It waits on ctx.Done() rather than racing a sleep (anti-flake).
+type budgetBlockValidator struct{}
+
+func (budgetBlockValidator) Validate(string) ([]detector.Match, error)             { return nil, nil }
+func (budgetBlockValidator) CalculateConfidence(string) (float64, map[string]bool) { return 0, nil }
+func (budgetBlockValidator) AnalyzeContext(string, detector.ContextInfo) float64   { return 0 }
+func (budgetBlockValidator) ValidateContent(string, string) ([]detector.Match, error) {
+	return nil, nil
+}
+func (budgetBlockValidator) ValidateContentCtx(ctx stdctx.Context, _, _ string) ([]detector.Match, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+// TestE2E_TimeBudgetReclaimsAndSurfaces proves a per-validator TIME budget (Move
+// C) reclaims a runaway validator promptly AND surfaces DeadlineExceeded through
+// the real stack (so the caller flags ScanResult.Incomplete), even though the
+// PARENT context never expired. The budget derives a tighter child deadline.
+func TestE2E_TimeBudgetReclaimsAndSurfaces(t *testing.T) {
+	wrapper := buildWrapper(t, map[string]detector.Validator{"BLOCK": budgetBlockValidator{}})
+	ctx := execguard.WithBudgets(stdctx.Background(), map[string]execguard.ValidatorBudget{
+		"BLOCK": {TimeLimit: 30 * time.Millisecond},
+	})
+
+	start := time.Now()
+	_, err := wrapper.ValidateProcessedContentCtx(ctx, processed("content"))
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Fatalf("time budget did not reclaim the runaway validator: took %v", elapsed)
+	}
+	if !errors.Is(err, stdctx.DeadlineExceeded) {
+		t.Fatalf("per-validator time budget must surface DeadlineExceeded, got %v", err)
+	}
 }

--- a/internal/validators/intellectualproperty/ctx_cancel_test.go
+++ b/internal/validators/intellectualproperty/ctx_cancel_test.go
@@ -1,0 +1,46 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package intellectualproperty
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestValidateContentCtx_ReclaimsRunawayMultiLineScan: a cancelled context stops a
+// large multi-line scan promptly (v2 Phase 3 per-line ctx polling, threaded into
+// detectPatternsByLine). The partial per-line matches are still reconstructed and
+// returned with ctx.Err().
+func TestValidateContentCtx_ReclaimsRunawayMultiLineScan(t *testing.T) {
+	v := NewValidator()
+	content := strings.Repeat("Copyright (c) 2024 Acme Corp. All rights reserved. Patent US1234567B2\n", 500000)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_, err := v.ValidateContentCtx(ctx, content, "<stdin>")
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Errorf("cancelled scan took %v; expected prompt return", elapsed)
+	}
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestValidateContent_BackgroundShimEqualsCtx: the non-ctx shim must produce the
+// same result as ValidateContentCtx with a never-cancelling context.
+func TestValidateContent_BackgroundShimEqualsCtx(t *testing.T) {
+	const content = "Copyright (c) 2024 Acme Corp. All rights reserved.\nPatent US1234567B2\n"
+	shim, err1 := NewValidator().ValidateContent(content, "<stdin>")
+	ctxRes, err2 := NewValidator().ValidateContentCtx(context.Background(), content, "<stdin>")
+	if err1 != nil || err2 != nil {
+		t.Fatalf("unexpected errors: shim=%v ctx=%v", err1, err2)
+	}
+	if len(shim) != len(ctxRes) {
+		t.Errorf("shim vs ctx match count differ: %d != %d", len(shim), len(ctxRes))
+	}
+}

--- a/internal/validators/intellectualproperty/validator.go
+++ b/internal/validators/intellectualproperty/validator.go
@@ -4,6 +4,7 @@
 package intellectualproperty
 
 import (
+	stdctx "context"
 	"fmt"
 	"os"
 	"regexp"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/awslabs/ferret-scan/internal/config"
 	"github.com/awslabs/ferret-scan/internal/detector"
+	"github.com/awslabs/ferret-scan/internal/execguard"
 	"github.com/awslabs/ferret-scan/internal/observability"
 )
 
@@ -697,12 +699,25 @@ func (v *Validator) Validate(filePath string) ([]detector.Match, error) {
 
 // ValidateContent validates preprocessed content for intellectual property references
 func (v *Validator) ValidateContent(content string, originalPath string) ([]detector.Match, error) {
+	// Backward-compatible shim: run with a background context (never cancels).
+	return v.ValidateContentCtx(stdctx.Background(), content, originalPath)
+}
+
+// ValidateContentCtx implements execguard.ContextAwareValidator: the context-aware
+// form of ValidateContent, polling ctx once per line (inside detectPatternsByLine)
+// so a runaway multi-line scan is reclaimed promptly (v2 Phase 3). On cancellation
+// the line loop stops; the partial per-line matches gathered so far are still run
+// through legal-notice reconstruction and returned along with ctx.Err().
+func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, originalPath string) ([]detector.Match, error) {
 	// Use line-based grouping for legal notice reconstruction
-	lineMatches := v.detectPatternsByLine(content, originalPath)
+	lineMatches := v.detectPatternsByLine(ctx, content, originalPath)
 
 	// Process line matches with legal notice reconstruction logic
 	processedMatches := v.processLineMatches(lineMatches)
 
+	if ctx.Err() != nil {
+		return processedMatches, ctx.Err()
+	}
 	return processedMatches, nil
 }
 
@@ -841,13 +856,18 @@ func (v *Validator) processLineMatches(lineMatches map[int][]detector.Match) []d
 }
 
 // detectPatternsByLine detects IP patterns and groups matches by line number
-func (v *Validator) detectPatternsByLine(content string, originalPath string) map[int][]detector.Match {
+func (v *Validator) detectPatternsByLine(ctx stdctx.Context, content string, originalPath string) map[int][]detector.Match {
 	lineMatches := make(map[int][]detector.Match)
 
 	// Split content into lines for processing
 	lines := strings.Split(content, "\n")
 
 	for lineNum, line := range lines {
+		// Cooperative cancellation (v2 Phase 3): stop promptly on deadline/cancel,
+		// returning the per-line matches gathered so far.
+		if execguard.LineLoopCancelled(ctx, lineNum) {
+			return lineMatches
+		}
 		// PERFORMANCE: keyword context impact and the open-source-license check
 		// are LINE-GLOBAL — they depend only on the line text, not on the
 		// individual match or its position. The previous code recomputed them

--- a/internal/validators/ipaddress/ctx_cancel_test.go
+++ b/internal/validators/ipaddress/ctx_cancel_test.go
@@ -1,0 +1,48 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ipaddress
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestValidateContentCtx_ReclaimsRunawayMultiLineScan: a cancelled context stops
+// a large multi-line IP scan promptly (v2 Phase 3 per-line ctx polling).
+func TestValidateContentCtx_ReclaimsRunawayMultiLineScan(t *testing.T) {
+	v := NewValidator()
+	content := strings.Repeat("host 203.0.113.42 gw 192.168.1.1 dns 8.8.8.8\n", 500000)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_, err := v.ValidateContentCtx(ctx, content, "<stdin>")
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Errorf("cancelled scan took %v; expected prompt return", elapsed)
+	}
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestValidateContent_BackgroundShimEqualsCtx: the non-ctx shim must produce the
+// exact same result as ValidateContentCtx with a never-cancelling context — that
+// is the behavior-preserving invariant (the shim just supplies context.Background).
+// Asserting equality avoids coupling the test to IP-scoring specifics.
+func TestValidateContent_BackgroundShimEqualsCtx(t *testing.T) {
+	v := NewValidator()
+	const content = "server address 203.0.113.50 for access\nprivate 10.0.0.5 internal\n"
+
+	shim, err1 := v.ValidateContent(content, "<stdin>")
+	ctxRes, err2 := v.ValidateContentCtx(context.Background(), content, "<stdin>")
+	if err1 != nil || err2 != nil {
+		t.Fatalf("unexpected errors: shim=%v ctx=%v", err1, err2)
+	}
+	if len(shim) != len(ctxRes) {
+		t.Errorf("shim vs ctx match count differ: %d != %d", len(shim), len(ctxRes))
+	}
+}

--- a/internal/validators/ipaddress/validator.go
+++ b/internal/validators/ipaddress/validator.go
@@ -4,12 +4,14 @@
 package ipaddress
 
 import (
+	stdctx "context"
 	"net"
 	"os"
 	"regexp"
 	"strings"
 
 	"github.com/awslabs/ferret-scan/internal/detector"
+	"github.com/awslabs/ferret-scan/internal/execguard"
 	"github.com/awslabs/ferret-scan/internal/observability"
 )
 
@@ -264,6 +266,15 @@ func (v *Validator) Validate(filePath string) ([]detector.Match, error) {
 
 // ValidateContent validates preprocessed content for IP addresses
 func (v *Validator) ValidateContent(content string, originalPath string) ([]detector.Match, error) {
+	// Backward-compatible shim: run with a background context (never cancels).
+	return v.ValidateContentCtx(stdctx.Background(), content, originalPath)
+}
+
+// ValidateContentCtx implements execguard.ContextAwareValidator: the context-aware
+// form of ValidateContent, polling ctx once per line so a runaway multi-line scan
+// is reclaimed promptly (v2 Phase 3). Returns partial matches + ctx.Err() on
+// cancellation.
+func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, originalPath string) ([]detector.Match, error) {
 	var finishTiming func(bool, map[string]interface{})
 	if v.observer != nil {
 		finishTiming = v.observer.StartTiming("ipaddress_validator", "validate_content", originalPath)
@@ -276,6 +287,13 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 
 	// Process each pattern type
 	for lineNum, line := range lines {
+		// Cooperative cancellation (v2 Phase 3): bail promptly on deadline/cancel.
+		if execguard.LineLoopCancelled(ctx, lineNum) {
+			if finishTiming != nil {
+				finishTiming(false, map[string]interface{}{"cancelled": true, "match_count": len(matches)})
+			}
+			return matches, ctx.Err()
+		}
 		// Cheap per-line fast paths: every IPv6 form needs a ":" and the
 		// compressed form additionally needs a "::". Skipping the (multi-branch)
 		// IPv6 regexes on lines that cannot possibly contain such an address

--- a/internal/validators/passport/ctx_cancel_test.go
+++ b/internal/validators/passport/ctx_cancel_test.go
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package passport
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestValidateContentCtx_ReclaimsRunawayMultiLineScan: a cancelled context stops a
+// large multi-line scan promptly (v2 Phase 3 per-line ctx polling).
+func TestValidateContentCtx_ReclaimsRunawayMultiLineScan(t *testing.T) {
+	v := NewValidator()
+	content := strings.Repeat("passport number 123456789 issued to traveler\n", 500000)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_, err := v.ValidateContentCtx(ctx, content, "<stdin>")
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Errorf("cancelled scan took %v; expected prompt return", elapsed)
+	}
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestValidateContent_BackgroundShimEqualsCtx: the non-ctx shim must produce the
+// same result as ValidateContentCtx with a never-cancelling context.
+func TestValidateContent_BackgroundShimEqualsCtx(t *testing.T) {
+	const content = "passport number 123456789 issued to traveler\nsecond line 987654321\n"
+	shim, err1 := NewValidator().ValidateContent(content, "<stdin>")
+	ctxRes, err2 := NewValidator().ValidateContentCtx(context.Background(), content, "<stdin>")
+	if err1 != nil || err2 != nil {
+		t.Fatalf("unexpected errors: shim=%v ctx=%v", err1, err2)
+	}
+	if len(shim) != len(ctxRes) {
+		t.Errorf("shim vs ctx match count differ: %d != %d", len(shim), len(ctxRes))
+	}
+}

--- a/internal/validators/passport/validator.go
+++ b/internal/validators/passport/validator.go
@@ -4,12 +4,14 @@
 package passport
 
 import (
+	stdctx "context"
 	"regexp"
 	"strings"
 	"unicode"
 
 	"github.com/awslabs/ferret-scan/internal/context"
 	"github.com/awslabs/ferret-scan/internal/detector"
+	"github.com/awslabs/ferret-scan/internal/execguard"
 	"github.com/awslabs/ferret-scan/internal/observability"
 )
 
@@ -346,12 +348,25 @@ const maxMatchesPerLinePerPattern = 2000
 
 // ValidateContent validates preprocessed content for passport numbers
 func (v *Validator) ValidateContent(content string, originalPath string) ([]detector.Match, error) {
+	// Backward-compatible shim: run with a background context (never cancels).
+	return v.ValidateContentCtx(stdctx.Background(), content, originalPath)
+}
+
+// ValidateContentCtx implements execguard.ContextAwareValidator: the context-aware
+// form of ValidateContent, polling ctx once per line so a runaway multi-line scan
+// is reclaimed promptly (v2 Phase 3). On cancellation it returns the matches
+// gathered so far plus ctx.Err().
+func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, originalPath string) ([]detector.Match, error) {
 	var matches []detector.Match
 
 	// Split content into lines for processing
 	lines := strings.Split(content, "\n")
 
 	for lineNum, line := range lines {
+		// Cooperative cancellation (v2 Phase 3): bail promptly on deadline/cancel.
+		if execguard.LineLoopCancelled(ctx, lineNum) {
+			return matches, ctx.Err()
+		}
 		// Per-LINE work hoisted OUT of the per-match loop. These values depend
 		// only on the line (not on the individual match), so computing them once
 		// per line instead of once per match removes the dominant

--- a/internal/validators/personname/ctx_cancel_test.go
+++ b/internal/validators/personname/ctx_cancel_test.go
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package personname
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestValidateContentCtx_ReclaimsRunawayMultiLineScan: a cancelled context stops a
+// large multi-line scan promptly (v2 Phase 3 per-line ctx polling). personname
+// returns the pre-dedup partial matches plus ctx.Err() on cancel.
+func TestValidateContentCtx_ReclaimsRunawayMultiLineScan(t *testing.T) {
+	v := NewValidator()
+	content := strings.Repeat("John Smith and Jane Doe met Robert Brown today\n", 500000)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_, err := v.ValidateContentCtx(ctx, content, "<stdin>")
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Errorf("cancelled scan took %v; expected prompt return", elapsed)
+	}
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestValidateContent_BackgroundShimEqualsCtx: the non-ctx shim must produce the
+// same result as ValidateContentCtx with a never-cancelling context.
+func TestValidateContent_BackgroundShimEqualsCtx(t *testing.T) {
+	const content = "John Smith and Jane Doe met Robert Brown today\nAlice Johnson called\n"
+	shim, err1 := NewValidator().ValidateContent(content, "<stdin>")
+	ctxRes, err2 := NewValidator().ValidateContentCtx(context.Background(), content, "<stdin>")
+	if err1 != nil || err2 != nil {
+		t.Fatalf("unexpected errors: shim=%v ctx=%v", err1, err2)
+	}
+	if len(shim) != len(ctxRes) {
+		t.Errorf("shim vs ctx match count differ: %d != %d", len(shim), len(ctxRes))
+	}
+}

--- a/internal/validators/personname/validator.go
+++ b/internal/validators/personname/validator.go
@@ -4,6 +4,7 @@
 package personname
 
 import (
+	stdctx "context"
 	"regexp"
 	"slices"
 	"strings"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/awslabs/ferret-scan/internal/context"
 	"github.com/awslabs/ferret-scan/internal/detector"
+	"github.com/awslabs/ferret-scan/internal/execguard"
 	"github.com/awslabs/ferret-scan/internal/observability"
 )
 
@@ -105,6 +107,15 @@ func (v *Validator) Validate(filePath string) ([]detector.Match, error) {
 
 // ValidateContent implements the detector.Validator interface for preprocessed content
 func (v *Validator) ValidateContent(content string, originalPath string) ([]detector.Match, error) {
+	// Backward-compatible shim: run with a background context (never cancels).
+	return v.ValidateContentCtx(stdctx.Background(), content, originalPath)
+}
+
+// ValidateContentCtx implements execguard.ContextAwareValidator: the context-aware
+// form of ValidateContent, polling ctx once per line so a runaway multi-line scan
+// is reclaimed promptly (v2 Phase 3). On cancellation it returns the (pre-dedup)
+// matches gathered so far plus ctx.Err().
+func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, originalPath string) ([]detector.Match, error) {
 	var matches []detector.Match
 
 	// Ensure name databases are loaded
@@ -112,6 +123,10 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 
 	lines := strings.Split(content, "\n")
 	for lineNum, line := range lines {
+		// Cooperative cancellation (v2 Phase 3): bail promptly on deadline/cancel.
+		if execguard.LineLoopCancelled(ctx, lineNum) {
+			return matches, ctx.Err()
+		}
 		lineMatches := v.findNamesInLine(line, lineNum+1, originalPath)
 		matches = append(matches, lineMatches...)
 	}

--- a/internal/validators/phone/ctx_cancel_test.go
+++ b/internal/validators/phone/ctx_cancel_test.go
@@ -1,0 +1,42 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package phone
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestValidateContentCtx_ReclaimsRunawayMultiLineScan: a cancelled context stops
+// a large multi-line phone scan promptly (v2 Phase 3 per-line ctx polling).
+func TestValidateContentCtx_ReclaimsRunawayMultiLineScan(t *testing.T) {
+	v := NewValidator()
+	content := strings.Repeat("call 212-555-0142 or 415-555-0199 or 312-555-0123\n", 500000)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_, err := v.ValidateContentCtx(ctx, content, "<stdin>")
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Errorf("cancelled scan took %v; expected prompt return", elapsed)
+	}
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestValidateContent_BackgroundShimUnaffected: the non-ctx shim still detects.
+func TestValidateContent_BackgroundShimUnaffected(t *testing.T) {
+	v := NewValidator()
+	matches, err := v.ValidateContent("call me at 212-555-0142 tomorrow", "<stdin>")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Error("expected the phone number to be detected via the background shim")
+	}
+}

--- a/internal/validators/phone/validator.go
+++ b/internal/validators/phone/validator.go
@@ -4,6 +4,7 @@
 package phone
 
 import (
+	stdctx "context"
 	"os"
 	"regexp"
 	"sort"
@@ -11,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/awslabs/ferret-scan/internal/detector"
+	"github.com/awslabs/ferret-scan/internal/execguard"
 	"github.com/awslabs/ferret-scan/internal/observability"
 )
 
@@ -286,6 +288,15 @@ func (v *Validator) Validate(filePath string) ([]detector.Match, error) {
 
 // ValidateContent validates preprocessed content for phone numbers
 func (v *Validator) ValidateContent(content string, originalPath string) ([]detector.Match, error) {
+	// Backward-compatible shim: run with a background context (never cancels).
+	return v.ValidateContentCtx(stdctx.Background(), content, originalPath)
+}
+
+// ValidateContentCtx implements execguard.ContextAwareValidator: the context-aware
+// form of ValidateContent, polling ctx once per line so a runaway multi-line scan
+// is reclaimed promptly (v2 Phase 3). Returns partial matches + ctx.Err() on
+// cancellation.
+func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, originalPath string) ([]detector.Match, error) {
 	var finishTiming func(bool, map[string]interface{})
 	if v.observer != nil {
 		finishTiming = v.observer.StartTiming("phone_validator", "validate_content", originalPath)
@@ -298,6 +309,13 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 
 	// Process each pattern type
 	for lineNum, line := range lines {
+		// Cooperative cancellation (v2 Phase 3): bail promptly on deadline/cancel.
+		if execguard.LineLoopCancelled(ctx, lineNum) {
+			if finishTiming != nil {
+				finishTiming(false, map[string]interface{}{"cancelled": true, "match_count": len(matches)})
+			}
+			return matches, ctx.Err()
+		}
 		// Per-line state hoisted out of the per-match loop:
 		//   - dedup indexes the cleaned-digit form of every match already accepted
 		//     on THIS line so duplicate detection is O(1)-amortized per candidate

--- a/internal/validators/secrets/ctx_cancel_test.go
+++ b/internal/validators/secrets/ctx_cancel_test.go
@@ -1,0 +1,54 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package secrets
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestValidateContentCtx_ReclaimsRunawayMultiLineScan: a cancelled context stops a
+// large multi-line scan promptly (v2 Phase 3 per-line ctx polling). SECRETS' DoS
+// shape is many dense lines (per-line shell/entropy work), so the input is
+// many-lines rather than one long line.
+func TestValidateContentCtx_ReclaimsRunawayMultiLineScan(t *testing.T) {
+	v := NewValidator()
+	content := strings.Repeat("export API_KEY=\"AKIAIOSFODNN7EXAMPLE\" password=hunter2 token=abcd1234\n", 500000)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// An already-cancelled scan bails at the entry check before the whole-content
+	// context-analysis / multi-line passes, so this is near-instant. -race inflates
+	// wall-clock 5-20x, so relax the ceiling under the race detector.
+	ceiling := 500 * time.Millisecond
+	if raceEnabled {
+		ceiling = 5 * time.Second
+	}
+
+	start := time.Now()
+	_, err := v.ValidateContentCtx(ctx, content, "<stdin>")
+	if elapsed := time.Since(start); elapsed > ceiling {
+		t.Errorf("cancelled scan took %v; expected prompt return", elapsed)
+	}
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestValidateContent_BackgroundShimEqualsCtx: the non-ctx shim must produce the
+// same result as ValidateContentCtx with a never-cancelling context.
+func TestValidateContent_BackgroundShimEqualsCtx(t *testing.T) {
+	const content = "export API_KEY=\"AKIAIOSFODNN7EXAMPLE\"\npassword=hunter2\n"
+	shim, err1 := NewValidator().ValidateContent(content, "<stdin>")
+	ctxRes, err2 := NewValidator().ValidateContentCtx(context.Background(), content, "<stdin>")
+	if err1 != nil || err2 != nil {
+		t.Fatalf("unexpected errors: shim=%v ctx=%v", err1, err2)
+	}
+	if len(shim) != len(ctxRes) {
+		t.Errorf("shim vs ctx match count differ: %d != %d", len(shim), len(ctxRes))
+	}
+}

--- a/internal/validators/secrets/validator.go
+++ b/internal/validators/secrets/validator.go
@@ -4,6 +4,7 @@
 package secrets
 
 import (
+	stdctx "context"
 	"encoding/base64"
 	"math"
 	"regexp"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/awslabs/ferret-scan/internal/context"
 	"github.com/awslabs/ferret-scan/internal/detector"
+	"github.com/awslabs/ferret-scan/internal/execguard"
 	"github.com/awslabs/ferret-scan/internal/help"
 	"github.com/awslabs/ferret-scan/internal/observability"
 )
@@ -267,7 +269,24 @@ func (v *Validator) Validate(filePath string) ([]detector.Match, error) {
 
 // ValidateContent validates preprocessed content with enhanced context analysis
 func (v *Validator) ValidateContent(content string, originalPath string) ([]detector.Match, error) {
+	// Backward-compatible shim: run with a background context (never cancels).
+	return v.ValidateContentCtx(stdctx.Background(), content, originalPath)
+}
+
+// ValidateContentCtx implements execguard.ContextAwareValidator: the context-aware
+// form of ValidateContent, polling ctx once per line so a runaway multi-line scan
+// (SECRETS' DoS shape is many dense lines) is reclaimed promptly (v2 Phase 3). On
+// cancellation it returns the matches gathered so far plus ctx.Err().
+func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, originalPath string) ([]detector.Match, error) {
 	var matches []detector.Match
+
+	// Entry-level cancellation check (v2 Phase 3): the whole-content passes below
+	// (context analysis, multi-line secret scan) run before the polled per-line
+	// loop, so an already-cancelled/expired scan bails here rather than paying for
+	// them. LineLoopCancelled at i==0 reduces to ctx.Err() != nil.
+	if execguard.LineLoopCancelled(ctx, 0) {
+		return matches, ctx.Err()
+	}
 
 	// Perform context analysis for the entire content
 	contextInsights := v.contextAnalyzer.AnalyzeContext(content, originalPath)
@@ -284,6 +303,10 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 	lines := strings.Split(content, "\n")
 
 	for lineNum, line := range lines {
+		// Cooperative cancellation (v2 Phase 3): bail promptly on deadline/cancel.
+		if execguard.LineLoopCancelled(ctx, lineNum) {
+			return matches, ctx.Err()
+		}
 		// Pre-check if this line contains shell variable references to optimize performance
 		lineHasShellVars := v.LineContainsShellVariableReferences(line)
 

--- a/internal/validators/socialmedia/ctx_cancel_test.go
+++ b/internal/validators/socialmedia/ctx_cancel_test.go
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package socialmedia
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestValidateContentCtx_ReclaimsRunawayMultiLineScan: a cancelled context stops a
+// large multi-line scan promptly (v2 Phase 3 per-line ctx polling, threaded into
+// detectPatternsByLine). Uses newConfiguredValidator so patterns are compiled and
+// the per-line loop actually runs (the unconfigured validator returns early,
+// before the loop).
+func TestValidateContentCtx_ReclaimsRunawayMultiLineScan(t *testing.T) {
+	v := newConfiguredValidator()
+	content := strings.Repeat("follow https://twitter.com/johndoe and https://github.com/johndoe\n", 500000)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_, err := v.ValidateContentCtx(ctx, content, "<stdin>")
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Errorf("cancelled scan took %v; expected prompt return", elapsed)
+	}
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestValidateContent_BackgroundShimEqualsCtx: the non-ctx shim must produce the
+// same result as ValidateContentCtx with a never-cancelling context.
+func TestValidateContent_BackgroundShimEqualsCtx(t *testing.T) {
+	const content = "follow https://twitter.com/johndoe\nhttps://github.com/johndoe\n"
+	shim, err1 := newConfiguredValidator().ValidateContent(content, "<stdin>")
+	ctxRes, err2 := newConfiguredValidator().ValidateContentCtx(context.Background(), content, "<stdin>")
+	if err1 != nil || err2 != nil {
+		t.Fatalf("unexpected errors: shim=%v ctx=%v", err1, err2)
+	}
+	if len(shim) != len(ctxRes) {
+		t.Errorf("shim vs ctx match count differ: %d != %d", len(shim), len(ctxRes))
+	}
+}

--- a/internal/validators/socialmedia/validator.go
+++ b/internal/validators/socialmedia/validator.go
@@ -4,6 +4,7 @@
 package socialmedia
 
 import (
+	stdctx "context"
 	"fmt"
 	"os"
 	"regexp"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/awslabs/ferret-scan/internal/config"
 	"github.com/awslabs/ferret-scan/internal/detector"
+	"github.com/awslabs/ferret-scan/internal/execguard"
 	"github.com/awslabs/ferret-scan/internal/observability"
 )
 
@@ -558,6 +560,16 @@ func (v *Validator) Validate(filePath string) ([]detector.Match, error) {
 
 // ValidateContent validates preprocessed content for social media references
 func (v *Validator) ValidateContent(content string, originalPath string) ([]detector.Match, error) {
+	// Backward-compatible shim: run with a background context (never cancels).
+	return v.ValidateContentCtx(stdctx.Background(), content, originalPath)
+}
+
+// ValidateContentCtx implements execguard.ContextAwareValidator: the context-aware
+// form of ValidateContent, polling ctx once per line (inside detectPatternsByLine)
+// so a runaway multi-line scan is reclaimed promptly (v2 Phase 3). On cancellation
+// the line loop stops and the partial per-line matches gathered so far are
+// clustered and returned along with ctx.Err().
+func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, originalPath string) ([]detector.Match, error) {
 	var finishTiming func(bool, map[string]any)
 	if v.observer != nil {
 		finishTiming = v.observer.StartTiming("social_media_validator", "validate_content", originalPath)
@@ -605,7 +617,7 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 	}
 
 	// Use line-based processing for social media pattern detection with error handling
-	lineMatches, err := v.detectPatternsByLineWithErrorHandling(content, originalPath)
+	lineMatches, err := v.detectPatternsByLineWithErrorHandling(ctx, content, originalPath)
 	if err != nil {
 		// Log error but continue with empty results for graceful degradation
 		if v.observer != nil && v.observer.DebugObserver != nil {
@@ -656,11 +668,19 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 		}
 	}
 
+	// If the scan was cancelled/timed out mid-line-loop, the detection above
+	// returned only the lines processed before the deadline. Surface ctx.Err() so
+	// the caller records incomplete coverage (v2 Phase 3); the clustered partial
+	// matches are still returned.
+	if ctx.Err() != nil {
+		return processedMatches, ctx.Err()
+	}
+
 	return processedMatches, nil
 }
 
 // detectPatternsByLineWithErrorHandling wraps detectPatternsByLine with comprehensive error handling
-func (v *Validator) detectPatternsByLineWithErrorHandling(content string, originalPath string) (map[int][]detector.Match, error) {
+func (v *Validator) detectPatternsByLineWithErrorHandling(ctx stdctx.Context, content string, originalPath string) (map[int][]detector.Match, error) {
 	defer func() {
 		if r := recover(); r != nil {
 			// Log panic recovery for debugging
@@ -690,7 +710,7 @@ func (v *Validator) detectPatternsByLineWithErrorHandling(content string, origin
 	}
 
 	// Call the original method with error handling
-	lineMatches := v.detectPatternsByLine(content, originalPath)
+	lineMatches := v.detectPatternsByLine(ctx, content, originalPath)
 	return lineMatches, nil
 }
 
@@ -2521,7 +2541,7 @@ func (v *Validator) compileWhitelistPatterns() {
 
 // detectPatternsByLine detects social media patterns and groups matches by line number
 // with platform categorization, metadata tagging, and batch processing optimizations
-func (v *Validator) detectPatternsByLine(content string, originalPath string) map[int][]detector.Match {
+func (v *Validator) detectPatternsByLine(ctx stdctx.Context, content string, originalPath string) map[int][]detector.Match {
 	lineMatches := make(map[int][]detector.Match)
 
 	// If no patterns are configured, return empty results
@@ -2537,7 +2557,7 @@ func (v *Validator) detectPatternsByLine(content string, originalPath string) ma
 	useBatchProcessing := contentLength > 1024*1024 // 1MB threshold
 
 	if useBatchProcessing {
-		return v.detectPatternsByLineBatch(content, originalPath)
+		return v.detectPatternsByLineBatch(ctx, content, originalPath)
 	}
 
 	// Split content into lines for processing
@@ -2548,6 +2568,11 @@ func (v *Validator) detectPatternsByLine(content string, originalPath string) ma
 
 	// Process each line for social media patterns with optimizations
 	for lineNum, line := range lines {
+		// Cooperative cancellation (v2 Phase 3): stop promptly on deadline/cancel,
+		// returning the per-line matches gathered so far.
+		if execguard.LineLoopCancelled(ctx, lineNum) {
+			return lineMatches
+		}
 		// Skip empty lines early
 		if len(strings.TrimSpace(line)) == 0 {
 			continue
@@ -2561,7 +2586,7 @@ func (v *Validator) detectPatternsByLine(content string, originalPath string) ma
 }
 
 // detectPatternsByLineBatch processes large files using batch processing for better performance
-func (v *Validator) detectPatternsByLineBatch(content string, originalPath string) map[int][]detector.Match {
+func (v *Validator) detectPatternsByLineBatch(ctx stdctx.Context, content string, originalPath string) map[int][]detector.Match {
 	lineMatches := make(map[int][]detector.Match)
 
 	// Split content into lines
@@ -2576,6 +2601,11 @@ func (v *Validator) detectPatternsByLineBatch(content string, originalPath strin
 
 		// Process batch
 		for lineNum := i; lineNum < end; lineNum++ {
+			// Cooperative cancellation (v2 Phase 3): stop promptly on
+			// deadline/cancel, returning the per-line matches gathered so far.
+			if execguard.LineLoopCancelled(ctx, lineNum) {
+				return lineMatches
+			}
 			line := lines[lineNum]
 
 			// Skip empty lines early

--- a/internal/validators/ssn/ctx_cancel_test.go
+++ b/internal/validators/ssn/ctx_cancel_test.go
@@ -1,0 +1,106 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ssn
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/awslabs/ferret-scan/internal/execguard"
+)
+
+// TestValidateContentCtx_ReclaimsRunawayMultiLineScan is the v2 Phase 3
+// regression test: a large multi-line input that would otherwise run to
+// completion is reclaimed promptly when the context is already cancelled — the
+// validator polls ctx per line and returns ctx.Err() instead of scanning every
+// line.
+func TestValidateContentCtx_ReclaimsRunawayMultiLineScan(t *testing.T) {
+	v := NewValidator()
+
+	// Many lines of dense near-SSN tokens — enough that a full scan is clearly
+	// measurable, so an early return is unambiguous.
+	line := "ssn 449-87-4100 and 555-12-3456 and 111-22-3333"
+	content := strings.Repeat(line+"\n", 500000)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled: the loop must bail on (or before) the first check
+
+	start := time.Now()
+	matches, err := v.ValidateContentCtx(ctx, content, "<stdin>")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Error("expected a context error from a cancelled scan, got nil")
+	}
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+	// Reclaimed promptly: must not scan all 500k lines. Generous ceiling guards
+	// against a regression where the poll is missing (which would take seconds).
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("cancelled scan took %v; expected prompt return (per-line ctx poll missing?)", elapsed)
+	}
+	// Partial matches are acceptable (<= the first ctxCheckStride lines' worth);
+	// the point is we did NOT scan the whole input.
+	_ = matches
+}
+
+// TestValidateContentCtx_DeadlineWhileScanning verifies a deadline that fires
+// mid-scan also reclaims the loop (not just an already-cancelled context).
+func TestValidateContentCtx_DeadlineWhileScanning(t *testing.T) {
+	v := NewValidator()
+	content := strings.Repeat("ssn 449-87-4100 more text here\n", 2000000)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := v.ValidateContentCtx(ctx, content, "<stdin>")
+	elapsed := time.Since(start)
+
+	if err != context.DeadlineExceeded {
+		t.Errorf("expected context.DeadlineExceeded, got %v", err)
+	}
+	// Should stop within a small multiple of the 50ms budget, not scan 2M lines.
+	if elapsed > 5*time.Second {
+		t.Errorf("scan ran %v past a 50ms deadline; ctx polling not effective", elapsed)
+	}
+}
+
+// TestValidateContent_BackgroundShimUnaffected confirms the non-ctx shim behaves
+// exactly as before: a normal scan completes and finds the SSN.
+func TestValidateContent_BackgroundShimUnaffected(t *testing.T) {
+	v := NewValidator()
+	matches, err := v.ValidateContent("employee ssn: 449-87-4100 on record", "<stdin>")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Error("expected the SSN to be detected via the background shim")
+	}
+}
+
+// TestLineLoopCancelled_StrideBehavior locks the helper's cheap-check contract:
+// it reads ctx only on stride boundaries, and an already-done ctx is caught at
+// i==0.
+func TestLineLoopCancelled_StrideBehavior(t *testing.T) {
+	done, cancel := context.WithCancel(context.Background())
+	cancel()
+	if !execguard.LineLoopCancelled(done, 0) {
+		t.Error("expected cancellation to be detected at i=0")
+	}
+	// A live context never reports cancelled regardless of index.
+	live := context.Background()
+	for _, i := range []int{0, 1, 255, 256, 512} {
+		if execguard.LineLoopCancelled(live, i) {
+			t.Errorf("live context reported cancelled at i=%d", i)
+		}
+	}
+	// nil context never cancels.
+	if execguard.LineLoopCancelled(nil, 0) {
+		t.Error("nil context must not report cancelled")
+	}
+}

--- a/internal/validators/ssn/validator.go
+++ b/internal/validators/ssn/validator.go
@@ -4,11 +4,13 @@
 package ssn
 
 import (
+	stdctx "context"
 	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/awslabs/ferret-scan/internal/detector"
+	"github.com/awslabs/ferret-scan/internal/execguard"
 	"github.com/awslabs/ferret-scan/internal/observability"
 )
 
@@ -234,6 +236,16 @@ func (v *Validator) newLineContext(line string) *lineContext {
 
 // ValidateContent validates preprocessed content for SSNs
 func (v *Validator) ValidateContent(content string, originalPath string) ([]detector.Match, error) {
+	// Backward-compatible shim: run with a background context (never cancels).
+	return v.ValidateContentCtx(stdctx.Background(), content, originalPath)
+}
+
+// ValidateContentCtx implements execguard.ContextAwareValidator: it is the
+// context-aware form of ValidateContent, polling ctx once per line so a runaway
+// scan of a large multi-line input is reclaimed promptly (v2 Phase 3). On
+// cancellation it returns the matches gathered so far plus ctx.Err(), so a
+// timed-out scan surfaces partial findings rather than discarding them.
+func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, originalPath string) ([]detector.Match, error) {
 	var matches []detector.Match
 
 	// Split content into lines for processing
@@ -242,6 +254,11 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 	isDocx := strings.Contains(originalPath, ".docx")
 
 	for lineNum, line := range lines {
+		// Cooperative cancellation: stop promptly if the scan's deadline fired
+		// or it was cancelled, returning what we have plus the reason.
+		if execguard.LineLoopCancelled(ctx, lineNum) {
+			return matches, ctx.Err()
+		}
 		// Use FindAllStringIndex so we enumerate matches with their byte offsets in a
 		// single regex pass (FindAllString already did one pass; this is equivalent).
 		// We deliberately compute the context window from the FIRST occurrence of each

--- a/internal/validators/vin/ctx_cancel_test.go
+++ b/internal/validators/vin/ctx_cancel_test.go
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package vin
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestValidateContentCtx_ReclaimsRunawayMultiLineScan: a cancelled context stops a
+// large multi-line scan promptly (v2 Phase 3 per-line ctx polling).
+func TestValidateContentCtx_ReclaimsRunawayMultiLineScan(t *testing.T) {
+	v := NewValidator()
+	content := strings.Repeat("vehicle 1HGBH41JXMN109186 and JH4TB2H26CC000000 logged\n", 500000)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_, err := v.ValidateContentCtx(ctx, content, "<stdin>")
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Errorf("cancelled scan took %v; expected prompt return", elapsed)
+	}
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestValidateContent_BackgroundShimEqualsCtx: the non-ctx shim must produce the
+// same result as ValidateContentCtx with a never-cancelling context.
+func TestValidateContent_BackgroundShimEqualsCtx(t *testing.T) {
+	const content = "vehicle 1HGBH41JXMN109186\nJH4TB2H26CC000000\n"
+	shim, err1 := NewValidator().ValidateContent(content, "<stdin>")
+	ctxRes, err2 := NewValidator().ValidateContentCtx(context.Background(), content, "<stdin>")
+	if err1 != nil || err2 != nil {
+		t.Fatalf("unexpected errors: shim=%v ctx=%v", err1, err2)
+	}
+	if len(shim) != len(ctxRes) {
+		t.Errorf("shim vs ctx match count differ: %d != %d", len(shim), len(ctxRes))
+	}
+}

--- a/internal/validators/vin/validator.go
+++ b/internal/validators/vin/validator.go
@@ -4,10 +4,12 @@
 package vin
 
 import (
+	stdctx "context"
 	"regexp"
 	"strings"
 
 	"github.com/awslabs/ferret-scan/internal/detector"
+	"github.com/awslabs/ferret-scan/internal/execguard"
 	"github.com/awslabs/ferret-scan/internal/observability"
 )
 
@@ -193,6 +195,15 @@ func (v *Validator) Validate(filePath string) ([]detector.Match, error) {
 // boundary check reproduce the original fullContext/fullLine distinction
 // exactly (see analyzeContextHoisted).
 func (v *Validator) ValidateContent(content string, originalPath string) ([]detector.Match, error) {
+	// Backward-compatible shim: run with a background context (never cancels).
+	return v.ValidateContentCtx(stdctx.Background(), content, originalPath)
+}
+
+// ValidateContentCtx implements execguard.ContextAwareValidator: the context-aware
+// form of ValidateContent, polling ctx once per line so a runaway multi-line scan
+// is reclaimed promptly (v2 Phase 3). Returns partial matches + ctx.Err() on
+// cancellation.
+func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, originalPath string) ([]detector.Match, error) {
 	var finishTiming func(bool, map[string]interface{})
 	if v.observer != nil {
 		finishTiming = v.observer.StartTiming("vin_validator", "validate_content", originalPath)
@@ -202,6 +213,13 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 	lines := strings.Split(content, "\n")
 
 	for lineNum, line := range lines {
+		// Cooperative cancellation (v2 Phase 3): bail promptly on deadline/cancel.
+		if execguard.LineLoopCancelled(ctx, lineNum) {
+			if finishTiming != nil {
+				finishTiming(false, map[string]interface{}{"cancelled": true, "match_count": len(matches)})
+			}
+			return matches, ctx.Err()
+		}
 		locs := v.regex.FindAllStringIndex(line, -1)
 		if len(locs) == 0 {
 			continue


### PR DESCRIPTION
## What

**Move C** of the [v2 consolidation](docs/proposals/V2_ARCHITECTURE.md): operators can set a **per-validator execution budget** — a wall-clock `TimeLimit` and/or a `MatchLimit` — enforced at the single dispatch chokepoint. Both opt-in; **zero value = disabled = byte-identical** (golden passes with zero `UPDATE_GOLDEN`).

> ⚠️ **Stacked PR.** Base is `main` so CI runs, but this branch also contains #107 and #109's commits (they precede it in the stack). **Review only the top 2 commits**:
> - `…secrets + cloudresources` (ctx-teeth)
> - `…per-validator time + match budgets (Move C)`
> Merge #107 → #109 first; this rebases cleanly.

## Two commits here

### 1. ctx-teeth: secrets + cloudresources cooperative cancellation
Extends ctx-polling to the last two loop-driven validators so a time budget has teeth on **12/13** (METADATA stays exempt — not token-loop-driven, already per-item ctx). Both get `ValidateContentCtx` + an entry check before their whole-content pre-loop passes.

### 2. Move C budgets
- **New `execguard.ValidatorBudget{TimeLimit, MatchLimit}`**, carried on ctx via `execguard.WithBudgets` (no fan-out signature churn; empty map = parent ctx unchanged).
- **Time**: derives `context.WithTimeout(ctx, limit)` per validator → a runaway self-terminates at its own budget (all line-loop validators poll it). Tighter of {parent, budget} wins.
- **Match**: truncates a *successful* over-cap slice (order preserved) + returns `ErrMatchBudgetExceeded` with the kept matches. Never truncates an error-partial slice.
- **Keyed by logical check name** ("SSN"), not Go type — required threading the name from `SetupValidators` → `RegisterDocumentValidator` → fan-out (new `namedValidator`). Side benefit: panic/error logs now name the check, not `*ssn.Validator`.
- **Surfacing**: fixed the document bridge / `processDualPath` / `RunValidators` to (a) **keep** truncated/partial matches on budget/deadline outcomes and (b) **propagate** a representative budget/ctx error so `ScanResult.Incomplete` fires. Hard validator errors keep the historical discard-and-log behavior. No budgets configured ⇒ none of these paths change ⇒ byte-identical.
- **Config**: `ContentScanConfig.ValidatorBudgets` + `JobConfig.ValidatorBudgets`. Library-surface only; no CLI flag yet (separate UX decision).

## Verification

- **Real stack e2e**: time budget reclaims a runaway validator in ~30ms and surfaces `DeadlineExceeded` though the parent ctx never expired; match budget caps 50→5 kept through the full nested stack; under-cap unmutated.
- **Real binary** (`core.ScanContent`, 200k dense lines): match cap → 5 matches + `Incomplete`; time budget → reclaimed + `Incomplete`; disabled → 200000 matches, complete.
- **ctx-teeth**: per-validator ctx_cancel tests + negative controls (secrets 19.5s, cloudresources) confirm the polls are wired.
- Unit tests use the block-on-`ctx.Done` anti-flake pattern (no wall-clock races). Full suite + `-race` green; **golden byte-identical**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)