### PR TITLE
fix(validators): never log raw matched values in debug output (BSC4)

### DIFF
--- a/internal/validators/creditcard/validator.go
+++ b/internal/validators/creditcard/validator.go
@@ -708,7 +708,9 @@ func (v *Validator) logLuhnFailure(originalMatch, cleanMatch string, lineNum int
 
 	fmt.Fprintf(os.Stderr, "[DEBUG]  Credit Card Validator: Luhn test failed\n")
 	fmt.Fprintf(os.Stderr, "[DEBUG]   - File: %s, Line: %d\n", filePath, lineNum)
-	fmt.Fprintf(os.Stderr, "[DEBUG]   - Match: %s -> %s\n", originalMatch, cleanMatch)
+	// Never log the candidate digits themselves (BSC4: no card numbers in logs);
+	// the length is enough to debug Luhn/separator handling.
+	fmt.Fprintf(os.Stderr, "[DEBUG]   - Match: [HIDDEN] (raw len=%d, digits=%d)\n", len(originalMatch), len(cleanMatch))
 }
 
 func (v *Validator) isDebugEnabled() bool {

--- a/internal/validators/intellectualproperty/validator.go
+++ b/internal/validators/intellectualproperty/validator.go
@@ -3086,7 +3086,8 @@ func (v *Validator) logReconstructionDetails(originalMatches []detector.Match, r
 	// Also log to stderr in debug mode for comprehensive audit trail
 	if os.Getenv("FERRET_DEBUG") == "1" {
 		fmt.Fprintf(os.Stderr, "[DEBUG] Legal Notice Reconstruction: %d matches → 1 reconstructed match\n", len(originalMatches))
-		fmt.Fprintf(os.Stderr, "[DEBUG]   Text: '%s'\n", reconstructedMatch.Text)
+		// Do not log the matched text itself (BSC4: no matched values in logs).
+		fmt.Fprintf(os.Stderr, "[DEBUG]   Text: [HIDDEN] (len=%d)\n", len(reconstructedMatch.Text))
 		fmt.Fprintf(os.Stderr, "[DEBUG]   Confidence: %.1f%%", reconstructedMatch.Confidence)
 		if reconstructedMatch.Metadata != nil {
 			if boost, ok := reconstructedMatch.Metadata["confidence_boost"].(float64); ok {

--- a/internal/validators/socialmedia/validator.go
+++ b/internal/validators/socialmedia/validator.go
@@ -821,13 +821,14 @@ func (v *Validator) CalculateConfidence(match string) (float64, map[string]bool)
 	// Enhanced error handling for confidence calculation
 	defer func() {
 		if r := recover(); r != nil {
-			// Log panic recovery for debugging
+			// Log panic recovery for debugging — never include the matched value
+			// itself (BSC4: no PII in logs).
 			if v.observer != nil && v.observer.DebugObserver != nil {
-				v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Recovered from panic in CalculateConfidence for match '%s': %v", match, r))
+				v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Recovered from panic in CalculateConfidence for match [HIDDEN] (len=%d): %v", len(match), r))
 			}
 			if v.isDebugEnabled() {
 				fmt.Fprintf(os.Stderr, "[ERROR] Social Media Validator: Panic in confidence calculation\n")
-				fmt.Fprintf(os.Stderr, "[ERROR]   Match: %s\n", match)
+				fmt.Fprintf(os.Stderr, "[ERROR]   Match: [HIDDEN] (len=%d)\n", len(match))
 				fmt.Fprintf(os.Stderr, "[ERROR]   Panic: %v\n", r)
 				fmt.Fprintf(os.Stderr, "[ERROR]   Action: Returning low confidence for safety\n")
 			}
@@ -849,10 +850,10 @@ func (v *Validator) CalculateConfidence(match string) (float64, map[string]bool)
 	if platform == "" {
 		// Unknown platform - assign low confidence with enhanced logging
 		if v.observer != nil && v.observer.DebugObserver != nil {
-			v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Unknown platform for match: %s", match))
+			v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Unknown platform for match [HIDDEN] (len=%d)", len(match)))
 		}
 		if v.isDebugEnabled() {
-			fmt.Fprintf(os.Stderr, "[DEBUG] Social Media Validator: Unknown platform for match: %s\n", match)
+			fmt.Fprintf(os.Stderr, "[DEBUG] Social Media Validator: Unknown platform for match [HIDDEN] (len=%d)\n", len(match))
 		}
 		checks["platform_identified"] = false
 		return 10.0, checks
@@ -2805,7 +2806,8 @@ func (v *Validator) processMatchOptimized(match, platform string, patternIndex i
 
 	// Log match details in debug mode (only for high-confidence matches to reduce overhead)
 	if os.Getenv("FERRET_DEBUG") == "1" && confidence > 70 && v.observer != nil && v.observer.DebugObserver != nil {
-		v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Found %s match: '%s' (confidence: %.1f%%, type: %s, username: %s)", platform, match, confidence, patternType, username))
+		// Do not log the matched handle/URL or extracted username (BSC4: no PII in logs).
+		v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Found %s match: [HIDDEN] (len=%d, confidence: %.1f%%, type: %s)", platform, len(match), confidence, patternType))
 	}
 
 	return &socialMediaMatch
@@ -2930,7 +2932,7 @@ func (v *Validator) analyzeContextWithPlatformLine(match string, platform string
 
 	// Log detailed context analysis in debug mode
 	if v.observer != nil && v.observer.DebugObserver != nil {
-		v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Context analysis for %s match '%s': impact=%.1f", platform, match, confidenceImpact))
+		v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Context analysis for %s match [HIDDEN] (len=%d): impact=%.1f", platform, len(match), confidenceImpact))
 		if len(foundPositiveKeywords) > 0 {
 			v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("  Positive keywords found: %v", foundPositiveKeywords))
 		}


### PR DESCRIPTION
## Summary

Three validators logged the **raw matched candidate** in their debug/error output. Because `--show-match` is enforced downstream in the formatter layer (validators have no `ShowMatch` plumbing — `grep -rnE "ShowMatch|showMatch" internal/validators/` is empty), these lines leaked matched PII/secret material into logs **regardless of `--show-match`** whenever debug logging was enabled. That violates BSC4 ("never log … customer PII").

## What changed

Masked all six offending sites to the codebase's established `[HIDDEN]` placeholder plus a length metadatum (enough to debug the surrounding Luhn/reconstruction/context logic):

| Validator | Site |
|---|---|
| `creditcard` | `logLuhnFailure` — raw candidate digits (`original -> clean`) |
| `intellectualproperty` | `logReconstructionDetails` — reconstructed legal-notice text |
| `socialmedia` | `processMatchOptimized` — matched handle/URL **and** extracted username |
| `socialmedia` | `analyzeContextWithPlatformLine` — matched value in context-impact log |
| `socialmedia` | `CalculateConfidence` panic-recovery — matched value in `[ERROR]` + observer log |
| `socialmedia` | unknown-platform path — matched value in debug + observer log |

The other 9 validators that emit debug output were audited and already log **0** raw match values.

## Safety

Behavior-preserving — only debug/error **log strings** change; detection, output, and redaction are untouched.

- `go build ./...` ✅  `go vet` (touched pkgs) ✅  `gofmt -l` clean ✅
- **Golden regression net byte-identical** (no `UPDATE_GOLDEN`) ✅
- `go test ./...` full suite ✅
- `go test -race` on creditcard / socialmedia / intellectualproperty ✅

Part of the incremental v2 architecture-consolidation series (`v2-refactor`).