### PR TITLE
feat(v2-refactor): warn on incomplete scan coverage in the CLI (Phase 4)

### DIFF
--- a/cmd/incomplete_warning_test.go
+++ b/cmd/incomplete_warning_test.go
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/internal/parallel"
+)
+
+// TestWriteIncompleteCoverageWarning_NoneIsSilent: a fully-complete scan (no
+// incomplete files) must write nothing and report that nothing was written —
+// this is the common path and must never emit a spurious warning.
+func TestWriteIncompleteCoverageWarning_NoneIsSilent(t *testing.T) {
+	var buf bytes.Buffer
+	wrote := writeIncompleteCoverageWarning(&buf, nil, 5)
+	if wrote {
+		t.Error("expected no warning for a complete scan")
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected empty output, got %q", buf.String())
+	}
+}
+
+// TestWriteIncompleteCoverageWarning_SingleFile: one incomplete file names the
+// file and its reason on the warning.
+func TestWriteIncompleteCoverageWarning_SingleFile(t *testing.T) {
+	var buf bytes.Buffer
+	files := []parallel.FileDiagnostic{
+		{FilePath: "big.json", Reason: "validator execution did not complete: context deadline exceeded"},
+	}
+	wrote := writeIncompleteCoverageWarning(&buf, files, 1)
+	if !wrote {
+		t.Fatal("expected a warning to be written")
+	}
+	out := buf.String()
+	for _, want := range []string{"coverage incomplete", "1 of 1 file", "big.json", "context deadline exceeded", "findings may be missing"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("warning missing %q; got:\n%s", want, out)
+		}
+	}
+}
+
+// TestWriteIncompleteCoverageWarning_MultipleFiles: the count reflects incomplete
+// vs total, and every offending file is listed.
+func TestWriteIncompleteCoverageWarning_MultipleFiles(t *testing.T) {
+	var buf bytes.Buffer
+	files := []parallel.FileDiagnostic{
+		{FilePath: "a.txt", Reason: "validator match budget exceeded"},
+		{FilePath: "b.txt", Reason: "context deadline exceeded"},
+	}
+	wrote := writeIncompleteCoverageWarning(&buf, files, 10)
+	if !wrote {
+		t.Fatal("expected a warning to be written")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "2 of 10 file") {
+		t.Errorf("expected '2 of 10 file' count, got:\n%s", out)
+	}
+	if !strings.Contains(out, "a.txt") || !strings.Contains(out, "b.txt") {
+		t.Errorf("expected both offending files listed, got:\n%s", out)
+	}
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -683,6 +684,25 @@ func shouldSuppressProgressOutput(finalConfig *finalConfiguration, precommitConf
 		suppress = true
 	}
 	return suppress
+}
+
+// writeIncompleteCoverageWarning emits the v2 Phase 4 incomplete-coverage warning
+// to w when any file's validator coverage was cut short (per-file/per-validator
+// timeout, cancellation, or match budget). It returns true if a warning was
+// written. The warning goes to stderr (never stdout/JSON, so scripts parsing
+// results are unaffected) and is a CORRECTNESS signal — callers gate it only on
+// pre-commit mode, not on quiet/non-interactive, because CI is exactly where a
+// silently-partial scan is most dangerous. It never changes the exit code.
+func writeIncompleteCoverageWarning(w io.Writer, incompleteFiles []parallel.FileDiagnostic, totalFiles int) bool {
+	if len(incompleteFiles) == 0 {
+		return false
+	}
+	fmt.Fprintf(w, "WARNING: scan coverage incomplete — %d of %d file(s) were not fully scanned; findings may be missing:\n",
+		len(incompleteFiles), totalFiles)
+	for _, fd := range incompleteFiles {
+		fmt.Fprintf(w, "  %s: %s\n", fd.FilePath, fd.Reason)
+	}
+	return true
 }
 
 // extractedFlags holds safely extracted flag values to avoid repeated nil checks
