### PR TITLE
fix(video): guard 32-bit overflow in MP4 box-size comparison

### DIFF
--- a/internal/preprocessors/meta-extractors/meta-extract-videolib/video-extractor.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-videolib/video-extractor.go
@@ -394,7 +394,7 @@ func readMP4BoxWithContext(ctx context.Context, file *os.File) (*MP4Box, error) 
 			return nil, err
 		}
 		// Safe comparison with bounds checking
-		if n < 0 || n > math.MaxUint32 || uint32(n) != size {
+		if n < 0 || uint64(n) > math.MaxUint32 || uint32(n) != size {
 			return nil, fmt.Errorf("incomplete box read: expected %d, got %d", size, n)
 		}
 	}
@@ -1312,7 +1312,7 @@ func (ovr *OptimizedVideoReader) ReadBoxData(size uint32) ([]byte, error) {
 		return nil, err
 	}
 	// Safe comparison with bounds checking
-	if n < 0 || n > math.MaxUint32 || uint32(n) != size {
+	if n < 0 || uint64(n) > math.MaxUint32 || uint32(n) != size {
 		return nil, fmt.Errorf("incomplete box read: expected %d, got %d", size, n)
 	}
 


### PR DESCRIPTION
## Summary

Fixes a compile-time int overflow that breaks 32-bit builds of the
video-extractor preprocessor.

## Problem

`readMP4BoxWithContext` and `ReadBoxData` in video-extractor.go each
have a bounds check on the number of bytes read from an MP4 box:

    if n < 0 || n > math.MaxUint32 || uint32(n) != size {

`n` comes from `file.Read()` and is declared as `int`, whose width is
platform-dependent (64-bit on amd64/arm64, 32-bit on 386/arm). Because
`math.MaxUint32` is an untyped constant, the compiler tries to convert
it to the type of the other operand (`int`) for the comparison. On
32-bit platforms that constant (4294967295) doesn't fit in a 32-bit
int, so the build fails outright:

    video-extractor.go:397:19: math.MaxUint32 (untyped int constant
    4294967295) overflows int

It affects any 32-bit Go build target
(GOOS/GOARCH combos like linux/386, linux/arm, etc.)

## Fix

Cast `n` to `uint64` before comparing against `math.MaxUint32`:

    if n < 0 || uint64(n) > math.MaxUint32 || uint32(n) != size {

This mirrors the bounds-checking style already used for `size64`,
`creationTime64`, and `duration64` elsewhere in the same file, and
avoids the platform-dependent int width entirely. No behavior change
on 64-bit builds — the check is logically identical, just typed
correctly.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
