### PR TITLE
fix(redact): collapse overlapping matches so a contained span can't hide the wider one

### DIFF
--- a/internal/goldencorpus/corpus.go
+++ b/internal/goldencorpus/corpus.go
@@ -94,6 +94,17 @@ var Cases = []Case{
 			"invalid-luhn 4532015112830367\n",
 	},
 	{
+		Name: "creditcard_phone_overlap",
+		Description: "A space-separated card the PHONE validator also fires on (its trailing " +
+			"groups look like a phone number). Locks the overlap fix: format-preserving " +
+			"redaction must mask the whole card including the BIN (**** **** **** 0366), " +
+			"not just the head — the contained PHONE match must not win the tail and hide " +
+			"the card's un-redacted BIN. A standalone phone on the next line must still redact.",
+		Checks: []string{"CREDIT_CARD", "PHONE"},
+		Input: "card 4532 0151 1283 0366 here\n" +
+			"call 212-555-0142 today\n",
+	},
+	{
 		Name:        "secrets_aws",
 		Description: "AWS access key + secret-key shaped strings; locks SECRETS detection and confidence.",
 		Checks:      []string{"SECRETS"},

--- a/internal/goldencorpus/testdata/golden/creditcard_phone_overlap.csv
+++ b/internal/goldencorpus/testdata/golden/creditcard_phone_overlap.csv
@@ -1,0 +1,4 @@
+Filename,Type,Confidence Level,Confidence %,Line Number,Text
+<golden:creditcard_phone_overlap>,VISA,HIGH,100.0,1,4532 0151 1283 0366
+<golden:creditcard_phone_overlap>,PHONE,LOW,50.0,1,0151 1283 0366
+<golden:creditcard_phone_overlap>,PHONE,HIGH,100.0,2,212-555-0142

--- a/internal/goldencorpus/testdata/golden/creditcard_phone_overlap.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/creditcard_phone_overlap.gitlab-sast.json
@@ -1,0 +1,108 @@
+{
+  "remediations": [],
+  "scan": {
+    "analyzer": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "end_time": "<TIMESTAMP>",
+    "scanner": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "start_time": "<TIMESTAMP>",
+    "status": "success",
+    "type": "sast"
+  },
+  "version": "15.0.4",
+  "vulnerabilities": [
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected visa credit card in this file.\n\n**Location:** <golden:creditcard_phone_overlap> (line 1)\n**Confidence:** HIGH (100.0%)\n**Detected by:** creditcard validator\n\n**Context:**\n```\ncard 4532 0151 1283 0366 here\n```\n\n**Additional Information:**\n- card_type: VISA\n- context_impact: 15\n- source: preprocessed_content\n- vendor: Visa\n\n**Remediation:**\nRemove or mask credit card numbers. Consider using tokenization for legitimate payment processing needs.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "VISA"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "creditcard"
+        }
+      ],
+      "location": {
+        "end_line": 1,
+        "file": "<golden:creditcard_phone_overlap>",
+        "start_line": 1
+      },
+      "message": "Visa credit card detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Visa Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected phone number in this file.\n\n**Location:** <golden:creditcard_phone_overlap> (line 1)\n**Confidence:** LOW (50.0%)\n**Detected by:** phone validator\n\n**Context:**\n```\ncard 4532 0151 1283 0366 here\n```\n\n**Additional Information:**\n- context_impact: -55\n- source: preprocessed_content\n\n**Remediation:**\nRemove phone numbers or replace with example numbers (e.g., 555-0123).",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "PHONE"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "phone"
+        }
+      ],
+      "location": {
+        "end_line": 1,
+        "file": "<golden:creditcard_phone_overlap>",
+        "start_line": 1
+      },
+      "message": "Phone number detected: [HIDDEN] (confidence: LOW)",
+      "name": "Phone Number Detected",
+      "severity": "Medium"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected phone number in this file.\n\n**Location:** <golden:creditcard_phone_overlap> (line 2)\n**Confidence:** HIGH (100.0%)\n**Detected by:** phone validator\n\n**Context:**\n```\ncall 212-555-0142 today\n```\n\n**Additional Information:**\n- context_impact: 15\n- source: preprocessed_content\n\n**Remediation:**\nRemove phone numbers or replace with example numbers (e.g., 555-0123).",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "PHONE"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "phone"
+        }
+      ],
+      "location": {
+        "end_line": 2,
+        "file": "<golden:creditcard_phone_overlap>",
+        "start_line": 2
+      },
+      "message": "Phone number detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Phone Number Detected",
+      "severity": "Critical"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/creditcard_phone_overlap.json.json
+++ b/internal/goldencorpus/testdata/golden/creditcard_phone_overlap.json.json
@@ -1,0 +1,126 @@
+{
+  "results": [
+    {
+      "confidence": 100,
+      "confidence_level": "HIGH",
+      "filename": "<golden:creditcard_phone_overlap>",
+      "line_number": 1,
+      "metadata": {
+        "card_type": "VISA",
+        "confidence_adjustment": 0,
+        "context_confidence": 0,
+        "context_doctype": "Unknown",
+        "context_domain": "Unknown",
+        "context_impact": 15,
+        "original_confidence": 100,
+        "original_file": "<golden:creditcard_phone_overlap>",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "entropy": true,
+          "length": true,
+          "luhn": true,
+          "not_repeating": true,
+          "not_test": true,
+          "vendor": true
+        },
+        "validation_path": "document",
+        "vendor": "Visa"
+      },
+      "text": "4532 0151 1283 0366",
+      "type": "VISA",
+      "validator": "creditcard"
+    },
+    {
+      "confidence": 50,
+      "confidence_level": "LOW",
+      "filename": "<golden:creditcard_phone_overlap>",
+      "line_number": 1,
+      "metadata": {
+        "clean_number": "015112830366",
+        "confidence_adjustment": 0,
+        "context_confidence": 0,
+        "context_doctype": "Unknown",
+        "context_domain": "Unknown",
+        "context_impact": -55,
+        "country": "UK",
+        "format": "0XXX XXXXXXXX",
+        "original_confidence": 50,
+        "original_file": "<golden:creditcard_phone_overlap>",
+        "pattern_name": "UK_Standard",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "not_repeating": true,
+          "not_sequential": true,
+          "not_ssn_pattern": true,
+          "not_test_number": true,
+          "not_timestamp": true,
+          "reasonable_length": true,
+          "valid_country": true,
+          "valid_digits": true,
+          "valid_format": true
+        },
+        "validation_path": "document"
+      },
+      "text": "0151 1283 0366",
+      "type": "PHONE",
+      "validator": "phone"
+    },
+    {
+      "confidence": 100,
+      "confidence_level": "HIGH",
+      "filename": "<golden:creditcard_phone_overlap>",
+      "line_number": 2,
+      "metadata": {
+        "clean_number": "2125550142",
+        "confidence_adjustment": 0,
+        "context_confidence": 0,
+        "context_doctype": "Unknown",
+        "context_domain": "Unknown",
+        "context_impact": 15,
+        "country": "US/CA",
+        "format": "XXX-XXX-XXXX",
+        "original_confidence": 100,
+        "original_file": "<golden:creditcard_phone_overlap>",
+        "pattern_name": "US_Dashed",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "not_repeating": true,
+          "not_sequential": true,
+          "not_ssn_pattern": true,
+          "not_test_number": false,
+          "not_timestamp": true,
+          "reasonable_length": true,
+          "valid_country": true,
+          "valid_digits": true,
+          "valid_format": true
+        },
+        "validation_path": "document"
+      },
+      "text": "212-555-0142",
+      "type": "PHONE",
+      "validator": "phone"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/creditcard_phone_overlap.junit.xml
+++ b/internal/goldencorpus/testdata/golden/creditcard_phone_overlap.junit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
+  <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
+    <testcase name="&lt;golden:creditcard_phone_overlap&gt;" classname="security-scan" time="0.001">
+      <failure message="3 security findings detected" type="SECURITY_FINDINGS">Line 1: VISA detected with 100.0% confidence (HIGH)&#xA;Match: 4532 0151 1283 0366&#xA;Validator: creditcard&#xA;Line 2: PHONE detected with 100.0% confidence (HIGH)&#xA;Match: 212-555-0142&#xA;Validator: phone&#xA;Line 1: PHONE detected with 50.0% confidence (LOW)&#xA;Match: 0151 1283 0366&#xA;Validator: phone</failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/internal/goldencorpus/testdata/golden/creditcard_phone_overlap.redact_format_preserving.txt
+++ b/internal/goldencorpus/testdata/golden/creditcard_phone_overlap.redact_format_preserving.txt
@@ -1,0 +1,7 @@
+=== REDACTED ===
+card **** **** **** 0366 here
+call 212-***-0142 today
+=== FINDINGS (sorted) ===
+type=PHONE line=1 conf=low match=0151 1283 0366
+type=PHONE line=2 conf=high match=212-555-0142
+type=VISA line=1 conf=high match=4532 0151 1283 0366

