### PR TITLE
refactor(v2-refactor): make observability a swappable interface seam (gap 6.2)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1562,7 +1562,7 @@ func main() {
 	// Set up observability for all components
 	for _, validator := range allValidators {
 		if observableValidator, ok := validator.(interface {
-			SetObserver(observer *observability.StandardObserver)
+			SetObserver(observer observability.Observer)
 		}); ok {
 			var observer *observability.StandardObserver
 			if finalConfig.debug {

--- a/internal/observability/interfaces.go
+++ b/internal/observability/interfaces.go
@@ -9,6 +9,23 @@ type Observable interface {
 	GetComponentName() string
 }
 
-// Unused OperationData struct removed
+// Observer is the telemetry seam consumed across ferret-scan components.
+//
+// Components hold an Observer (this interface) rather than the concrete
+// *StandardObserver, so the telemetry implementation can be swapped without
+// touching every call site. *StandardObserver is the production implementation;
+// tests may supply their own.
+//
+// Debug() exposes the step-by-step debug observer (nil unless debug logging is
+// enabled). It replaces direct access to the former exported DebugObserver
+// field so the seam stays a pure interface.
+type Observer interface {
+	// StartTiming returns a function to complete timing for an operation.
+	StartTiming(component, operation, filePath string) func(success bool, metadata map[string]interface{})
+	// LogOperation logs structured operation data.
+	LogOperation(data StandardObservabilityData)
+	// Debug returns the debug observer, or nil when debug logging is off.
+	Debug() *DebugObserver
+}
 
-// Unused Observer interface and TrackedOperation removed
+// Unused OperationData struct removed

--- a/internal/observability/observer.go
+++ b/internal/observability/observer.go
@@ -32,6 +32,19 @@ func NewStandardObserver(level ObservabilityLevel, writer io.Writer) *StandardOb
 	}
 }
 
+// StandardObserver is the production implementation of the Observer seam.
+var _ Observer = (*StandardObserver)(nil)
+
+// Debug returns the attached debug observer, or nil when debug logging is off.
+// It implements the Observer interface so components can hold the interface
+// instead of this concrete type while still reaching the debug observer.
+func (o *StandardObserver) Debug() *DebugObserver {
+	if o == nil {
+		return nil
+	}
+	return o.DebugObserver
+}
+
 // StartTiming returns a function to complete timing
 func (o *StandardObserver) StartTiming(component, operation, filePath string) func(success bool, metadata map[string]interface{}) {
 	start := time.Now()

--- a/internal/parallel/parallel_processor.go
+++ b/internal/parallel/parallel_processor.go
@@ -18,7 +18,7 @@ import (
 // ParallelProcessor manages parallel file processing
 type ParallelProcessor struct {
 	workerPool *WorkerPool
-	observer   *observability.StandardObserver
+	observer   observability.Observer
 }
 
 // ProcessingStats tracks parallel processing statistics
@@ -47,7 +47,7 @@ type FileDiagnostic struct {
 }
 
 // NewParallelProcessor creates a new parallel processor
-func NewParallelProcessor(observer *observability.StandardObserver) *ParallelProcessor {
+func NewParallelProcessor(observer observability.Observer) *ParallelProcessor {
 	workers := runtime.NumCPU()
 	if workers > 8 {
 		workers = 8 // Cap at 8 workers to avoid resource exhaustion

--- a/internal/parallel/worker_pool.go
+++ b/internal/parallel/worker_pool.go
@@ -26,7 +26,7 @@ type WorkerPool struct {
 	wg             sync.WaitGroup
 	ctx            context.Context
 	cancel         context.CancelFunc
-	observer       *observability.StandardObserver
+	observer       observability.Observer
 	retryManager   *resilience.RetryManager
 	circuitBreaker *resilience.CircuitBreakerManager
 }
@@ -99,7 +99,7 @@ type Result struct {
 }
 
 // NewWorkerPool creates a new worker pool with resilience features
-func NewWorkerPool(workers int, observer *observability.StandardObserver) *WorkerPool {
+func NewWorkerPool(workers int, observer observability.Observer) *WorkerPool {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	// Initialize resilience components

--- a/internal/preprocessors/audio_metadata_preprocessor.go
+++ b/internal/preprocessors/audio_metadata_preprocessor.go
@@ -17,7 +17,7 @@ import (
 // AudioMetadataPreprocessor extracts metadata from audio files
 type AudioMetadataPreprocessor struct {
 	name            string
-	observer        *observability.StandardObserver
+	observer        observability.Observer
 	resourceManager *MediaResourceManager
 	errorHandler    *GracefulDegradationHandler
 	errorLogger     *ErrorLogger
@@ -96,8 +96,8 @@ func (amp *AudioMetadataPreprocessor) processAudioMetadataWithRetry(filePath str
 		// Check if we should retry
 		if amp.recoveryManager.ShouldRetry(errorType, attemptCount) {
 			// Log retry attempt
-			if amp.observer != nil && amp.observer.DebugObserver != nil {
-				amp.observer.DebugObserver.LogDetail("audio_metadata_preprocessor",
+			if amp.observer != nil && amp.observer.Debug() != nil {
+				amp.observer.Debug().LogDetail("audio_metadata_preprocessor",
 					fmt.Sprintf("Retrying audio metadata extraction for %s (attempt %d)", filePath, attemptCount+1))
 			}
 
@@ -111,7 +111,7 @@ func (amp *AudioMetadataPreprocessor) processAudioMetadataWithRetry(filePath str
 	}
 
 	// Log successful processing with detailed information
-	if amp.observer != nil && amp.observer.DebugObserver != nil {
+	if amp.observer != nil && amp.observer.Debug() != nil {
 		amp.logSuccessfulProcessing(filePath, audioMeta)
 	}
 
@@ -139,7 +139,7 @@ func (amp *AudioMetadataPreprocessor) GetSupportedExtensions() []string {
 }
 
 // SetObserver sets the observability component
-func (amp *AudioMetadataPreprocessor) SetObserver(observer *observability.StandardObserver) {
+func (amp *AudioMetadataPreprocessor) SetObserver(observer observability.Observer) {
 	amp.observer = observer
 }
 
@@ -318,24 +318,24 @@ func (amp *AudioMetadataPreprocessor) addAudioErrorContext(mediaErr *MediaProces
 func (amp *AudioMetadataPreprocessor) logSuccessfulProcessing(filePath string, audioMeta *audiolib.AudioMetadata) {
 	ext := strings.ToUpper(strings.TrimPrefix(filepath.Ext(filePath), "."))
 
-	amp.observer.DebugObserver.LogDetail("audio_metadata_preprocessor",
+	amp.observer.Debug().LogDetail("audio_metadata_preprocessor",
 		fmt.Sprintf("Successfully extracted audio metadata from %s file: %s", ext, filepath.Base(filePath)))
 
 	// Log technical specifications if available
 	if audioMeta.Duration > 0 {
-		amp.observer.DebugObserver.LogDetail("audio_metadata_preprocessor",
+		amp.observer.Debug().LogDetail("audio_metadata_preprocessor",
 			fmt.Sprintf("Audio specs - Duration: %s, Bitrate: %d, Sample Rate: %d, Channels: %d",
 				audioMeta.Duration.String(), audioMeta.Bitrate, audioMeta.SampleRate, audioMeta.Channels))
 	}
 
 	// Log interesting metadata if present (but be careful about privacy-sensitive information)
 	if audioMeta.Artist != "" && audioMeta.Title != "" {
-		amp.observer.DebugObserver.LogDetail("audio_metadata_preprocessor",
+		amp.observer.Debug().LogDetail("audio_metadata_preprocessor",
 			fmt.Sprintf("Track info found: %s - %s", audioMeta.Artist, audioMeta.Title))
 	}
 
 	if audioMeta.Album != "" && audioMeta.Year > 0 {
-		amp.observer.DebugObserver.LogDetail("audio_metadata_preprocessor",
+		amp.observer.Debug().LogDetail("audio_metadata_preprocessor",
 			fmt.Sprintf("Album info: %s (%d)", audioMeta.Album, audioMeta.Year))
 	}
 }

--- a/internal/preprocessors/base_metadata_preprocessor.go
+++ b/internal/preprocessors/base_metadata_preprocessor.go
@@ -22,7 +22,7 @@ type RouterInterface interface {
 type BaseMetadataPreprocessor struct {
 	name            string
 	processorType   string
-	observer        *observability.StandardObserver
+	observer        observability.Observer
 	router          RouterInterface
 	resourceManager *MediaResourceManager
 	errorHandler    *GracefulDegradationHandler
@@ -50,7 +50,7 @@ func (bmp *BaseMetadataPreprocessor) GetName() string {
 }
 
 // SetObserver sets the observability component
-func (bmp *BaseMetadataPreprocessor) SetObserver(observer *observability.StandardObserver) {
+func (bmp *BaseMetadataPreprocessor) SetObserver(observer observability.Observer) {
 	bmp.observer = observer
 }
 
@@ -65,7 +65,7 @@ func (bmp *BaseMetadataPreprocessor) GetUtilities() *SharedUtilities {
 }
 
 // GetObserver returns the observer instance
-func (bmp *BaseMetadataPreprocessor) GetObserver() *observability.StandardObserver {
+func (bmp *BaseMetadataPreprocessor) GetObserver() observability.Observer {
 	return bmp.observer
 }
 
@@ -76,34 +76,34 @@ func (bmp *BaseMetadataPreprocessor) GetRouter() RouterInterface {
 
 // LogDebugInfo logs debug information if observer is available
 func (bmp *BaseMetadataPreprocessor) LogDebugInfo(message string) {
-	if bmp.observer != nil && bmp.observer.DebugObserver != nil {
-		bmp.observer.DebugObserver.LogDetail(bmp.name, message)
+	if bmp.observer != nil && bmp.observer.Debug() != nil {
+		bmp.observer.Debug().LogDetail(bmp.name, message)
 	}
 }
 
 // LogFileSystemInfo logs file system information for observability (excluded from validator content)
 func (bmp *BaseMetadataPreprocessor) LogFileSystemInfo(filename string, fileSize int64, mimeType string) {
-	if bmp.observer != nil && bmp.observer.DebugObserver != nil {
+	if bmp.observer != nil && bmp.observer.Debug() != nil {
 		message := fmt.Sprintf("File system info - Name: %s, Size: %d bytes, Type: %s", filename, fileSize, mimeType)
-		bmp.observer.DebugObserver.LogDetail(bmp.name, message)
+		bmp.observer.Debug().LogDetail(bmp.name, message)
 	}
 }
 
 // LogSuccessfulProcessing logs successful processing information
 func (bmp *BaseMetadataPreprocessor) LogSuccessfulProcessing(filename string, fileSize int64, mimeType string) {
-	if bmp.observer != nil && bmp.observer.DebugObserver != nil {
+	if bmp.observer != nil && bmp.observer.Debug() != nil {
 		message := fmt.Sprintf("Successfully extracted %s metadata - Name: %s, Size: %d bytes, Type: %s",
 			bmp.processorType, filename, fileSize, mimeType)
-		bmp.observer.DebugObserver.LogDetail(bmp.name, message)
+		bmp.observer.Debug().LogDetail(bmp.name, message)
 	}
 }
 
 // LogRetryAttempt logs retry attempt information
 func (bmp *BaseMetadataPreprocessor) LogRetryAttempt(filePath string, attemptCount int) {
-	if bmp.observer != nil && bmp.observer.DebugObserver != nil {
+	if bmp.observer != nil && bmp.observer.Debug() != nil {
 		message := fmt.Sprintf("Retrying %s metadata extraction for %s (attempt %d)",
 			bmp.processorType, filePath, attemptCount+1)
-		bmp.observer.DebugObserver.LogDetail(bmp.name, message)
+		bmp.observer.Debug().LogDetail(bmp.name, message)
 	}
 }
 

--- a/internal/preprocessors/image_metadata_preprocessor.go
+++ b/internal/preprocessors/image_metadata_preprocessor.go
@@ -17,7 +17,7 @@ import (
 // ImageMetadataPreprocessor extracts metadata from image files
 type ImageMetadataPreprocessor struct {
 	name            string
-	observer        *observability.StandardObserver
+	observer        observability.Observer
 	resourceManager *MediaResourceManager
 	errorHandler    *GracefulDegradationHandler
 	errorLogger     *ErrorLogger
@@ -94,8 +94,8 @@ func (imp *ImageMetadataPreprocessor) processImageMetadataWithRetry(filePath str
 		// Check if we should retry
 		if imp.recoveryManager.ShouldRetry(errorType, attemptCount) {
 			// Log retry attempt
-			if imp.observer != nil && imp.observer.DebugObserver != nil {
-				imp.observer.DebugObserver.LogDetail("image_metadata_preprocessor",
+			if imp.observer != nil && imp.observer.Debug() != nil {
+				imp.observer.Debug().LogDetail("image_metadata_preprocessor",
 					fmt.Sprintf("Retrying image metadata extraction for %s (attempt %d)", filePath, attemptCount+1))
 			}
 
@@ -109,7 +109,7 @@ func (imp *ImageMetadataPreprocessor) processImageMetadataWithRetry(filePath str
 	}
 
 	// Log successful processing with detailed information
-	if imp.observer != nil && imp.observer.DebugObserver != nil {
+	if imp.observer != nil && imp.observer.Debug() != nil {
 		imp.logSuccessfulProcessing(filePath, exifData)
 	}
 
@@ -131,10 +131,10 @@ func (imp *ImageMetadataPreprocessor) formatImageMetadata(exifData *meta_extract
 	var metadataText strings.Builder
 
 	// Debug: Log all GPS-related tags
-	if imp.observer != nil && imp.observer.DebugObserver != nil {
+	if imp.observer != nil && imp.observer.Debug() != nil {
 		for key, value := range exifData.Tags {
 			if strings.Contains(strings.ToLower(key), "gps") {
-				imp.observer.DebugObserver.LogDetail("image_metadata_preprocessor",
+				imp.observer.Debug().LogDetail("image_metadata_preprocessor",
 					fmt.Sprintf("GPS tag found: %s = %s", key, value))
 			}
 		}
@@ -171,8 +171,8 @@ func (imp *ImageMetadataPreprocessor) formatImageMetadata(exifData *meta_extract
 			delete(exifData.Tags, "GPSSpeed")
 			delete(exifData.Tags, "GPSSpeedRef")
 
-			if imp.observer != nil && imp.observer.DebugObserver != nil {
-				imp.observer.DebugObserver.LogDetail("image_metadata_preprocessor",
+			if imp.observer != nil && imp.observer.Debug() != nil {
+				imp.observer.Debug().LogDetail("image_metadata_preprocessor",
 					fmt.Sprintf("Consolidated GPS coordinates: %s", consolidatedGPS))
 			}
 		}
@@ -199,7 +199,7 @@ func (imp *ImageMetadataPreprocessor) GetSupportedExtensions() []string {
 }
 
 // SetObserver sets the observability component
-func (imp *ImageMetadataPreprocessor) SetObserver(observer *observability.StandardObserver) {
+func (imp *ImageMetadataPreprocessor) SetObserver(observer observability.Observer) {
 	imp.observer = observer
 }
 
@@ -398,20 +398,20 @@ func (imp *ImageMetadataPreprocessor) logSuccessfulProcessing(filePath string, e
 	tagCount := len(exifData.Tags)
 	ext := strings.ToUpper(strings.TrimPrefix(filepath.Ext(filePath), "."))
 
-	imp.observer.DebugObserver.LogDetail("image_metadata_preprocessor",
+	imp.observer.Debug().LogDetail("image_metadata_preprocessor",
 		fmt.Sprintf("Successfully extracted %d metadata tags from %s image: %s", tagCount, ext, filepath.Base(filePath)))
 
 	// Log interesting metadata if present
 	if camera, exists := exifData.Tags["Make"]; exists {
 		if model, exists := exifData.Tags["Model"]; exists {
-			imp.observer.DebugObserver.LogDetail("image_metadata_preprocessor",
+			imp.observer.Debug().LogDetail("image_metadata_preprocessor",
 				fmt.Sprintf("Camera info: %s %s", camera, model))
 		}
 	}
 
 	if gpsLat, hasLat := exifData.Tags["GPSLatitudeDecimal"]; hasLat {
 		if gpsLong, hasLong := exifData.Tags["GPSLongitudeDecimal"]; hasLong {
-			imp.observer.DebugObserver.LogDetail("image_metadata_preprocessor",
+			imp.observer.Debug().LogDetail("image_metadata_preprocessor",
 				fmt.Sprintf("GPS coordinates found: %s, %s", gpsLat, gpsLong))
 		}
 	}

--- a/internal/preprocessors/office_metadata_preprocessor.go
+++ b/internal/preprocessors/office_metadata_preprocessor.go
@@ -163,7 +163,7 @@ func (omp *OfficeMetadataPreprocessor) GetSupportedExtensions() []string {
 }
 
 // SetObserver sets the observability component
-func (omp *OfficeMetadataPreprocessor) SetObserver(observer *observability.StandardObserver) {
+func (omp *OfficeMetadataPreprocessor) SetObserver(observer observability.Observer) {
 	omp.BaseMetadataPreprocessor.SetObserver(observer)
 }
 

--- a/internal/preprocessors/pdf_metadata_preprocessor.go
+++ b/internal/preprocessors/pdf_metadata_preprocessor.go
@@ -215,7 +215,7 @@ func (pmp *PDFMetadataPreprocessor) GetSupportedExtensions() []string {
 }
 
 // SetObserver sets the observability component
-func (pmp *PDFMetadataPreprocessor) SetObserver(observer *observability.StandardObserver) {
+func (pmp *PDFMetadataPreprocessor) SetObserver(observer observability.Observer) {
 	pmp.BaseMetadataPreprocessor.SetObserver(observer)
 }
 

--- a/internal/preprocessors/plaintext_preprocessor.go
+++ b/internal/preprocessors/plaintext_preprocessor.go
@@ -17,7 +17,7 @@ import (
 // PlainTextPreprocessor handles plain text files by passing their content through
 // This ensures text files are processed through the same pipeline as other file types
 type PlainTextPreprocessor struct {
-	observer        *observability.StandardObserver
+	observer        observability.Observer
 	enableRedaction bool
 }
 
@@ -34,7 +34,7 @@ func NewPlainTextPreprocessorWithConfig(enableRedaction bool) *PlainTextPreproce
 }
 
 // SetObserver sets the observability component
-func (ptp *PlainTextPreprocessor) SetObserver(observer *observability.StandardObserver) {
+func (ptp *PlainTextPreprocessor) SetObserver(observer observability.Observer) {
 	ptp.observer = observer
 }
 
@@ -100,8 +100,8 @@ func (ptp *PlainTextPreprocessor) Process(filePath string) (*ProcessedContent, e
 	var finishStep func(bool, string)
 	if ptp.observer != nil {
 		finishTiming = ptp.observer.StartTiming("plaintext_preprocessor", "process_file", filePath)
-		if ptp.observer.DebugObserver != nil {
-			finishStep = ptp.observer.DebugObserver.StartStep("plaintext_preprocessor", "process_file", filePath)
+		if ptp.observer.Debug() != nil {
+			finishStep = ptp.observer.Debug().StartStep("plaintext_preprocessor", "process_file", filePath)
 		}
 	}
 
@@ -332,8 +332,8 @@ func (ptp *PlainTextPreprocessor) createOptimizedPositionMappings(result *Proces
 		mappingCount++
 	}
 
-	if ptp.observer != nil && ptp.observer.DebugObserver != nil {
-		ptp.observer.DebugObserver.LogDetail("plaintext_preprocessor",
+	if ptp.observer != nil && ptp.observer.Debug() != nil {
+		ptp.observer.Debug().LogDetail("plaintext_preprocessor",
 			fmt.Sprintf("Created %d optimized position mappings for %d lines (%.1f%% reduction)",
 				mappingCount, len(lines),
 				100.0*(1.0-float64(mappingCount)/float64(len(lines)))))

--- a/internal/preprocessors/preprocessor.go
+++ b/internal/preprocessors/preprocessor.go
@@ -127,7 +127,7 @@ type Preprocessor interface {
 	GetSupportedExtensions() []string
 
 	// SetObserver sets the observability component
-	SetObserver(observer *observability.StandardObserver)
+	SetObserver(observer observability.Observer)
 }
 
 // PreprocessorManager manages all available preprocessors

--- a/internal/preprocessors/text_preprocessor.go
+++ b/internal/preprocessors/text_preprocessor.go
@@ -17,7 +17,7 @@ import (
 type TextPreprocessor struct {
 	name                string
 	supportedExtensions []string
-	observer            *observability.StandardObserver
+	observer            observability.Observer
 }
 
 // NewTextPreprocessor creates a new text preprocessor
@@ -33,7 +33,7 @@ func NewTextPreprocessor() *TextPreprocessor {
 }
 
 // SetObserver sets the observability component
-func (tp *TextPreprocessor) SetObserver(observer *observability.StandardObserver) {
+func (tp *TextPreprocessor) SetObserver(observer observability.Observer) {
 	tp.observer = observer
 }
 
@@ -66,8 +66,8 @@ func (tp *TextPreprocessor) Process(filePath string) (*ProcessedContent, error) 
 	var finishStep func(bool, string)
 	if tp.observer != nil {
 		finishTiming = tp.observer.StartTiming("text_preprocessor", "process_file", filePath)
-		if tp.observer.DebugObserver != nil {
-			finishStep = tp.observer.DebugObserver.StartStep("text_preprocessor", "process_file", filePath)
+		if tp.observer.Debug() != nil {
+			finishStep = tp.observer.Debug().StartStep("text_preprocessor", "process_file", filePath)
 		}
 	}
 
@@ -188,8 +188,8 @@ func (tp *TextPreprocessor) createPDFPositionMappings(content *ProcessedContent,
 	content.AddPositionMetadata("page_count", content.PageCount)
 	content.AddPositionMetadata("confidence_reason", "pdf_text_layer_extraction")
 
-	if tp.observer != nil && tp.observer.DebugObserver != nil {
-		tp.observer.DebugObserver.LogDetail("text_preprocessor",
+	if tp.observer != nil && tp.observer.Debug() != nil {
+		tp.observer.Debug().LogDetail("text_preprocessor",
 			fmt.Sprintf("Created %d position mappings for PDF with %d pages",
 				len(content.PositionMappings), content.PageCount))
 	}
@@ -206,8 +206,8 @@ func (tp *TextPreprocessor) createOfficePositionMappings(content *ProcessedConte
 	content.AddPositionMetadata("document_format", content.Format)
 	content.AddPositionMetadata("confidence_reason", "office_xml_structure_extraction")
 
-	if tp.observer != nil && tp.observer.DebugObserver != nil {
-		tp.observer.DebugObserver.LogDetail("text_preprocessor",
+	if tp.observer != nil && tp.observer.Debug() != nil {
+		tp.observer.Debug().LogDetail("text_preprocessor",
 			fmt.Sprintf("Created %d position mappings for %s document",
 				len(content.PositionMappings), content.Format))
 	}

--- a/internal/preprocessors/textract_preprocessor.go
+++ b/internal/preprocessors/textract_preprocessor.go
@@ -142,7 +142,7 @@ func (tp *TextractPreprocessor) IsEnabled() bool {
 }
 
 // SetObserver sets the observability component (minimal implementation)
-func (tp *TextractPreprocessor) SetObserver(observer *observability.StandardObserver) {
+func (tp *TextractPreprocessor) SetObserver(observer observability.Observer) {
 	// Minimal implementation for interface compliance
 }
 

--- a/internal/preprocessors/transcribe_preprocessor.go
+++ b/internal/preprocessors/transcribe_preprocessor.go
@@ -141,7 +141,7 @@ func (tp *TranscribePreprocessor) SetBucket(bucket string) {
 }
 
 // SetObserver sets the observability component (minimal implementation)
-func (tp *TranscribePreprocessor) SetObserver(observer *observability.StandardObserver) {
+func (tp *TranscribePreprocessor) SetObserver(observer observability.Observer) {
 	// Minimal implementation for interface compliance
 }
 */

--- a/internal/preprocessors/video_metadata_preprocessor.go
+++ b/internal/preprocessors/video_metadata_preprocessor.go
@@ -68,7 +68,7 @@ func (vmp *VideoMetadataPreprocessor) processVideoMetadata(filePath string) (*Pr
 }
 
 // SetObserver sets the observability component
-func (vmp *VideoMetadataPreprocessor) SetObserver(observer *observability.StandardObserver) {
+func (vmp *VideoMetadataPreprocessor) SetObserver(observer observability.Observer) {
 	vmp.BaseMetadataPreprocessor.SetObserver(observer)
 }
 

--- a/internal/redactors/image/redactor.go
+++ b/internal/redactors/image/redactor.go
@@ -28,7 +28,7 @@ import (
 // ImageMetadataRedactor implements redaction for image files by removing metadata
 type ImageMetadataRedactor struct {
 	// observer handles observability and metrics
-	observer *observability.StandardObserver
+	observer observability.Observer
 
 	// outputManager handles file system operations
 	outputManager *redactors.OutputStructureManager
@@ -93,7 +93,7 @@ func (f ImageFormat) String() string {
 }
 
 // NewImageMetadataRedactor creates a new ImageMetadataRedactor
-func NewImageMetadataRedactor(outputManager *redactors.OutputStructureManager, observer *observability.StandardObserver) *ImageMetadataRedactor {
+func NewImageMetadataRedactor(outputManager *redactors.OutputStructureManager, observer observability.Observer) *ImageMetadataRedactor {
 	if observer == nil {
 		observer = observability.NewStandardObserver(observability.ObservabilityMetrics, nil)
 	}
@@ -122,7 +122,7 @@ func NewImageMetadataRedactor(outputManager *redactors.OutputStructureManager, o
 }
 
 // NewImageMetadataRedactorWithOptions creates a new ImageMetadataRedactor with custom options
-func NewImageMetadataRedactorWithOptions(outputManager *redactors.OutputStructureManager, observer *observability.StandardObserver, preserveQuality bool) *ImageMetadataRedactor {
+func NewImageMetadataRedactorWithOptions(outputManager *redactors.OutputStructureManager, observer observability.Observer, preserveQuality bool) *ImageMetadataRedactor {
 	redactor := NewImageMetadataRedactor(outputManager, observer)
 	redactor.preserveImageQuality = preserveQuality
 	return redactor

--- a/internal/redactors/manager.go
+++ b/internal/redactors/manager.go
@@ -21,7 +21,7 @@ type RedactionManager struct {
 	redactors map[string]Redactor
 
 	// observer handles observability and metrics
-	observer *observability.StandardObserver
+	observer observability.Observer
 
 	// outputManager handles file system operations
 	outputManager *OutputStructureManager
@@ -218,7 +218,7 @@ type FileRedactionResult struct {
 }
 
 // NewRedactionManager creates a new RedactionManager with default configuration
-func NewRedactionManager(outputManager *OutputStructureManager, observer *observability.StandardObserver) *RedactionManager {
+func NewRedactionManager(outputManager *OutputStructureManager, observer observability.Observer) *RedactionManager {
 	if observer == nil {
 		observer = observability.NewStandardObserver(observability.ObservabilityMetrics, nil)
 	}
@@ -253,7 +253,7 @@ func NewRedactionManager(outputManager *OutputStructureManager, observer *observ
 }
 
 // NewRedactionManagerWithConfig creates a new RedactionManager with custom configuration
-func NewRedactionManagerWithConfig(outputManager *OutputStructureManager, observer *observability.StandardObserver, config *RedactionManagerConfig) *RedactionManager {
+func NewRedactionManagerWithConfig(outputManager *OutputStructureManager, observer observability.Observer, config *RedactionManagerConfig) *RedactionManager {
 	if observer == nil {
 		observer = observability.NewStandardObserver(observability.ObservabilityMetrics, nil)
 	}
@@ -840,7 +840,7 @@ func (rm *RedactionManager) GetOutputManager() *OutputStructureManager {
 }
 
 // GetObserver returns the observer for use by external redactor registration
-func (rm *RedactionManager) GetObserver() *observability.StandardObserver {
+func (rm *RedactionManager) GetObserver() observability.Observer {
 	return rm.observer
 }
 

--- a/internal/redactors/office/redactor.go
+++ b/internal/redactors/office/redactor.go
@@ -23,7 +23,7 @@ import (
 // OfficeRedactor implements redaction for Microsoft Office documents using unified ZIP/XML approach
 type OfficeRedactor struct {
 	// observer handles observability and metrics
-	observer *observability.StandardObserver
+	observer observability.Observer
 
 	// outputManager handles file system operations
 	outputManager *redactors.OutputStructureManager
@@ -70,7 +70,7 @@ func (dt OfficeDocumentType) String() string {
 }
 
 // NewOfficeRedactor creates a new OfficeRedactor
-func NewOfficeRedactor(outputManager *redactors.OutputStructureManager, observer *observability.StandardObserver) *OfficeRedactor {
+func NewOfficeRedactor(outputManager *redactors.OutputStructureManager, observer observability.Observer) *OfficeRedactor {
 	if observer == nil {
 		observer = observability.NewStandardObserver(observability.ObservabilityMetrics, nil)
 	}
@@ -86,7 +86,7 @@ func NewOfficeRedactor(outputManager *redactors.OutputStructureManager, observer
 }
 
 // NewOfficeRedactorWithPositionCorrelation creates a new OfficeRedactor with custom position correlation settings
-func NewOfficeRedactorWithPositionCorrelation(outputManager *redactors.OutputStructureManager, observer *observability.StandardObserver, correlator position.PositionCorrelator, confidenceThreshold float64) *OfficeRedactor {
+func NewOfficeRedactorWithPositionCorrelation(outputManager *redactors.OutputStructureManager, observer observability.Observer, correlator position.PositionCorrelator, confidenceThreshold float64) *OfficeRedactor {
 	if observer == nil {
 		observer = observability.NewStandardObserver(observability.ObservabilityMetrics, nil)
 	}

--- a/internal/redactors/output_manager.go
+++ b/internal/redactors/output_manager.go
@@ -20,7 +20,7 @@ type OutputStructureManager struct {
 	baseOutputDir string
 
 	// observer handles observability and metrics
-	observer *observability.StandardObserver
+	observer observability.Observer
 
 	// preservePermissions indicates whether to preserve original file permissions
 	preservePermissions bool
@@ -39,7 +39,7 @@ type FileInfo struct {
 }
 
 // NewOutputStructureManager creates a new OutputStructureManager
-func NewOutputStructureManager(baseOutputDir string, observer *observability.StandardObserver) (*OutputStructureManager, error) {
+func NewOutputStructureManager(baseOutputDir string, observer observability.Observer) (*OutputStructureManager, error) {
 	if baseOutputDir == "" {
 		return nil, fmt.Errorf("base output directory cannot be empty")
 	}

--- a/internal/redactors/pdf/redactor.go
+++ b/internal/redactors/pdf/redactor.go
@@ -28,7 +28,7 @@ import (
 // pipeline here.
 type PDFRedactor struct {
 	// observer handles observability and metrics
-	observer *observability.StandardObserver
+	observer observability.Observer
 
 	// pdfConfig contains PDF-specific configuration used for validation
 	pdfConfig *model.Configuration
@@ -39,7 +39,7 @@ type PDFRedactor struct {
 // outputManager is currently unused because no document is produced (redaction
 // is unimplemented); it is retained in the signature so the call site does not
 // change when real redaction — which needs the output manager — is added.
-func NewPDFRedactor(outputManager *redactors.OutputStructureManager, observer *observability.StandardObserver) *PDFRedactor {
+func NewPDFRedactor(outputManager *redactors.OutputStructureManager, observer observability.Observer) *PDFRedactor {
 	if observer == nil {
 		observer = observability.NewStandardObserver(observability.ObservabilityMetrics, nil)
 	}

--- a/internal/redactors/plaintext/redactor.go
+++ b/internal/redactors/plaintext/redactor.go
@@ -21,7 +21,7 @@ import (
 // PlainTextRedactor implements redaction for plain text files
 type PlainTextRedactor struct {
 	// observer handles observability and metrics
-	observer *observability.StandardObserver
+	observer observability.Observer
 
 	// outputManager handles file system operations
 	outputManager *redactors.OutputStructureManager
@@ -40,7 +40,7 @@ type PlainTextRedactor struct {
 }
 
 // NewPlainTextRedactor creates a new PlainTextRedactor
-func NewPlainTextRedactor(outputManager *redactors.OutputStructureManager, observer *observability.StandardObserver) *PlainTextRedactor {
+func NewPlainTextRedactor(outputManager *redactors.OutputStructureManager, observer observability.Observer) *PlainTextRedactor {
 	if observer == nil {
 		observer = observability.NewStandardObserver(observability.ObservabilityMetrics, nil)
 	}
@@ -56,7 +56,7 @@ func NewPlainTextRedactor(outputManager *redactors.OutputStructureManager, obser
 }
 
 // NewPlainTextRedactorWithPositionCorrelation creates a new PlainTextRedactor with custom position correlation settings
-func NewPlainTextRedactorWithPositionCorrelation(outputManager *redactors.OutputStructureManager, observer *observability.StandardObserver, correlator position.PositionCorrelator, confidenceThreshold float64) *PlainTextRedactor {
+func NewPlainTextRedactorWithPositionCorrelation(outputManager *redactors.OutputStructureManager, observer observability.Observer, correlator position.PositionCorrelator, confidenceThreshold float64) *PlainTextRedactor {
 	if observer == nil {
 		observer = observability.NewStandardObserver(observability.ObservabilityMetrics, nil)
 	}

--- a/internal/redactors/validation/generic_validator.go
+++ b/internal/redactors/validation/generic_validator.go
@@ -16,7 +16,7 @@ import (
 // GenericDocumentValidator provides basic validation for any document type
 type GenericDocumentValidator struct {
 	// observer handles observability and metrics
-	observer *observability.StandardObserver
+	observer observability.Observer
 
 	// supportedTypes lists the file types this validator can handle
 	supportedTypes []string
@@ -26,7 +26,7 @@ type GenericDocumentValidator struct {
 }
 
 // NewGenericDocumentValidator creates a new generic document validator
-func NewGenericDocumentValidator(observer *observability.StandardObserver) *GenericDocumentValidator {
+func NewGenericDocumentValidator(observer observability.Observer) *GenericDocumentValidator {
 	if observer == nil {
 		observer = observability.NewStandardObserver(observability.ObservabilityMetrics, nil)
 	}

--- a/internal/redactors/validation/recovery.go
+++ b/internal/redactors/validation/recovery.go
@@ -17,7 +17,7 @@ import (
 // RecoveryManager handles document processing failure recovery
 type RecoveryManager struct {
 	// observer handles observability and metrics
-	observer *observability.StandardObserver
+	observer observability.Observer
 
 	// config contains recovery configuration
 	config *RecoveryConfig
@@ -133,7 +133,7 @@ type RecoveryResult struct {
 }
 
 // NewRecoveryManager creates a new RecoveryManager
-func NewRecoveryManager(observer *observability.StandardObserver) *RecoveryManager {
+func NewRecoveryManager(observer observability.Observer) *RecoveryManager {
 	if observer == nil {
 		observer = observability.NewStandardObserver(observability.ObservabilityMetrics, nil)
 	}

--- a/internal/redactors/validation/validator.go
+++ b/internal/redactors/validation/validator.go
@@ -198,7 +198,7 @@ type ValidationManager struct {
 	validators map[string]DocumentValidator
 
 	// observer handles observability and metrics
-	observer *observability.StandardObserver
+	observer observability.Observer
 
 	// config contains validation configuration
 	config *ValidationConfig
@@ -292,7 +292,7 @@ type ValidatorStats struct {
 }
 
 // NewValidationManager creates a new ValidationManager
-func NewValidationManager(observer *observability.StandardObserver) *ValidationManager {
+func NewValidationManager(observer observability.Observer) *ValidationManager {
 	if observer == nil {
 		observer = observability.NewStandardObserver(observability.ObservabilityMetrics, nil)
 	}

--- a/internal/router/content_router.go
+++ b/internal/router/content_router.go
@@ -14,7 +14,7 @@ import (
 
 // ContentRouter intelligently separates metadata from document body content
 type ContentRouter struct {
-	observer   *observability.StandardObserver
+	observer   observability.Observer
 	fileRouter *FileRouter // Reference to FileRouter for file type detection
 }
 
@@ -75,7 +75,7 @@ func (cr *ContentRouter) SetFileRouter(fileRouter *FileRouter) {
 }
 
 // SetObserver sets the observability component
-func (cr *ContentRouter) SetObserver(observer *observability.StandardObserver) {
+func (cr *ContentRouter) SetObserver(observer observability.Observer) {
 	cr.observer = observer
 }
 
@@ -114,9 +114,9 @@ func (cr *ContentRouter) RouteContent(processedContent *preprocessors.ProcessedC
 		routedContent.DocumentBody = processedContent.Text
 
 		// Debug logging for file type filtering decision
-		if cr.observer != nil && cr.observer.DebugObserver != nil {
+		if cr.observer != nil && cr.observer.Debug() != nil {
 			ext := strings.ToLower(filepath.Ext(processedContent.OriginalPath))
-			cr.observer.DebugObserver.LogDetail("file_type_filtering",
+			cr.observer.Debug().LogDetail("file_type_filtering",
 				fmt.Sprintf("Metadata validation skipped - File: %s, Extension: %s, Reason: file type does not support metadata",
 					filepath.Base(processedContent.OriginalPath), ext))
 		}

--- a/internal/router/file_router.go
+++ b/internal/router/file_router.go
@@ -21,7 +21,7 @@ type FileRouter struct {
 	preprocessors []preprocessors.Preprocessor
 	metrics       *RouterMetrics
 	logger        *DebugLogger
-	observer      *observability.StandardObserver
+	observer      observability.Observer
 }
 
 // MaxFileSize is the default maximum file size the router will process (100 MB).
@@ -262,8 +262,8 @@ func (fr *FileRouter) CanContainMetadata(filePath string) bool {
 	canContain := isMetadataCapableFile(ext)
 
 	// Debug logging for file type detection decisions
-	if fr.observer != nil && fr.observer.DebugObserver != nil {
-		fr.observer.DebugObserver.LogDetail("file_type_detection",
+	if fr.observer != nil && fr.observer.Debug() != nil {
+		fr.observer.Debug().LogDetail("file_type_detection",
 			fmt.Sprintf("File: %s, Extension: %s, CanContainMetadata: %t",
 				filepath.Base(filePath), ext, canContain))
 	}
@@ -277,8 +277,8 @@ func (fr *FileRouter) GetMetadataType(filePath string) string {
 	metadataType := getMetadataTypeForExtension(ext)
 
 	// Debug logging for metadata type detection
-	if fr.observer != nil && fr.observer.DebugObserver != nil {
-		fr.observer.DebugObserver.LogDetail("metadata_type_detection",
+	if fr.observer != nil && fr.observer.Debug() != nil {
+		fr.observer.Debug().LogDetail("metadata_type_detection",
 			fmt.Sprintf("File: %s, Extension: %s, MetadataType: %s",
 				filepath.Base(filePath), ext, metadataType))
 	}

--- a/internal/validators/cloudresources/cloudresources.go
+++ b/internal/validators/cloudresources/cloudresources.go
@@ -68,7 +68,7 @@ type Validator struct {
 	customPatterns []*regexp.Regexp
 
 	// Observability (following standard pattern).
-	observer *observability.StandardObserver
+	observer observability.Observer
 }
 
 // NewValidator creates and returns a new Validator instance
@@ -98,7 +98,7 @@ func NewValidator() *Validator {
 }
 
 // SetObserver sets the observability component.
-func (v *Validator) SetObserver(observer *observability.StandardObserver) {
+func (v *Validator) SetObserver(observer observability.Observer) {
 	v.observer = observer
 }
 
@@ -328,8 +328,8 @@ func (v *Validator) Validate(filePath string) ([]detector.Match, error) {
 
 // logDetail is a nil-safe debug logging helper.
 func (v *Validator) logDetail(msg string) {
-	if v.observer != nil && v.observer.DebugObserver != nil {
-		v.observer.DebugObserver.LogDetail("cloud_resources", msg)
+	if v.observer != nil && v.observer.Debug() != nil {
+		v.observer.Debug().LogDetail("cloud_resources", msg)
 	}
 }
 
@@ -712,10 +712,10 @@ func (v *Validator) Configure(cfg *config.Config) {
 }
 
 func (v *Validator) logStartup() {
-	if v.observer == nil || v.observer.DebugObserver == nil {
+	if v.observer == nil || v.observer.Debug() == nil {
 		return
 	}
-	v.observer.DebugObserver.LogDetail("cloud_resources",
+	v.observer.Debug().LogDetail("cloud_resources",
 		fmt.Sprintf("Cloud Resource Validator initialized: %d built-in patterns, %d custom patterns",
 			len(v.patterns), len(v.customPatterns)))
 	enabledCount := 0
@@ -724,7 +724,7 @@ func (v *Validator) logStartup() {
 			enabledCount++
 		}
 	}
-	v.observer.DebugObserver.LogDetail("cloud_resources",
+	v.observer.Debug().LogDetail("cloud_resources",
 		fmt.Sprintf("Providers: %d enabled, %d disabled", enabledCount, len(v.enabledProviders)-enabledCount))
 }
 

--- a/internal/validators/creditcard/validator.go
+++ b/internal/validators/creditcard/validator.go
@@ -48,7 +48,7 @@ type Validator struct {
 	negativeKeywordRegex *regexp.Regexp
 
 	// Observability
-	observer *observability.StandardObserver
+	observer observability.Observer
 }
 
 // BINRange represents a range of valid BIN numbers for efficient lookup
@@ -158,7 +158,7 @@ func initBINRanges() []BINRange {
 }
 
 // SetObserver sets the observability component
-func (v *Validator) SetObserver(observer *observability.StandardObserver) {
+func (v *Validator) SetObserver(observer observability.Observer) {
 	v.observer = observer
 }
 

--- a/internal/validators/detector.go
+++ b/internal/validators/detector.go
@@ -38,7 +38,7 @@ type Detector struct {
 	bridge *EnhancedValidatorBridge
 	// observer is retained because MetadataValidatorAdapter needs it at setup
 	// time (to wrap non-PreprocessorAware metadata validators).
-	observer *observability.StandardObserver
+	observer observability.Observer
 }
 
 // compile-time guarantee the facade keeps satisfying the validator contracts.
@@ -51,12 +51,12 @@ var (
 // DualPathConfig values mirror the former NewDualPathIntegration exactly so
 // behavior is unchanged (debug logging is driven by the observer's
 // DebugObserver, as before — there is no separate "real-time metrics" flag).
-func NewDetector(observer *observability.StandardObserver) *Detector {
+func NewDetector(observer observability.Observer) *Detector {
 	config := &DualPathConfig{
 		EnableContextIntegration: true,
 		EnableFallbackMode:       true,
 		EnableMetrics:            true,
-		EnableDebugLogging:       observer != nil && observer.DebugObserver != nil,
+		EnableDebugLogging:       observer != nil && observer.Debug() != nil,
 		MaxRetries:               3,
 	}
 

--- a/internal/validators/dual_path_bridge.go
+++ b/internal/validators/dual_path_bridge.go
@@ -26,7 +26,7 @@ type EnhancedValidatorBridge struct {
 	metadataBridge  *MetadataValidatorBridge
 	contentRouter   *router.ContentRouter
 	contextAnalyzer *context.ContextAnalyzer
-	observer        *observability.StandardObserver
+	observer        observability.Observer
 
 	// Configuration
 	config *DualPathConfig
@@ -50,7 +50,7 @@ type namedValidator struct {
 type DocumentValidatorBridge struct {
 	validators      []namedValidator
 	contextAnalyzer *context.ContextAnalyzer
-	observer        *observability.StandardObserver
+	observer        observability.Observer
 	metrics         *DocumentValidationMetrics
 	mu              sync.RWMutex
 }
@@ -59,7 +59,7 @@ type DocumentValidatorBridge struct {
 type MetadataValidatorBridge struct {
 	metadataValidator PreprocessorAwareValidator
 	contextAnalyzer   *context.ContextAnalyzer
-	observer          *observability.StandardObserver
+	observer          observability.Observer
 	metrics           *MetadataValidationMetrics
 	mu                sync.RWMutex
 }
@@ -195,7 +195,7 @@ func NewMetadataValidatorBridge() *MetadataValidatorBridge {
 }
 
 // SetObserver sets the observability component for all bridges
-func (evb *EnhancedValidatorBridge) SetObserver(observer *observability.StandardObserver) {
+func (evb *EnhancedValidatorBridge) SetObserver(observer observability.Observer) {
 	evb.observer = observer
 	evb.contentRouter.SetObserver(observer)
 	evb.documentBridge.SetObserver(observer)
@@ -234,8 +234,8 @@ func (evb *EnhancedValidatorBridge) ProcessContentCtx(ctx stdctx.Context, conten
 	var finishStep func(bool, string)
 	if evb.observer != nil {
 		finishTiming = evb.observer.StartTiming("enhanced_validator_bridge", "process_content", content.OriginalPath)
-		if evb.observer.DebugObserver != nil {
-			finishStep = evb.observer.DebugObserver.StartStep("enhanced_validator_bridge", "process_content", content.OriginalPath)
+		if evb.observer.Debug() != nil {
+			finishStep = evb.observer.Debug().StartStep("enhanced_validator_bridge", "process_content", content.OriginalPath)
 		}
 	}
 
@@ -246,8 +246,8 @@ func (evb *EnhancedValidatorBridge) ProcessContentCtx(ctx stdctx.Context, conten
 		contextInsights = evb.contextAnalyzer.AnalyzeContext(content.Text, content.OriginalPath)
 		evb.updateContextMetrics(time.Since(contextStartTime))
 
-		if evb.observer != nil && evb.observer.DebugObserver != nil {
-			evb.observer.DebugObserver.LogDetail("context_analysis", fmt.Sprintf("Domain: %s, DocumentType: %s, Confidence: %.2f",
+		if evb.observer != nil && evb.observer.Debug() != nil {
+			evb.observer.Debug().LogDetail("context_analysis", fmt.Sprintf("Domain: %s, DocumentType: %s, Confidence: %.2f",
 				contextInsights.Domain, contextInsights.DocumentType, contextInsights.DomainConfidence))
 		}
 	}
@@ -456,9 +456,9 @@ func (evb *EnhancedValidatorBridge) processDualPath(ctx stdctx.Context, routedCo
 	}
 
 	// Log partial failures but continue with successful results
-	if len(processingErrors) > 0 && evb.observer != nil && evb.observer.DebugObserver != nil {
+	if len(processingErrors) > 0 && evb.observer != nil && evb.observer.Debug() != nil {
 		for _, procErr := range processingErrors {
-			evb.observer.DebugObserver.LogDetail("partial_validation_failure", procErr.Error())
+			evb.observer.Debug().LogDetail("partial_validation_failure", procErr.Error())
 		}
 	}
 
@@ -540,8 +540,8 @@ func (evb *EnhancedValidatorBridge) applyCrossPathConfidenceAdjustments(matches 
 			matches[i].Metadata["original_confidence"] = originalConfidence
 		}
 
-		if evb.observer != nil && evb.observer.DebugObserver != nil {
-			evb.observer.DebugObserver.LogDetail("cross_path_correlation",
+		if evb.observer != nil && evb.observer.Debug() != nil {
+			evb.observer.Debug().LogDetail("cross_path_correlation",
 				fmt.Sprintf("Applied %.1f correlation boost to %d matches", correlationBoost, len(matches)))
 		}
 	}
@@ -564,8 +564,8 @@ func (evb *EnhancedValidatorBridge) routeContentWithRetry(content *preprocessors
 		}
 
 		lastErr = err
-		if evb.observer != nil && evb.observer.DebugObserver != nil {
-			evb.observer.DebugObserver.LogDetail("routing_retry",
+		if evb.observer != nil && evb.observer.Debug() != nil {
+			evb.observer.Debug().LogDetail("routing_retry",
 				fmt.Sprintf("Routing attempt %d/%d failed: %v", attempt, maxRetries, err))
 		}
 
@@ -581,8 +581,8 @@ func (evb *EnhancedValidatorBridge) routeContentWithRetry(content *preprocessors
 // processContentLegacy provides fallback to legacy aggregation behavior. ctx is
 // threaded to the document-path dispatch chokepoint.
 func (evb *EnhancedValidatorBridge) processContentLegacy(ctx stdctx.Context, content *preprocessors.ProcessedContent, contextInsights context.ContextInsights) ([]detector.Match, error) {
-	if evb.observer != nil && evb.observer.DebugObserver != nil {
-		evb.observer.DebugObserver.LogDetail("fallback", "Using legacy content aggregation")
+	if evb.observer != nil && evb.observer.Debug() != nil {
+		evb.observer.Debug().LogDetail("fallback", "Using legacy content aggregation")
 	}
 
 	// Process content with all validators using legacy approach
@@ -629,9 +629,9 @@ func (evb *EnhancedValidatorBridge) processContentLegacy(ctx stdctx.Context, con
 	}
 
 	// Log processing errors but don't fail completely
-	if len(processingErrors) > 0 && evb.observer != nil && evb.observer.DebugObserver != nil {
+	if len(processingErrors) > 0 && evb.observer != nil && evb.observer.Debug() != nil {
 		for _, procErr := range processingErrors {
-			evb.observer.DebugObserver.LogDetail("legacy_processing_errors", procErr.Error())
+			evb.observer.Debug().LogDetail("legacy_processing_errors", procErr.Error())
 		}
 	}
 
@@ -647,7 +647,7 @@ func (dvb *DocumentValidatorBridge) RegisterValidator(name string, validator det
 }
 
 // SetObserver sets the observability component
-func (dvb *DocumentValidatorBridge) SetObserver(observer *observability.StandardObserver) {
+func (dvb *DocumentValidatorBridge) SetObserver(observer observability.Observer) {
 	dvb.observer = observer
 }
 
@@ -709,8 +709,8 @@ func (dvb *DocumentValidatorBridge) ProcessDocumentContentCtx(ctx stdctx.Context
 	dvb.mu.RUnlock()
 
 	if len(validators) == 0 {
-		if dvb.observer != nil && dvb.observer.DebugObserver != nil {
-			dvb.observer.DebugObserver.LogDetail("document_bridge", "No document validators registered")
+		if dvb.observer != nil && dvb.observer.Debug() != nil {
+			dvb.observer.Debug().LogDetail("document_bridge", "No document validators registered")
 		}
 		return allMatches, nil
 	}
@@ -882,8 +882,8 @@ func (dvb *DocumentValidatorBridge) ProcessDocumentContentCtx(ctx stdctx.Context
 	}
 
 	// Log validation errors but don't fail completely if some validators succeeded
-	if len(validationErrors) > 0 && dvb.observer != nil && dvb.observer.DebugObserver != nil {
-		dvb.observer.DebugObserver.LogDetail("document_validation_errors",
+	if len(validationErrors) > 0 && dvb.observer != nil && dvb.observer.Debug() != nil {
+		dvb.observer.Debug().LogDetail("document_validation_errors",
 			fmt.Sprintf("%d out of %d validators failed", len(validationErrors), len(validators)))
 	}
 
@@ -921,7 +921,7 @@ func (mvb *MetadataValidatorBridge) SetValidator(validator PreprocessorAwareVali
 }
 
 // SetObserver sets the observability component
-func (mvb *MetadataValidatorBridge) SetObserver(observer *observability.StandardObserver) {
+func (mvb *MetadataValidatorBridge) SetObserver(observer observability.Observer) {
 	mvb.observer = observer
 }
 
@@ -948,8 +948,8 @@ func (mvb *MetadataValidatorBridge) ProcessMetadataContentCtx(ctx stdctx.Context
 	mvb.mu.RUnlock()
 
 	if validator == nil {
-		if mvb.observer != nil && mvb.observer.DebugObserver != nil {
-			mvb.observer.DebugObserver.LogDetail("metadata_bridge", "No metadata validator configured")
+		if mvb.observer != nil && mvb.observer.Debug() != nil {
+			mvb.observer.Debug().LogDetail("metadata_bridge", "No metadata validator configured")
 		}
 		if finishTiming != nil {
 			finishTiming(false, map[string]interface{}{"error": "no metadata validator configured"})
@@ -958,9 +958,9 @@ func (mvb *MetadataValidatorBridge) ProcessMetadataContentCtx(ctx stdctx.Context
 	}
 
 	if len(metadataItems) == 0 {
-		if mvb.observer != nil && mvb.observer.DebugObserver != nil {
-			mvb.observer.DebugObserver.LogDetail("metadata_bridge", "No metadata items to process - file type does not support metadata validation")
-			mvb.observer.DebugObserver.LogMetric("metadata_validator_skip", "files_skipped_no_metadata", 1)
+		if mvb.observer != nil && mvb.observer.Debug() != nil {
+			mvb.observer.Debug().LogDetail("metadata_bridge", "No metadata items to process - file type does not support metadata validation")
+			mvb.observer.Debug().LogMetric("metadata_validator_skip", "files_skipped_no_metadata", 1)
 		}
 
 		// Update skip metrics
@@ -1078,8 +1078,8 @@ func (mvb *MetadataValidatorBridge) ProcessMetadataContentCtx(ctx stdctx.Context
 	}
 
 	// Log validation errors but don't fail completely if some items succeeded
-	if len(validationErrors) > 0 && mvb.observer != nil && mvb.observer.DebugObserver != nil {
-		mvb.observer.DebugObserver.LogDetail("metadata_validation_errors",
+	if len(validationErrors) > 0 && mvb.observer != nil && mvb.observer.Debug() != nil {
+		mvb.observer.Debug().LogDetail("metadata_validation_errors",
 			fmt.Sprintf("%d out of %d metadata items failed validation", len(validationErrors), len(metadataItems)))
 	}
 
@@ -1340,20 +1340,20 @@ func (evb *EnhancedValidatorBridge) ResetMetrics() {
 
 // LogOperationalStatus logs the current operational status for monitoring
 func (evb *EnhancedValidatorBridge) LogOperationalStatus() {
-	if evb.observer == nil || evb.observer.DebugObserver == nil {
+	if evb.observer == nil || evb.observer.Debug() == nil {
 		return
 	}
 
 	metrics := evb.GetDetailedMetrics()
 
-	evb.observer.DebugObserver.LogDetail("operational_status", "Enhanced Validator Bridge Status:")
-	evb.observer.DebugObserver.LogDetail("operational_status", fmt.Sprintf("  Total Validations: %v", metrics["total_validations"]))
-	evb.observer.DebugObserver.LogDetail("operational_status", fmt.Sprintf("  Success Rate: %.2f%%",
+	evb.observer.Debug().LogDetail("operational_status", "Enhanced Validator Bridge Status:")
+	evb.observer.Debug().LogDetail("operational_status", fmt.Sprintf("  Total Validations: %v", metrics["total_validations"]))
+	evb.observer.Debug().LogDetail("operational_status", fmt.Sprintf("  Success Rate: %.2f%%",
 		float64(metrics["successful_validations"].(int64))/float64(metrics["total_validations"].(int64))*100))
-	evb.observer.DebugObserver.LogDetail("operational_status", fmt.Sprintf("  Fallback Activations: %v", metrics["fallback_activations"]))
-	evb.observer.DebugObserver.LogDetail("operational_status", fmt.Sprintf("  Routing Success Rate: %.2f%%",
+	evb.observer.Debug().LogDetail("operational_status", fmt.Sprintf("  Fallback Activations: %v", metrics["fallback_activations"]))
+	evb.observer.Debug().LogDetail("operational_status", fmt.Sprintf("  Routing Success Rate: %.2f%%",
 		metrics["routing_success_rate"].(float64)*100))
-	evb.observer.DebugObserver.LogDetail("operational_status", fmt.Sprintf("  Average Processing Time: %vms", metrics["average_processing_time_ms"]))
+	evb.observer.Debug().LogDetail("operational_status", fmt.Sprintf("  Average Processing Time: %vms", metrics["average_processing_time_ms"]))
 }
 
 // getDefaultDualPathConfig returns default configuration

--- a/internal/validators/dual_path_integration.go
+++ b/internal/validators/dual_path_integration.go
@@ -22,7 +22,7 @@ import (
 // Phase 2, Move B — see detector.go and docs/proposals/V2_ARCHITECTURE.md.)
 type MetadataValidatorAdapter struct {
 	validator detector.Validator
-	observer  *observability.StandardObserver
+	observer  observability.Observer
 }
 
 // Validate implements detector.Validator interface
@@ -87,8 +87,8 @@ func (mva *MetadataValidatorAdapter) GetSupportedPreprocessors() []string {
 // SetPreprocessorValidationRules implements PreprocessorAwareValidator interface
 func (mva *MetadataValidatorAdapter) SetPreprocessorValidationRules(rules map[string]ValidationRule) {
 	// This is a no-op for the adapter since standard validators don't support this
-	if mva.observer != nil && mva.observer.DebugObserver != nil {
-		mva.observer.DebugObserver.LogDetail("metadata_adapter",
+	if mva.observer != nil && mva.observer.Debug() != nil {
+		mva.observer.Debug().LogDetail("metadata_adapter",
 			fmt.Sprintf("SetPreprocessorValidationRules called with %d rules (no-op for standard validator)", len(rules)))
 	}
 }

--- a/internal/validators/email/validator.go
+++ b/internal/validators/email/validator.go
@@ -137,7 +137,7 @@ type Validator struct {
 	businessPatterns []string
 
 	// Observability
-	observer *observability.StandardObserver
+	observer observability.Observer
 }
 
 // NewValidator creates and returns a new Validator instance
@@ -188,7 +188,7 @@ func NewValidator() *Validator {
 }
 
 // SetObserver sets the observability component
-func (v *Validator) SetObserver(observer *observability.StandardObserver) {
+func (v *Validator) SetObserver(observer observability.Observer) {
 	v.observer = observer
 }
 
@@ -198,8 +198,8 @@ func (v *Validator) Validate(filePath string) ([]detector.Match, error) {
 	var finishStep func(bool, string)
 	if v.observer != nil {
 		finishTiming = v.observer.StartTiming("email_validator", "validate_file", filePath)
-		if v.observer.DebugObserver != nil {
-			finishStep = v.observer.DebugObserver.StartStep("email_validator", "validate_file", filePath)
+		if v.observer.Debug() != nil {
+			finishStep = v.observer.Debug().StartStep("email_validator", "validate_file", filePath)
 		}
 	}
 

--- a/internal/validators/intellectualproperty/validator.go
+++ b/internal/validators/intellectualproperty/validator.go
@@ -84,7 +84,7 @@ type Validator struct {
 	legalNoticeConfig LegalNoticeConfig
 
 	// Observability
-	observer *observability.StandardObserver
+	observer observability.Observer
 }
 
 // LegalNoticeAnalysis contains the results of analyzing whether multiple IP patterns
@@ -294,7 +294,7 @@ func NewValidator() *Validator {
 }
 
 // SetObserver sets the observability component
-func (v *Validator) SetObserver(observer *observability.StandardObserver) {
+func (v *Validator) SetObserver(observer observability.Observer) {
 	v.observer = observer
 }
 
@@ -340,10 +340,10 @@ func (v *Validator) Configure(cfg *config.Config) {
 				// Validate regex pattern using regexp.Compile()
 				if _, err := regexp.Compile(processedPattern); err != nil {
 					// Log warning for invalid pattern but continue with valid ones
-					if v.observer != nil && v.observer.DebugObserver != nil {
-						v.observer.DebugObserver.LogDetail("intellectualproperty", fmt.Sprintf("Invalid internal URL pattern '%s': %v", urlStr, err))
+					if v.observer != nil && v.observer.Debug() != nil {
+						v.observer.Debug().LogDetail("intellectualproperty", fmt.Sprintf("Invalid internal URL pattern '%s': %v", urlStr, err))
 						// Log specific invalid patterns with error details in debug mode
-						v.observer.DebugObserver.LogDetail("intellectualproperty", fmt.Sprintf("Skipping invalid regex pattern: '%s' - Error: %v", urlStr, err))
+						v.observer.Debug().LogDetail("intellectualproperty", fmt.Sprintf("Skipping invalid regex pattern: '%s' - Error: %v", urlStr, err))
 					}
 
 					// Also log to stderr in debug mode for comprehensive logging
@@ -364,19 +364,19 @@ func (v *Validator) Configure(cfg *config.Config) {
 		v.internalURLPatterns = validPatterns
 
 		// Log number of successfully loaded patterns in debug mode (requirement 7.2)
-		if v.observer != nil && v.observer.DebugObserver != nil {
-			v.observer.DebugObserver.LogDetail("intellectualproperty", fmt.Sprintf("Internal URL pattern validation: %d valid, %d invalid patterns", len(validPatterns), invalidCount))
+		if v.observer != nil && v.observer.Debug() != nil {
+			v.observer.Debug().LogDetail("intellectualproperty", fmt.Sprintf("Internal URL pattern validation: %d valid, %d invalid patterns", len(validPatterns), invalidCount))
 			if len(validPatterns) > 0 {
 				// Requirement 7.2: Log the number of active patterns
-				v.observer.DebugObserver.LogDetail("intellectualproperty", fmt.Sprintf("Successfully loaded %d internal URL patterns", len(validPatterns)))
+				v.observer.Debug().LogDetail("intellectualproperty", fmt.Sprintf("Successfully loaded %d internal URL patterns", len(validPatterns)))
 				// Requirement 7.1: Log the loaded internal URL patterns at startup
 				for i, pattern := range validPatterns {
-					v.observer.DebugObserver.LogDetail("intellectualproperty", fmt.Sprintf("  Active pattern %d: %s", i+1, pattern))
+					v.observer.Debug().LogDetail("intellectualproperty", fmt.Sprintf("  Active pattern %d: %s", i+1, pattern))
 				}
 			}
 			// Requirement 7.3: Log any skipped invalid patterns
 			if invalidCount > 0 {
-				v.observer.DebugObserver.LogDetail("intellectualproperty", fmt.Sprintf("Skipped %d invalid internal URL patterns during configuration", invalidCount))
+				v.observer.Debug().LogDetail("intellectualproperty", fmt.Sprintf("Skipped %d invalid internal URL patterns during configuration", invalidCount))
 			}
 		}
 
@@ -437,8 +437,8 @@ func (v *Validator) Configure(cfg *config.Config) {
 				normalized := strings.ToLower(strings.TrimSpace(dtStr))
 				v.disabledTypes[normalized] = true
 
-				if v.observer != nil && v.observer.DebugObserver != nil {
-					v.observer.DebugObserver.LogDetail("intellectualproperty",
+				if v.observer != nil && v.observer.Debug() != nil {
+					v.observer.Debug().LogDetail("intellectualproperty",
 						fmt.Sprintf("Disabled IP sub-type: %s", normalized))
 				}
 			}
@@ -480,8 +480,8 @@ func (v *Validator) applyIPPatternOverride(
 		// Invalid regex from config: log and keep the built-in default.
 		// Mirror the internal_urls override path (see validator.go ~L297) so
 		// behavior is consistent across all configurable IP regex fields.
-		if v.observer != nil && v.observer.DebugObserver != nil {
-			v.observer.DebugObserver.LogDetail("intellectualproperty",
+		if v.observer != nil && v.observer.Debug() != nil {
+			v.observer.Debug().LogDetail("intellectualproperty",
 				fmt.Sprintf("Invalid %s pattern %q: %v — keeping built-in default", patternKey, raw, err))
 		}
 		fmt.Fprintf(os.Stderr,
@@ -498,8 +498,8 @@ func (v *Validator) applyIPPatternOverride(
 	*patternStore = processed
 	*regexStore = compiled
 
-	if v.observer != nil && v.observer.DebugObserver != nil {
-		v.observer.DebugObserver.LogDetail("intellectualproperty",
+	if v.observer != nil && v.observer.Debug() != nil {
+		v.observer.Debug().LogDetail("intellectualproperty",
 			fmt.Sprintf("Applied %s pattern override from config: %s", patternKey, processed))
 	}
 }
@@ -526,8 +526,8 @@ func (v *Validator) logNoInternalURLPatterns(reason string) {
 	message := "Internal URL detection disabled: " + reason + ". Configure 'validators.intellectual_property.internal_urls' to enable internal URL detection."
 
 	// Log to debug observer for detailed logging
-	if v.observer != nil && v.observer.DebugObserver != nil {
-		v.observer.DebugObserver.LogDetail("intellectualproperty", message)
+	if v.observer != nil && v.observer.Debug() != nil {
+		v.observer.Debug().LogDetail("intellectualproperty", message)
 
 		// Include configuration guidance in verbose mode warnings (requirement 6.4)
 		guidance := "Example configuration:\n" +
@@ -543,7 +543,7 @@ func (v *Validator) logNoInternalURLPatterns(reason string) {
 			"  AWS: \"http[s]?:\\\\/\\\\/.*\\\\.amazonaws\\\\.com\", \"http[s]?:\\\\/\\\\/.*\\\\.s3\\\\..*\"\n" +
 			"  Azure: \"http[s]?:\\\\/\\\\/.*\\\\.azurewebsites\\\\.net\", \"http[s]?:\\\\/\\\\/.*\\\\.blob\\\\.core\\\\.windows\\\\.net\"\n" +
 			"  GCP: \"http[s]?:\\\\/\\\\/.*\\\\.googleapis\\\\.com\", \"http[s]?:\\\\/\\\\/.*\\\\.appspot\\\\.com\""
-		v.observer.DebugObserver.LogDetail("intellectualproperty", fmt.Sprintf("Configuration guidance for internal URL patterns:\n%s", guidance))
+		v.observer.Debug().LogDetail("intellectualproperty", fmt.Sprintf("Configuration guidance for internal URL patterns:\n%s", guidance))
 
 		// Also log configuration guidance to stderr in verbose/debug mode
 		if os.Getenv("FERRET_DEBUG") == "1" {
@@ -592,8 +592,8 @@ func (v *Validator) compileInternalURLPatterns() {
 	// Handle empty pattern arrays gracefully (len() for nil slices is defined as zero)
 	if len(v.internalURLPatterns) == 0 {
 		v.regexInternalURLs = []*regexp.Regexp{}
-		if v.observer != nil && v.observer.DebugObserver != nil {
-			v.observer.DebugObserver.LogDetail("intellectualproperty", "No internal URL patterns to compile - empty pattern array")
+		if v.observer != nil && v.observer.Debug() != nil {
+			v.observer.Debug().LogDetail("intellectualproperty", "No internal URL patterns to compile - empty pattern array")
 		}
 		return
 	}
@@ -607,8 +607,8 @@ func (v *Validator) compileInternalURLPatterns() {
 		// Skip empty patterns gracefully
 		if pattern == "" {
 			failedCount++
-			if v.observer != nil && v.observer.DebugObserver != nil {
-				v.observer.DebugObserver.LogDetail("intellectualproperty", fmt.Sprintf("Skipping empty internal URL pattern at index %d", i+1))
+			if v.observer != nil && v.observer.Debug() != nil {
+				v.observer.Debug().LogDetail("intellectualproperty", fmt.Sprintf("Skipping empty internal URL pattern at index %d", i+1))
 			}
 			if os.Getenv("FERRET_DEBUG") == "1" {
 				fmt.Fprintf(os.Stderr, "[WARNING] Intellectual Property Validator: Empty internal URL pattern at index %d - skipping\n", i+1)
@@ -623,11 +623,11 @@ func (v *Validator) compileInternalURLPatterns() {
 			failedCount++
 
 			// Log compilation errors for debugging with enhanced context
-			if v.observer != nil && v.observer.DebugObserver != nil {
-				v.observer.DebugObserver.LogDetail("intellectualproperty", fmt.Sprintf("Failed to compile internal URL pattern %d: '%s' - Error: %v", i+1, pattern, err))
+			if v.observer != nil && v.observer.Debug() != nil {
+				v.observer.Debug().LogDetail("intellectualproperty", fmt.Sprintf("Failed to compile internal URL pattern %d: '%s' - Error: %v", i+1, pattern, err))
 				// Provide additional context about the error type
 				if strings.Contains(err.Error(), "invalid") {
-					v.observer.DebugObserver.LogDetail("intellectualproperty", fmt.Sprintf("Pattern %d contains invalid regex syntax - check for unescaped special characters", i+1))
+					v.observer.Debug().LogDetail("intellectualproperty", fmt.Sprintf("Pattern %d contains invalid regex syntax - check for unescaped special characters", i+1))
 				}
 			}
 
@@ -653,10 +653,10 @@ func (v *Validator) compileInternalURLPatterns() {
 	}
 
 	// Log compilation summary in debug mode
-	if v.observer != nil && v.observer.DebugObserver != nil {
-		v.observer.DebugObserver.LogDetail("intellectualproperty", fmt.Sprintf("Internal URL pattern compilation complete: %d successful, %d failed", compiledCount, failedCount))
+	if v.observer != nil && v.observer.Debug() != nil {
+		v.observer.Debug().LogDetail("intellectualproperty", fmt.Sprintf("Internal URL pattern compilation complete: %d successful, %d failed", compiledCount, failedCount))
 		if compiledCount > 0 {
-			v.observer.DebugObserver.LogDetail("intellectualproperty", fmt.Sprintf("Successfully compiled %d internal URL regex patterns", compiledCount))
+			v.observer.Debug().LogDetail("intellectualproperty", fmt.Sprintf("Successfully compiled %d internal URL regex patterns", compiledCount))
 		}
 	}
 
@@ -681,8 +681,8 @@ func (v *Validator) Validate(filePath string) ([]detector.Match, error) {
 	var finishStep func(bool, string)
 	if v.observer != nil {
 		finishTiming = v.observer.StartTiming("ip_validator", "validate_file", filePath)
-		if v.observer.DebugObserver != nil {
-			finishStep = v.observer.DebugObserver.StartStep("ip_validator", "validate_file", filePath)
+		if v.observer.Debug() != nil {
+			finishStep = v.observer.Debug().StartStep("ip_validator", "validate_file", filePath)
 		}
 	}
 
@@ -747,15 +747,15 @@ func (v *Validator) processLineMatches(lineMatches map[int][]detector.Match) []d
 					finalMatches = append(finalMatches, reconstructed)
 
 					// Log reconstruction decision in debug mode
-					if v.observer != nil && v.observer.DebugObserver != nil {
-						v.observer.DebugObserver.LogDetail("intellectualproperty",
+					if v.observer != nil && v.observer.Debug() != nil {
+						v.observer.Debug().LogDetail("intellectualproperty",
 							fmt.Sprintf("Line %d: Reconstructed %d matches into single legal notice (confidence: %.1f%%)",
 								lineNum+1, len(matches), reconstructed.Confidence))
 
 						// Log the reconstruction success with details
 						if reconstructed.Metadata != nil {
 							if boost, ok := reconstructed.Metadata["confidence_boost"].(float64); ok {
-								v.observer.DebugObserver.LogDetail("intellectualproperty",
+								v.observer.Debug().LogDetail("intellectualproperty",
 									fmt.Sprintf("  Confidence boost: +%.1f%%, Reconstruction type: %s",
 										boost, reconstructed.Metadata["reconstruction_type"]))
 							}
@@ -765,7 +765,7 @@ func (v *Validator) processLineMatches(lineMatches map[int][]detector.Match) []d
 					// Graceful degradation: if reconstruction failed, keep original matches
 					finalMatches = append(finalMatches, matches...)
 
-					if v.observer != nil && v.observer.DebugObserver != nil {
+					if v.observer != nil && v.observer.Debug() != nil {
 						errorMsg := "unknown error"
 						if reconstructionError != nil {
 							errorMsg = reconstructionError.Error()
@@ -775,10 +775,10 @@ func (v *Validator) processLineMatches(lineMatches map[int][]detector.Match) []d
 							errorMsg = "empty text"
 						}
 
-						v.observer.DebugObserver.LogDetail("intellectualproperty",
+						v.observer.Debug().LogDetail("intellectualproperty",
 							fmt.Sprintf("Line %d: Reconstruction failed (%s), keeping %d separate matches",
 								lineNum+1, errorMsg, len(matches)))
-						v.observer.DebugObserver.LogDetail("intellectualproperty",
+						v.observer.Debug().LogDetail("intellectualproperty",
 							fmt.Sprintf("  Graceful degradation applied: Falling back to original matches"))
 					}
 				}
@@ -787,13 +787,13 @@ func (v *Validator) processLineMatches(lineMatches map[int][]detector.Match) []d
 				finalMatches = append(finalMatches, matches...)
 
 				// Log decision to keep separate in debug mode
-				if v.observer != nil && v.observer.DebugObserver != nil {
-					v.observer.DebugObserver.LogDetail("intellectualproperty",
+				if v.observer != nil && v.observer.Debug() != nil {
+					v.observer.Debug().LogDetail("intellectualproperty",
 						fmt.Sprintf("Line %d: Keeping %d matches separate - %s",
 							lineNum+1, len(matches), analysis.ReconstructionReason))
 
 					// Log additional context for the decision
-					v.observer.DebugObserver.LogDetail("intellectualproperty",
+					v.observer.Debug().LogDetail("intellectualproperty",
 						fmt.Sprintf("  Analysis: proximity=%.2f, confidence=%.1f%%, legal_notice=%v",
 							analysis.ProximityScore, analysis.Confidence, analysis.IsLegalNotice))
 				}
@@ -802,7 +802,7 @@ func (v *Validator) processLineMatches(lineMatches map[int][]detector.Match) []d
 	}
 
 	// Log final processing summary with detailed statistics
-	if v.observer != nil && v.observer.DebugObserver != nil {
+	if v.observer != nil && v.observer.Debug() != nil {
 		totalOriginalMatches := 0
 		linesWithMultipleMatches := 0
 		reconstructedCount := 0
@@ -823,23 +823,23 @@ func (v *Validator) processLineMatches(lineMatches map[int][]detector.Match) []d
 			}
 		}
 
-		v.observer.DebugObserver.LogDetail("intellectualproperty",
+		v.observer.Debug().LogDetail("intellectualproperty",
 			fmt.Sprintf("Legal notice processing complete: %d original matches → %d final matches",
 				totalOriginalMatches, len(finalMatches)))
 
-		v.observer.DebugObserver.LogDetail("intellectualproperty",
+		v.observer.Debug().LogDetail("intellectualproperty",
 			fmt.Sprintf("  Lines with multiple matches: %d", linesWithMultipleMatches))
 
-		v.observer.DebugObserver.LogDetail("intellectualproperty",
+		v.observer.Debug().LogDetail("intellectualproperty",
 			fmt.Sprintf("  Reconstructed legal notices: %d", reconstructedCount))
 
-		v.observer.DebugObserver.LogDetail("intellectualproperty",
+		v.observer.Debug().LogDetail("intellectualproperty",
 			fmt.Sprintf("  Matches kept separate: %d", len(finalMatches)-reconstructedCount))
 
 		// Calculate reduction percentage
 		if totalOriginalMatches > 0 {
 			reductionPercent := float64(totalOriginalMatches-len(finalMatches)) / float64(totalOriginalMatches) * 100
-			v.observer.DebugObserver.LogDetail("intellectualproperty",
+			v.observer.Debug().LogDetail("intellectualproperty",
 				fmt.Sprintf("  Match reduction: %.1f%% (%d fewer matches)", reductionPercent, totalOriginalMatches-len(finalMatches)))
 		}
 
@@ -896,8 +896,8 @@ func (v *Validator) detectPatternsByLine(ctx stdctx.Context, content string, ori
 					match := line[matchStart:matchEnd]
 
 					// Debug logging to verify this code path is reached
-					if v.observer != nil && v.observer.DebugObserver != nil {
-						v.observer.DebugObserver.LogDetail("intellectualproperty",
+					if v.observer != nil && v.observer.Debug() != nil {
+						v.observer.Debug().LogDetail("intellectualproperty",
 							fmt.Sprintf("INTERNAL URL MATCH FOUND: '%s' - setting HIGH confidence", match))
 					}
 					// Configured internal URLs always start at HIGH confidence
@@ -1804,8 +1804,8 @@ func (v *Validator) analyzeLegalNoticeContext(matches []detector.Match) LegalNot
 	defer func() {
 		if r := recover(); r != nil {
 			// Log panic recovery and provide safe fallback
-			if v.observer != nil && v.observer.DebugObserver != nil {
-				v.observer.DebugObserver.LogDetail("intellectualproperty",
+			if v.observer != nil && v.observer.Debug() != nil {
+				v.observer.Debug().LogDetail("intellectualproperty",
 					fmt.Sprintf("Recovered from panic during legal notice analysis: %v", r))
 			}
 
@@ -1835,7 +1835,7 @@ func (v *Validator) analyzeLegalNoticeContext(matches []detector.Match) LegalNot
 	analysis.ShouldReconstruct, analysis.ReconstructionReason = v.makeReconstructionDecision(analysis)
 
 	// Log the analysis decision in debug mode
-	if v.observer != nil && v.observer.DebugObserver != nil {
+	if v.observer != nil && v.observer.Debug() != nil {
 		v.logLegalNoticeAnalysis(matches, analysis)
 	}
 
@@ -2157,8 +2157,8 @@ func (v *Validator) reconstructLegalNoticeWithFallback(matches []detector.Match)
 	defer func() {
 		if r := recover(); r != nil {
 			// Log panic recovery in debug mode
-			if v.observer != nil && v.observer.DebugObserver != nil {
-				v.observer.DebugObserver.LogDetail("intellectualproperty",
+			if v.observer != nil && v.observer.Debug() != nil {
+				v.observer.Debug().LogDetail("intellectualproperty",
 					fmt.Sprintf("Recovered from panic during legal notice reconstruction: %v", r))
 			}
 		}
@@ -2393,7 +2393,7 @@ func (v *Validator) reconstructLegalNotice(matches []detector.Match) detector.Ma
 	}
 
 	// Log reconstruction details in debug mode
-	if v.observer != nil && v.observer.DebugObserver != nil {
+	if v.observer != nil && v.observer.Debug() != nil {
 		v.logReconstructionDetails(matches, reconstructedMatch, analysis)
 	}
 
@@ -2669,7 +2669,7 @@ func (v *Validator) calculateReconstructedConfidence(matches []detector.Match, a
 	}
 
 	// Log detailed confidence boost calculation in debug mode
-	if v.observer != nil && v.observer.DebugObserver != nil {
+	if v.observer != nil && v.observer.Debug() != nil {
 		v.logConfidenceBoostCalculation(matches, analysis, baseConfidence, reconstructedConfidence)
 	}
 
@@ -2678,15 +2678,15 @@ func (v *Validator) calculateReconstructedConfidence(matches []detector.Match, a
 
 // logProximityCalculationDetails logs detailed proximity calculation information
 func (v *Validator) logProximityCalculationDetails(matches []detector.Match, proximityScore float64) {
-	if v.observer == nil || v.observer.DebugObserver == nil {
+	if v.observer == nil || v.observer.Debug() == nil {
 		return
 	}
 
-	v.observer.DebugObserver.LogDetail("intellectualproperty",
+	v.observer.Debug().LogDetail("intellectualproperty",
 		fmt.Sprintf("  Proximity Analysis:"))
 
 	if len(matches) <= 1 {
-		v.observer.DebugObserver.LogDetail("intellectualproperty",
+		v.observer.Debug().LogDetail("intellectualproperty",
 			fmt.Sprintf("    Single match - proximity score: %.2f (perfect)", proximityScore))
 		return
 	}
@@ -2702,7 +2702,7 @@ func (v *Validator) logProximityCalculationDetails(matches []detector.Match, pro
 	}
 
 	if allSameLine {
-		v.observer.DebugObserver.LogDetail("intellectualproperty",
+		v.observer.Debug().LogDetail("intellectualproperty",
 			fmt.Sprintf("    Same-line matches detected (line %d)", firstLineNum))
 
 		// Calculate positions within the line for same-line matches
@@ -2723,9 +2723,9 @@ func (v *Validator) logProximityCalculationDetails(matches []detector.Match, pro
 		}
 
 		span := maxPos - minPos
-		v.observer.DebugObserver.LogDetail("intellectualproperty",
+		v.observer.Debug().LogDetail("intellectualproperty",
 			fmt.Sprintf("    Character span within line: %d (threshold: %.0f)", span, SameLineProximityThreshold))
-		v.observer.DebugObserver.LogDetail("intellectualproperty",
+		v.observer.Debug().LogDetail("intellectualproperty",
 			fmt.Sprintf("    Same-line proximity score: %.2f", proximityScore))
 	} else {
 		// Multi-line proximity calculation
@@ -2748,12 +2748,12 @@ func (v *Validator) logProximityCalculationDetails(matches []detector.Match, pro
 		span := maxPos - minPos
 		threshold := float64(v.legalNoticeConfig.ProximityThreshold)
 
-		v.observer.DebugObserver.LogDetail("intellectualproperty",
+		v.observer.Debug().LogDetail("intellectualproperty",
 			fmt.Sprintf("    Multi-line matches: lines %d-%d",
 				matches[0].LineNumber, matches[len(matches)-1].LineNumber))
-		v.observer.DebugObserver.LogDetail("intellectualproperty",
+		v.observer.Debug().LogDetail("intellectualproperty",
 			fmt.Sprintf("    Character span: %d (threshold: %.0f)", span, threshold))
-		v.observer.DebugObserver.LogDetail("intellectualproperty",
+		v.observer.Debug().LogDetail("intellectualproperty",
 			fmt.Sprintf("    Multi-line proximity score: %.2f", proximityScore))
 	}
 
@@ -2769,26 +2769,26 @@ func (v *Validator) logProximityCalculationDetails(matches []detector.Match, pro
 		proximityLevel = "VERY_FAR"
 	}
 
-	v.observer.DebugObserver.LogDetail("intellectualproperty",
+	v.observer.Debug().LogDetail("intellectualproperty",
 		fmt.Sprintf("    Proximity classification: %s (score: %.2f)", proximityLevel, proximityScore))
 }
 
 // logSemanticGroupingDetails logs detailed semantic grouping analysis
 func (v *Validator) logSemanticGroupingDetails(matches []detector.Match, semanticGroups []string) {
-	if v.observer == nil || v.observer.DebugObserver == nil {
+	if v.observer == nil || v.observer.Debug() == nil {
 		return
 	}
 
-	v.observer.DebugObserver.LogDetail("intellectualproperty",
+	v.observer.Debug().LogDetail("intellectualproperty",
 		fmt.Sprintf("  Semantic Analysis:"))
 
 	if len(semanticGroups) == 0 {
-		v.observer.DebugObserver.LogDetail("intellectualproperty",
+		v.observer.Debug().LogDetail("intellectualproperty",
 			fmt.Sprintf("    No semantic patterns detected"))
 		return
 	}
 
-	v.observer.DebugObserver.LogDetail("intellectualproperty",
+	v.observer.Debug().LogDetail("intellectualproperty",
 		fmt.Sprintf("    Detected patterns: %v", semanticGroups))
 
 	// Log what each semantic group means
@@ -2823,7 +2823,7 @@ func (v *Validator) logSemanticGroupingDetails(matches []detector.Match, semanti
 			description = "Unknown pattern"
 		}
 
-		v.observer.DebugObserver.LogDetail("intellectualproperty",
+		v.observer.Debug().LogDetail("intellectualproperty",
 			fmt.Sprintf("      %s: %s", group, description))
 	}
 
@@ -2838,43 +2838,43 @@ func (v *Validator) logSemanticGroupingDetails(matches []detector.Match, semanti
 	}
 
 	if len(ipTypes) > 0 {
-		v.observer.DebugObserver.LogDetail("intellectualproperty",
+		v.observer.Debug().LogDetail("intellectualproperty",
 			fmt.Sprintf("    IP type distribution: %v", ipTypes))
 	}
 }
 
 // logDecisionTreeReasoning logs the decision-making process for reconstruction
 func (v *Validator) logDecisionTreeReasoning(analysis LegalNoticeAnalysis) {
-	if v.observer == nil || v.observer.DebugObserver == nil {
+	if v.observer == nil || v.observer.Debug() == nil {
 		return
 	}
 
-	v.observer.DebugObserver.LogDetail("intellectualproperty",
+	v.observer.Debug().LogDetail("intellectualproperty",
 		fmt.Sprintf("  Decision Tree Analysis:"))
 
 	// Log configuration status
-	v.observer.DebugObserver.LogDetail("intellectualproperty",
+	v.observer.Debug().LogDetail("intellectualproperty",
 		fmt.Sprintf("    Legal notice reconstruction enabled: %v", v.legalNoticeConfig.Enabled))
 
 	if !v.legalNoticeConfig.Enabled {
-		v.observer.DebugObserver.LogDetail("intellectualproperty",
+		v.observer.Debug().LogDetail("intellectualproperty",
 			fmt.Sprintf("    → Reconstruction disabled by configuration"))
 		return
 	}
 
 	// Log threshold checks
-	v.observer.DebugObserver.LogDetail("intellectualproperty",
+	v.observer.Debug().LogDetail("intellectualproperty",
 		fmt.Sprintf("    Confidence threshold check: %.1f%% >= %.1f%% = %v",
 			analysis.Confidence, ReconstructionMinConfidence,
 			analysis.Confidence >= ReconstructionMinConfidence))
 
-	v.observer.DebugObserver.LogDetail("intellectualproperty",
+	v.observer.Debug().LogDetail("intellectualproperty",
 		fmt.Sprintf("    Proximity threshold check: %.2f >= %.2f = %v",
 			analysis.ProximityScore, ReconstructionMinProximity,
 			analysis.ProximityScore >= ReconstructionMinProximity))
 
 	// Log legal notice pattern check
-	v.observer.DebugObserver.LogDetail("intellectualproperty",
+	v.observer.Debug().LogDetail("intellectualproperty",
 		fmt.Sprintf("    Legal notice pattern detected: %v", analysis.IsLegalNotice))
 
 	// Log specific decision factors
@@ -2888,7 +2888,7 @@ func (v *Validator) logDecisionTreeReasoning(analysis LegalNoticeAnalysis) {
 		for _, group := range analysis.SemanticGrouping {
 			if group == indicator {
 				hasStrongIndicator = true
-				v.observer.DebugObserver.LogDetail("intellectualproperty",
+				v.observer.Debug().LogDetail("intellectualproperty",
 					fmt.Sprintf("    Strong indicator found: %s", indicator))
 				break
 			}
@@ -2900,24 +2900,24 @@ func (v *Validator) logDecisionTreeReasoning(analysis LegalNoticeAnalysis) {
 
 	// Log final decision reasoning
 	if analysis.ShouldReconstruct {
-		v.observer.DebugObserver.LogDetail("intellectualproperty",
+		v.observer.Debug().LogDetail("intellectualproperty",
 			fmt.Sprintf("    → DECISION: RECONSTRUCT (%s)", analysis.ReconstructionReason))
 	} else {
-		v.observer.DebugObserver.LogDetail("intellectualproperty",
+		v.observer.Debug().LogDetail("intellectualproperty",
 			fmt.Sprintf("    → DECISION: KEEP SEPARATE (%s)", analysis.ReconstructionReason))
 	}
 }
 
 // logConfidenceBoostCalculation logs detailed confidence boost calculations
 func (v *Validator) logConfidenceBoostCalculation(matches []detector.Match, analysis LegalNoticeAnalysis, baseConfidence float64, finalConfidence float64) {
-	if v.observer == nil || v.observer.DebugObserver == nil {
+	if v.observer == nil || v.observer.Debug() == nil {
 		return
 	}
 
-	v.observer.DebugObserver.LogDetail("intellectualproperty",
+	v.observer.Debug().LogDetail("intellectualproperty",
 		fmt.Sprintf("  Confidence Boost Calculation:"))
 
-	v.observer.DebugObserver.LogDetail("intellectualproperty",
+	v.observer.Debug().LogDetail("intellectualproperty",
 		fmt.Sprintf("    Base confidence (highest individual): %.1f%%", baseConfidence))
 
 	totalBoost := 0.0
@@ -2940,14 +2940,14 @@ func (v *Validator) logConfidenceBoostCalculation(matches []detector.Match, anal
 	}
 
 	if noticeTypeBoost > 0 {
-		v.observer.DebugObserver.LogDetail("intellectualproperty",
+		v.observer.Debug().LogDetail("intellectualproperty",
 			fmt.Sprintf("    Notice type boost (%s): +%.1f%%", analysis.NoticeType, noticeTypeBoost))
 		totalBoost += noticeTypeBoost
 	}
 
 	// Log general legal notice boost
 	if boost, ok := v.legalNoticeConfig.ConfidenceBoosts["legal_notice"]; ok {
-		v.observer.DebugObserver.LogDetail("intellectualproperty",
+		v.observer.Debug().LogDetail("intellectualproperty",
 			fmt.Sprintf("    General legal notice boost: +%.1f%%", boost))
 		totalBoost += boost
 	}
@@ -2955,7 +2955,7 @@ func (v *Validator) logConfidenceBoostCalculation(matches []detector.Match, anal
 	// Log proximity boost
 	proximityBoost := analysis.ProximityScore * MaxProximityBonus
 	if proximityBoost > 0 {
-		v.observer.DebugObserver.LogDetail("intellectualproperty",
+		v.observer.Debug().LogDetail("intellectualproperty",
 			fmt.Sprintf("    Proximity boost (%.2f × %.1f%%): +%.1f%%",
 				analysis.ProximityScore, MaxProximityBonus, proximityBoost))
 		totalBoost += proximityBoost
@@ -2974,7 +2974,7 @@ func (v *Validator) logConfidenceBoostCalculation(matches []detector.Match, anal
 			groupBoost = 2.5
 		}
 		if groupBoost > 0 {
-			v.observer.DebugObserver.LogDetail("intellectualproperty",
+			v.observer.Debug().LogDetail("intellectualproperty",
 				fmt.Sprintf("    Semantic boost (%s): +%.1f%%", group, groupBoost))
 			semanticBoost += groupBoost
 		}
@@ -2986,60 +2986,60 @@ func (v *Validator) logConfidenceBoostCalculation(matches []detector.Match, anal
 	var ipTypeBoost float64
 	if len(ipTypes) >= 3 {
 		ipTypeBoost = 4.0
-		v.observer.DebugObserver.LogDetail("intellectualproperty",
+		v.observer.Debug().LogDetail("intellectualproperty",
 			fmt.Sprintf("    IP type diversity boost (3+ types): +%.1f%%", ipTypeBoost))
 	} else if len(ipTypes) >= 2 {
 		ipTypeBoost = 2.0
-		v.observer.DebugObserver.LogDetail("intellectualproperty",
+		v.observer.Debug().LogDetail("intellectualproperty",
 			fmt.Sprintf("    IP type diversity boost (2 types): +%.1f%%", ipTypeBoost))
 	}
 	totalBoost += ipTypeBoost
 
 	// Log total calculation
 	calculatedConfidence := baseConfidence + totalBoost
-	v.observer.DebugObserver.LogDetail("intellectualproperty",
+	v.observer.Debug().LogDetail("intellectualproperty",
 		fmt.Sprintf("    Total boost applied: +%.1f%%", totalBoost))
-	v.observer.DebugObserver.LogDetail("intellectualproperty",
+	v.observer.Debug().LogDetail("intellectualproperty",
 		fmt.Sprintf("    Calculated confidence: %.1f%% + %.1f%% = %.1f%%",
 			baseConfidence, totalBoost, calculatedConfidence))
 
 	// Log capping if applied
 	if calculatedConfidence != finalConfidence {
 		if finalConfidence == v.legalNoticeConfig.MaxConfidence {
-			v.observer.DebugObserver.LogDetail("intellectualproperty",
+			v.observer.Debug().LogDetail("intellectualproperty",
 				fmt.Sprintf("    Capped at maximum: %.1f%% → %.1f%%", calculatedConfidence, finalConfidence))
 		} else if finalConfidence == v.legalNoticeConfig.MinConfidenceThreshold {
-			v.observer.DebugObserver.LogDetail("intellectualproperty",
+			v.observer.Debug().LogDetail("intellectualproperty",
 				fmt.Sprintf("    Raised to minimum: %.1f%% → %.1f%%", calculatedConfidence, finalConfidence))
 		}
 	}
 
-	v.observer.DebugObserver.LogDetail("intellectualproperty",
+	v.observer.Debug().LogDetail("intellectualproperty",
 		fmt.Sprintf("    Final confidence: %.1f%%", finalConfidence))
 }
 
 // logReconstructionDetails logs detailed information about the reconstruction process
 func (v *Validator) logReconstructionDetails(originalMatches []detector.Match, reconstructedMatch detector.Match, analysis LegalNoticeAnalysis) {
-	if v.observer == nil || v.observer.DebugObserver == nil {
+	if v.observer == nil || v.observer.Debug() == nil {
 		return
 	}
 
-	v.observer.DebugObserver.LogDetail("intellectualproperty",
+	v.observer.Debug().LogDetail("intellectualproperty",
 		fmt.Sprintf("Legal notice reconstruction completed:"))
 
-	v.observer.DebugObserver.LogDetail("intellectualproperty",
+	v.observer.Debug().LogDetail("intellectualproperty",
 		fmt.Sprintf("  Original matches: %d", len(originalMatches)))
 
-	v.observer.DebugObserver.LogDetail("intellectualproperty",
+	v.observer.Debug().LogDetail("intellectualproperty",
 		fmt.Sprintf("  Reconstructed text: '%s'", reconstructedMatch.Text))
 
-	v.observer.DebugObserver.LogDetail("intellectualproperty",
+	v.observer.Debug().LogDetail("intellectualproperty",
 		fmt.Sprintf("  Final confidence: %.1f%%", reconstructedMatch.Confidence))
 
 	// Log detailed confidence boost calculation
 	if reconstructedMatch.Metadata != nil {
 		if boost, ok := reconstructedMatch.Metadata["confidence_boost"].(float64); ok {
-			v.observer.DebugObserver.LogDetail("intellectualproperty",
+			v.observer.Debug().LogDetail("intellectualproperty",
 				fmt.Sprintf("  Confidence boost applied: +%.1f%%", boost))
 
 			// Find base confidence for detailed logging
@@ -3053,23 +3053,23 @@ func (v *Validator) logReconstructionDetails(originalMatches []detector.Match, r
 		}
 
 		if ipTypes, ok := reconstructedMatch.Metadata["ip_types"].([]string); ok {
-			v.observer.DebugObserver.LogDetail("intellectualproperty",
+			v.observer.Debug().LogDetail("intellectualproperty",
 				fmt.Sprintf("  IP types combined: %v", ipTypes))
 		}
 
 		if reconstructionType, ok := reconstructedMatch.Metadata["reconstruction_type"].(string); ok {
-			v.observer.DebugObserver.LogDetail("intellectualproperty",
+			v.observer.Debug().LogDetail("intellectualproperty",
 				fmt.Sprintf("  Reconstruction type: %s", reconstructionType))
 		}
 
 		if proximityScore, ok := reconstructedMatch.Metadata["proximity_score"].(float64); ok {
-			v.observer.DebugObserver.LogDetail("intellectualproperty",
+			v.observer.Debug().LogDetail("intellectualproperty",
 				fmt.Sprintf("  Proximity score: %.2f", proximityScore))
 		}
 	}
 
 	// Log original match details with enhanced information
-	v.observer.DebugObserver.LogDetail("intellectualproperty",
+	v.observer.Debug().LogDetail("intellectualproperty",
 		fmt.Sprintf("  Original match breakdown:"))
 	for i, match := range originalMatches {
 		ipType := "unknown"
@@ -3078,7 +3078,7 @@ func (v *Validator) logReconstructionDetails(originalMatches []detector.Match, r
 				ipType = t
 			}
 		}
-		v.observer.DebugObserver.LogDetail("intellectualproperty",
+		v.observer.Debug().LogDetail("intellectualproperty",
 			fmt.Sprintf("    Match %d: '%s' (type: %s, confidence: %.1f%%, line: %d)",
 				i+1, match.Text, ipType, match.Confidence, match.LineNumber))
 	}
@@ -3099,30 +3099,30 @@ func (v *Validator) logReconstructionDetails(originalMatches []detector.Match, r
 
 // logLegalNoticeAnalysis logs the analysis decision for debugging
 func (v *Validator) logLegalNoticeAnalysis(matches []detector.Match, analysis LegalNoticeAnalysis) {
-	if v.observer == nil || v.observer.DebugObserver == nil {
+	if v.observer == nil || v.observer.Debug() == nil {
 		return
 	}
 
 	// Log basic analysis info
-	v.observer.DebugObserver.LogDetail("intellectualproperty",
+	v.observer.Debug().LogDetail("intellectualproperty",
 		fmt.Sprintf("Legal notice analysis for %d matches:", len(matches)))
 
 	// Log detailed proximity calculation
 	v.logProximityCalculationDetails(matches, analysis.ProximityScore)
 
-	v.observer.DebugObserver.LogDetail("intellectualproperty",
+	v.observer.Debug().LogDetail("intellectualproperty",
 		fmt.Sprintf("  Is Legal Notice: %v", analysis.IsLegalNotice))
 
-	v.observer.DebugObserver.LogDetail("intellectualproperty",
+	v.observer.Debug().LogDetail("intellectualproperty",
 		fmt.Sprintf("  Notice Type: %s", analysis.NoticeType))
 
-	v.observer.DebugObserver.LogDetail("intellectualproperty",
+	v.observer.Debug().LogDetail("intellectualproperty",
 		fmt.Sprintf("  Analysis Confidence: %.1f%%", analysis.Confidence))
 
-	v.observer.DebugObserver.LogDetail("intellectualproperty",
+	v.observer.Debug().LogDetail("intellectualproperty",
 		fmt.Sprintf("  Should Reconstruct: %v", analysis.ShouldReconstruct))
 
-	v.observer.DebugObserver.LogDetail("intellectualproperty",
+	v.observer.Debug().LogDetail("intellectualproperty",
 		fmt.Sprintf("  Reconstruction Reason: %s", analysis.ReconstructionReason))
 
 	// Log detailed semantic grouping analysis
@@ -3136,7 +3136,7 @@ func (v *Validator) logLegalNoticeAnalysis(matches []detector.Match, analysis Le
 				ipType = t
 			}
 		}
-		v.observer.DebugObserver.LogDetail("intellectualproperty",
+		v.observer.Debug().LogDetail("intellectualproperty",
 			fmt.Sprintf("  Match %d: '%s' (type: %s, line: %d, confidence: %.1f%%, position: %d)",
 				i+1, match.Text, ipType, match.LineNumber, match.Confidence, v.calculateCharacterPosition(match)))
 	}

--- a/internal/validators/ipaddress/validator.go
+++ b/internal/validators/ipaddress/validator.go
@@ -86,7 +86,7 @@ type Validator struct {
 	nonSensitiveNets []*net.IPNet
 
 	// Observability
-	observer *observability.StandardObserver
+	observer observability.Observer
 }
 
 // ipPattern represents an IP address pattern with its type info
@@ -237,7 +237,7 @@ func NewValidator() *Validator {
 }
 
 // SetObserver sets the observability component
-func (v *Validator) SetObserver(observer *observability.StandardObserver) {
+func (v *Validator) SetObserver(observer observability.Observer) {
 	v.observer = observer
 }
 
@@ -247,8 +247,8 @@ func (v *Validator) Validate(filePath string) ([]detector.Match, error) {
 	var finishStep func(bool, string)
 	if v.observer != nil {
 		finishTiming = v.observer.StartTiming("ipaddress_validator", "validate_file", filePath)
-		if v.observer.DebugObserver != nil {
-			finishStep = v.observer.DebugObserver.StartStep("ipaddress_validator", "validate_file", filePath)
+		if v.observer.Debug() != nil {
+			finishStep = v.observer.Debug().StartStep("ipaddress_validator", "validate_file", filePath)
 		}
 	}
 

--- a/internal/validators/metadata/metadata_validator.go
+++ b/internal/validators/metadata/metadata_validator.go
@@ -93,7 +93,7 @@ const (
 // Validator implements the detector.Validator and PreprocessorAwareValidator interfaces for metadata
 type Validator struct {
 	// Observability
-	observer *observability.StandardObserver
+	observer observability.Observer
 
 	// Preprocessor-aware validation rules
 	validationRules map[string]ValidationRule
@@ -119,15 +119,15 @@ func (v *Validator) ValidateMetadataContent(content router.MetadataContent) ([]d
 	var finishTiming func(bool, map[string]interface{})
 	if v.observer != nil {
 		finishTiming = v.observer.StartTiming("metadata_validator", "validate_metadata_content", content.SourceFile)
-		if v.observer.DebugObserver != nil {
-			v.observer.DebugObserver.LogDetail("metadata_validator",
+		if v.observer.Debug() != nil {
+			v.observer.Debug().LogDetail("metadata_validator",
 				fmt.Sprintf("Processing content from %s (type: %s), content length: %d",
 					content.SourceFile, content.PreprocessorType, len(content.Content)))
 			contentPreview := content.Content
 			if len(contentPreview) > 200 {
 				contentPreview = contentPreview[:200] + "..."
 			}
-			v.observer.DebugObserver.LogDetail("metadata_validator",
+			v.observer.Debug().LogDetail("metadata_validator",
 				fmt.Sprintf("Content preview: %s", contentPreview))
 		}
 	}
@@ -296,7 +296,7 @@ func (v *Validator) initializeDefaultValidationRules() {
 }
 
 // SetObserver sets the observability component
-func (v *Validator) SetObserver(observer *observability.StandardObserver) {
+func (v *Validator) SetObserver(observer observability.Observer) {
 	v.observer = observer
 }
 
@@ -306,8 +306,8 @@ func (v *Validator) Validate(filePath string) ([]detector.Match, error) {
 	var finishStep func(bool, string)
 	if v.observer != nil {
 		finishTiming = v.observer.StartTiming("metadata_validator", "validate_file", filePath)
-		if v.observer.DebugObserver != nil {
-			finishStep = v.observer.DebugObserver.StartStep("metadata_validator", "validate_file", filePath)
+		if v.observer.Debug() != nil {
+			finishStep = v.observer.Debug().StartStep("metadata_validator", "validate_file", filePath)
 		}
 	}
 

--- a/internal/validators/passport/validator.go
+++ b/internal/validators/passport/validator.go
@@ -91,7 +91,7 @@ type Validator struct {
 	globalTestPassports []string
 
 	// Observability
-	observer *observability.StandardObserver
+	observer observability.Observer
 }
 
 // NewValidator creates and returns a new Validator instance
@@ -217,7 +217,7 @@ func NewValidator() *Validator {
 }
 
 // SetObserver sets the observability component
-func (v *Validator) SetObserver(observer *observability.StandardObserver) {
+func (v *Validator) SetObserver(observer observability.Observer) {
 	v.observer = observer
 }
 
@@ -320,8 +320,8 @@ func (v *Validator) Validate(filePath string) ([]detector.Match, error) {
 	var finishStep func(bool, string)
 	if v.observer != nil {
 		finishTiming = v.observer.StartTiming("passport_validator", "validate_file", filePath)
-		if v.observer.DebugObserver != nil {
-			finishStep = v.observer.DebugObserver.StartStep("passport_validator", "validate_file", filePath)
+		if v.observer.Debug() != nil {
+			finishStep = v.observer.Debug().StartStep("passport_validator", "validate_file", filePath)
 		}
 	}
 

--- a/internal/validators/personname/validator.go
+++ b/internal/validators/personname/validator.go
@@ -50,7 +50,7 @@ type Validator struct {
 	negativeKeywords []string
 
 	// Performance monitoring
-	observer *observability.StandardObserver
+	observer observability.Observer
 
 	// Thread safety for lazy loading
 	once sync.Once

--- a/internal/validators/phone/validator.go
+++ b/internal/validators/phone/validator.go
@@ -63,7 +63,7 @@ type Validator struct {
 	sortedCountryCodes []string
 
 	// Observability
-	observer *observability.StandardObserver
+	observer observability.Observer
 }
 
 // phonePattern represents a phone number pattern with its format info
@@ -259,7 +259,7 @@ func NewValidator() *Validator {
 }
 
 // SetObserver sets the observability component
-func (v *Validator) SetObserver(observer *observability.StandardObserver) {
+func (v *Validator) SetObserver(observer observability.Observer) {
 	v.observer = observer
 }
 
@@ -269,8 +269,8 @@ func (v *Validator) Validate(filePath string) ([]detector.Match, error) {
 	var finishStep func(bool, string)
 	if v.observer != nil {
 		finishTiming = v.observer.StartTiming("phone_validator", "validate_file", filePath)
-		if v.observer.DebugObserver != nil {
-			finishStep = v.observer.DebugObserver.StartStep("phone_validator", "validate_file", filePath)
+		if v.observer.Debug() != nil {
+			finishStep = v.observer.Debug().StartStep("phone_validator", "validate_file", filePath)
 		}
 	}
 

--- a/internal/validators/secrets/validator.go
+++ b/internal/validators/secrets/validator.go
@@ -75,7 +75,7 @@ type Validator struct {
 	variablePatterns  []*regexp.Regexp
 
 	// Observability
-	observer *observability.StandardObserver
+	observer observability.Observer
 }
 
 // NewValidator creates a new secrets validator
@@ -166,7 +166,7 @@ func NewValidator() *Validator {
 }
 
 // SetObserver sets the observability component
-func (v *Validator) SetObserver(observer *observability.StandardObserver) {
+func (v *Validator) SetObserver(observer observability.Observer) {
 	v.observer = observer
 }
 
@@ -251,8 +251,8 @@ func (v *Validator) Validate(filePath string) ([]detector.Match, error) {
 	var finishStep func(bool, string)
 	if v.observer != nil {
 		finishTiming = v.observer.StartTiming("secrets_validator", "validate_file", filePath)
-		if v.observer.DebugObserver != nil {
-			finishStep = v.observer.DebugObserver.StartStep("secrets_validator", "validate_file", filePath)
+		if v.observer.Debug() != nil {
+			finishStep = v.observer.Debug().StartStep("secrets_validator", "validate_file", filePath)
 		}
 	}
 

--- a/internal/validators/socialmedia/validator.go
+++ b/internal/validators/socialmedia/validator.go
@@ -91,7 +91,7 @@ type Validator struct {
 	clusteringConfig SocialMediaClusteringConfig
 
 	// Observability
-	observer *observability.StandardObserver
+	observer observability.Observer
 }
 
 // SocialMediaClusteringAnalysis contains the results of analyzing whether multiple social media matches
@@ -278,7 +278,7 @@ func NewValidator() *Validator {
 }
 
 // SetObserver sets the observability component
-func (v *Validator) SetObserver(observer *observability.StandardObserver) {
+func (v *Validator) SetObserver(observer observability.Observer) {
 	v.observer = observer
 }
 
@@ -351,9 +351,9 @@ func (v *Validator) Configure(cfg *config.Config) {
 						// Validate regex pattern using regexp.Compile()
 						if _, err := regexp.Compile(processedPattern); err != nil {
 							// Log warning for invalid pattern but continue with valid ones
-							if v.observer != nil && v.observer.DebugObserver != nil {
-								v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Invalid %s pattern '%s': %v", platform, patternStr, err))
-								v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Skipping invalid regex pattern for %s: '%s' - Error: %v", platform, patternStr, err))
+							if v.observer != nil && v.observer.Debug() != nil {
+								v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Invalid %s pattern '%s': %v", platform, patternStr, err))
+								v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Skipping invalid regex pattern for %s: '%s' - Error: %v", platform, patternStr, err))
 							}
 
 							// Log invalid pattern in debug mode
@@ -375,16 +375,16 @@ func (v *Validator) Configure(cfg *config.Config) {
 				}
 
 				// Log platform-specific pattern validation results
-				if v.observer != nil && v.observer.DebugObserver != nil {
-					v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Platform %s pattern validation: %d valid, %d invalid patterns", platform, len(validPatterns), invalidCount))
+				if v.observer != nil && v.observer.Debug() != nil {
+					v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Platform %s pattern validation: %d valid, %d invalid patterns", platform, len(validPatterns), invalidCount))
 					if len(validPatterns) > 0 {
-						v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Successfully loaded %d patterns for platform %s", len(validPatterns), platform))
+						v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Successfully loaded %d patterns for platform %s", len(validPatterns), platform))
 						for i, pattern := range validPatterns {
-							v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("  %s pattern %d: %s", platform, i+1, pattern))
+							v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("  %s pattern %d: %s", platform, i+1, pattern))
 						}
 					}
 					if invalidCount > 0 {
-						v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Skipped %d invalid patterns for platform %s", invalidCount, platform))
+						v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Skipped %d invalid patterns for platform %s", invalidCount, platform))
 					}
 				}
 
@@ -399,13 +399,13 @@ func (v *Validator) Configure(cfg *config.Config) {
 		v.platformPatterns = validPlatforms
 
 		// Log overall pattern validation summary
-		if v.observer != nil && v.observer.DebugObserver != nil {
-			v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Social media pattern validation: %d total valid patterns across %d platforms, %d invalid patterns", totalPatterns, len(validPlatforms), totalInvalid))
+		if v.observer != nil && v.observer.Debug() != nil {
+			v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Social media pattern validation: %d total valid patterns across %d platforms, %d invalid patterns", totalPatterns, len(validPlatforms), totalInvalid))
 			if len(validPlatforms) > 0 {
-				v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Successfully loaded patterns for platforms: %v", v.getPlatformNames(validPlatforms)))
+				v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Successfully loaded patterns for platforms: %v", v.getPlatformNames(validPlatforms)))
 			}
 			if totalInvalid > 0 {
-				v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Skipped %d invalid social media patterns during configuration", totalInvalid))
+				v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Skipped %d invalid social media patterns during configuration", totalInvalid))
 			}
 		}
 
@@ -443,8 +443,8 @@ func (v *Validator) Configure(cfg *config.Config) {
 		}
 		if len(customKeywords) > 0 {
 			v.positiveKeywords = customKeywords
-			if v.observer != nil && v.observer.DebugObserver != nil {
-				v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Loaded %d custom positive keywords", len(customKeywords)))
+			if v.observer != nil && v.observer.Debug() != nil {
+				v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Loaded %d custom positive keywords", len(customKeywords)))
 			}
 		}
 	}
@@ -459,8 +459,8 @@ func (v *Validator) Configure(cfg *config.Config) {
 		}
 		if len(customKeywords) > 0 {
 			v.negativeKeywords = customKeywords
-			if v.observer != nil && v.observer.DebugObserver != nil {
-				v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Loaded %d custom negative keywords", len(customKeywords)))
+			if v.observer != nil && v.observer.Debug() != nil {
+				v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Loaded %d custom negative keywords", len(customKeywords)))
 			}
 		}
 	}
@@ -483,8 +483,8 @@ func (v *Validator) Configure(cfg *config.Config) {
 		}
 		if len(customPlatformKeywords) > 0 {
 			v.platformKeywords = customPlatformKeywords
-			if v.observer != nil && v.observer.DebugObserver != nil {
-				v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Loaded custom platform keywords for %d platforms", len(customPlatformKeywords)))
+			if v.observer != nil && v.observer.Debug() != nil {
+				v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Loaded custom platform keywords for %d platforms", len(customPlatformKeywords)))
 			}
 		}
 	}
@@ -503,8 +503,8 @@ func (v *Validator) Configure(cfg *config.Config) {
 				// Validate regex pattern
 				if _, err := regexp.Compile(processedPattern); err != nil {
 					// Log warning for invalid whitelist pattern but continue with valid ones
-					if v.observer != nil && v.observer.DebugObserver != nil {
-						v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Invalid whitelist pattern '%s': %v", patternStr, err))
+					if v.observer != nil && v.observer.Debug() != nil {
+						v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Invalid whitelist pattern '%s': %v", patternStr, err))
 					}
 
 					// Log invalid whitelist pattern in debug mode
@@ -522,10 +522,10 @@ func (v *Validator) Configure(cfg *config.Config) {
 		if len(validWhitelistPatterns) > 0 {
 			v.whitelistPatterns = customWhitelistPatterns
 			v.compileWhitelistPatterns()
-			if v.observer != nil && v.observer.DebugObserver != nil {
-				v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Loaded %d valid whitelist patterns (%d invalid patterns skipped)", len(validWhitelistPatterns), invalidCount))
+			if v.observer != nil && v.observer.Debug() != nil {
+				v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Loaded %d valid whitelist patterns (%d invalid patterns skipped)", len(validWhitelistPatterns), invalidCount))
 				for i, pattern := range customWhitelistPatterns {
-					v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("  Whitelist pattern %d: %s", i+1, pattern))
+					v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("  Whitelist pattern %d: %s", i+1, pattern))
 				}
 			}
 
@@ -535,8 +535,8 @@ func (v *Validator) Configure(cfg *config.Config) {
 			}
 		} else if invalidCount > 0 {
 			// All whitelist patterns were invalid
-			if v.observer != nil && v.observer.DebugObserver != nil {
-				v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("All %d configured whitelist patterns are invalid", invalidCount))
+			if v.observer != nil && v.observer.Debug() != nil {
+				v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("All %d configured whitelist patterns are invalid", invalidCount))
 			}
 		}
 	}
@@ -579,8 +579,8 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 	defer func() {
 		if r := recover(); r != nil {
 			// Log panic recovery for debugging
-			if v.observer != nil && v.observer.DebugObserver != nil {
-				v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Recovered from panic in ValidateContent for %s: %v", originalPath, r))
+			if v.observer != nil && v.observer.Debug() != nil {
+				v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Recovered from panic in ValidateContent for %s: %v", originalPath, r))
 			}
 			if os.Getenv("FERRET_DEBUG") == "1" {
 				fmt.Fprintf(os.Stderr, "[ERROR] Social Media: ValidateContent panic: %v\n", r)
@@ -591,8 +591,8 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 	// Memory management and monitoring for large files
 	contentLength := len(content)
 	if contentLength > 50*1024*1024 { // 50MB threshold
-		if v.observer != nil && v.observer.DebugObserver != nil {
-			v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Processing large file %s (%d MB) - enabling memory optimization", originalPath, contentLength/(1024*1024)))
+		if v.observer != nil && v.observer.Debug() != nil {
+			v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Processing large file %s (%d MB) - enabling memory optimization", originalPath, contentLength/(1024*1024)))
 		}
 		if os.Getenv("FERRET_DEBUG") == "1" {
 			fmt.Fprintf(os.Stderr, "[INFO] Social Media: Processing large file %d MB\n", contentLength/(1024*1024))
@@ -607,8 +607,8 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 
 	// Check if patterns are configured before processing
 	if !v.patternsConfigured || len(v.compiledPatterns) == 0 {
-		if v.observer != nil && v.observer.DebugObserver != nil {
-			v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("No social media patterns configured for %s - returning empty results", originalPath))
+		if v.observer != nil && v.observer.Debug() != nil {
+			v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("No social media patterns configured for %s - returning empty results", originalPath))
 		}
 		if finishTiming != nil {
 			finishTiming(true, map[string]any{"match_count": 0, "content_length": contentLength, "patterns_configured": false})
@@ -620,8 +620,8 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 	lineMatches, err := v.detectPatternsByLineWithErrorHandling(ctx, content, originalPath)
 	if err != nil {
 		// Log error but continue with empty results for graceful degradation
-		if v.observer != nil && v.observer.DebugObserver != nil {
-			v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Pattern detection failed for %s: %v", originalPath, err))
+		if v.observer != nil && v.observer.Debug() != nil {
+			v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Pattern detection failed for %s: %v", originalPath, err))
 		}
 		if os.Getenv("FERRET_DEBUG") == "1" {
 			fmt.Fprintf(os.Stderr, "[ERROR] Social Media: Pattern detection failed: %v\n", err)
@@ -636,8 +636,8 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 	processedMatches, err := v.processLineMatchesWithClusteringAndErrorHandling(lineMatches, originalPath)
 	if err != nil {
 		// Log error but return individual matches for graceful degradation
-		if v.observer != nil && v.observer.DebugObserver != nil {
-			v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Clustering failed for %s, using individual matches: %v", originalPath, err))
+		if v.observer != nil && v.observer.Debug() != nil {
+			v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Clustering failed for %s, using individual matches: %v", originalPath, err))
 		}
 		if os.Getenv("FERRET_DEBUG") == "1" {
 			fmt.Fprintf(os.Stderr, "[WARN] Social Media: Clustering failed: %v\n", err)
@@ -663,8 +663,8 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 	// Memory cleanup for large files
 	if contentLength > 50*1024*1024 {
 		// Force garbage collection for large files to free memory
-		if v.observer != nil && v.observer.DebugObserver != nil {
-			v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Completed processing large file %s - memory cleanup initiated", originalPath))
+		if v.observer != nil && v.observer.Debug() != nil {
+			v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Completed processing large file %s - memory cleanup initiated", originalPath))
 		}
 	}
 
@@ -684,8 +684,8 @@ func (v *Validator) detectPatternsByLineWithErrorHandling(ctx stdctx.Context, co
 	defer func() {
 		if r := recover(); r != nil {
 			// Log panic recovery for debugging
-			if v.observer != nil && v.observer.DebugObserver != nil {
-				v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Recovered from panic in detectPatternsByLine for %s: %v", originalPath, r))
+			if v.observer != nil && v.observer.Debug() != nil {
+				v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Recovered from panic in detectPatternsByLine for %s: %v", originalPath, r))
 			}
 			if os.Getenv("FERRET_DEBUG") == "1" {
 				fmt.Fprintf(os.Stderr, "[ERROR] Social Media: Pattern detection panic: %v\n", r)
@@ -695,16 +695,16 @@ func (v *Validator) detectPatternsByLineWithErrorHandling(ctx stdctx.Context, co
 
 	// Check for empty content
 	if len(content) == 0 {
-		if v.observer != nil && v.observer.DebugObserver != nil {
-			v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Empty content for %s - returning empty results", originalPath))
+		if v.observer != nil && v.observer.Debug() != nil {
+			v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Empty content for %s - returning empty results", originalPath))
 		}
 		return make(map[int][]detector.Match), nil
 	}
 
 	// Check if patterns are available
 	if len(v.compiledPatterns) == 0 {
-		if v.observer != nil && v.observer.DebugObserver != nil {
-			v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("No compiled patterns available for %s", originalPath))
+		if v.observer != nil && v.observer.Debug() != nil {
+			v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("No compiled patterns available for %s", originalPath))
 		}
 		return make(map[int][]detector.Match), nil
 	}
@@ -719,8 +719,8 @@ func (v *Validator) processLineMatchesWithClusteringAndErrorHandling(lineMatches
 	defer func() {
 		if r := recover(); r != nil {
 			// Log panic recovery for debugging
-			if v.observer != nil && v.observer.DebugObserver != nil {
-				v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Recovered from panic in clustering for %s: %v", originalPath, r))
+			if v.observer != nil && v.observer.Debug() != nil {
+				v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Recovered from panic in clustering for %s: %v", originalPath, r))
 			}
 			if os.Getenv("FERRET_DEBUG") == "1" {
 				fmt.Fprintf(os.Stderr, "[ERROR] Social Media: Clustering panic: %v\n", r)
@@ -730,8 +730,8 @@ func (v *Validator) processLineMatchesWithClusteringAndErrorHandling(lineMatches
 
 	// Check for empty line matches
 	if len(lineMatches) == 0 {
-		if v.observer != nil && v.observer.DebugObserver != nil {
-			v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("No line matches for clustering in %s", originalPath))
+		if v.observer != nil && v.observer.Debug() != nil {
+			v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("No line matches for clustering in %s", originalPath))
 		}
 		return []detector.Match{}, nil
 	}
@@ -766,8 +766,8 @@ func (v *Validator) processLineMatchesWithClustering(lineMatches map[int][]detec
 	// finding is reported, so above the cap we return matches individually.
 	// Real documents stay far below this bound, so behavior is unchanged there.
 	if len(allMatches) > maxClusterMatches {
-		if v.observer != nil && v.observer.DebugObserver != nil {
-			v.observer.DebugObserver.LogDetail("socialmedia",
+		if v.observer != nil && v.observer.Debug() != nil {
+			v.observer.Debug().LogDetail("socialmedia",
 				fmt.Sprintf("Skipping clustering for %s: %d matches exceeds cap %d; returning individual matches",
 					originalPath, len(allMatches), maxClusterMatches))
 		}
@@ -793,8 +793,8 @@ func (v *Validator) processLineMatchesWithClustering(lineMatches map[int][]detec
 				reconstructedMatch, err := v.reconstructSocialMediaClusterWithFallback(clusterGroup)
 				if err != nil {
 					// Fallback: add individual matches if reconstruction fails
-					if v.observer != nil && v.observer.DebugObserver != nil {
-						v.observer.DebugObserver.LogDetail("socialmedia",
+					if v.observer != nil && v.observer.Debug() != nil {
+						v.observer.Debug().LogDetail("socialmedia",
 							fmt.Sprintf("Social media cluster reconstruction failed, using individual matches: %v", err))
 					}
 					processedMatches = append(processedMatches, clusterGroup...)
@@ -822,8 +822,8 @@ func (v *Validator) CalculateConfidence(match string) (float64, map[string]bool)
 	defer func() {
 		if r := recover(); r != nil {
 			// Log panic recovery for debugging
-			if v.observer != nil && v.observer.DebugObserver != nil {
-				v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Recovered from panic in CalculateConfidence for match '%s': %v", match, r))
+			if v.observer != nil && v.observer.Debug() != nil {
+				v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Recovered from panic in CalculateConfidence for match '%s': %v", match, r))
 			}
 			if v.isDebugEnabled() {
 				fmt.Fprintf(os.Stderr, "[ERROR] Social Media Validator: Panic in confidence calculation\n")
@@ -836,8 +836,8 @@ func (v *Validator) CalculateConfidence(match string) (float64, map[string]bool)
 
 	// Input validation
 	if match == "" {
-		if v.observer != nil && v.observer.DebugObserver != nil {
-			v.observer.DebugObserver.LogDetail("socialmedia", "Empty match provided to CalculateConfidence")
+		if v.observer != nil && v.observer.Debug() != nil {
+			v.observer.Debug().LogDetail("socialmedia", "Empty match provided to CalculateConfidence")
 		}
 		checks["valid_input"] = false
 		return 0.0, checks
@@ -848,8 +848,8 @@ func (v *Validator) CalculateConfidence(match string) (float64, map[string]bool)
 	platform := v.identifyPlatform(match)
 	if platform == "" {
 		// Unknown platform - assign low confidence with enhanced logging
-		if v.observer != nil && v.observer.DebugObserver != nil {
-			v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Unknown platform for match: %s", match))
+		if v.observer != nil && v.observer.Debug() != nil {
+			v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Unknown platform for match: %s", match))
 		}
 		if v.isDebugEnabled() {
 			fmt.Fprintf(os.Stderr, "[DEBUG] Social Media Validator: Unknown platform for match: %s\n", match)
@@ -2153,9 +2153,9 @@ func (v *Validator) ensureCaseInsensitive(pattern string) string {
 // logConfigurationError logs configuration loading errors with comprehensive context
 func (v *Validator) logConfigurationError(errorType string, reason string) {
 	// Log through observability system if available
-	if v.observer != nil && v.observer.DebugObserver != nil {
-		v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Configuration error: %s - %s", errorType, reason))
-		v.observer.DebugObserver.LogDetail("socialmedia", "Social media detection is disabled due to configuration error")
+	if v.observer != nil && v.observer.Debug() != nil {
+		v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Configuration error: %s - %s", errorType, reason))
+		v.observer.Debug().LogDetail("socialmedia", "Social media detection is disabled due to configuration error")
 	}
 
 	// Also log to stderr in debug mode for comprehensive error tracking
@@ -2178,8 +2178,8 @@ func (v *Validator) logNoSocialMediaPatterns(reason string) {
 	message := "Social media detection disabled: " + reason + ". Configure 'validators.social_media.platform_patterns' to enable social media detection."
 
 	// Log to debug observer for detailed logging
-	if v.observer != nil && v.observer.DebugObserver != nil {
-		v.observer.DebugObserver.LogDetail("socialmedia", message)
+	if v.observer != nil && v.observer.Debug() != nil {
+		v.observer.Debug().LogDetail("socialmedia", message)
 	}
 
 	// Also log to stderr in debug mode for comprehensive audit trail
@@ -2191,7 +2191,7 @@ func (v *Validator) logNoSocialMediaPatterns(reason string) {
 	}
 
 	// Continue with existing detailed guidance logging
-	if v.observer != nil && v.observer.DebugObserver != nil {
+	if v.observer != nil && v.observer.Debug() != nil {
 
 		// Include configuration guidance in verbose mode warnings
 		guidance := "Example configuration:\n" +
@@ -2222,7 +2222,7 @@ func (v *Validator) logNoSocialMediaPatterns(reason string) {
 			"      - \"example\"\n" +
 			"      - \"test\"\n" +
 			"      - \"placeholder\""
-		v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Configuration guidance for social media patterns:\n%s", guidance))
+		v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Configuration guidance for social media patterns:\n%s", guidance))
 
 		// Also log configuration guidance to stderr in verbose/debug mode
 		if os.Getenv("FERRET_DEBUG") == "1" {
@@ -2276,8 +2276,8 @@ func (v *Validator) compilePlatformPatterns() {
 	// Handle empty pattern maps gracefully
 	if len(v.platformPatterns) == 0 {
 		v.compiledPatterns = make(map[string][]*regexp.Regexp)
-		if v.observer != nil && v.observer.DebugObserver != nil {
-			v.observer.DebugObserver.LogDetail("socialmedia", "No social media patterns to compile - empty pattern map")
+		if v.observer != nil && v.observer.Debug() != nil {
+			v.observer.Debug().LogDetail("socialmedia", "No social media patterns to compile - empty pattern map")
 		}
 		return
 	}
@@ -2306,8 +2306,8 @@ func (v *Validator) compilePlatformPatterns() {
 			if pattern == "" {
 				failedCount++
 				totalFailed++
-				if v.observer != nil && v.observer.DebugObserver != nil {
-					v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Skipping empty %s pattern at index %d", platform, i+1))
+				if v.observer != nil && v.observer.Debug() != nil {
+					v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Skipping empty %s pattern at index %d", platform, i+1))
 				}
 				continue
 			}
@@ -2332,11 +2332,11 @@ func (v *Validator) compilePlatformPatterns() {
 				totalFailed++
 
 				// Log compilation errors for debugging with enhanced context
-				if v.observer != nil && v.observer.DebugObserver != nil {
-					v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Failed to compile %s pattern %d: '%s' - Error: %v", platform, i+1, pattern, err))
+				if v.observer != nil && v.observer.Debug() != nil {
+					v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Failed to compile %s pattern %d: '%s' - Error: %v", platform, i+1, pattern, err))
 					// Provide additional context about the error type
 					if strings.Contains(err.Error(), "invalid") {
-						v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("%s pattern %d contains invalid regex syntax - check for unescaped special characters", platform, i+1))
+						v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("%s pattern %d contains invalid regex syntax - check for unescaped special characters", platform, i+1))
 					}
 				}
 
@@ -2372,10 +2372,10 @@ func (v *Validator) compilePlatformPatterns() {
 		}
 
 		// Log platform-specific compilation summary in debug mode
-		if v.observer != nil && v.observer.DebugObserver != nil {
-			v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Platform %s pattern compilation: %d successful, %d failed", platform, compiledCount, failedCount))
+		if v.observer != nil && v.observer.Debug() != nil {
+			v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Platform %s pattern compilation: %d successful, %d failed", platform, compiledCount, failedCount))
 			if compiledCount > 0 {
-				v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Successfully compiled %d regex patterns for platform %s", compiledCount, platform))
+				v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Successfully compiled %d regex patterns for platform %s", compiledCount, platform))
 			}
 		}
 
@@ -2389,10 +2389,10 @@ func (v *Validator) compilePlatformPatterns() {
 	}
 
 	// Log overall compilation summary in debug mode
-	if v.observer != nil && v.observer.DebugObserver != nil {
-		v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Social media pattern compilation complete: %d total successful, %d total failed across %d platforms", totalCompiled, totalFailed, len(v.compiledPatterns)))
+	if v.observer != nil && v.observer.Debug() != nil {
+		v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Social media pattern compilation complete: %d total successful, %d total failed across %d platforms", totalCompiled, totalFailed, len(v.compiledPatterns)))
 		if totalCompiled > 0 {
-			v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Successfully compiled patterns for platforms: %v", v.getPlatformNames(v.compiledPatterns)))
+			v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Successfully compiled patterns for platforms: %v", v.getPlatformNames(v.compiledPatterns)))
 		}
 	}
 
@@ -2409,8 +2409,8 @@ func (v *Validator) compilePlatformPatterns() {
 	}
 
 	// Log performance metrics for pattern compilation
-	if v.observer != nil && v.observer.DebugObserver != nil {
-		v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Pattern compilation performance: %d cache hits, %d new compilations", cacheHits, totalCompiled-cacheHits))
+	if v.observer != nil && v.observer.Debug() != nil {
+		v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Pattern compilation performance: %d cache hits, %d new compilations", cacheHits, totalCompiled-cacheHits))
 	}
 
 	// If all patterns failed to compile, log a warning
@@ -2424,15 +2424,15 @@ func (v *Validator) compileOptimizedPattern(pattern string) (*regexp.Regexp, err
 	// Pre-validate pattern for common issues to fail fast
 	if strings.Contains(pattern, "(?P<") {
 		// Named capture groups can be slower - warn but allow
-		if v.observer != nil && v.observer.DebugObserver != nil {
-			v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Pattern contains named capture group which may impact performance: %s", pattern))
+		if v.observer != nil && v.observer.Debug() != nil {
+			v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Pattern contains named capture group which may impact performance: %s", pattern))
 		}
 	}
 
 	// Check for potentially expensive patterns
 	if strings.Contains(pattern, ".*.*") || strings.Contains(pattern, ".+.+") {
-		if v.observer != nil && v.observer.DebugObserver != nil {
-			v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Pattern contains potentially expensive nested quantifiers: %s", pattern))
+		if v.observer != nil && v.observer.Debug() != nil {
+			v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Pattern contains potentially expensive nested quantifiers: %s", pattern))
 		}
 	}
 
@@ -2453,12 +2453,12 @@ func (v *Validator) monitorMemoryUsage(operation string, metadata map[string]any
 	// In a production environment, this could integrate with runtime.MemStats
 	// or other memory profiling tools
 
-	if v.observer != nil && v.observer.DebugObserver != nil {
-		v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Memory monitoring: %s", operation))
+	if v.observer != nil && v.observer.Debug() != nil {
+		v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Memory monitoring: %s", operation))
 
 		// Log metadata if provided
 		for key, value := range metadata {
-			v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("  %s: %v", key, value))
+			v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("  %s: %v", key, value))
 		}
 	}
 }
@@ -2469,8 +2469,8 @@ func (v *Validator) compileWhitelistPatterns() {
 	// Handle empty whitelist patterns gracefully
 	if len(v.whitelistPatterns) == 0 {
 		v.compiledWhitelistPatterns = []*regexp.Regexp{}
-		if v.observer != nil && v.observer.DebugObserver != nil {
-			v.observer.DebugObserver.LogDetail("socialmedia", "No whitelist patterns to compile - empty pattern list")
+		if v.observer != nil && v.observer.Debug() != nil {
+			v.observer.Debug().LogDetail("socialmedia", "No whitelist patterns to compile - empty pattern list")
 		}
 		return
 	}
@@ -2484,8 +2484,8 @@ func (v *Validator) compileWhitelistPatterns() {
 		// Skip empty patterns gracefully
 		if pattern == "" {
 			failedCount++
-			if v.observer != nil && v.observer.DebugObserver != nil {
-				v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Skipping empty whitelist pattern at index %d", i+1))
+			if v.observer != nil && v.observer.Debug() != nil {
+				v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Skipping empty whitelist pattern at index %d", i+1))
 			}
 			if os.Getenv("FERRET_DEBUG") == "1" {
 				fmt.Fprintf(os.Stderr, "[WARNING] Social Media Validator: Empty whitelist pattern at index %d - skipping\n", i+1)
@@ -2503,8 +2503,8 @@ func (v *Validator) compileWhitelistPatterns() {
 			failedCount++
 
 			// Log compilation errors for debugging
-			if v.observer != nil && v.observer.DebugObserver != nil {
-				v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Failed to compile whitelist pattern %d: '%s' - Error: %v", i+1, pattern, err))
+			if v.observer != nil && v.observer.Debug() != nil {
+				v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Failed to compile whitelist pattern %d: '%s' - Error: %v", i+1, pattern, err))
 			}
 
 			// Also log to stderr in debug mode
@@ -2523,10 +2523,10 @@ func (v *Validator) compileWhitelistPatterns() {
 	}
 
 	// Log compilation summary
-	if v.observer != nil && v.observer.DebugObserver != nil {
-		v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Whitelist pattern compilation: %d successful, %d failed", compiledCount, failedCount))
+	if v.observer != nil && v.observer.Debug() != nil {
+		v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Whitelist pattern compilation: %d successful, %d failed", compiledCount, failedCount))
 		if compiledCount > 0 {
-			v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Successfully compiled %d whitelist regex patterns", compiledCount))
+			v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Successfully compiled %d whitelist regex patterns", compiledCount))
 		}
 	}
 
@@ -2546,8 +2546,8 @@ func (v *Validator) detectPatternsByLine(ctx stdctx.Context, content string, ori
 
 	// If no patterns are configured, return empty results
 	if len(v.compiledPatterns) == 0 {
-		if v.observer != nil && v.observer.DebugObserver != nil {
-			v.observer.DebugObserver.LogDetail("socialmedia", "No compiled patterns available for social media detection")
+		if v.observer != nil && v.observer.Debug() != nil {
+			v.observer.Debug().LogDetail("socialmedia", "No compiled patterns available for social media detection")
 		}
 		return lineMatches
 	}
@@ -2621,9 +2621,9 @@ func (v *Validator) detectPatternsByLineBatch(ctx stdctx.Context, content string
 		}
 
 		// Log progress for very large files
-		if v.observer != nil && v.observer.DebugObserver != nil && len(lines) > 10000 {
+		if v.observer != nil && v.observer.Debug() != nil && len(lines) > 10000 {
 			progress := float64(end) / float64(len(lines)) * 100
-			v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Batch processing progress: %.1f%% (%d/%d lines)", progress, end, len(lines)))
+			v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Batch processing progress: %.1f%% (%d/%d lines)", progress, end, len(lines)))
 		}
 	}
 
@@ -2804,8 +2804,8 @@ func (v *Validator) processMatchOptimized(match, platform string, patternIndex i
 	}
 
 	// Log match details in debug mode (only for high-confidence matches to reduce overhead)
-	if os.Getenv("FERRET_DEBUG") == "1" && confidence > 70 && v.observer != nil && v.observer.DebugObserver != nil {
-		v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Found %s match: '%s' (confidence: %.1f%%, type: %s, username: %s)", platform, match, confidence, patternType, username))
+	if os.Getenv("FERRET_DEBUG") == "1" && confidence > 70 && v.observer != nil && v.observer.Debug() != nil {
+		v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Found %s match: '%s' (confidence: %.1f%%, type: %s, username: %s)", platform, match, confidence, patternType, username))
 	}
 
 	return &socialMediaMatch
@@ -2929,16 +2929,16 @@ func (v *Validator) analyzeContextWithPlatformLine(match string, platform string
 	}
 
 	// Log detailed context analysis in debug mode
-	if v.observer != nil && v.observer.DebugObserver != nil {
-		v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("Context analysis for %s match '%s': impact=%.1f", platform, match, confidenceImpact))
+	if v.observer != nil && v.observer.Debug() != nil {
+		v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Context analysis for %s match '%s': impact=%.1f", platform, match, confidenceImpact))
 		if len(foundPositiveKeywords) > 0 {
-			v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("  Positive keywords found: %v", foundPositiveKeywords))
+			v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("  Positive keywords found: %v", foundPositiveKeywords))
 		}
 		if len(foundPlatformKeywords) > 0 {
-			v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("  Platform keywords found: %v", foundPlatformKeywords))
+			v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("  Platform keywords found: %v", foundPlatformKeywords))
 		}
 		if len(foundNegativeKeywords) > 0 {
-			v.observer.DebugObserver.LogDetail("socialmedia", fmt.Sprintf("  Negative keywords found: %v", foundNegativeKeywords))
+			v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("  Negative keywords found: %v", foundNegativeKeywords))
 		}
 	}
 
@@ -4005,8 +4005,8 @@ func (v *Validator) analyzeSocialMediaClusteringContext(matches []detector.Match
 	defer func() {
 		if r := recover(); r != nil {
 			// Log panic recovery and provide safe fallback
-			if v.observer != nil && v.observer.DebugObserver != nil {
-				v.observer.DebugObserver.LogDetail("socialmedia",
+			if v.observer != nil && v.observer.Debug() != nil {
+				v.observer.Debug().LogDetail("socialmedia",
 					fmt.Sprintf("Recovered from panic during social media clustering analysis: %v", r))
 			}
 
@@ -4042,7 +4042,7 @@ func (v *Validator) analyzeSocialMediaClusteringContext(matches []detector.Match
 	analysis.ShouldReconstruct, analysis.ReconstructionReason = v.makeClusteringDecision(analysis)
 
 	// Log the analysis decision in debug mode
-	if v.observer != nil && v.observer.DebugObserver != nil {
+	if v.observer != nil && v.observer.Debug() != nil {
 		v.logClusteringAnalysis(matches, analysis)
 	}
 
@@ -4326,8 +4326,8 @@ func (v *Validator) reconstructSocialMediaClusterWithFallback(matches []detector
 	reconstructed, err := v.reconstructSocialMediaCluster(matches)
 	if err != nil {
 		// Log the error and return it for fallback handling
-		if v.observer != nil && v.observer.DebugObserver != nil {
-			v.observer.DebugObserver.LogDetail("socialmedia",
+		if v.observer != nil && v.observer.Debug() != nil {
+			v.observer.Debug().LogDetail("socialmedia",
 				fmt.Sprintf("Social media cluster reconstruction failed: %v", err))
 		}
 		return detector.Match{}, err
@@ -4335,8 +4335,8 @@ func (v *Validator) reconstructSocialMediaClusterWithFallback(matches []detector
 
 	// Validate the reconstructed match
 	if err := v.validateReconstructedCluster(reconstructed, matches); err != nil {
-		if v.observer != nil && v.observer.DebugObserver != nil {
-			v.observer.DebugObserver.LogDetail("socialmedia",
+		if v.observer != nil && v.observer.Debug() != nil {
+			v.observer.Debug().LogDetail("socialmedia",
 				fmt.Sprintf("Reconstructed cluster validation failed: %v", err))
 		}
 		return detector.Match{}, err
@@ -4567,33 +4567,33 @@ func (v *Validator) validateReconstructedCluster(reconstructed detector.Match, o
 
 // logClusteringAnalysis logs detailed clustering analysis information
 func (v *Validator) logClusteringAnalysis(matches []detector.Match, analysis SocialMediaClusteringAnalysis) {
-	if v.observer == nil || v.observer.DebugObserver == nil {
+	if v.observer == nil || v.observer.Debug() == nil {
 		return
 	}
 
-	v.observer.DebugObserver.LogDetail("socialmedia",
+	v.observer.Debug().LogDetail("socialmedia",
 		fmt.Sprintf("Social media clustering analysis for %d matches:", len(matches)))
-	v.observer.DebugObserver.LogDetail("socialmedia",
+	v.observer.Debug().LogDetail("socialmedia",
 		fmt.Sprintf("  Cluster Type: %s", analysis.ClusterType))
-	v.observer.DebugObserver.LogDetail("socialmedia",
+	v.observer.Debug().LogDetail("socialmedia",
 		fmt.Sprintf("  Is Profile Cluster: %t", analysis.IsProfileCluster))
-	v.observer.DebugObserver.LogDetail("socialmedia",
+	v.observer.Debug().LogDetail("socialmedia",
 		fmt.Sprintf("  Confidence: %.2f", analysis.Confidence))
-	v.observer.DebugObserver.LogDetail("socialmedia",
+	v.observer.Debug().LogDetail("socialmedia",
 		fmt.Sprintf("  Proximity Score: %.2f", analysis.ProximityScore))
-	v.observer.DebugObserver.LogDetail("socialmedia",
+	v.observer.Debug().LogDetail("socialmedia",
 		fmt.Sprintf("  Platforms: %v", analysis.PlatformGrouping))
-	v.observer.DebugObserver.LogDetail("socialmedia",
+	v.observer.Debug().LogDetail("socialmedia",
 		fmt.Sprintf("  User Identifiers: %v", analysis.UserIdentifiers))
-	v.observer.DebugObserver.LogDetail("socialmedia",
+	v.observer.Debug().LogDetail("socialmedia",
 		fmt.Sprintf("  Should Reconstruct: %t", analysis.ShouldReconstruct))
-	v.observer.DebugObserver.LogDetail("socialmedia",
+	v.observer.Debug().LogDetail("socialmedia",
 		fmt.Sprintf("  Reconstruction Reason: %s", analysis.ReconstructionReason))
 
 	// Log clustering factors
-	v.observer.DebugObserver.LogDetail("socialmedia", "  Clustering Factors:")
+	v.observer.Debug().LogDetail("socialmedia", "  Clustering Factors:")
 	for factor, score := range analysis.ClusteringFactors {
-		v.observer.DebugObserver.LogDetail("socialmedia",
+		v.observer.Debug().LogDetail("socialmedia",
 			fmt.Sprintf("    %s: %.2f", factor, score))
 	}
 }
@@ -4679,8 +4679,8 @@ func (v *Validator) isPartOfEmailAddress(match, line string) bool {
 	// If we find a complete email address that contains our match, it's a false positive
 	if emailRegex.MatchString(line) {
 		// Log the filtering for debugging
-		if v.observer != nil && v.observer.DebugObserver != nil {
-			v.observer.DebugObserver.LogDetail("socialmedia",
+		if v.observer != nil && v.observer.Debug() != nil {
+			v.observer.Debug().LogDetail("socialmedia",
 				fmt.Sprintf("Filtered social media false positive: '%s' is part of email address in line: %s",
 					match, line))
 		}
@@ -4713,8 +4713,8 @@ func (v *Validator) isFalsePositiveHandle(match, line string, matchOffset int) b
 	usernameLower := strings.ToLower(username)
 	for _, pattern := range docPatterns {
 		if usernameLower == pattern {
-			if v.observer != nil && v.observer.DebugObserver != nil {
-				v.observer.DebugObserver.LogDetail("socialmedia",
+			if v.observer != nil && v.observer.Debug() != nil {
+				v.observer.Debug().LogDetail("socialmedia",
 					fmt.Sprintf("Filtered documentation annotation: '%s' in line: %s", match, line))
 			}
 			return true
@@ -4723,8 +4723,8 @@ func (v *Validator) isFalsePositiveHandle(match, line string, matchOffset int) b
 
 	// Code comment context (// @something or /* @something)
 	if strings.Contains(lineLower, "//") || strings.Contains(lineLower, "/*") || strings.Contains(lineLower, "*/") {
-		if v.observer != nil && v.observer.DebugObserver != nil {
-			v.observer.DebugObserver.LogDetail("socialmedia",
+		if v.observer != nil && v.observer.Debug() != nil {
+			v.observer.Debug().LogDetail("socialmedia",
 				fmt.Sprintf("Filtered code comment annotation: '%s' in line: %s", match, line))
 		}
 		return true
@@ -4733,8 +4733,8 @@ func (v *Validator) isFalsePositiveHandle(match, line string, matchOffset int) b
 	// Invalid Twitter handle patterns
 	// Twitter handles cannot start with numbers, underscores, or be too short
 	if len(username) < 2 || strings.HasPrefix(username, "_") || regexp.MustCompile(`^\d`).MatchString(username) {
-		if v.observer != nil && v.observer.DebugObserver != nil {
-			v.observer.DebugObserver.LogDetail("socialmedia",
+		if v.observer != nil && v.observer.Debug() != nil {
+			v.observer.Debug().LogDetail("socialmedia",
 				fmt.Sprintf("Filtered invalid handle format: '%s' in line: %s", match, line))
 		}
 		return true
@@ -4746,8 +4746,8 @@ func (v *Validator) isFalsePositiveHandle(match, line string, matchOffset int) b
 	if matchIndex >= 0 && matchIndex+len(match) < len(line) {
 		nextChar := line[matchIndex+len(match)]
 		if nextChar == '-' || nextChar == '.' {
-			if v.observer != nil && v.observer.DebugObserver != nil {
-				v.observer.DebugObserver.LogDetail("socialmedia",
+			if v.observer != nil && v.observer.Debug() != nil {
+				v.observer.Debug().LogDetail("socialmedia",
 					fmt.Sprintf("Filtered partial domain match: '%s' in line: %s", match, line))
 			}
 			return true

--- a/internal/validators/ssn/validator.go
+++ b/internal/validators/ssn/validator.go
@@ -98,7 +98,7 @@ type Validator struct {
 	globalTestPatterns []string
 
 	// Observability
-	observer *observability.StandardObserver
+	observer observability.Observer
 }
 
 // NewValidator creates and returns a new Validator instance
@@ -163,7 +163,7 @@ func NewValidator() *Validator {
 }
 
 // SetObserver sets the observability component
-func (v *Validator) SetObserver(observer *observability.StandardObserver) {
+func (v *Validator) SetObserver(observer observability.Observer) {
 	v.observer = observer
 }
 
@@ -173,8 +173,8 @@ func (v *Validator) Validate(filePath string) ([]detector.Match, error) {
 	var finishStep func(bool, string)
 	if v.observer != nil {
 		finishTiming = v.observer.StartTiming("ssn_validator", "validate_file", filePath)
-		if v.observer.DebugObserver != nil {
-			finishStep = v.observer.DebugObserver.StartStep("ssn_validator", "validate_file", filePath)
+		if v.observer.Debug() != nil {
+			finishStep = v.observer.Debug().StartStep("ssn_validator", "validate_file", filePath)
 		}
 	}
 

--- a/internal/validators/vin/validator.go
+++ b/internal/validators/vin/validator.go
@@ -102,7 +102,7 @@ type Validator struct {
 
 	testPatterns []string
 
-	observer *observability.StandardObserver
+	observer observability.Observer
 }
 
 // NewValidator creates and returns a new VIN Validator instance.
@@ -153,7 +153,7 @@ func NewValidator() *Validator {
 }
 
 // SetObserver sets the observability component.
-func (v *Validator) SetObserver(observer *observability.StandardObserver) {
+func (v *Validator) SetObserver(observer observability.Observer) {
 	v.observer = observer
 }
 
@@ -163,8 +163,8 @@ func (v *Validator) Validate(filePath string) ([]detector.Match, error) {
 	var finishStep func(bool, string)
 	if v.observer != nil {
 		finishTiming = v.observer.StartTiming("vin_validator", "validate_file", filePath)
-		if v.observer.DebugObserver != nil {
-			finishStep = v.observer.DebugObserver.StartStep("vin_validator", "validate_file", filePath)
+		if v.observer.Debug() != nil {
+			finishStep = v.observer.Debug().StartStep("vin_validator", "validate_file", filePath)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Gap **6.2** of the v2 architecture consolidation: the telemetry layer was hard-wired. Every component held the concrete `*observability.StandardObserver` — threaded through ~43 signatures (`SetObserver`, constructors, `GetObserver`) and 36 struct fields — and reached the debug logger through the exported `DebugObserver` **field** at 353 call sites. That made the single telemetry implementation impossible to swap or fake in tests.

This introduces a proper interface seam.

## What changed

- **New `observability.Observer` interface** (`StartTiming`, `LogOperation`, `Debug`) + a nil-safe `Debug() *DebugObserver` accessor on `*StandardObserver` that replaces direct `.DebugObserver` field reads. A compile-time `var _ Observer = (*StandardObserver)(nil)` locks the implementation.
- **Holders now depend on `Observer`, not the concrete type** — swapped across `preprocessors`, all `validators`, `redactors`, `router`, `parallel`, `core` (fields, params, returns).
- **Construction sites stay concrete** (`cmd/main.go`, `core/scanner.go`): they build a `*StandardObserver` and write its `DebugObserver` field during wiring, exactly as before — only the *holders* became the interface.
- The anonymous `SetObserver` type-assertion in `cmd/main.go` was updated to the `Observer`-typed method, so observers still attach (a silent-detach risk the compiler wouldn't catch).

## Why it's behavior-preserving

The only nil observer ever supplied is an **untyped** nil (`passport SetObserver(nil)` test), so the interface field's `== nil` guards behave identically to the former pointer-nil guards — no typed-nil trap. No type switches or reflection touch the observer type.

## Verification

- **Golden regression net byte-identical** (no `UPDATE_GOLDEN`) ✅
- `go build` / `go vet` / `gofmt -l` clean ✅
- Full `go test ./...` (40 pkgs) ✅  •  `-race` on validators/parallel/core/router ✅
- **Debug-mode A/B vs `origin/main`:** `--debug` stderr is byte-identical once pre-existing map-iteration ordering is normalized (the baseline binary was shown to vary run-to-run on its own), proving all 353 `Debug()` read-site swaps preserved every debug log call. `stdout`/JSON identical.

No public/exported behavior change; `pkg/redact` surface untouched.