### PR TITLE
feat(v2-refactor): surface incomplete scan coverage in the web UI (Phase 4)

### DIFF
--- a/internal/web/assets/template.html
+++ b/internal/web/assets/template.html
@@ -1803,6 +1803,7 @@
             currentResults = [];
             window.suppressedCount = 0;
             window.suppressedFindings = [];
+            window.incompleteReasons = [];
             const totalFiles = queue.length;
 
             for (let i = 0; i < totalFiles; i++) {
@@ -1869,6 +1870,14 @@
                 window.suppressedCount = (window.suppressedCount || 0) + data.suppressed.length;
             }
 
+            // Track degraded coverage (v2 Phase 4): if the backend reports the scan
+            // was incomplete for this file, remember the reason so displayResults
+            // can warn that findings may be missing rather than imply a clean scan.
+            if (data.incomplete) {
+                window.incompleteReasons = (window.incompleteReasons || []);
+                window.incompleteReasons.push(data.incomplete_reason || 'coverage incomplete');
+            }
+
             return data.results || [];
         }
 
@@ -1897,6 +1906,17 @@
                 showAlert(`Scan complete: ${currentResults.length} findings detected`, 'success');
             } else {
                 showAlert('Scan complete: No sensitive data found', 'success');
+            }
+
+            // Degraded-coverage warning (v2 Phase 4): a timed-out / budget-limited
+            // scan may be MISSING findings, so a clean-looking result must not be
+            // trusted as complete. Surface it as a persistent warning alert.
+            const incompleteReasons = window.incompleteReasons || [];
+            if (incompleteReasons.length > 0) {
+                const detail = incompleteReasons.length === 1
+                    ? incompleteReasons[0]
+                    : `${incompleteReasons.length} files were not fully scanned`;
+                showAlert(`⚠ Scan coverage incomplete — findings may be missing: ${detail}`, 'warning');
             }
         }
 