--- a/internal/goldencorpus/testdata/golden/creditcard_phone_overlap.redact_simple.txt
+++ b/internal/goldencorpus/testdata/golden/creditcard_phone_overlap.redact_simple.txt
@@ -1,0 +1,7 @@
+=== REDACTED ===
+card [CREDIT-CARD-REDACTED] here
+call [PHONE-REDACTED] today
+=== FINDINGS (sorted) ===
+type=PHONE line=1 conf=low match=0151 1283 0366
+type=PHONE line=2 conf=high match=212-555-0142
+type=VISA line=1 conf=high match=4532 0151 1283 0366

--- a/internal/goldencorpus/testdata/golden/creditcard_phone_overlap.sarif.json
+++ b/internal/goldencorpus/testdata/golden/creditcard_phone_overlap.sarif.json
@@ -1,0 +1,264 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/refs/heads/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:creditcard_phone_overlap>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "card \ncard 4532 0151 1283 0366 here\n here"
+                  },
+                  "startLine": 1
+                },
+                "region": {
+                  "endColumn": 25,
+                  "snippet": {
+                    "text": "card 4532 0151 1283 0366 here"
+                  },
+                  "startColumn": 6,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "VISA Detected in <golden:creditcard_phone_overlap> at line 1 (confidence: 100.0% - HIGH). Matched text: '4532 0151 1283 0366'"
+          },
+          "properties": {
+            "confidence": 100,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "card_type": "VISA",
+              "confidence_adjustment": 0,
+              "context_confidence": 0,
+              "context_doctype": "Unknown",
+              "context_domain": "Unknown",
+              "context_impact": 15,
+              "original_confidence": 100,
+              "original_file": "<golden:creditcard_phone_overlap>",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "digits": true,
+                "entropy": true,
+                "length": true,
+                "luhn": true,
+                "not_repeating": true,
+                "not_test": true,
+                "vendor": true
+              },
+              "validation_path": "document",
+              "vendor": "Visa"
+            },
+            "validator": "creditcard"
+          },
+          "rank": 75,
+          "ruleId": "VISA"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:creditcard_phone_overlap>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "card 4532 \ncard 4532 0151 1283 0366 here\n here"
+                  },
+                  "startLine": 1
+                },
+                "region": {
+                  "endColumn": 25,
+                  "snippet": {
+                    "text": "card 4532 0151 1283 0366 here"
+                  },
+                  "startColumn": 11,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Phone Number Detected in <golden:creditcard_phone_overlap> at line 1 (confidence: 50.0% - LOW). Matched text: '0151 1283 0366'"
+          },
+          "properties": {
+            "confidence": 50,
+            "confidenceLevel": "LOW",
+            "metadata": {
+              "clean_number": "015112830366",
+              "confidence_adjustment": 0,
+              "context_confidence": 0,
+              "context_doctype": "Unknown",
+              "context_domain": "Unknown",
+              "context_impact": -55,
+              "country": "UK",
+              "format": "0XXX XXXXXXXX",
+              "original_confidence": 50,
+              "original_file": "<golden:creditcard_phone_overlap>",
+              "pattern_name": "UK_Standard",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "not_repeating": true,
+                "not_sequential": true,
+                "not_ssn_pattern": true,
+                "not_test_number": true,
+                "not_timestamp": true,
+                "reasonable_length": true,
+                "valid_country": true,
+                "valid_digits": true,
+                "valid_format": true
+              },
+              "validation_path": "document"
+            },
+            "negativeKeywords": [
+              "card"
+            ],
+            "validator": "phone"
+          },
+          "rank": 50,
+          "ruleId": "PHONE"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:creditcard_phone_overlap>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "call \ncall 212-555-0142 today\n today"
+                  },
+                  "startLine": 2
+                },
+                "region": {
+                  "endColumn": 18,
+                  "snippet": {
+                    "text": "call 212-555-0142 today"
+                  },
+                  "startColumn": 6,
+                  "startLine": 2
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Phone Number Detected in <golden:creditcard_phone_overlap> at line 2 (confidence: 100.0% - HIGH). Matched text: '212-555-0142'"
+          },
+          "properties": {
+            "confidence": 100,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "clean_number": "2125550142",
+              "confidence_adjustment": 0,
+              "context_confidence": 0,
+              "context_doctype": "Unknown",
+              "context_domain": "Unknown",
+              "context_impact": 15,
+              "country": "US/CA",
+              "format": "XXX-XXX-XXXX",
+              "original_confidence": 100,
+              "original_file": "<golden:creditcard_phone_overlap>",
+              "pattern_name": "US_Dashed",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "not_repeating": true,
+                "not_sequential": true,
+                "not_ssn_pattern": true,
+                "not_test_number": false,
+                "not_timestamp": true,
+                "reasonable_length": true,
+                "valid_country": true,
+                "valid_digits": true,
+                "valid_format": true
+              },
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "call"
+            ],
+            "validator": "phone"
+          },
+          "rank": 75,
+          "ruleId": "PHONE"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/awslabs/ferret-scan",
+          "name": "Ferret Scan",
+          "rules": [
+            {
+              "fullDescription": {
+                "text": "A phone number was detected in the scanned content. Phone numbers can be considered personally identifiable information (PII) depending on context and jurisdiction."
+              },
+              "help": {
+                "text": "Phone numbers may be considered PII under various privacy regulations. Evaluate whether this phone number should be present in the code. If it's for testing purposes, use clearly fake numbers (e.g., 555-0100 to 555-0199 in North America). For production use, store phone numbers in secure configuration systems with appropriate access controls."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/PHONE.md",
+              "id": "PHONE",
+              "shortDescription": {
+                "text": "Phone Number Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type VISA was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/VISA.md",
+              "id": "VISA",
+              "shortDescription": {
+                "text": "VISA Detected"
+              }
+            }
+          ],
+          "semanticVersion": "0.0.0-development",
+          "version": "0.0.0-development"
+        }
+      },
+      "versionControlProvenance": [
+        {
+          "mappedTo": {
+            "uriBaseId": "%SRCROOT%"
+          },
+          "repositoryUri": "https://github.com/awslabs/ferret-scan",
+          "revisionId": "0.0.0-development"
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/internal/goldencorpus/testdata/golden/creditcard_phone_overlap.txt
+++ b/internal/goldencorpus/testdata/golden/creditcard_phone_overlap.txt
@@ -1,0 +1,5 @@
+LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH               FILE
+---------------------------------------------------------------------------------------------
+[HIGH  ] creditcard   VISA                  100.00% line     1 4532 0151 1283 0366 <golden:creditcard_phone_overlap>
+[HIGH  ] phone        PHONE                 100.00% line     2 212-555-0142        <golden:creditcard_phone_overlap>
+[LOW   ] phone        PHONE                  50.00% line     1 0151 1283 0366      <golden:creditcard_phone_overlap>

--- a/internal/goldencorpus/testdata/golden/creditcard_phone_overlap.yaml
+++ b/internal/goldencorpus/testdata/golden/creditcard_phone_overlap.yaml
@@ -1,0 +1,108 @@
+results:
+    - text: 4532 0151 1283 0366
+      line_number: 1
+      type: VISA
+      confidence: 100
+      confidence_level: HIGH
+      filename: <golden:creditcard_phone_overlap>
+      validator: creditcard
+      metadata:
+        card_type: VISA
+        confidence_adjustment: 0
+        context_confidence: 0
+        context_doctype: Unknown
+        context_domain: Unknown
+        context_impact: 15
+        original_confidence: 100
+        original_file: <golden:creditcard_phone_overlap>
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            entropy: true
+            length: true
+            luhn: true
+            not_repeating: true
+            not_test: true
+            vendor: true
+        validation_path: document
+        vendor: Visa
+    - text: 0151 1283 0366
+      line_number: 1
+      type: PHONE
+      confidence: 50
+      confidence_level: LOW
+      filename: <golden:creditcard_phone_overlap>
+      validator: phone
+      metadata:
+        clean_number: "015112830366"
+        confidence_adjustment: 0
+        context_confidence: 0
+        context_doctype: Unknown
+        context_domain: Unknown
+        context_impact: -55
+        country: UK
+        format: 0XXX XXXXXXXX
+        original_confidence: 50
+        original_file: <golden:creditcard_phone_overlap>
+        pattern_name: UK_Standard
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            not_repeating: true
+            not_sequential: true
+            not_ssn_pattern: true
+            not_test_number: true
+            not_timestamp: true
+            reasonable_length: true
+            valid_country: true
+            valid_digits: true
+            valid_format: true
+        validation_path: document
+    - text: 212-555-0142
+      line_number: 2
+      type: PHONE
+      confidence: 100
+      confidence_level: HIGH
+      filename: <golden:creditcard_phone_overlap>
+      validator: phone
+      metadata:
+        clean_number: "2125550142"
+        confidence_adjustment: 0
+        context_confidence: 0
+        context_doctype: Unknown
+        context_domain: Unknown
+        context_impact: 15
+        country: US/CA
+        format: XXX-XXX-XXXX
+        original_confidence: 100
+        original_file: <golden:creditcard_phone_overlap>
+        pattern_name: US_Dashed
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            not_repeating: true
+            not_sequential: true
+            not_ssn_pattern: true
+            not_test_number: false
+            not_timestamp: true
+            reasonable_length: true
+            valid_country: true
+            valid_digits: true
+            valid_format: true
+        validation_path: document

--- a/internal/redactors/office/redactor.go
+++ b/internal/redactors/office/redactor.go
@@ -440,6 +440,11 @@ func (or *OfficeRedactor) redactOfficeContent(zipContents *OfficeZipContents, ex
 		modifiedContents.Files[fileName] = content
 	}
 
+	// Collapse overlapping matches to their widest span so a smaller match
+	// contained in a larger one doesn't get redacted first and hide the larger
+	// match's un-redacted head. See redactors.ResolveOverlaps.
+	matches = redactors.ResolveOverlaps(matches)
+
 	// Process each match
 	for _, match := range matches {
 		mapping, err := or.redactMatch(modifiedContents, extractedText, textPositions, match, strategy, docType)

--- a/internal/redactors/overlap.go
+++ b/internal/redactors/overlap.go
@@ -1,0 +1,118 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package redactors
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+)
+
+// ResolveOverlaps drops any match whose span is fully contained within a
+// larger match on the same line, keeping only the wider (more-covering) span.
+//
+// Why this exists: redaction applies matches one at a time by locating each
+// match's text in the (progressively mutated) content. When two matches
+// overlap — e.g. a CREDIT_CARD match "4532 0151 1283 0366" and a PHONE match
+// "0151 1283 0366" the phone validator also fired on — applying the smaller one
+// first rewrites the text so the larger one can no longer be found, and its
+// redaction is silently skipped. That left the un-redacted head of the larger
+// span (here, the card's BIN) exposed in the output.
+//
+// Collapsing to the widest span is always leak-safe: the surviving match covers
+// the dropped match's region too, so no sensitive sub-span is left in the clear.
+//
+// Matches are located within their line via detector.Match.Context.FullLine.
+// A match whose position cannot be determined (empty FullLine, text not found)
+// is kept as-is and never subsumes another, so callers see no behavior change
+// for inputs that don't overlap. Input order is preserved for survivors.
+func ResolveOverlaps(matches []detector.Match) []detector.Match {
+	if len(matches) < 2 {
+		return matches
+	}
+
+	// span records where a match sits within its line, or ok=false when the
+	// position could not be resolved.
+	type span struct {
+		line       int
+		start, end int
+		ok         bool
+	}
+
+	// Assign each match to a concrete occurrence of its text within the line.
+	// Repeated (line, text) pairs consume successive occurrences left-to-right
+	// so two identical matches don't both claim the first occurrence.
+	cursor := make(map[int]map[string]int, len(matches))
+	spans := make([]span, len(matches))
+	for i := range matches {
+		m := &matches[i]
+		line := m.Context.FullLine
+		if line == "" || m.Text == "" {
+			continue
+		}
+		byText, ok := cursor[m.LineNumber]
+		if !ok {
+			byText = make(map[string]int)
+			cursor[m.LineNumber] = byText
+		}
+		from := byText[m.Text]
+		idx := strings.Index(line[from:], m.Text)
+		if idx < 0 {
+			// Fall back to the first occurrence rather than losing the match.
+			idx = strings.Index(line, m.Text)
+			if idx < 0 {
+				continue
+			}
+			spans[i] = span{line: m.LineNumber, start: idx, end: idx + len(m.Text), ok: true}
+			continue
+		}
+		start := from + idx
+		spans[i] = span{line: m.LineNumber, start: start, end: start + len(m.Text), ok: true}
+		byText[m.Text] = start + len(m.Text)
+	}
+
+	// Consider wider spans first so a contained match is always tested against
+	// the largest span that could subsume it.
+	order := make([]int, len(matches))
+	for i := range order {
+		order[i] = i
+	}
+	sort.SliceStable(order, func(a, b int) bool {
+		sa, sb := spans[order[a]], spans[order[b]]
+		return (sa.end - sa.start) > (sb.end - sb.start)
+	})
+
+	keep := make([]bool, len(matches))
+	var accepted []span
+	for _, i := range order {
+		s := spans[i]
+		if !s.ok {
+			// Unresolvable position: keep it, and don't let it subsume others.
+			keep[i] = true
+			continue
+		}
+		contained := false
+		for _, a := range accepted {
+			if a.line == s.line && a.start <= s.start && s.end <= a.end &&
+				(a.end-a.start) > (s.end-s.start) {
+				contained = true
+				break
+			}
+		}
+		if contained {
+			continue // dropped: fully inside a wider surviving match
+		}
+		keep[i] = true
+		accepted = append(accepted, s)
+	}
+
+	out := make([]detector.Match, 0, len(matches))
+	for i := range matches {
+		if keep[i] {
+			out = append(out, matches[i])
+		}
+	}
+	return out
+}

--- a/internal/redactors/overlap_test.go
+++ b/internal/redactors/overlap_test.go
@@ -1,0 +1,126 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package redactors
+
+import (
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+)
+
+func mkMatch(dataType, text, fullLine string, line int) detector.Match {
+	return detector.Match{
+		Text:       text,
+		Type:       dataType,
+		LineNumber: line,
+		Context:    detector.ContextInfo{FullLine: fullLine},
+	}
+}
+
+func types(ms []detector.Match) []string {
+	out := make([]string, len(ms))
+	for i, m := range ms {
+		out[i] = m.Type
+	}
+	return out
+}
+
+func TestResolveOverlaps_DropsContainedMatch(t *testing.T) {
+	line := "spaced 4532 0151 1283 0366"
+	matches := []detector.Match{
+		mkMatch("VISA", "4532 0151 1283 0366", line, 1),
+		mkMatch("PHONE", "0151 1283 0366", line, 1),
+	}
+	got := ResolveOverlaps(matches)
+	if len(got) != 1 || got[0].Type != "VISA" {
+		t.Fatalf("expected only the wider VISA match to survive, got %v", types(got))
+	}
+}
+
+func TestResolveOverlaps_DropWinsRegardlessOfInputOrder(t *testing.T) {
+	line := "spaced 4532 0151 1283 0366"
+	// Contained match listed first.
+	matches := []detector.Match{
+		mkMatch("PHONE", "0151 1283 0366", line, 1),
+		mkMatch("VISA", "4532 0151 1283 0366", line, 1),
+	}
+	got := ResolveOverlaps(matches)
+	if len(got) != 1 || got[0].Type != "VISA" {
+		t.Fatalf("expected only VISA to survive regardless of order, got %v", types(got))
+	}
+}
+
+func TestResolveOverlaps_KeepsNonOverlapping(t *testing.T) {
+	line := "call 212-555-0142 or card 4532-0151-1283-0366"
+	matches := []detector.Match{
+		mkMatch("PHONE", "212-555-0142", line, 1),
+		mkMatch("VISA", "4532-0151-1283-0366", line, 1),
+	}
+	got := ResolveOverlaps(matches)
+	if len(got) != 2 {
+		t.Fatalf("expected both disjoint matches to survive, got %v", types(got))
+	}
+}
+
+func TestResolveOverlaps_DifferentLinesNeverSubsume(t *testing.T) {
+	// Identical text on different lines must not subsume each other.
+	matches := []detector.Match{
+		mkMatch("VISA", "4532 0151 1283 0366", "card 4532 0151 1283 0366", 1),
+		mkMatch("PHONE", "0151 1283 0366", "phone 0151 1283 0366", 2),
+	}
+	got := ResolveOverlaps(matches)
+	if len(got) != 2 {
+		t.Fatalf("matches on different lines must both survive, got %v (len %d)", types(got), len(got))
+	}
+}
+
+func TestResolveOverlaps_PartialOverlapKeepsBoth(t *testing.T) {
+	// Overlapping but neither fully contains the other: keep both (dropping
+	// either would leave part of it exposed).
+	line := "aaabbbccc"
+	matches := []detector.Match{
+		mkMatch("A", "aaabbb", line, 1),
+		mkMatch("B", "bbbccc", line, 1),
+	}
+	got := ResolveOverlaps(matches)
+	if len(got) != 2 {
+		t.Fatalf("partial overlap must keep both, got %v", types(got))
+	}
+}
+
+func TestResolveOverlaps_UnresolvablePositionKept(t *testing.T) {
+	// No FullLine context: position can't be resolved, so keep as-is and don't
+	// subsume anything.
+	matches := []detector.Match{
+		{Text: "4532 0151 1283 0366", Type: "VISA", LineNumber: 1},
+		{Text: "0151 1283 0366", Type: "PHONE", LineNumber: 1},
+	}
+	got := ResolveOverlaps(matches)
+	if len(got) != 2 {
+		t.Fatalf("unresolvable matches must be kept unchanged, got %v", types(got))
+	}
+}
+
+func TestResolveOverlaps_ThreeNested(t *testing.T) {
+	line := "xx 4532 0151 1283 0366 yy"
+	matches := []detector.Match{
+		mkMatch("VISA", "4532 0151 1283 0366", line, 1),
+		mkMatch("PHONE", "0151 1283 0366", line, 1),
+		mkMatch("OTHER", "1283 0366", line, 1),
+	}
+	got := ResolveOverlaps(matches)
+	if len(got) != 1 || got[0].Type != "VISA" {
+		t.Fatalf("expected only widest VISA to survive nested containment, got %v", types(got))
+	}
+}
+
+func TestResolveOverlaps_EmptyAndSingle(t *testing.T) {
+	if got := ResolveOverlaps(nil); got != nil {
+		t.Errorf("nil in -> nil out, got %v", got)
+	}
+	one := []detector.Match{mkMatch("VISA", "x", "x", 1)}
+	if got := ResolveOverlaps(one); len(got) != 1 {
+		t.Errorf("single match must pass through, got %v", types(got))
+	}
+}

--- a/internal/redactors/plaintext/redactor.go
+++ b/internal/redactors/plaintext/redactor.go
@@ -190,6 +190,13 @@ func (ptr *PlainTextRedactor) redactText(originalText string, matches []detector
 		return originalText, []redactors.RedactionMapping{}, nil
 	}
 
+	// Collapse overlapping matches to their widest span first. Otherwise a
+	// smaller match contained in a larger one (e.g. a PHONE match inside a
+	// spaced CREDIT_CARD match) gets redacted first, mutating the text so the
+	// larger match can no longer be located — leaving its un-redacted head
+	// (the card's BIN) exposed. See redactors.ResolveOverlaps.
+	matches = redactors.ResolveOverlaps(matches)
+
 	// Sort matches by position (descending) to avoid position shifts during replacement
 	sortedMatches := ptr.sortMatchesByPosition(matches)
 


### PR DESCRIPTION
## Summary

Follow-up to #137. That PR masked the credit-card BIN in format-preserving output, but a related leak remained for **space-separated** cards.

A card like `4532 0151 1283 0366` also triggers the **PHONE** validator on its trailing groups (`0151 1283 0366`). Redaction applied matches independently in reverse-position order, so the *contained* PHONE match was redacted **first** — mutating the text so the wider CREDIT_CARD match could no longer be located by `strings.Index`, and its redaction was **silently skipped**. The card's un-redacted head (the BIN) leaked:

```
before:  4532 0151 1283 0366  ->  4532 015* **** 0366   ❌ BIN exposed
after:   4532 0151 1283 0366  ->  **** **** **** 0366   ✅
```

## Fix

Add `redactors.ResolveOverlaps`: a pre-pass that drops any match whose span is fully contained within a wider match on the same line, keeping only the widest span. Collapsing to the widest span is always **leak-safe** — the surviving match covers the dropped match's region too, so no sensitive sub-span is left in the clear.

Wired into **both** redaction apply-loops that had this independent-apply bug:
- `internal/redactors/plaintext/redactText` (also the path used by the `pkg/redact` public engine — web UI, library, Lambda)
- `internal/redactors/office/redactOfficeContent`

Matches are located within their line via `Match.Context.FullLine`; a match whose position can't be resolved is kept as-is and never subsumes another, so non-overlapping inputs see zero behavior change.

## What does NOT change
- **Detection is untouched** — findings reports (`json`/`csv`/`sarif`/`gitlab-sast`/`junit`/`text`) still list every match, including the subsumed one. Only *redaction* collapses overlaps.
- Standalone matches and disjoint same-line matches redact exactly as before (verified: `212-555-0142` on its own line still → `212-***-0142`; two disjoint cards on one line both mask).

## Testing
- New unit tests for `ResolveOverlaps`: containment (both input orders), disjoint, partial overlap (keep both), different lines, unresolvable position, triple-nested, empty/single.
- New golden corpus case `creditcard_phone_overlap` (CREDIT_CARD + PHONE) locking the redacted output across formats.
- `go build ./...`, `go vet`, full `go test ./...` (41 packages) and the integration suite all pass.
- Verified end-to-end via the built binary (stdin streaming + file redaction).