### PR TITLE
fix(v2-refactor): unify file-type routing to one source of truth (gap 5.3)

### DIFF
--- a/internal/router/extension_routing_test.go
+++ b/internal/router/extension_routing_test.go
@@ -1,0 +1,114 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package router
+
+import (
+	"testing"
+
+	"github.com/awslabs/ferret-scan/internal/preprocessors"
+)
+
+// TestExtensionRouting_MatchesPreprocessorCapability is the drift guard (v2 gap
+// 5.3): the routing gate (isBinaryDocument / getMetadataTypeForExtension) must
+// never classify an extension as processable that NO registered preprocessor can
+// actually handle. Before the fix, the router carried its own broader hardcoded
+// list, so e.g. a .heic file passed the gate then hit a mid-pipeline
+// "no preprocessor can handle file" error. Now both derive from the shared
+// FileExtensionValidator, so the gate and the workers agree.
+func TestExtensionRouting_MatchesPreprocessorCapability(t *testing.T) {
+	fr := NewFileRouter(false)
+	RegisterDefaultPreprocessors(fr)
+	// Actually instantiate the preprocessors (registration only stores factories;
+	// fr.preprocessors is empty until InitializePreprocessors runs) — mirrors
+	// core.ScanFile's setup.
+	fr.InitializePreprocessors(CreateRouterConfig(false, nil, "", false))
+
+	// The full set the old router list claimed to support.
+	exts := []string{
+		".docx", ".doc", ".xlsx", ".xls", ".pptx", ".ppt", ".odt", ".ods", ".odp",
+		".pdf",
+		".jpg", ".jpeg", ".png", ".gif", ".tiff", ".tif", ".bmp", ".webp",
+		".heic", ".heif", ".raw", ".cr2", ".nef", ".arw",
+		".mp4", ".mov", ".avi", ".mkv", ".wmv", ".flv", ".webm", ".m4v", ".3gp", ".ogv",
+		".mp3", ".flac", ".wav", ".ogg", ".m4a", ".aac", ".wma", ".opus",
+	}
+
+	for _, ext := range exts {
+		gated := isBinaryDocument(ext)
+		// Does any registered preprocessor actually accept this extension?
+		probe := "sample" + ext
+		canHandle := false
+		for _, p := range fr.preprocessors {
+			if p.CanProcess(probe) {
+				canHandle = true
+				break
+			}
+		}
+		// The gate must not claim to process what nothing can handle, and must not
+		// reject what a preprocessor can handle — they must agree exactly.
+		if gated != canHandle {
+			t.Errorf("%s: gate isBinaryDocument=%v but preprocessor-capable=%v (drift)", ext, gated, canHandle)
+		}
+		// getMetadataTypeForExtension must return a concrete type iff gated in.
+		mt := getMetadataTypeForExtension(ext)
+		if gated && mt == "none" {
+			t.Errorf("%s: gated in but metadata type resolved to none", ext)
+		}
+		if !gated && mt != "none" {
+			t.Errorf("%s: not gated in but metadata type = %q (expected none)", ext, mt)
+		}
+	}
+}
+
+// TestExtensionRouting_SupportedTypesUnchanged pins the extensions that were
+// genuinely supported before AND after the fix, so this refactor cannot silently
+// drop a real capability.
+func TestExtensionRouting_SupportedTypesUnchanged(t *testing.T) {
+	want := map[string]string{
+		".docx": "office_metadata", ".xlsx": "office_metadata", ".pptx": "office_metadata",
+		".odt": "office_metadata", ".ods": "office_metadata", ".odp": "office_metadata",
+		".pdf": "document_metadata",
+		".jpg": "image_metadata", ".jpeg": "image_metadata", ".png": "image_metadata",
+		".gif": "image_metadata", ".tiff": "image_metadata", ".tif": "image_metadata",
+		".bmp": "image_metadata", ".webp": "image_metadata",
+		".mp4": "video_metadata", ".mov": "video_metadata", ".m4v": "video_metadata",
+		".mp3": "audio_metadata", ".flac": "audio_metadata", ".wav": "audio_metadata", ".m4a": "audio_metadata",
+	}
+	for ext, mt := range want {
+		if !isBinaryDocument(ext) {
+			t.Errorf("%s: expected still-supported (isBinaryDocument=true), got false", ext)
+		}
+		if got := getMetadataTypeForExtension(ext); got != mt {
+			t.Errorf("%s: metadata type = %q, want %q", ext, got, mt)
+		}
+	}
+}
+
+// TestExtensionRouting_UnsupportedTypesSkipped pins that the previously-drifting
+// extensions (gated in by the old list but handled by no preprocessor) now route
+// to a clean "unsupported" skip instead of a mid-pipeline error.
+func TestExtensionRouting_UnsupportedTypesSkipped(t *testing.T) {
+	skipped := []string{
+		".doc", ".xls", ".ppt", // legacy binary Office (only OOXML/ODF are handled)
+		".heic", ".heif", ".raw", ".cr2", ".nef", ".arw",
+		".avi", ".mkv", ".wmv", ".flv", ".webm", ".3gp", ".ogv",
+		".ogg", ".aac", ".wma", ".opus",
+	}
+	for _, ext := range skipped {
+		if isBinaryDocument(ext) {
+			t.Errorf("%s: expected unsupported (isBinaryDocument=false), got true", ext)
+		}
+		if got := getMetadataTypeForExtension(ext); got != "none" {
+			t.Errorf("%s: metadata type = %q, want none", ext, got)
+		}
+	}
+}
+
+// TestExtensionRouting_ValidatorConstructs is a light guard that the shared
+// validator the gate delegates to is non-nil and usable.
+func TestExtensionRouting_ValidatorConstructs(t *testing.T) {
+	if preprocessors.NewFileExtensionValidator() == nil {
+		t.Fatal("NewFileExtensionValidator returned nil")
+	}
+}