--- a/internal/web/incomplete_response_test.go
+++ b/internal/web/incomplete_response_test.go
@@ -1,0 +1,72 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package web
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/internal/parallel"
+)
+
+// TestSummarizeIncompleteFiles covers the v2 Phase 4 degraded-coverage summary
+// the /scan response carries: empty when complete, names the single offender,
+// counts several.
+func TestSummarizeIncompleteFiles(t *testing.T) {
+	if got := summarizeIncompleteFiles(nil, 3); got != "" {
+		t.Errorf("complete scan must summarize to empty string, got %q", got)
+	}
+
+	one := []parallel.FileDiagnostic{{FilePath: "big.json", Reason: "context deadline exceeded"}}
+	got := summarizeIncompleteFiles(one, 1)
+	for _, want := range []string{"big.json", "context deadline exceeded", "findings may be missing"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("single-file summary missing %q; got %q", want, got)
+		}
+	}
+
+	many := []parallel.FileDiagnostic{
+		{FilePath: "a.txt", Reason: "match budget exceeded"},
+		{FilePath: "b.txt", Reason: "context deadline exceeded"},
+	}
+	got = summarizeIncompleteFiles(many, 10)
+	if !strings.Contains(got, "2 of 10 files") {
+		t.Errorf("multi-file summary should count '2 of 10 files', got %q", got)
+	}
+}
+
+// TestScanResponse_CompleteScanOmitsIncompleteFields is the behavior-preserving
+// guarantee: a complete scan's JSON must NOT contain the new incomplete fields
+// (omitempty), so existing clients see byte-identical output to before Phase 4.
+func TestScanResponse_CompleteScanOmitsIncompleteFields(t *testing.T) {
+	out, err := json.Marshal(ScanResponse{Success: true})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(out)
+	if strings.Contains(s, "incomplete") {
+		t.Errorf("complete scan response must omit incomplete fields, got %s", s)
+	}
+}
+
+// TestScanResponse_IncompleteScanSurfacesFields confirms the fields are present
+// and populated when coverage was cut short.
+func TestScanResponse_IncompleteScanSurfacesFields(t *testing.T) {
+	out, err := json.Marshal(ScanResponse{
+		Success:          true,
+		Incomplete:       true,
+		IncompleteReason: "coverage incomplete for big.json: context deadline exceeded — findings may be missing",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, `"incomplete":true`) {
+		t.Errorf("incomplete scan must set incomplete=true, got %s", s)
+	}
+	if !strings.Contains(s, `"incomplete_reason"`) {
+		t.Errorf("incomplete scan must carry incomplete_reason, got %s", s)
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/awslabs/ferret-scan/internal/explain"
 	"github.com/awslabs/ferret-scan/internal/formatters"
 	formatterShared "github.com/awslabs/ferret-scan/internal/formatters/shared"
+	"github.com/awslabs/ferret-scan/internal/parallel"
 	"github.com/awslabs/ferret-scan/internal/paths"
 	"github.com/awslabs/ferret-scan/internal/platform"
 	"github.com/awslabs/ferret-scan/internal/suppressions"
@@ -77,6 +78,14 @@ type ScanResponse struct {
 	Results    []formatterShared.JSONMatch `json:"results"`
 	Suppressed []detector.SuppressedMatch  `json:"suppressed,omitempty"`
 	Error      string                      `json:"error,omitempty"`
+	// Incomplete reports that validator coverage was cut short for at least one
+	// uploaded file (a per-file/per-validator timeout, cancellation, or match
+	// budget), so findings may be MISSING — the scan must not be presented as
+	// clean/complete (v2 Phase 4). Both fields are omitempty, so a fully-complete
+	// scan's JSON is byte-identical to before this field existed (older clients
+	// ignore unknown fields either way).
+	Incomplete       bool   `json:"incomplete,omitempty"`
+	IncompleteReason string `json:"incomplete_reason,omitempty"`
 }
 
 // NewWebServer creates a new web server instance bound to loopback. Used by
@@ -444,6 +453,7 @@ func (ws *WebServer) handleScan(responseWriter http.ResponseWriter, request *htt
 	var allMatches []detector.Match
 	var suppressedMatches []detector.SuppressedMatch
 	suppressedCount := 0
+	var incompleteFiles []parallel.FileDiagnostic
 
 	for i, fileHeader := range files {
 		displayName := fileHeader.Filename
@@ -452,7 +462,7 @@ func (ws *WebServer) handleScan(responseWriter http.ResponseWriter, request *htt
 		if relativePath != "" && len(files) == 1 {
 			displayName = relativePath
 		}
-		matches, suppressed, suppCount, err := ws.processUploadedFileWithCLILogic(fileHeader, i, confidence, checks, verbose, recursive, displayName)
+		matches, suppressed, suppCount, incomplete, err := ws.processUploadedFileWithCLILogic(fileHeader, i, confidence, checks, verbose, recursive, displayName)
 		if err != nil {
 			ws.sendError(responseWriter, err.Error())
 			return
@@ -460,6 +470,7 @@ func (ws *WebServer) handleScan(responseWriter http.ResponseWriter, request *htt
 		allMatches = append(allMatches, matches...)
 		suppressedMatches = append(suppressedMatches, suppressed...)
 		suppressedCount += suppCount
+		incompleteFiles = append(incompleteFiles, incomplete...)
 	}
 
 	// Use CLI's JSON formatter with CLI's confidence parsing.
@@ -505,17 +516,41 @@ func (ws *WebServer) handleScan(responseWriter http.ResponseWriter, request *htt
 		}
 	}
 
+	// Surface degraded coverage (v2 Phase 4): if any uploaded file's validator
+	// coverage was cut short, the results may be missing findings — flag it so the
+	// UI can warn rather than present a partial scan as clean. omitempty keeps a
+	// complete scan's JSON byte-identical to before.
+	incompleteReason := summarizeIncompleteFiles(incompleteFiles, len(files))
+
 	// Return the exact CLI structure wrapped in success response
 	responseWriter.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(responseWriter).Encode(ScanResponse{
-		Success:    true,
-		Results:    cliResponse.Results,
-		Suppressed: cliResponse.Suppressed,
+		Success:          true,
+		Results:          cliResponse.Results,
+		Suppressed:       cliResponse.Suppressed,
+		Incomplete:       len(incompleteFiles) > 0,
+		IncompleteReason: incompleteReason,
 	})
 }
 
+// summarizeIncompleteFiles builds a short, payload-free explanation of degraded
+// coverage for the scan response, or "" when coverage was complete. It names the
+// single offending file, or counts them when several were incomplete.
+func summarizeIncompleteFiles(incompleteFiles []parallel.FileDiagnostic, totalFiles int) string {
+	switch len(incompleteFiles) {
+	case 0:
+		return ""
+	case 1:
+		return fmt.Sprintf("coverage incomplete for %s: %s — findings may be missing",
+			incompleteFiles[0].FilePath, incompleteFiles[0].Reason)
+	default:
+		return fmt.Sprintf("coverage incomplete for %d of %d files — findings may be missing",
+			len(incompleteFiles), totalFiles)
+	}
+}
+
 // processUploadedFileWithCLILogic handles user file uploads using full CLI scanning logic
-func (ws *WebServer) processUploadedFileWithCLILogic(uploadedFile *multipart.FileHeader, fileIndex int, confidence, checks string, verbose, recursive bool, displayName string) ([]detector.Match, []detector.SuppressedMatch, int, error) {
+func (ws *WebServer) processUploadedFileWithCLILogic(uploadedFile *multipart.FileHeader, fileIndex int, confidence, checks string, verbose, recursive bool, displayName string) ([]detector.Match, []detector.SuppressedMatch, int, []parallel.FileDiagnostic, error) {
 	if displayName == "" {
 		displayName = uploadedFile.Filename
 	}
@@ -523,7 +558,7 @@ func (ws *WebServer) processUploadedFileWithCLILogic(uploadedFile *multipart.Fil
 	// Open uploaded file
 	file, err := uploadedFile.Open()
 	if err != nil {
-		return nil, nil, 0, fmt.Errorf("failed to open file %s: %v", displayName, err)
+		return nil, nil, 0, nil, fmt.Errorf("failed to open file %s: %v", displayName, err)
 	}
 	defer file.Close()
 
@@ -531,7 +566,7 @@ func (ws *WebServer) processUploadedFileWithCLILogic(uploadedFile *multipart.Fil
 	tempDir := paths.GetTempDir()
 	tempFile, err := os.CreateTemp(tempDir, fmt.Sprintf("ferret_upload_%d_%d_*.%s", time.Now().Unix(), fileIndex, ws.getFileExtension(uploadedFile.Filename)))
 	if err != nil {
-		return nil, nil, 0, fmt.Errorf("failed to create temporary file in %s: %v", tempDir, err)
+		return nil, nil, 0, nil, fmt.Errorf("failed to create temporary file in %s: %v", tempDir, err)
 	}
 	defer os.Remove(tempFile.Name())
 	defer tempFile.Close()
@@ -541,7 +576,7 @@ func (ws *WebServer) processUploadedFileWithCLILogic(uploadedFile *multipart.Fil
 	limitedReader := io.LimitReader(file, maxFileSize)
 	_, err = io.Copy(tempFile, limitedReader)
 	if err != nil {
-		return nil, nil, 0, fmt.Errorf("failed to copy file content: %v", err)
+		return nil, nil, 0, nil, fmt.Errorf("failed to copy file content: %v", err)
 	}
 
 	// Normalize the temporary file path for the current platform
@@ -551,8 +586,11 @@ func (ws *WebServer) processUploadedFileWithCLILogic(uploadedFile *multipart.Fil
 	return ws.runFullCLIScan(normalizedTempPath, displayName, confidence, checks, verbose, recursive)
 }
 
-// runFullCLIScan executes the full CLI scanning logic with configuration and suppression support
-func (ws *WebServer) runFullCLIScan(filePath, originalFilename, confidence, checks string, verbose, recursive bool) ([]detector.Match, []detector.SuppressedMatch, int, error) {
+// runFullCLIScan executes the full CLI scanning logic with configuration and
+// suppression support. The returned []parallel.FileDiagnostic is non-empty when
+// this file's validator coverage was cut short (v2 Phase 4 incomplete signal),
+// so the caller can surface degraded coverage to the operator.
+func (ws *WebServer) runFullCLIScan(filePath, originalFilename, confidence, checks string, verbose, recursive bool) ([]detector.Match, []detector.SuppressedMatch, int, []parallel.FileDiagnostic, error) {
 	cfg := ws.loadConfiguration(ws.configPath)
 
 	var checksSlice []string
@@ -562,7 +600,7 @@ func (ws *WebServer) runFullCLIScan(filePath, originalFilename, confidence, chec
 
 	suppressionManager, err := ws.initializeSuppressionManager(ws.suppressionsPath)
 	if err != nil {
-		return nil, nil, 0, fmt.Errorf("failed to initialize suppression manager: %v", err)
+		return nil, nil, 0, nil, fmt.Errorf("failed to initialize suppression manager: %v", err)
 	}
 
 	// Scan without applying suppressions — the filename on each match is the
@@ -584,7 +622,18 @@ func (ws *WebServer) runFullCLIScan(filePath, originalFilename, confidence, chec
 
 	result, err := core.ScanFile(scanConfig)
 	if err != nil {
-		return nil, nil, 0, fmt.Errorf("scanning failed: %v", err)
+		return nil, nil, 0, nil, fmt.Errorf("scanning failed: %v", err)
+	}
+
+	// Capture the v2 Phase 4 incomplete-coverage signal, keyed by the display
+	// filename (rewritten below for matches; here we use the original name the
+	// operator uploaded). Non-empty only when this file's coverage was cut short.
+	var incomplete []parallel.FileDiagnostic
+	if result.Incomplete {
+		incomplete = []parallel.FileDiagnostic{{
+			FilePath: ws.sanitizeFilenameForDisplay(originalFilename),
+			Reason:   result.IncompleteReason,
+		}}
 	}
 
 	// Rewrite each match's filename to the original upload name so hashes
@@ -618,7 +667,7 @@ func (ws *WebServer) runFullCLIScan(filePath, originalFilename, confidence, chec
 		}
 	}
 
-	return unsuppressed, suppressed, len(suppressed), nil
+	return unsuppressed, suppressed, len(suppressed), incomplete, nil
 }
 
 // handleExport exports scan results in the requested format


### PR DESCRIPTION
## What

Completes the Phase 4 `Incomplete`-signal consumption started for the CLI (#112). The web server **ignored** `ScanResult.Incomplete`, so a scan whose validator coverage was cut short (a per-file/per-validator **timeout**, **cancellation**, or Move C **match/time budget**) was presented in the UI as a **clean, complete scan** — missing findings looking like no findings.

## Now surfaced end-to-end

- `runFullCLIScan` / `processUploadedFileWithCLILogic` return the per-file `[]parallel.FileDiagnostic` from `result.Incomplete`/`IncompleteReason`.
- `handleScan` aggregates across uploaded files → two new **omitempty** `ScanResponse` fields: `incomplete` (bool) + `incomplete_reason` (payload-free summary; names the single offender or counts several).
- The embedded UI shows a persistent **warning alert** — `⚠ Scan coverage incomplete — findings may be missing: <detail>` — alongside the normal success alert.

## Behavior-preserving

- New response fields are `omitempty` → a **complete** scan's JSON is byte-identical to before. **Verified with the real binary**: a normal `/scan` response has neither `incomplete` nor `incomplete_reason` keys; server starts (HTTP 200); served HTML embeds the new warning JS.
- Detection/formats/redaction untouched — **golden byte-identical**. No change to `/export` or the client-side redaction contract.

## Tests
Web unit tests for `summarizeIncompleteFiles` (none/single/multiple) + the `ScanResponse` omitempty/populated JSON contract. Full suite + `-race` green.

Branches off `main` (consumes #104's merged signal; independent of the open #107/#108/#109/#110 stack and CLI #112).

## Remaining Phase 4 follow-ups (tracked, not here)
- Optional `--fail-on-incomplete` exit-code knob (CLI).
- `--validator-budget` CLI flag (Move C is library-only today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)