### PR TITLE
feat(v2-refactor): --fail-on-incomplete flag + fail_on_incomplete config (Phase 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,8 +232,22 @@ echo "secret: 4532-0151-1283-0366" | ./ferret-scan --file -
 - `--no-color`: Disable colored output (useful for logging or non-terminal output)
 - `--show-match`: Display the actual matched text in findings (otherwise shows [HIDDEN])
 - `--quiet`: Suppress progress output (useful for scripts and CI/CD)
+- `--fail-on-incomplete`: Exit with code `3` if any file's validator coverage was cut short (a per-file/per-validator timeout, cancellation, or budget). Off by default — incomplete coverage otherwise only prints a warning to stderr and leaves the exit code unchanged. Useful in CI to fail a pipeline rather than trust a partial scan. See [Exit Codes](#exit-codes).
 - `--help`: Show help information
 - `--version`: Show version information
+
+#### Exit Codes
+
+`ferret-scan` uses these process exit codes so scripts and CI can branch on the outcome:
+
+| Code | Meaning |
+|------|---------|
+| `0`  | Scan completed. In default mode this is returned even when findings exist (findings are reported in the output, not via exit code); pre-commit mode overrides this — see below. |
+| `1`  | A system or usage error (bad flags, unreadable input, internal failure). |
+| `2`  | No files to process (nothing matched the given paths/filters). |
+| `3`  | **Coverage was incomplete** and `--fail-on-incomplete` was set — at least one file was not fully scanned (timeout, cancellation, or a per-validator budget), so findings may be missing. Only ever returned when the flag is passed. |
+
+In **pre-commit mode** (`--pre-commit-mode`) the exit code instead reflects findings/confidence so a commit can be blocked; `--fail-on-incomplete` composes with it, escalating an otherwise-clean (`0`) pre-commit result to `3` without downgrading a findings-based non-zero result.
 
 #### File Processing Options
 - `--enable-preprocessors`: Enable text extraction from documents (PDF, Office files) (default: true, use `--enable-preprocessors=false` to disable)

--- a/cmd/fail_on_incomplete_config_test.go
+++ b/cmd/fail_on_incomplete_config_test.go
@@ -1,0 +1,51 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"testing"
+
+	"github.com/awslabs/ferret-scan/internal/config"
+)
+
+// TestResolveConfiguration_FailOnIncomplete covers the config/profile precedence
+// for fail_on_incomplete (no CLI flag set in-test, so isFlagSet is false — the
+// flag-override branch is exercised end-to-end by the binary smoke test and by
+// TestResolveIncompleteExitCode). Order: config default -> profile overrides.
+func TestResolveConfiguration_FailOnIncomplete(t *testing.T) {
+	t.Run("defaults false when unset", func(t *testing.T) {
+		final := resolveConfiguration(&config.Config{}, nil, &configFlags{})
+		if final.failOnIncomplete {
+			t.Error("expected failOnIncomplete=false by default")
+		}
+	})
+
+	t.Run("config default true", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Defaults.FailOnIncomplete = true
+		final := resolveConfiguration(cfg, nil, &configFlags{})
+		if !final.failOnIncomplete {
+			t.Error("expected config Defaults.FailOnIncomplete=true to be honored")
+		}
+	})
+
+	t.Run("profile overrides config", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Defaults.FailOnIncomplete = true
+		prof := &config.Profile{FailOnIncomplete: false}
+		final := resolveConfiguration(cfg, prof, &configFlags{})
+		if final.failOnIncomplete {
+			t.Error("expected active profile FailOnIncomplete=false to override config default true")
+		}
+	})
+
+	t.Run("profile enables when config default false", func(t *testing.T) {
+		cfg := &config.Config{}
+		prof := &config.Profile{FailOnIncomplete: true}
+		final := resolveConfiguration(cfg, prof, &configFlags{})
+		if !final.failOnIncomplete {
+			t.Error("expected active profile FailOnIncomplete=true to enable")
+		}
+	})
+}

--- a/cmd/incomplete_warning_test.go
+++ b/cmd/incomplete_warning_test.go
@@ -11,6 +11,35 @@ import (
 	"github.com/awslabs/ferret-scan/internal/parallel"
 )
 
