### PR TITLE
fix(redact): mask credit-card BIN in format-preserving output; use white-bg centered logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # ferret-scan
 
-<img src="docs/images/ferret-scan-logo.png" alt="ferret-scan" width="240" />
+<p align="center">
+  <img src="docs/images/ferret-scan-logo-original.png" alt="ferret-scan" width="240" />
+</p>
 
 **Find and redact sensitive data before it leaks.** A single-binary Go CLI (plus embedded web UI and Go library) that detects PII, secrets, and IP markers in your files and streams — then redacts them in place, format-preserving, with context-aware confidence scoring. No runtime dependencies. No data leaves your host.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -964,7 +964,7 @@ redaction:
 | Strategy | What it produces | Best for |
 |----------|-----------------|----------|
 | `simple` | `[CREDIT-CARD-REDACTED]` | External sharing, maximum security |
-| `format_preserving` | `4916****2832`, `j***@acme.com` | Downstream format validation |
+| `format_preserving` | `************2832`, `j***@acme.com` | Downstream format validation |
 | `synthetic` | `4111356762812018`, `Regan Dubois` | Test data generation, realistic output |
 
 ### Supported File Types

--- a/docs/user-guides/README-Redaction.md
+++ b/docs/user-guides/README-Redaction.md
@@ -48,7 +48,7 @@ Use this when the document will be shared externally or when downstream systems 
 Masks the sensitive portion while keeping separators, length, and structure intact. Useful when downstream systems validate format.
 
 ```
-4916338506082832  →  4916********2832   (first 4 + last 4 visible)
+4916338506082832  →  ************2832   (last 4 visible; BIN masked)
 372-84-1951       →  ***-**-1951        (last 4 digits visible)
 john@acme.com     →  j***@acme.com      (first char + domain visible)
 312-867-4201      →  312-***-4201       (area code + last 4 visible)
@@ -72,7 +72,7 @@ ghp_16C7e42F...   →  ghp_ab3pMN5XQuRE  (same ghp_ prefix)
 
 | Validator | `simple` | `format_preserving` | `synthetic` |
 |-----------|:--------:|:-------------------:|:-----------:|
-| CREDIT_CARD | ✅ | ✅ Luhn-valid mask | ✅ Valid Luhn number |
+| CREDIT_CARD | ✅ | ✅ Last 4 visible | ✅ Valid Luhn number |
 | SSN | ✅ | ✅ Last 4 visible | ✅ Invalid area code |
 | EMAIL | ✅ | ✅ First char + domain | ✅ Random user@example.com |
 | PHONE | ✅ | ✅ Area code + last 4 | ✅ Same format |

--- a/internal/goldencorpus/testdata/golden/creditcard_brands.redact_format_preserving.txt
+++ b/internal/goldencorpus/testdata/golden/creditcard_brands.redact_format_preserving.txt
@@ -1,7 +1,7 @@
 === REDACTED ===
-visa 4532********0366
-mastercard 5425********9903
-amex 3742*******0126
+visa ************0366
+mastercard ************9903
+amex ***********0126
 invalid-luhn 4532015112830367
 === FINDINGS (sorted) ===
 type=AMERICAN_EXPRESS line=3 conf=high match=374245455400126

--- a/internal/goldencorpus/testdata/golden/mixed_pii_basic.redact_format_preserving.txt
+++ b/internal/goldencorpus/testdata/golden/mixed_pii_basic.redact_format_preserving.txt
@@ -2,7 +2,7 @@
 Contact j*******@example.com or call 212-***-0142.
 AWS key ******************** in the config.
 SSN ***-**-4100 on file.
-Card 4532-****-****-0366 expires soon.
+Card ****-****-****-0366 expires soon.
 === FINDINGS (sorted) ===
 type=AWS_ACCESS_KEY line=2 conf=medium match=AKIAIOSFODNN7EXAMPLE
 type=BUSINESS line=1 conf=low match=john.doe@example.com

--- a/internal/redactors/replacement/creditcard_test.go
+++ b/internal/redactors/replacement/creditcard_test.go
@@ -45,13 +45,14 @@ func TestCreditCard_SimpleIsGenericPlaceholder(t *testing.T) {
 }
 
 // TestCreditCard_FormatPreservingConsistentAcrossBrands confirms every brand
-// gets the same credit-card format-preserving mask (first-4 + last-4 visible,
-// middle masked, structure preserved) rather than the generic full mask.
+// gets the same credit-card format-preserving mask (last-4 visible, everything
+// else — including the BIN / first-4 — masked, structure preserved) rather than
+// the generic full mask.
 func TestCreditCard_FormatPreservingConsistentAcrossBrands(t *testing.T) {
 	const card = "4532-0151-1283-0366"
 	want := FormatPreserving(card, "CREDIT_CARD")
-	// Sanity: the generic CC mask keeps first-4 and last-4 and masks the middle.
-	if !strings.HasPrefix(want, "4532") || !strings.HasSuffix(want, "0366") || !strings.Contains(want, "*") {
+	// Sanity: the CC mask keeps only the last-4 and masks the BIN / first-4.
+	if strings.Contains(want, "4532") || !strings.HasSuffix(want, "0366") || !strings.Contains(want, "*") {
 		t.Fatalf("unexpected baseline CC mask %q", want)
 	}
 	for _, ct := range allCardTypes {

--- a/internal/redactors/replacement/replacement.go
+++ b/internal/redactors/replacement/replacement.go
@@ -156,18 +156,17 @@ func preserveCreditCard(original string) string {
 	if len(cleaned) < 8 {
 		return strings.Repeat("*", len(original))
 	}
-	first4 := cleaned[:4]
+	// Mask everything except the last 4 digits. The BIN / first-4 digits are
+	// sensitive (they identify the issuer and card range) and must not survive
+	// into the redacted output — only the tail is kept for reference.
 	last4 := cleaned[len(cleaned)-4:]
-	middle := strings.Repeat("*", len(cleaned)-8)
-	digits := first4 + middle + last4
 	di := 0
 	return digitRe.ReplaceAllStringFunc(original, func(_ string) string {
-		if di < len(digits) {
-			r := string(digits[di])
-			di++
-			return r
+		defer func() { di++ }()
+		if di < len(cleaned)-4 {
+			return "*"
 		}
-		return "*"
+		return string(last4[di-(len(cleaned)-4)])
 	})
 }
 


### PR DESCRIPTION
## Summary

Two changes:

### 1. Mask the credit-card BIN in format-preserving redaction
Format-preserving redaction previously kept **both** the first-4 (BIN) and last-4 visible:
`4532015112830366` → `4532********0366`. The BIN identifies the card issuer and range and is sensitive, so it should not survive into redacted output. Now only the last-4 tail is kept:

- `4532015112830366` → `************0366`
- `4532-0151-1283-0366` → `****-****-****-0366` (separators/length preserved)

This mirrors the existing SSN redactor (`preserveSSN`). The change lives in the single shared `replacement.Generate()`, so it applies to **every** redaction caller:

- plaintext + office redactors
- the `pkg/redact` public engine (web UI, Go library, Lambda)
- (PDF content redaction is deliberately unimplemented — it fails rather than emit output)

Findings-report formats (`json`/`csv`/`sarif`/`gitlab-sast`/`junit`/`text`) already redact the match value to `[HIDDEN]` by default and are unaffected; the raw value only appears behind the explicit `--show-match` opt-in (unchanged, consistent for all data types).

### 2. README logo: white background + centered
The README used a transparent-background PNG that renders darkly on GitHub dark mode. Switched to the opaque white-background variant (`ferret-scan-logo-original.png`) and centered it.

## Changes
- `internal/redactors/replacement/replacement.go` — `preserveCreditCard` now masks all but the last-4
- `internal/redactors/replacement/creditcard_test.go` — updated the cross-brand consistency test's baseline sanity assertion
- Regenerated golden fixtures (`creditcard_brands`, `mixed_pii_basic`)
- `docs/user-guides/README-Redaction.md`, `docs/configuration.md` — doc examples + support table
- `README.md` — white-bg, centered logo

## Testing
- `go build ./...` ✅
- `go test ./internal/redactors/... ./internal/goldencorpus/... ./pkg/redact/...` ✅
- Full integration suite (`./tests/integration/`, stdin/redaction) ✅
- Verified end-to-end via the built binary across stdin streaming, file-based redaction, and all report formats

## Notes / not in this PR
- **Pre-existing overlap bug (not introduced here):** a *space-separated* card `4532 0151 1283 0366` still leaks its BIN because the PHONE validator matches the trailing `0151 1283 0366` and wins that region. Confirmed identical on `main` before this change. Worth a separate fix.
- The local pre-commit ASH/ferret-scan hooks flag only pre-existing corpus false-positives (example emails in docs, the intentional AWS test key in a golden fixture, synthetic-token prefixes in `replacement.go`) — none on lines this PR introduces. CI is the gate.