@@ -1544,6 +1564,11 @@ func main() {
 	var allMatches []detector.Match
 	processedFiles := 0
 	skippedFiles := 0
+	// incompleteFiles captures files whose validator coverage was cut short (a
+	// per-file/per-validator timeout, cancellation, or match budget — v2 Phase 4).
+	// Populated from ProcessingStats.IncompleteFiles below and surfaced as a
+	// stderr warning so a partially-scanned run is never silently reported clean.
+	var incompleteFiles []parallel.FileDiagnostic
 
 	// Suppress progress messages in pre-commit mode or quiet mode
 	if !shouldSuppressProgressOutput(finalConfig, precommitConfig, isInteractive) {
@@ -1661,6 +1686,7 @@ func main() {
 
 			allMatches = append(allMatches, parallelMatches...)
 			processedFiles = stats.ProcessedFiles
+			incompleteFiles = stats.IncompleteFiles
 
 			// Handle inline redaction results if redaction was enabled
 			if finalConfig.enableRedaction && redactionManager != nil {
@@ -1714,6 +1740,16 @@ func main() {
 			fmt.Fprintf(os.Stderr, "Scan complete: %d files processed in %s\n",
 				processedFiles, elapsed.Round(time.Millisecond))
 		}
+	}
+
+	// Incomplete-coverage warning (v2 Phase 4): a file whose validator coverage
+	// was cut short (per-file/per-validator timeout, cancellation, or match
+	// budget) means findings may be MISSING — the run must not be reported as a
+	// clean, complete scan. Suppressed only in pre-commit mode, which owns a
+	// strict machine-readable output contract. Exit code is deliberately
+	// unchanged (default still 0) — this is an advisory warning.
+	if precommitConfig == nil {
+		writeIncompleteCoverageWarning(os.Stderr, incompleteFiles, len(supportedFiles))
 	}
 
 	// Advisory explanation pass (opt-in via --explain). Annotate the full

--- a/cmd/stdin.go
+++ b/cmd/stdin.go
@@ -18,6 +18,7 @@ import (
 	"github.com/awslabs/ferret-scan/internal/core"
 	"github.com/awslabs/ferret-scan/internal/detector"
 	"github.com/awslabs/ferret-scan/internal/formatters"
+	"github.com/awslabs/ferret-scan/internal/parallel"
 	"github.com/awslabs/ferret-scan/internal/precommit"
 	"github.com/awslabs/ferret-scan/internal/redactors"
 	plaintextredactor "github.com/awslabs/ferret-scan/internal/redactors/plaintext"
@@ -180,6 +181,16 @@ func runStdinScan(in stdinScanInputs) int {
 	elapsed := time.Since(start)
 
 	allMatches := result.Matches // not yet suppressed since we passed nil manager
+
+	// Incomplete-coverage warning (v2 Phase 4): if the stdin scan's validator
+	// coverage was cut short (a per-validator timeout, cancellation, or match
+	// budget), findings may be MISSING. Uses the same helper/format as the file
+	// path (a single virtual "file"); suppressed only in pre-commit mode. Exit
+	// code is deliberately unchanged — advisory warning only.
+	if precommitConfig == nil && result.Incomplete {
+		writeIncompleteCoverageWarning(os.Stderr,
+			[]parallel.FileDiagnostic{{FilePath: scanCfg.VirtualPath, Reason: result.IncompleteReason}}, 1)
+	}
 
 	// --generate-suppressions writes against raw matches before suppression.
 	if finalCfg.generateSuppressions {


### PR DESCRIPTION
## What

The `ScanResult.Incomplete` / `ProcessingStats.IncompleteFiles` signal (landed in #104 on the file path, plus the `ScanContent`/stdin path) was **fully plumbed but consumed nowhere** — CLI, stdin, and web all ignored it. So a scan whose validator coverage was cut short (a per-file/per-validator **timeout**, a **cancellation**, or a Move C **match/time budget**) was reported as a **clean, complete scan**. For a DLP tool that's the dangerous failure mode: *missing findings look like no findings.*

The CLI now surfaces it:

```
WARNING: scan coverage incomplete — 1 of 1 file(s) were not fully scanned; findings may be missing:
  big.json: validator execution did not complete: context deadline exceeded
```

## Design (chosen: warn on stderr, exit unchanged)

- **stderr only** — never stdout/JSON, so scripts and CI parsing results are unaffected (findings output byte-identical).
- **Exit code UNCHANGED** (default still 0). Advisory warning, not a failure — non-breaking. A `--fail-on-incomplete` knob can be a later follow-up if CI wants to enforce complete coverage.
- **Not gated on quiet/non-interactive** — this is a *correctness* signal, and CI (non-interactive) is exactly where a silently-partial scan is most dangerous. Suppressed only in **pre-commit mode** (strict machine-readable contract).
- File path (from `ProcessingStats.IncompleteFiles`) and stdin path (from `ScanResult.Incomplete`) share one helper, `writeIncompleteCoverageWarning`.

## Verification

- **Behavior-preserving**: detection/formats/redaction untouched — **golden byte-identical**.
- **No spurious warning on a normal scan** — verified with the real binary on both file and stdin paths (exit 0, zero warnings); pre-commit mode unaffected.
- Producer side (`IncompleteFiles` populated on timeout) is already regression-tested in `internal/parallel/diagnostics_test.go`; this PR adds `cmd` tests for the consumer/formatter (none / single / multiple files).
- Full suite green.

Branches off `main` (consumes the #104 signal; **independent** of the open #107/#108/#109/#110 stack).

## Follow-ups (not in this PR)
- **Web-server** consumption of `Incomplete` (separate surface).
- Optional `--fail-on-incomplete` exit-code knob for CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)