### PR TITLE
fix(redact): route all credit-card brands through card redaction

### DIFF
--- a/internal/redactors/replacement/creditcard_test.go
+++ b/internal/redactors/replacement/creditcard_test.go
@@ -1,0 +1,90 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package replacement
+
+import (
+	"strings"
+	"testing"
+)
+
+// These tests lock in that EVERY credit-card finding type the validator can
+// emit routes to credit-card redaction across all three strategies. Before
+// this was centralised, the Simple/FormatPreserving/Synthetic switches listed
+// only VISA/MASTERCARD/AMERICAN_EXPRESS/DISCOVER, so the other brands the
+// validator emits (MAESTRO, JCB, DINERS_CLUB, UNIONPAY) were handled
+// inconsistently — Simple would leak the brand as "[JCB-REDACTED]" and
+// FormatPreserving/Synthetic would fall through to the generic branches.
+
+// allCardTypes is every finding type getCreditCardType (in
+// internal/validators/creditcard) can return. Keep in sync with it and with
+// the creditCardTypes map.
+var allCardTypes = []string{
+	"CREDIT_CARD", "VISA", "MASTERCARD", "MAESTRO", "AMERICAN_EXPRESS",
+	"JCB", "DINERS_CLUB", "DISCOVER", "UNIONPAY",
+}
+
+func TestCreditCard_AllTypesRecognised(t *testing.T) {
+	for _, ct := range allCardTypes {
+		if !isCreditCardType(ct) {
+			t.Errorf("isCreditCardType(%q) = false, want true — this brand would "+
+				"fall through to the generic redaction branch", ct)
+		}
+	}
+}
+
+// TestCreditCard_SimpleIsGenericPlaceholder confirms every brand collapses to
+// the same brand-free placeholder under the Simple strategy (no "[JCB-REDACTED]").
+func TestCreditCard_SimpleIsGenericPlaceholder(t *testing.T) {
+	const want = "[CREDIT-CARD-REDACTED]"
+	for _, ct := range allCardTypes {
+		if got := Simple(ct); got != want {
+			t.Errorf("Simple(%q) = %q, want %q", ct, got, want)
+		}
+	}
+}
+
+// TestCreditCard_FormatPreservingConsistentAcrossBrands confirms every brand
+// gets the same credit-card format-preserving mask (first-4 + last-4 visible,
+// middle masked, structure preserved) rather than the generic full mask.
+func TestCreditCard_FormatPreservingConsistentAcrossBrands(t *testing.T) {
+	const card = "4532-0151-1283-0366"
+	want := FormatPreserving(card, "CREDIT_CARD")
+	// Sanity: the generic CC mask keeps first-4 and last-4 and masks the middle.
+	if !strings.HasPrefix(want, "4532") || !strings.HasSuffix(want, "0366") || !strings.Contains(want, "*") {
+		t.Fatalf("unexpected baseline CC mask %q", want)
+	}
+	for _, ct := range allCardTypes {
+		if got := FormatPreserving(card, ct); got != want {
+			t.Errorf("FormatPreserving(card, %q) = %q, want %q (brand should use "+
+				"the same CC mask as CREDIT_CARD)", ct, got, want)
+		}
+	}
+}
+
+// TestCreditCard_SyntheticConsistentAcrossBrands confirms every brand routes to
+// the synthetic credit-card generator (a Luhn-valid fake), not the generic
+// random-string fallback. We can't assert the exact value (it's random), so we
+// assert structural properties the generic fallback would not satisfy.
+func TestCreditCard_SyntheticConsistentAcrossBrands(t *testing.T) {
+	const card = "4532015112830366"
+	for _, ct := range allCardTypes {
+		got, err := Synthetic(card, ct)
+		if err != nil {
+			t.Errorf("Synthetic(card, %q) error: %v", ct, err)
+			continue
+		}
+		// syntheticCreditCard preserves length and emits only digits;
+		// the generic randomString fallback emits mixed alphanumerics.
+		if len(got) != len(card) {
+			t.Errorf("Synthetic(card, %q) length = %d, want %d", ct, len(got), len(card))
+		}
+		for _, r := range got {
+			if r < '0' || r > '9' {
+				t.Errorf("Synthetic(card, %q) = %q contains non-digit %q — did not route "+
+					"to the credit-card generator", ct, got, string(r))
+				break
+			}
+		}
+	}
+}

