### PR TITLE
feat(metrics): weekly passive download-metrics dashboard

### DIFF
--- a/.github/workflows/download-metrics.yml
+++ b/.github/workflows/download-metrics.yml
@@ -39,7 +39,9 @@ jobs:
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add docs/metrics/downloads.csv
-            git commit -m "chore(metrics): weekly download snapshot"
+            # [skip ci]: this is a data-only commit; no need to trigger the
+            # push-triggered build/test/scan workflows (matches repo convention).
+            git commit -m "chore(metrics): weekly download snapshot [skip ci]"
             git push
           else
             echo "No metrics change to commit."

--- a/.github/workflows/download-metrics.yml
+++ b/.github/workflows/download-metrics.yml
@@ -1,0 +1,63 @@
+name: Download Metrics
+
+# Weekly snapshot of public download/pull counts across all distribution
+# channels (PyPI, ECR Public, GitHub release binaries). Passive only: queries
+# public APIs, makes NO change to the ferret-scan binary and generates NO
+# egress from the tool itself. Appends one row to docs/metrics/downloads.csv.
+
+on:
+  schedule:
+    # Mondays 06:00 UTC
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+# Least privilege: only needs to read releases and commit the CSV back.
+permissions:
+  contents: write
+
+concurrency:
+  group: download-metrics
+  cancel-in-progress: false
+
+jobs:
+  collect:
+    runs-on: ubuntu-latest
+    # Do not run on forks (no upstream data to commit; avoids failed cron noise).
+    if: github.repository == 'awslabs/ferret-scan'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Collect download metrics
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 scripts/collect-download-metrics.py
+
+      - name: Commit updated metrics
+        run: |
+          if [ -n "$(git status --porcelain docs/metrics/downloads.csv)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add docs/metrics/downloads.csv
+            git commit -m "chore(metrics): weekly download snapshot"
+            git push
+          else
+            echo "No metrics change to commit."
+          fi
+
+      - name: Job summary
+        if: always()
+        run: |
+          {
+            echo "## 📊 Download metrics snapshot"
+            echo ""
+            echo "Latest row in \`docs/metrics/downloads.csv\`:"
+            echo ""
+            echo '```'
+            head -1 docs/metrics/downloads.csv
+            tail -1 docs/metrics/downloads.csv
+            echo '```'
+            echo ""
+            echo "> ECR and GitHub columns are lifetime-cumulative; week-over-week"
+            echo "> deltas give weekly pulls. PyPI columns are rolling windows."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -196,6 +196,10 @@ python-package/dist/
 python-package/ferret_scan/_version.py
 *.egg-info/
 
+# Python bytecode
+__pycache__/
+*.py[cod]
+
 # Generated and analysis files
 .docs-build/
 .doc-cache/

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -1,0 +1,67 @@
+# Download Metrics
+
+`downloads.csv` is a weekly snapshot of ferret-scan's public download/pull
+counts across every distribution channel. It is produced **passively** — by
+querying public APIs — with **no change to the ferret-scan binary and no
+network egress from the tool itself**. The tool remains egress-free by design;
+usage is measured from the outside.
+
+## How it is collected
+
+- **Automatically:** the [`Download Metrics`](../../.github/workflows/download-metrics.yml)
+  workflow runs every Monday 06:00 UTC (and on manual dispatch) and commits a
+  new row via `github-actions[bot]`.
+- **Locally / on demand:**
+
+  ```bash
+  python3 scripts/collect-download-metrics.py
+  ```
+
+  (Set `GITHUB_TOKEN` to avoid the low unauthenticated GitHub rate limit.)
+
+## Columns
+
+| Column | Source | Meaning |
+|---|---|---|
+| `date` | — | UTC date the snapshot was taken |
+| `latest_release` | GitHub Releases API | Newest non-prerelease tag at snapshot time (correlate spikes to releases) |
+| `pypi_last_day` | pypistats.org | PyPI installs in the last day (mirrors excluded) |
+| `pypi_last_week` | pypistats.org | PyPI installs in the last 7 days |
+| `pypi_last_month` | pypistats.org | PyPI installs in the last 30 days |
+| `pypi_last_month_with_mirrors` | pypistats.org | Last-30-day installs **including** mirrors (track CI/mirror noise ratio) |
+| `pypi_py3_7_30d` … `pypi_py3_13_30d` | pypistats.org | Last-30-day installs per declared Python minor version |
+| `pypi_py_other_30d` | pypistats.org | Last-30-day installs for unknown/`null` or out-of-range Python versions |
+| `ecr_pulls_total` | ECR Public gallery API | **Lifetime cumulative** pulls of `public.ecr.aws/awslabs/ferret-scan` (all tags) |
+| `ecr_pulls_delta` | computed | `ecr_pulls_total` minus the previous row's value (weekly pulls) |
+| `github_binary_downloads_total` | GitHub Releases API | **Lifetime cumulative** sum of `download_count` across all release assets |
+| `github_binary_downloads_delta` | computed | `github_binary_downloads_total` minus the previous row's value (weekly downloads) |
+| `gh_linux_amd64` … `gh_windows_arm64` | GitHub Releases API | **Lifetime cumulative** per-platform asset downloads (shows which platforms matter) |
+
+## Reading the numbers
+
+- **PyPI columns are rolling windows** — read them directly.
+- **ECR / GitHub totals are lifetime-cumulative.** Use the `*_delta` columns
+  for the weekly rate (they are `total − previous row`; blank on the first row
+  and whenever the prior value is missing). The per-platform `gh_*` columns are
+  also cumulative — diff across rows for a weekly per-platform rate.
+- The three channels measure **different funnel stages** and should not be
+  summed. In particular the PyPI package is a thin shim that downloads the Go
+  binary from GitHub on first run, so a `pip install` does not equal a GitHub
+  binary download.
+- All counters include CI re-installs / re-pulls and cannot dedupe users;
+  treat them as ceilings, not unique-user counts.
+- **Missing cells** mean a channel's API was unreachable that run (e.g. a
+  pypistats `429`); the rest of the row is still valid.
+
+## Not collected: installer breakdown
+
+pip vs uv vs poetry is **not** included — pypistats has no installer endpoint,
+and that split is only available in the PyPI BigQuery dataset, which requires
+GCP credentials and is out of scope for this zero-secret job.
+
+## What is intentionally **not** measured
+
+Execution / active-user counts. There is no passive signal for "a scan ran";
+only an in-binary phone-home could produce it. That was deliberately **not**
+added — keeping the scanner egress-free is a security property worth more than
+execution telemetry, especially for a tool pointed at sensitive data.

--- a/docs/metrics/downloads.csv
+++ b/docs/metrics/downloads.csv
@@ -1,0 +1,2 @@
+date,latest_release,pypi_last_day,pypi_last_week,pypi_last_month,pypi_last_month_with_mirrors,pypi_py3_7_30d,pypi_py3_8_30d,pypi_py3_9_30d,pypi_py3_10_30d,pypi_py3_11_30d,pypi_py3_12_30d,pypi_py3_13_30d,pypi_py_other_30d,ecr_pulls_total,ecr_pulls_delta,github_binary_downloads_total,github_binary_downloads_delta,gh_linux_amd64,gh_linux_arm64,gh_darwin_amd64,gh_darwin_arm64,gh_windows_amd64,gh_windows_arm64
+2026-07-02,v1.10.0,78,544,1560,3736,6,3,6,2,9,328,665,576,2872,,1583,,141,138,140,153,145,142

--- a/scripts/collect-download-metrics.py
+++ b/scripts/collect-download-metrics.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Collect ferret-scan download metrics from all public distribution channels.
+
+Queries public APIs with NO change to the ferret-scan binary and NO egress from
+the tool itself:
+
+  * PyPI installs   -- pypistats.org (rolling windows, with/without mirrors,
+                       and a per-Python-version breakdown)
+  * Docker pulls    -- Amazon ECR Public gallery API (lifetime cumulative)
+  * GitHub binaries -- GitHub Releases API, per-platform + total asset
+                       download_count (lifetime cumulative)
+
+Appends one row to docs/metrics/downloads.csv (creating it with a header if
+absent). Cumulative counters (ECR, GitHub) also get a *_delta column computed
+against the previous row, so week-over-week pulls are readable directly.
+
+Runnable locally (python3 scripts/collect-download-metrics.py) or from CI. A
+GITHUB_TOKEN in the environment is used for the GitHub API to avoid the low
+unauthenticated rate limit; everything else is unauthenticated public data.
+
+Per-channel network failures are recorded as empty cells rather than failing
+the whole run, so a transient pypistats 429 never blocks the snapshot.
+
+NOTE: installer breakdown (pip vs uv vs poetry) is intentionally absent --
+pypistats has no installer endpoint; that split is only in the PyPI BigQuery
+dataset, which needs GCP credentials and is out of scope here.
+"""
+
+import csv
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+
+PYPI_PACKAGE = "ferret-scan"
+ECR_ALIAS = "awslabs"
+ECR_REPO = "ferret-scan"
+GITHUB_REPO = "awslabs/ferret-scan"
+
+# Declared support range (see python-package/setup.py classifiers). Anything
+# outside this set -- newer 3.14+, or "null"/unknown -- folds into py_other so
+# the CSV header stays stable as new Python versions appear.
+PY_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+
+# GitHub release asset basename fragments -> column suffix. Matched as a
+# substring of the asset name (e.g. "ferret-scan_1.10.0_linux_amd64").
+GH_PLATFORMS = [
+    ("linux_amd64", "gh_linux_amd64"),
+    ("linux_arm64", "gh_linux_arm64"),
+    ("darwin_amd64", "gh_darwin_amd64"),
+    ("darwin_arm64", "gh_darwin_arm64"),
+    ("windows_amd64", "gh_windows_amd64"),
+    ("windows_arm64", "gh_windows_arm64"),
+]
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CSV_PATH = os.path.join(REPO_ROOT, "docs", "metrics", "downloads.csv")
+
+COLUMNS = (
+    ["date", "latest_release"]
+    + ["pypi_last_day", "pypi_last_week", "pypi_last_month", "pypi_last_month_with_mirrors"]
+    + [f"pypi_py{v.replace('.', '_')}_30d" for v in PY_VERSIONS]
+    + ["pypi_py_other_30d"]
+    + ["ecr_pulls_total", "ecr_pulls_delta"]
+    + ["github_binary_downloads_total", "github_binary_downloads_delta"]
+    + [col for _, col in GH_PLATFORMS]
+)
+
+USER_AGENT = "ferret-scan-metrics/1.0 (+https://github.com/awslabs/ferret-scan)"
+
+
+def _get(url, headers=None, data=None, method="GET", retries=3, timeout=30):
+    """HTTP request with simple backoff. Returns parsed JSON or raises."""
+    hdrs = {"User-Agent": USER_AGENT, "Accept": "application/json"}
+    if headers:
+        hdrs.update(headers)
+    body = data.encode() if isinstance(data, str) else data
+    last_err = None
+    for attempt in range(retries):
+        try:
+            req = urllib.request.Request(url, data=body, headers=hdrs, method=method)
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                return json.loads(resp.read().decode())
+        except urllib.error.HTTPError as e:
+            last_err = e
+            if e.code != 429 and e.code < 500:  # only retry 429 / 5xx
+                break
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as e:
+            last_err = e
+        if attempt < retries - 1:
+            time.sleep(2 ** attempt)  # 1s, 2s
+    raise last_err
+
+
+def _sum_last_days(rows, days=30, predicate=None):
+    """Sum `downloads` over the most recent `days` distinct dates in a
+    pypistats daily series, optionally filtered by a category predicate."""
+    dates = sorted({r["date"] for r in rows})[-days:]
+    recent = set(dates)
+    return sum(
+        r["downloads"]
+        for r in rows
+        if r["date"] in recent and (predicate is None or predicate(r["category"]))
+    )
+
+
+def collect_pypi_windows():
+    """Rolling last_day / last_week / last_month install counts (no mirrors)."""
+    data = _get(f"https://pypistats.org/api/packages/{PYPI_PACKAGE}/recent")["data"]
+    return data.get("last_day"), data.get("last_week"), data.get("last_month")
+
+
+def collect_pypi_with_mirrors_month():
+    """Mirror-inclusive installs over the last 30 days (tracks CI/mirror noise)."""
+    rows = _get(f"https://pypistats.org/api/packages/{PYPI_PACKAGE}/overall?mirrors=true")["data"]
+    return _sum_last_days(rows, 30, predicate=lambda c: c == "with_mirrors")
+
+
+def collect_pypi_by_pyversion():
+    """Last-30-day installs per declared Python minor version, plus an
+    `other` catch-all for null/unknown and versions outside the support range."""
+    rows = _get(f"https://pypistats.org/api/packages/{PYPI_PACKAGE}/python_minor")["data"]
+    known = set(PY_VERSIONS)
+    out = {v: _sum_last_days(rows, 30, predicate=lambda c, ver=v: c == ver) for v in PY_VERSIONS}
+    out["other"] = _sum_last_days(rows, 30, predicate=lambda c: c not in known)
+    return out
+
+
+def collect_ecr():
+    """Lifetime cumulative pull count for the ECR Public repository (all tags)."""
+    url = "https://api.us-east-1.gallery.ecr.aws/getRepositoryCatalogData"
+    payload = json.dumps({"registryAliasName": ECR_ALIAS, "repositoryName": ECR_REPO})
+    res = _get(url, headers={"Content-Type": "application/json"}, data=payload, method="POST")
+    return res.get("insightData", {}).get("downloadCount")
+
+
+def collect_github():
+    """Per-platform + total + latest tag from the GitHub Releases API (lifetime)."""
+    headers = {"Accept": "application/vnd.github+json"}
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    per_platform = {col: 0 for _, col in GH_PLATFORMS}
+    total = 0
+    latest_tag = None
+    page = 1
+    while True:
+        url = f"https://api.github.com/repos/{GITHUB_REPO}/releases?per_page=100&page={page}"
+        releases = _get(url, headers=headers)
+        if not releases:
+            break
+        for rel in releases:
+            # First non-draft, non-prerelease tag seen (API returns newest first).
+            if latest_tag is None and not rel.get("draft") and not rel.get("prerelease"):
+                latest_tag = rel.get("tag_name")
+            for asset in rel.get("assets", []):
+                count = asset.get("download_count", 0)
+                total += count
+                name = asset.get("name", "")
+                for frag, col in GH_PLATFORMS:
+                    if frag in name:
+                        per_platform[col] += count
+                        break
+        if len(releases) < 100:
+            break
+        page += 1
+    return total, latest_tag, per_platform
+
+
+def _previous_row():
+    """Last data row of the existing CSV (for delta computation), or {}."""
+    if not os.path.exists(CSV_PATH) or os.path.getsize(CSV_PATH) == 0:
+        return {}
+    with open(CSV_PATH, newline="") as f:
+        rows = list(csv.DictReader(f))
+    return rows[-1] if rows else {}
+
+
+def _delta(current, prev_row, key):
+    """current - previous, or "" if either side is missing/non-numeric."""
+    if current is None:
+        return ""
+    prev = (prev_row or {}).get(key, "")
+    try:
+        return current - int(prev)
+    except (ValueError, TypeError):
+        return ""
+
+
+def safe(collector, name, default=None):
+    try:
+        return collector()
+    except Exception as e:  # noqa: BLE001 - one bad channel must not sink the row
+        print(f"WARN: {name} collection failed: {e}", file=sys.stderr)
+        return default
+
+
+def main():
+    prev = _previous_row()
+
+    day, week, month = safe(collect_pypi_windows, "pypi-windows", (None, None, None))
+    time.sleep(1)  # be polite to pypistats between calls
+    month_mirrors = safe(collect_pypi_with_mirrors_month, "pypi-mirrors")
+    time.sleep(1)
+    by_pyver = safe(collect_pypi_by_pyversion, "pypi-pyversion", {})
+
+    ecr = safe(collect_ecr, "ecr")
+    gh = safe(collect_github, "github", (None, None, {}))
+    gh_total, latest_tag, gh_platforms = gh
+
+    row = {
+        "date": datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+        "latest_release": latest_tag,
+        "pypi_last_day": day,
+        "pypi_last_week": week,
+        "pypi_last_month": month,
+        "pypi_last_month_with_mirrors": month_mirrors,
+        "ecr_pulls_total": ecr,
+        "ecr_pulls_delta": _delta(ecr, prev, "ecr_pulls_total"),
+        "github_binary_downloads_total": gh_total,
+        "github_binary_downloads_delta": _delta(gh_total, prev, "github_binary_downloads_total"),
+    }
+    for v in PY_VERSIONS:
+        row[f"pypi_py{v.replace('.', '_')}_30d"] = by_pyver.get(v)
+    row["pypi_py_other_30d"] = by_pyver.get("other")
+    for _, col in GH_PLATFORMS:
+        row[col] = gh_platforms.get(col) if gh_platforms else None
+
+    os.makedirs(os.path.dirname(CSV_PATH), exist_ok=True)
+    write_header = not os.path.exists(CSV_PATH) or os.path.getsize(CSV_PATH) == 0
+    with open(CSV_PATH, "a", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=COLUMNS)
+        if write_header:
+            writer.writeheader()
+        writer.writerow({k: ("" if row.get(k) is None else row.get(k)) for k in COLUMNS})
+
+    print(f"Appended {row['date']} to {os.path.relpath(CSV_PATH, REPO_ROOT)}")
+    for k in COLUMNS:
+        print(f"  {k}: {row.get(k)}")
+
+    # Surface a hard failure only if every channel was unreachable.
+    if day is None and ecr is None and gh_total is None:
+        print("ERROR: all channels failed", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Implements **goal #1 (downloads)** of the tracking plan: a weekly snapshot of public download/pull counts across all three distribution channels — **with no change to the ferret-scan binary and no network egress from the tool itself**. Usage is measured passively from public APIs.

**Goal #2 (executions) is deliberately NOT implemented.** There is no passive signal for "a scan ran" — only an in-binary phone-home could produce it, which would break the tool's documented zero-egress invariant (TB-1) on a scanner pointed at sensitive data. Keeping the binary egress-free is worth more than execution telemetry. This is called out in the metrics README and the commit body so it's a documented decision, not an omission.

## What it collects

| Channel | Data | Source |
|---|---|---|
| **PyPI** | rolling day/week/month, with-mirrors, per-Python-version (30d) | pypistats.org |
| **Docker** | lifetime cumulative pulls | ECR Public gallery API |
| **GitHub** | total + **per-platform** asset downloads, latest tag | GitHub Releases API |

Cumulative counters (ECR, GitHub) also get `*_delta` columns computed against the previous row, so week-over-week rates are readable directly.

## Files

- **scripts/collect-download-metrics.py** — stdlib-only collector (no deps). Per-channel failures degrade to empty cells rather than failing the run (verified against a live pypistats `429`).
- **.github/workflows/download-metrics.yml** — weekly cron + manual dispatch; SHA-pinned `checkout` (TB-08 control); least-privilege `contents: write`; commits the CSV via `github-actions[bot]`; renders a markdown job summary; skipped on forks.
- **docs/metrics/downloads.csv** — append-only data, seeded with the 2026-07-02 snapshot.
- **docs/metrics/README.md** — column reference + how to read cumulative-vs-windowed columns.
- **.gitignore** — ignore `__pycache__/` / `*.py[cod]`.

## Verification

- Collector run live end-to-end; all channels populate (per-platform GitHub downloads are near-even at 138–153 across all 6 platforms — visible only via this split).
- CSV schema stable at 24 columns across header + rows; delta logic round-trips correctly (0 vs seed).
- Workflow YAML validated; Python `py_compile` clean.
- Resilience confirmed: a transient pypistats `429` left those cells empty and the run still exited 0.

## Notes

- Installer breakdown (pip vs uv vs poetry) is omitted — pypistats has no installer endpoint; that split is BigQuery-only (needs GCP creds, out of scope for a zero-secret job).
- No project Python line-length gate exists (no ruff/flake8/black config; existing `cli.py` runs to 119 chars), so lines are not reflowed to the IDE's 79-char default.