--- a/internal/router/file_router.go
+++ b/internal/router/file_router.go
@@ -288,23 +288,32 @@ func (fr *FileRouter) GetMetadataType(filePath string) string {
 
 // Helper functions
 
+// extValidator is the SINGLE source of truth for which extensions the metadata
+// preprocessors actually handle. The router's routing gate (isBinaryDocument /
+// isMetadataCapableFile / getMetadataTypeForExtension) delegates to it so the
+// gate can never claim to process an extension that no preprocessor supports.
+//
+// Previously the router carried its own broader hardcoded list (adding e.g.
+// .heic/.doc/.avi/.ogg) that had DRIFTED from what the preprocessors' own
+// FileExtensionValidator recognizes. A .heic file passed the gate, then reached
+// processFileInternal where every preprocessor's CanProcess returned false,
+// producing a mid-pipeline "no preprocessor can handle file" error instead of a
+// clean "unsupported file type" skip. Deriving the gate from the same validator
+// the preprocessors use removes that drift (v2 gap 5.3).
+var extValidator = preprocessors.NewFileExtensionValidator()
+
+// extProbe turns a bare extension (".heic") into a filename the
+// FileExtensionValidator's path-based predicates can inspect (its Is*File
+// methods run filepath.Ext internally, which returns "" for a bare ".heic").
+func extProbe(ext string) string { return "f" + ext }
+
 func isBinaryDocument(ext string) bool {
-	binaryExts := map[string]bool{
-		// Office documents
-		".docx": true, ".doc": true, ".xlsx": true, ".xls": true, ".pptx": true, ".ppt": true,
-		".odt": true, ".ods": true, ".odp": true,
-		// PDF documents
-		".pdf": true,
-		// Image formats
-		".jpg": true, ".jpeg": true, ".png": true, ".gif": true, ".tiff": true, ".tif": true,
-		".bmp": true, ".webp": true, ".heic": true, ".heif": true, ".raw": true, ".cr2": true, ".nef": true, ".arw": true,
-		// Video formats
-		".mp4": true, ".mov": true, ".avi": true, ".mkv": true, ".wmv": true, ".flv": true,
-		".webm": true, ".m4v": true, ".3gp": true, ".ogv": true,
-		// Audio formats
-		".mp3": true, ".flac": true, ".wav": true, ".ogg": true, ".m4a": true, ".aac": true, ".wma": true, ".opus": true,
-	}
-	return binaryExts[ext]
+	p := extProbe(ext)
+	return extValidator.IsOfficeFile(p) ||
+		extValidator.IsPDFFile(p) ||
+		extValidator.IsImageFile(p) ||
+		extValidator.IsVideoFile(p) ||
+		extValidator.IsAudioFile(p)
 }
 
 // isMetadataCapableFile determines if a file extension indicates metadata capability
@@ -313,18 +322,22 @@ func isMetadataCapableFile(ext string) bool {
 	return isBinaryDocument(ext)
 }
 
-// getMetadataTypeForExtension returns the specific metadata type for preprocessor routing
+// getMetadataTypeForExtension returns the specific metadata type for preprocessor
+// routing, keyed off the shared FileExtensionValidator. The returned strings are
+// the same the specialized preprocessors identify with (office/document/image/
+// video/audio_metadata); "none" for anything no preprocessor handles.
 func getMetadataTypeForExtension(ext string) string {
-	switch ext {
-	case ".docx", ".doc", ".xlsx", ".xls", ".pptx", ".ppt", ".odt", ".ods", ".odp":
+	p := extProbe(ext)
+	switch {
+	case extValidator.IsOfficeFile(p):
 		return "office_metadata"
-	case ".pdf":
+	case extValidator.IsPDFFile(p):
 		return "document_metadata"
-	case ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".tiff", ".tif", ".webp", ".heic", ".heif", ".raw", ".cr2", ".nef", ".arw":
+	case extValidator.IsImageFile(p):
 		return "image_metadata"
-	case ".mp4", ".mov", ".avi", ".mkv", ".wmv", ".flv", ".webm", ".m4v", ".3gp", ".ogv":
+	case extValidator.IsVideoFile(p):
 		return "video_metadata"
-	case ".mp3", ".flac", ".wav", ".ogg", ".m4a", ".aac", ".wma", ".opus":
+	case extValidator.IsAudioFile(p):
 		return "audio_metadata"
 	default:
 		return "none"


### PR DESCRIPTION
## What

The router's routing gate (`isBinaryDocument`) carried its **own hardcoded extension list** that had **drifted** from what the metadata preprocessors actually handle (their shared `FileExtensionValidator`).

The gate listed ~14 extensions no preprocessor supports — `.doc/.xls/.ppt` (only OOXML/ODF are handled), `.heic/.heif/.raw/.cr2/.nef/.arw`, `.avi/.mkv/.wmv/.flv/.webm/.3gp/.ogv`, `.ogg/.aac/.wma/.opus`. Scanning one:
1. passed `CanProcessFile` → "Binary document"
2. reached `processFileInternal`, where every preprocessor's `CanProcess` returned false
3. → mid-pipeline error **`"no preprocessor can handle file: X"`** instead of a clean "unsupported file type" skip.

## Fix
`isBinaryDocument` / `isMetadataCapableFile` / `getMetadataTypeForExtension` now **delegate to the same `preprocessors.FileExtensionValidator`** the preprocessors use — one source of truth. The router gate now has **zero hardcoded extension literals**, so the gate can never again claim to process something no preprocessor handles.

## Behavior change (the only one)
Those ~14 drifted extensions now route to a clean **"Unsupported file type" skip** instead of erroring mid-scan. **No extension that previously succeeded changes** — the genuinely-supported set (all OOXML/ODF office, `.pdf`, images jpg/jpeg/png/gif/tiff/tif/bmp/webp, video mp4/mov/m4v, audio mp3/flac/wav/m4a) is byte-identical, and the metadata-type strings are unchanged. **Golden corpus byte-identical.**

## Scope (deliberately narrow — "only A")
- Does **not** add content-sniffing (`net/http.DetectContentType` / `mimetype`) — that's a separate enhancement (route renamed/extensionless files by magic bytes).
- Leaves `content_router.go`'s embedded-media substring heuristic alone (different concern: classifies already-extracted text, not files).

## Tests (new `extension_routing_test.go`)
A **drift guard** that wires up the real preprocessors and asserts the gate agrees with them for every extension — it fails if any list drifts again (negative-controlled: reintroducing `.heic` drift makes it fail with the exact message). Plus pins for the still-supported set and the now-skipped set. Full suite + `-race` + vet green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)