--- a/internal/redactors/replacement/replacement.go
+++ b/internal/redactors/replacement/replacement.go
@@ -76,11 +76,40 @@ func Generate(originalText, dataType string, strategy redactors.RedactionStrateg
 
 // ─── Simple ──────────────────────────────────────────────────────────────────
 
+// creditCardTypes is the set of finding types the credit-card validator can
+// emit: the generic "CREDIT_CARD" plus every brand-specific sub-type
+// getCreditCardType can return. All of them must route to credit-card
+// redaction so that (a) a brand name never leaks through the Simple
+// placeholder (e.g. "[JCB-REDACTED]") and (b) every brand gets the same
+// format-preserving credit-card mask instead of falling through to the
+// generic full-mask branch. Previously only VISA/MASTERCARD/AMERICAN_EXPRESS/
+// DISCOVER were listed, so MAESTRO/JCB/DINERS_CLUB/UNIONPAY were handled
+// inconsistently. Keep this list in sync with getCreditCardType in
+// internal/validators/creditcard.
+var creditCardTypes = map[string]bool{
+	"CREDIT_CARD":      true,
+	"VISA":             true,
+	"MASTERCARD":       true,
+	"MAESTRO":          true,
+	"AMERICAN_EXPRESS": true,
+	"JCB":              true,
+	"DINERS_CLUB":      true,
+	"DISCOVER":         true,
+	"UNIONPAY":         true,
+}
+
+// isCreditCardType reports whether dataType is a credit-card finding type
+// (generic or any brand sub-type).
+func isCreditCardType(dataType string) bool {
+	return creditCardTypes[dataType]
+}
+
 // Simple returns a bracketed placeholder for the given data type.
 func Simple(dataType string) string {
-	switch dataType {
-	case "CREDIT_CARD", "VISA", "MASTERCARD", "AMERICAN_EXPRESS", "DISCOVER":
+	if isCreditCardType(dataType) {
 		return "[CREDIT-CARD-REDACTED]"
+	}
+	switch dataType {
 	case "SSN":
 		return "[SSN-REDACTED]"
 	case "EMAIL", "GMAIL", "BUSINESS":
@@ -105,9 +134,10 @@ func Simple(dataType string) string {
 // FormatPreserving returns a replacement that keeps the original structure
 // (separators, length, character types) while masking the sensitive content.
 func FormatPreserving(original, dataType string) string {
-	switch dataType {
-	case "CREDIT_CARD", "VISA", "MASTERCARD", "AMERICAN_EXPRESS", "DISCOVER":
+	if isCreditCardType(dataType) {
 		return preserveCreditCard(original)
+	}
+	switch dataType {
 	case "SSN":
 		return preserveSSN(original)
 	case "EMAIL", "GMAIL", "BUSINESS":
@@ -207,9 +237,10 @@ func preserveIP(original string) string {
 
 // Synthetic generates realistic-looking but fake data of the same type.
 func Synthetic(original, dataType string) (string, error) {
-	switch dataType {
-	case "CREDIT_CARD", "VISA", "MASTERCARD", "AMERICAN_EXPRESS", "DISCOVER":
+	if isCreditCardType(dataType) {
 		return syntheticCreditCard(original)
+	}
+	switch dataType {
 	case "SSN":
 		return syntheticSSN(original)
 	case "EMAIL", "GMAIL", "BUSINESS":


### PR DESCRIPTION
## Problem

`getCreditCardType` (in `internal/validators/creditcard`) emits **nine** finding types:

```
CREDIT_CARD, VISA, MASTERCARD, MAESTRO, AMERICAN_EXPRESS, JCB, DINERS_CLUB, DISCOVER, UNIONPAY
```

But the replacement switches in `internal/redactors/replacement/replacement.go` (`Simple`, `FormatPreserving`, `Synthetic`) each listed only **four** — `VISA`, `MASTERCARD`, `AMERICAN_EXPRESS`, `DISCOVER`. The other brands were handled inconsistently:

- **`simple`**: leaked the brand as the placeholder — e.g. `[JCB-REDACTED]` instead of `[CREDIT-CARD-REDACTED]`.
- **`format_preserving`** / **`synthetic`**: fell through to the generic branches (full asterisk mask / random string) instead of credit-card redaction, so a Maestro/JCB/Diners/UnionPay card didn't get the same treatment as a Visa.

## Fix

Centralise the brand set into a single `creditCardTypes` map + `isCreditCardType()` helper, used by all three strategy switches. Every brand now redacts identically. Keeping the list in one place (next to a comment pointing at `getCreditCardType`) prevents the three switches from drifting apart again.

Added `creditcard_test.go` asserting all nine types route consistently:
- recognised by `isCreditCardType`
- `simple` → the same brand-free `[CREDIT-CARD-REDACTED]` placeholder
- `format_preserving` → the same card mask as `CREDIT_CARD`
- `synthetic` → the credit-card generator (digits, length-preserved), not the generic random-string fallback

## Scope

**No change to the masking format itself** — recognised brands still mask to first-four + last-four under `format_preserving` (PCI-DSS 3.4.1 permits up to BIN + last-four). The golden corpus is unchanged and passes without regeneration, confirming observable behavior is unchanged except for the previously-inconsistent brands.

## Verification

- `go vet ./...`, `go build ./...` — clean
- `go test -race` (excl. `tests/integration`) — **40 packages, 0 failures**
- Golden corpus: **0 changes**, passes without `UPDATE_GOLDEN`
- End-to-end: JCB/Diners now mask like Visa; `simple` emits no `[JCB-REDACTED]`

> Note: branched from `main` (pre-`/v2`). If #135 (module path → `/v2`) merges first, this needs a trivial rebase to pick up the `/v2` import path in `replacement.go` — no logical conflict.