+// TestResolveIncompleteExitCode covers the --fail-on-incomplete exit policy: a
+// clean base escalates to 3 only when enabled AND coverage was incomplete; a
+// non-zero base (findings/error) is never downgraded; disabled is a pass-through.
+func TestResolveIncompleteExitCode(t *testing.T) {
+	cases := []struct {
+		name       string
+		base       int
+		failOn     bool
+		incomplete int
+		want       int
+	}{
+		{"disabled, clean, no incomplete", 0, false, 0, 0},
+		{"disabled, clean, incomplete ignored", 0, false, 2, 0},
+		{"enabled, clean, no incomplete", 0, true, 0, 0},
+		{"enabled, clean, incomplete -> 3", 0, true, 1, exitCodeIncompleteCoverage},
+		{"enabled, findings base 1, incomplete -> keep 1", 1, true, 1, 1},
+		{"enabled, precommit base 2, incomplete -> keep 2", 2, true, 3, 2},
+		{"disabled, findings base 1 -> keep 1", 1, false, 0, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveIncompleteExitCode(tc.base, tc.failOn, tc.incomplete); got != tc.want {
+				t.Errorf("resolveIncompleteExitCode(%d,%v,%d) = %d, want %d",
+					tc.base, tc.failOn, tc.incomplete, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestWriteIncompleteCoverageWarning_NoneIsSilent: a fully-complete scan (no
 // incomplete files) must write nothing and report that nothing was written —
 // this is the common path and must never emit a spurious warning.

--- a/cmd/incomplete_warning_test.go
+++ b/cmd/incomplete_warning_test.go
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/internal/parallel"
+)
+
+// TestWriteIncompleteCoverageWarning_NoneIsSilent: a fully-complete scan (no
+// incomplete files) must write nothing and report that nothing was written —
+// this is the common path and must never emit a spurious warning.
+func TestWriteIncompleteCoverageWarning_NoneIsSilent(t *testing.T) {
+	var buf bytes.Buffer
+	wrote := writeIncompleteCoverageWarning(&buf, nil, 5)
+	if wrote {
+		t.Error("expected no warning for a complete scan")
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected empty output, got %q", buf.String())
+	}
+}
+
+// TestWriteIncompleteCoverageWarning_SingleFile: one incomplete file names the
+// file and its reason on the warning.
+func TestWriteIncompleteCoverageWarning_SingleFile(t *testing.T) {
+	var buf bytes.Buffer
+	files := []parallel.FileDiagnostic{
+		{FilePath: "big.json", Reason: "validator execution did not complete: context deadline exceeded"},
+	}
+	wrote := writeIncompleteCoverageWarning(&buf, files, 1)
+	if !wrote {
+		t.Fatal("expected a warning to be written")
+	}
+	out := buf.String()
+	for _, want := range []string{"coverage incomplete", "1 of 1 file", "big.json", "context deadline exceeded", "findings may be missing"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("warning missing %q; got:\n%s", want, out)
+		}
+	}
+}
+
+// TestWriteIncompleteCoverageWarning_MultipleFiles: the count reflects incomplete
+// vs total, and every offending file is listed.
+func TestWriteIncompleteCoverageWarning_MultipleFiles(t *testing.T) {
+	var buf bytes.Buffer
+	files := []parallel.FileDiagnostic{
+		{FilePath: "a.txt", Reason: "validator match budget exceeded"},
+		{FilePath: "b.txt", Reason: "context deadline exceeded"},
+	}
+	wrote := writeIncompleteCoverageWarning(&buf, files, 10)
+	if !wrote {
+		t.Fatal("expected a warning to be written")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "2 of 10 file") {
+		t.Errorf("expected '2 of 10 file' count, got:\n%s", out)
+	}
+	if !strings.Contains(out, "a.txt") || !strings.Contains(out, "b.txt") {
+		t.Errorf("expected both offending files listed, got:\n%s", out)
+	}
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -57,6 +57,25 @@ import (
 	// "github.com/awslabs/ferret-scan/internal/validators/comprehend"
 )
 
+// exitCodeIncompleteCoverage is returned when --fail-on-incomplete is set and at
+// least one file's validator coverage was cut short (timeout, cancellation, or a
+// per-validator budget). It is distinct from the other CLI exit codes — 0 (clean),
+// 1 (system/usage error), and 2 (no files to process) — so CI can tell degraded
+// coverage apart from a genuinely clean scan.
+const exitCodeIncompleteCoverage = 3
+
+// resolveIncompleteExitCode applies the --fail-on-incomplete policy on top of a
+// base exit code: when enabled and coverage was incomplete, an otherwise-clean
+// result (base 0) escalates to exitCodeIncompleteCoverage, but a non-zero base
+// (findings/errors the caller already fails on) is never downgraded. It is a pure
+// function so both the file and stdin paths share one tested decision.
+func resolveIncompleteExitCode(base int, failOnIncomplete bool, incompleteCount int) int {
+	if failOnIncomplete && incompleteCount > 0 && base == 0 {
+		return exitCodeIncompleteCoverage
+	}
+	return base
+}
+
 // loadConfiguration loads the configuration file or returns default config.
 //
 // When the user passes an explicit --config <path> flag, parse errors and
@@ -105,6 +124,7 @@ type configFlags struct {
 	quiet                bool
 	showSuppressed       bool
 	generateSuppressions bool
+	failOnIncomplete     bool
 	// GENAI_DISABLED: GenAI-related configuration flags
 	// enableGenAI         bool
 	// genaiServices       string
@@ -146,6 +166,7 @@ type finalConfiguration struct {
 	quiet                bool
 	showSuppressed       bool
 	generateSuppressions bool
+	failOnIncomplete     bool
 	disableIPTypes       string
 }
 
@@ -409,6 +430,18 @@ func resolveConfiguration(cfg *config.Config, activeProfile *config.Profile, fla
 	}
 	if isFlagSet("generate-suppressions") {
 		final.generateSuppressions = flags.generateSuppressions
+	}
+
+	// Fail on incomplete coverage: config default -> profile -> flag (flag wins).
+	final.failOnIncomplete = false // default fallback
+	if cfg != nil {
+		final.failOnIncomplete = cfg.Defaults.FailOnIncomplete
+	}
+	if activeProfile != nil {
+		final.failOnIncomplete = activeProfile.FailOnIncomplete
+	}
+	if isFlagSet("fail-on-incomplete") {
+		final.failOnIncomplete = flags.failOnIncomplete
 	}
 
 	// Disable IP types
@@ -729,6 +762,7 @@ type extractedFlags struct {
 	showMatch            bool
 	showSuppressed       bool
 	generateSuppressions bool
+	failOnIncomplete     bool
 	enableRedaction      bool
 	redactionOutputDir   string
 	redactionStrategy    string
@@ -755,6 +789,7 @@ type flagPointers struct {
 	showMatch            *bool
 	showSuppressed       *bool
 	generateSuppressions *bool
+	failOnIncomplete     *bool
 	enableRedaction      *bool
 	listProfiles         *bool
 	respectGitignore     *bool
@@ -801,6 +836,7 @@ func extractAllFlags(flags flagPointers) extractedFlags {
 		showMatch:            getBoolFlag(flags.showMatch),
 		showSuppressed:       getBoolFlag(flags.showSuppressed),
 		generateSuppressions: getBoolFlag(flags.generateSuppressions),
+		failOnIncomplete:     getBoolFlag(flags.failOnIncomplete),
 		enableRedaction:      getBoolFlag(flags.enableRedaction),
 		redactionOutputDir:   getStringFlag(flags.redactionOutputDir),
 		redactionStrategy:    getStringFlag(flags.redactionStrategy),
@@ -865,6 +901,7 @@ func main() {
 	// estimateOnly := flag.Bool("estimate-only", false, "Show cost estimate and exit without processing")
 	quiet := flag.Bool("quiet", false, "Suppress progress output (useful for scripts and CI/CD)")
 	precommitMode := flag.Bool("pre-commit-mode", false, "Enable pre-commit optimizations (quiet mode, no colors, appropriate exit codes)")
+	failOnIncomplete := flag.Bool("fail-on-incomplete", false, "Exit non-zero (3) if any file's validator coverage was cut short (timeout, cancellation, or budget). Default off: incomplete coverage only warns on stderr.")
 
 	// Redaction flags
 	enableRedaction := flag.Bool("enable-redaction", false, "Enable redaction of sensitive data found in documents")
@@ -911,6 +948,7 @@ func main() {
 		showMatch:            showMatch,
 		showSuppressed:       showSuppressed,
 		generateSuppressions: generateSuppressions,
+		failOnIncomplete:     failOnIncomplete,
 		enableRedaction:      enableRedaction,
 		listProfiles:         listProfiles,
 		respectGitignore:     respectGitignore,
@@ -1028,6 +1066,7 @@ func main() {
 		quiet:                flags.quiet,
 		showSuppressed:       flags.showSuppressed,
 		generateSuppressions: flags.generateSuppressions,
+		failOnIncomplete:     flags.failOnIncomplete,
 		disableIPTypes:       flags.disableIPTypes,
 	})
 
@@ -1103,6 +1142,16 @@ func main() {
 		if finalConfig.showSuppressed {
 			fmt.Fprintf(os.Stderr, "Error: --preprocess-only cannot be used with --show-suppressed\n")
 			fmt.Fprintf(os.Stderr, "Preprocess-only mode does not perform validation.\n")
+			os.Exit(1)
+		}
+
+		// --fail-on-incomplete gates on validator COVERAGE, which preprocess-only
+		// never produces (it exits before validation). Only reject when the flag
+		// was passed EXPLICITLY — a global config/profile default (fail_on_incomplete:
+		// true) must not break every --preprocess-only run.
+		if isFlagSet("fail-on-incomplete") {
+			fmt.Fprintf(os.Stderr, "Error: --preprocess-only cannot be used with --fail-on-incomplete\n")
+			fmt.Fprintf(os.Stderr, "Preprocess-only mode does not perform validation, so coverage is never incomplete.\n")
 			os.Exit(1)
 		}
 
@@ -1910,14 +1959,19 @@ func main() {
 		}
 	}
 
-	// Use pre-commit exit code logic if in pre-commit mode
+	// Use pre-commit exit code logic if in pre-commit mode. --fail-on-incomplete
+	// (flag OR config/profile default) then escalates a clean result to the
+	// incomplete-coverage code without downgrading a findings/error verdict.
 	if precommitConfig != nil {
 		exitCode := precommit.GetExitCode(hasFindings, hasErrors, highestConfidence, precommitConfig)
-		os.Exit(exitCode)
+		os.Exit(resolveIncompleteExitCode(exitCode, finalConfig.failOnIncomplete, len(incompleteFiles)))
 	}
 
-	// Default behavior: always exit with code 0 (traditional behavior)
-	os.Exit(0)
+	// Default behavior: exit 0 (findings are reported in output, not via exit code)
+	// unless --fail-on-incomplete escalates a cut-short scan to code 3. Distinct
+	// code lets CI tell "incomplete coverage" apart from clean (0), error (1), and
+	// no-files (2). Settable via --fail-on-incomplete or config fail_on_incomplete.
+	os.Exit(resolveIncompleteExitCode(0, finalConfig.failOnIncomplete, len(incompleteFiles)))
 }
 
 // parseConfidenceLevels delegates to core.ParseConfidenceLevels to avoid code duplication between CLI and web modes.
@@ -2481,6 +2535,14 @@ func validateWebModeFlags() error {
 	if isFlagSet("list-profiles") {
 		incompatibleFlags = append(incompatibleFlags, "--list-profiles")
 		troubleshooting = append(troubleshooting, "Web mode does not currently support configuration profiles")
+	}
+
+	// --fail-on-incomplete controls the CLI process exit code; the web server is a
+	// long-running process with no scan-level exit code to influence (it reports
+	// incomplete coverage per-scan in the response instead).
+	if isFlagSet("fail-on-incomplete") {
+		incompatibleFlags = append(incompatibleFlags, "--fail-on-incomplete")
+		troubleshooting = append(troubleshooting, "Web mode reports incomplete coverage per scan in its response, not via a process exit code")
 	}
 
 	// Check for CLI-specific suppression flags

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -683,6 +684,25 @@ func shouldSuppressProgressOutput(finalConfig *finalConfiguration, precommitConf
 		suppress = true
 	}
 	return suppress
+}
+
+// writeIncompleteCoverageWarning emits the v2 Phase 4 incomplete-coverage warning
+// to w when any file's validator coverage was cut short (per-file/per-validator
+// timeout, cancellation, or match budget). It returns true if a warning was
+// written. The warning goes to stderr (never stdout/JSON, so scripts parsing
+// results are unaffected) and is a CORRECTNESS signal — callers gate it only on
+// pre-commit mode, not on quiet/non-interactive, because CI is exactly where a
+// silently-partial scan is most dangerous. It never changes the exit code.
+func writeIncompleteCoverageWarning(w io.Writer, incompleteFiles []parallel.FileDiagnostic, totalFiles int) bool {
+	if len(incompleteFiles) == 0 {
+		return false
+	}
+	fmt.Fprintf(w, "WARNING: scan coverage incomplete — %d of %d file(s) were not fully scanned; findings may be missing:\n",
+		len(incompleteFiles), totalFiles)
+	for _, fd := range incompleteFiles {
+		fmt.Fprintf(w, "  %s: %s\n", fd.FilePath, fd.Reason)
+	}
+	return true
 }
 
 // extractedFlags holds safely extracted flag values to avoid repeated nil checks
@@ -1544,6 +1564,11 @@ func main() {
 	var allMatches []detector.Match
 	processedFiles := 0
 	skippedFiles := 0
+	// incompleteFiles captures files whose validator coverage was cut short (a
+	// per-file/per-validator timeout, cancellation, or match budget — v2 Phase 4).
+	// Populated from ProcessingStats.IncompleteFiles below and surfaced as a
+	// stderr warning so a partially-scanned run is never silently reported clean.
+	var incompleteFiles []parallel.FileDiagnostic
 
 	// Suppress progress messages in pre-commit mode or quiet mode
 	if !shouldSuppressProgressOutput(finalConfig, precommitConfig, isInteractive) {
@@ -1661,6 +1686,7 @@ func main() {
 
 			allMatches = append(allMatches, parallelMatches...)
 			processedFiles = stats.ProcessedFiles
+			incompleteFiles = stats.IncompleteFiles
 
 			// Handle inline redaction results if redaction was enabled
 			if finalConfig.enableRedaction && redactionManager != nil {
@@ -1714,6 +1740,16 @@ func main() {
 			fmt.Fprintf(os.Stderr, "Scan complete: %d files processed in %s\n",
 				processedFiles, elapsed.Round(time.Millisecond))
 		}
+	}
+
+	// Incomplete-coverage warning (v2 Phase 4): a file whose validator coverage
+	// was cut short (per-file/per-validator timeout, cancellation, or match
+	// budget) means findings may be MISSING — the run must not be reported as a
+	// clean, complete scan. Suppressed only in pre-commit mode, which owns a
+	// strict machine-readable output contract. Exit code is deliberately
+	// unchanged (default still 0) — this is an advisory warning.
+	if precommitConfig == nil {
+		writeIncompleteCoverageWarning(os.Stderr, incompleteFiles, len(supportedFiles))
 	}
 
 	// Advisory explanation pass (opt-in via --explain). Annotate the full

--- a/cmd/stdin.go
+++ b/cmd/stdin.go
@@ -18,6 +18,7 @@ import (
 	"github.com/awslabs/ferret-scan/internal/core"
 	"github.com/awslabs/ferret-scan/internal/detector"
 	"github.com/awslabs/ferret-scan/internal/formatters"
+	"github.com/awslabs/ferret-scan/internal/parallel"
 	"github.com/awslabs/ferret-scan/internal/precommit"
 	"github.com/awslabs/ferret-scan/internal/redactors"
 	plaintextredactor "github.com/awslabs/ferret-scan/internal/redactors/plaintext"
@@ -180,6 +181,16 @@ func runStdinScan(in stdinScanInputs) int {
 	elapsed := time.Since(start)
 
 	allMatches := result.Matches // not yet suppressed since we passed nil manager
+
+	// Incomplete-coverage warning (v2 Phase 4): if the stdin scan's validator
+	// coverage was cut short (a per-validator timeout, cancellation, or match
+	// budget), findings may be MISSING. Uses the same helper/format as the file
+	// path (a single virtual "file"); suppressed only in pre-commit mode. Exit
+	// code is deliberately unchanged — advisory warning only.
+	if precommitConfig == nil && result.Incomplete {
+		writeIncompleteCoverageWarning(os.Stderr,
+			[]parallel.FileDiagnostic{{FilePath: scanCfg.VirtualPath, Reason: result.IncompleteReason}}, 1)
+	}
 
 	// --generate-suppressions writes against raw matches before suppression.
 	if finalCfg.generateSuppressions {

--- a/cmd/stdin.go
+++ b/cmd/stdin.go
@@ -124,6 +124,7 @@ func runStdinScan(in stdinScanInputs) int {
 		showMatch:            in.flags.showMatch,
 		showSuppressed:       in.flags.showSuppressed,
 		generateSuppressions: in.flags.generateSuppressions,
+		failOnIncomplete:     in.flags.failOnIncomplete,
 		enableRedaction:      in.flags.enableRedaction,
 		redactionOutputDir:   "",
 		redactionStrategy:    in.flags.redactionStrategy,
@@ -301,13 +302,20 @@ func runStdinScan(in stdinScanInputs) int {
 	}
 
 	// Exit-code parity with file mode: default mode always 0, pre-commit
-	// uses precommit.GetExitCode based on findings/confidence.
+	// uses precommit.GetExitCode based on findings/confidence. --fail-on-incomplete
+	// escalates an otherwise-clean exit to exitCodeIncompleteCoverage (3) when the
+	// scan's coverage was cut short, but never downgrades a non-zero verdict.
 	hasFindings := len(unsuppressedMatches) > 0
+	incompleteCount := 0
+	if result.Incomplete {
+		incompleteCount = 1
+	}
 	if precommitConfig != nil {
 		highest := highestConfidenceLevel(unsuppressedMatches)
-		return precommit.GetExitCode(hasFindings, false, highest, precommitConfig)
+		exitCode := precommit.GetExitCode(hasFindings, false, highest, precommitConfig)
+		return resolveIncompleteExitCode(exitCode, finalCfg.failOnIncomplete, incompleteCount)
 	}
-	return 0
+	return resolveIncompleteExitCode(0, finalCfg.failOnIncomplete, incompleteCount)
 }
 
 // runStdinPreprocessOnly emits the stdin buffer in the same format

--- a/config.yaml
+++ b/config.yaml
@@ -20,6 +20,7 @@ defaults:
   quiet: false # Suppress progress output (useful for scripts and CI/CD)
   show_suppressed: false # Include suppressed findings in output with [SUPP] marker
   generate_suppressions: false # Generate suppression rules for all findings
+  fail_on_incomplete: false # Exit code 3 if any file's validator coverage was cut short (timeout/cancellation/budget)
 
   # File exclusion patterns — glob syntax, applied in addition to --exclude on CLI
   # Uncomment and customize for your repo. Paths are matched against both the

--- a/docs/PRE_COMMIT_INTEGRATION.md
+++ b/docs/PRE_COMMIT_INTEGRATION.md
@@ -113,6 +113,13 @@ When `--pre-commit-mode` is enabled, Ferret Scan automatically:
 - **Optimizes performance** - Uses efficient batch processing for multiple files
 - **Respects file filtering** - Only processes files passed by pre-commit's file filtering
 
+> **Tip — fail on incomplete coverage.** Add `--fail-on-incomplete` to make the
+> hook exit `3` when any file's validator coverage was cut short (a timeout,
+> cancellation, or per-validator budget), so a partially-scanned file blocks the
+> commit instead of passing silently. Without the flag, incomplete coverage only
+> prints a warning to stderr. It escalates an otherwise-clean pre-commit result to
+> `3` and never downgrades a findings-based non-zero exit.
+
 ## Environment Detection
 
 Ferret Scan automatically detects pre-commit environments by checking for:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -240,6 +240,7 @@ Profiles now support all command-line options and include specialized configurat
 - `show_suppressed`: Include suppressed findings in output
 - `respect_gitignore`: Honor `.gitignore` files when scanning (opt-in; see [File Exclusion Patterns](#file-exclusion-patterns))
 - `generate_suppressions`: Auto-generate suppression rules
+- `fail_on_incomplete`: Exit with code `3` when a scan's validator coverage was cut short (timeout, cancellation, or a per-validator budget). Off by default; equivalent to the `--fail-on-incomplete` flag, which overrides this setting. See the README [Exit Codes](../README.md#exit-codes).
 
 ### CLI-Only Options (Not Configurable in YAML)
 
@@ -813,6 +814,7 @@ defaults:
   quiet: false
   show_suppressed: false
   generate_suppressions: false
+  fail_on_incomplete: false       # Exit code 3 if any file's coverage was cut short (timeout/budget)
   respect_gitignore: true         # Honor .gitignore, .git/info/exclude, global git excludes
 
   exclude_patterns:

--- a/examples/ferret.yaml
+++ b/examples/ferret.yaml
@@ -32,6 +32,7 @@ defaults:
   quiet: false                 # Suppress progress output
   show_suppressed: false       # Include suppressed findings in output
   generate_suppressions: false # Generate suppression rules for all findings
+  fail_on_incomplete: false    # Exit code 3 if a file's validator coverage was cut short (timeout/budget)
   respect_gitignore: true      # Honor .gitignore, .git/info/exclude, global git excludes
 
   # --explain (CLI flag only; not a YAML option)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,7 @@ type Config struct {
 		Quiet                bool     `yaml:"quiet"`
 		ShowSuppressed       bool     `yaml:"show_suppressed"`
 		GenerateSuppressions bool     `yaml:"generate_suppressions"`
+		FailOnIncomplete     bool     `yaml:"fail_on_incomplete"`
 	} `yaml:"defaults"`
 
 	// Global validator configurations
@@ -121,6 +122,7 @@ type Profile struct {
 	Quiet                bool     `yaml:"quiet"`
 	ShowSuppressed       bool     `yaml:"show_suppressed"`
 	GenerateSuppressions bool     `yaml:"generate_suppressions"`
+	FailOnIncomplete     bool     `yaml:"fail_on_incomplete"`
 	// GENAI_DISABLED: GenAI enablement flag for profiles
 	// EnableGenAI         bool                              `yaml:"enable_genai"`
 	// GENAI_DISABLED: Cost estimation only mode flag

--- a/internal/help/help.go
+++ b/internal/help/help.go
@@ -139,6 +139,7 @@ func (h *System) ShowGeneralHelp() {
 	// fmt.Fprintln(w, "  --estimate-only\t\tShow cost estimate and exit without processing")
 	fmt.Fprintln(w, "  --quiet\t\tSuppress progress output (useful for scripts and CI/CD)")
 	fmt.Fprintln(w, "  --pre-commit-mode\t\tEnable pre-commit optimizations (quiet mode, no colors, appropriate exit codes)")
+	fmt.Fprintln(w, "  --fail-on-incomplete\t\tExit non-zero (3) if any file's validator coverage was cut short (timeout, cancellation, or budget). Default off: incomplete coverage only warns on stderr.")
 	fmt.Fprintln(w, "  --disable-ip-types\t<types>\tComma-separated list of IP sub-types to skip: copyright,patent,trademark,trade_secret,internal_url")
 	fmt.Fprintln(w, "  --enable-redaction\t\tEnable redaction of sensitive data found in documents")
 	fmt.Fprintln(w, "  --redaction-output-dir\t<path>\tDirectory where redacted files will be stored (default: ./redacted)")


### PR DESCRIPTION
## What

Opt-in knob to **fail a run** when validator coverage was cut short (a per-file/per-validator **timeout**, **cancellation**, or Move C **budget**) instead of only warning on stderr (#112). Lets CI reject a partial scan rather than silently trust it.

> ⚠️ **Stacked on #112.** Base is `main` for CI, but the diff includes #112's commit until it merges. **Review the top commit** (`--fail-on-incomplete flag + fail_on_incomplete config`).

## Behavior

- **CLI flag** `--fail-on-incomplete` **and config/profile key** `fail_on_incomplete` (works from the config file too, not just the command line). Resolved with the standard precedence — config default → profile → flag (flag wins) — exactly like `--quiet`.
- **Exit code 3** (distinct from 0=clean, 1=error, 2=no-files) when enabled AND coverage was incomplete. Shared pure helper `resolveIncompleteExitCode`: escalates an otherwise-clean (0) result to 3, but **never downgrades** a findings/error verdict (pre-commit's blocking exit is preserved). Used by both the file and stdin paths.
- **Default OFF** → exit code unchanged; fully backward-compatible.

## Invalid combinations rejected (also answers "which flag combos are issues?")

- **`--web` + `--fail-on-incomplete`**: the web server is long-running with no scan-level exit code (it reports incomplete coverage per-scan in the response, added in #113).
- **`--preprocess-only` + `--fail-on-incomplete`**: preprocess-only exits before validation, so coverage is never "incomplete". Gated on `isFlagSet` (explicit flag only) so a global `fail_on_incomplete: true` config default does **not** break every `--preprocess-only` run.

## Docs + help
`--help` text, README (new **Exit Codes** table for 0/1/2/3 + pre-commit composition), `configuration.md` (profile options + annotated example), `PRE_COMMIT_INTEGRATION.md` (CI tip), and shipped `config.yaml` / `examples/ferret.yaml` defaults.

## Tests
`resolveIncompleteExitCode` truth table; `resolveConfiguration` precedence for `fail_on_incomplete` (config default + profile override both directions). Verified with the real binary: complete scan exits 0 with flag/config on; config parses cleanly; both invalid combinations rejected (exit 1). golden byte-identical; full suite + `-race` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)