### PR TITLE
feat(core): add RedactFile and share redaction-manager setup

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,10 +33,6 @@ import (
 	"github.com/awslabs/ferret-scan/v2/internal/help"
 	"github.com/awslabs/ferret-scan/v2/internal/observability"
 	"github.com/awslabs/ferret-scan/v2/internal/redactors"
-	"github.com/awslabs/ferret-scan/v2/internal/redactors/image"
-	"github.com/awslabs/ferret-scan/v2/internal/redactors/office"
-	"github.com/awslabs/ferret-scan/v2/internal/redactors/pdf"
-	"github.com/awslabs/ferret-scan/v2/internal/redactors/plaintext"
 	"github.com/awslabs/ferret-scan/v2/internal/validators"
 
 	"github.com/awslabs/ferret-scan/v2/internal/formatters"
@@ -652,39 +648,6 @@ func handleProfiles(cfg *config.Config, listProfiles bool, profileName, configFi
 		}
 	}
 	return activeProfile
-}
-
-// registerDefaultRedactors registers all default redactors with the manager
-func registerDefaultRedactors(manager *redactors.RedactionManager) error {
-	// Get the output manager and observer from the redaction manager
-	outputManager := manager.GetOutputManager()
-	observer := manager.GetObserver()
-
-	// Register PlainText redactor
-	plainTextRedactor := plaintext.NewPlainTextRedactor(outputManager, observer)
-	if err := manager.RegisterRedactor(plainTextRedactor); err != nil {
-		return fmt.Errorf("failed to register PlainText redactor: %w", err)
-	}
-
-	// Register PDF redactor
-	pdfRedactor := pdf.NewPDFRedactor(outputManager, observer)
-	if err := manager.RegisterRedactor(pdfRedactor); err != nil {
-		return fmt.Errorf("failed to register PDF redactor: %w", err)
-	}
-
-	// Register Office redactor
-	officeRedactor := office.NewOfficeRedactor(outputManager, observer)
-	if err := manager.RegisterRedactor(officeRedactor); err != nil {
-		return fmt.Errorf("failed to register Office redactor: %w", err)
-	}
-
-	// Register Image Metadata redactor
-	imageRedactor := image.NewImageMetadataRedactor(outputManager, observer)
-	if err := manager.RegisterRedactor(imageRedactor); err != nil {
-		return fmt.Errorf("failed to register Image Metadata redactor: %w", err)
-	}
-
-	return nil
 }
 
 // getBoolFlag safely gets the value of a boolean flag pointer, returning false if nil
@@ -1549,34 +1512,14 @@ func main() {
 			redactionObserver = observability.NewStandardObserver(observability.ObservabilityMetrics, os.Stderr)
 		}
 
-		// Create output structure manager
-		outputManager, err := redactors.NewOutputStructureManager(finalConfig.redactionOutputDir, redactionObserver)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error creating output structure manager: %v\n", err)
-			os.Exit(1)
-		}
-
-		// Parse the CLI redaction strategy
+		// Build the redaction manager with all default redactors via the shared
+		// core factory (single source of truth, also used by core.RedactFile).
 		strategy := redactors.ParseRedactionStrategy(finalConfig.redactionStrategy)
-
-		// Create redaction manager config with CLI strategy
-		redactionConfig := &redactors.RedactionManagerConfig{
-			DefaultStrategy:         strategy,
-			MaxConcurrentRedactions: 4,
-			EnableBatchProcessing:   true,
-			BatchSize:               100,
-			RetryAttempts:           3,
-			RetryDelay:              time.Second * 2,
-			EnableAuditTrail:        true,
-			FailureHandling:         redactors.FailureHandlingGraceful,
-		}
-
-		// Create redaction manager with custom config
-		redactionManager = redactors.NewRedactionManagerWithConfig(outputManager, redactionObserver, redactionConfig)
-
-		// Register default redactors
-		if err := registerDefaultRedactors(redactionManager); err != nil {
-			fmt.Fprintf(os.Stderr, "Error registering default redactors: %v\n", err)
+		var mgrErr error
+		redactionManager, _, mgrErr = core.NewDefaultRedactionManager(
+			finalConfig.redactionOutputDir, strategy, redactionObserver)
+		if mgrErr != nil {
+			fmt.Fprintf(os.Stderr, "Error creating redaction manager: %v\n", mgrErr)
 			os.Exit(1)
 		}
 

--- a/internal/core/redact.go
+++ b/internal/core/redact.go
@@ -1,0 +1,205 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package core
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/awslabs/ferret-scan/v2/internal/config"
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/observability"
+	"github.com/awslabs/ferret-scan/v2/internal/parallel"
+	"github.com/awslabs/ferret-scan/v2/internal/redactors"
+	"github.com/awslabs/ferret-scan/v2/internal/redactors/image"
+	"github.com/awslabs/ferret-scan/v2/internal/redactors/office"
+	"github.com/awslabs/ferret-scan/v2/internal/redactors/pdf"
+	"github.com/awslabs/ferret-scan/v2/internal/redactors/plaintext"
+	"github.com/awslabs/ferret-scan/v2/internal/router"
+	"github.com/awslabs/ferret-scan/v2/internal/validators"
+)
+
+// RedactConfig configures a single-file redaction pass.
+type RedactConfig struct {
+	// FilePath is the file to scan and redact.
+	FilePath string
+	// OutputDir is the base directory where the redacted copy is written. The
+	// redactor mirrors the input's path structure beneath this directory.
+	OutputDir string
+	// Strategy is one of "simple", "format_preserving" (default), or "synthetic".
+	Strategy string
+	// Checks selects validators; empty or ["all"] runs every validator.
+	Checks []string
+	// Config is the loaded engine config (use config.LoadConfigOrDefault("")).
+	Config *config.Config
+	// LogWriter receives payload-free progress output; defaults to io.Discard
+	// here so in-process callers never leak to stderr.
+	LogWriter io.Writer
+}
+
+// RedactResult reports the outcome of a redaction.
+type RedactResult struct {
+	// RedactedFilePath is the path to the written redacted document.
+	RedactedFilePath string
+	// RedactionCount is the number of sensitive values redacted.
+	RedactionCount int
+	// Strategy is the strategy actually applied.
+	Strategy string
+	// Matches are the detections that drove the redaction (payload-free unless
+	// the caller inspects Text).
+	Matches []detector.Match
+}
+
+// RedactFile scans a single file and writes a redacted copy to OutputDir using
+// the appropriate format-aware redactor (plaintext/CSV/JSON, PDF, Office,
+// image-metadata). It mirrors the CLI's redaction wiring, which core.ScanFile
+// intentionally leaves to the caller (ScanFile passes a nil redaction manager).
+//
+// A redacted .docx stays a .docx, a .pdf stays a .pdf, and image redaction
+// strips EXIF/GPS metadata — the output is a real file of the same type, safe
+// to share.
+func RedactFile(cfg RedactConfig) (*RedactResult, error) {
+	logWriter := resolveLogWriter(cfg.LogWriter)
+	observer := observability.NewStandardObserver(observability.ObservabilityMetrics, logWriter)
+
+	// Build the filtered validator set + detection facade (same as ScanFile).
+	enabledChecks := ParseChecksToRun(cfg.Checks)
+	standardValidators := BuildValidatorSet(enabledChecks, cfg.Config, nil)
+	detectorFacade := validators.NewDetector(observer)
+	if err := detectorFacade.SetupValidators(standardValidators); err != nil {
+		return nil, fmt.Errorf("failed to set up validators: %w", err)
+	}
+	validatorsList := []detector.Validator{detectorFacade}
+
+	// Router with preprocessors enabled so PDF/DOCX/image content is extracted.
+	fileRouter := router.NewFileRouter(false)
+	router.RegisterDefaultPreprocessors(fileRouter)
+	fileRouter.InitializePreprocessors(router.CreateRouterConfig(false, nil, "", true))
+	detectorFacade.SetFileRouter(fileRouter)
+
+	if canProcess, reason := fileRouter.CanProcessFile(cfg.FilePath, true, false); !canProcess {
+		return nil, fmt.Errorf("file type not supported for redaction: %s (%s)", cfg.FilePath, reason)
+	}
+
+	// Build the redaction manager with all default redactors registered. This
+	// is the SAME shared factory the CLI uses (NewDefaultRedactionManager), so
+	// manager config and the set of registered redactors live in one place.
+	strategy := redactors.ParseRedactionStrategy(cfg.Strategy)
+	redactionManager, outputManager, err := NewDefaultRedactionManager(cfg.OutputDir, strategy, observer)
+	if err != nil {
+		return nil, err
+	}
+
+	// The worker pool writes the redacted copy to the mirrored output path
+	// (GetOutputManager().CreateMirroredPath). Compute it up front so we can
+	// report and verify it — the manager keeps only an audit trail, not a
+	// queryable path index.
+	redactedPath, err := outputManager.CreateMirroredPath(cfg.FilePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute output path: %w", err)
+	}
+
+	// Run the worker pool WITH the redaction manager so it performs inline
+	// redaction and writes the output file.
+	jobConfig := &parallel.JobConfig{
+		EnableRedaction:   true,
+		RedactionStrategy: cfg.Strategy,
+	}
+	pp := parallel.NewParallelProcessor(observer)
+	matches, _, err := pp.ProcessFilesWithProgress(
+		[]string{cfg.FilePath}, validatorsList, fileRouter, jobConfig, redactionManager, nil)
+	if err != nil {
+		return nil, fmt.Errorf("redaction processing failed: %w", err)
+	}
+
+	// The worker pool only writes an output file when there is at least one
+	// match to redact. For a clean file (no findings), copy the original to the
+	// output path so callers always have a file to hand off — a clean document
+	// is safe to share as-is.
+	if _, statErr := os.Stat(redactedPath); statErr != nil {
+		if len(matches) == 0 {
+			if copyErr := copyFile(cfg.FilePath, redactedPath); copyErr != nil {
+				return nil, fmt.Errorf("failed to copy clean file to output: %w", copyErr)
+			}
+		} else {
+			return nil, fmt.Errorf("redaction did not produce an output file at %s: %w", redactedPath, statErr)
+		}
+	}
+
+	return &RedactResult{
+		RedactedFilePath: redactedPath,
+		RedactionCount:   len(matches),
+		Strategy:         strategy.String(),
+		Matches:          matches,
+	}, nil
+}
+
+// copyFile copies src to dst, creating parent directories as needed. Used to
+// pass through a clean (no-findings) file so there is always an output to share.
+func copyFile(src, dst string) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	in, err := os.Open(src) // #nosec G304 - src is a caller-provided scan target
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+
+	out, err := os.Create(dst) // #nosec G304 - dst is under the caller's output dir
+	if err != nil {
+		return err
+	}
+	defer func() { _ = out.Close() }()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Close()
+}
+
+// NewDefaultRedactionManager builds a RedactionManager with the standard
+// manager config and all format-aware redactors registered (plaintext/CSV/JSON,
+// PDF, Office, image-metadata). It is the single source of truth for redaction
+// setup, shared by the CLI (cmd/main.go) and core.RedactFile so the manager
+// config and the set of registered redactors never drift between them.
+//
+// Adding a new redactor or changing manager tuning is a one-line change here.
+// It returns the manager and its output manager (callers need the latter to
+// compute mirrored output paths).
+func NewDefaultRedactionManager(outputDir string, strategy redactors.RedactionStrategy,
+	observer observability.Observer) (*redactors.RedactionManager, *redactors.OutputStructureManager, error) {
+
+	outputManager, err := redactors.NewOutputStructureManager(outputDir, observer)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create output manager: %w", err)
+	}
+
+	manager := redactors.NewRedactionManagerWithConfig(outputManager, observer,
+		&redactors.RedactionManagerConfig{
+			DefaultStrategy:         strategy,
+			MaxConcurrentRedactions: 4,
+			EnableBatchProcessing:   true,
+			BatchSize:               100,
+			RetryAttempts:           3,
+			RetryDelay:              time.Second * 2,
+			EnableAuditTrail:        true,
+			FailureHandling:         redactors.FailureHandlingGraceful,
+		})
+
+	for _, r := range []redactors.Redactor{
+		plaintext.NewPlainTextRedactor(outputManager, observer),
+		pdf.NewPDFRedactor(outputManager, observer),
+		office.NewOfficeRedactor(outputManager, observer),
+		image.NewImageMetadataRedactor(outputManager, observer),
+	} {
+		if err := manager.RegisterRedactor(r); err != nil {
+			return nil, nil, fmt.Errorf("failed to register redactor %s: %w", r.GetName(), err)
+		}
+	}
+	return manager, outputManager, nil
+}

--- a/internal/core/redact_test.go
+++ b/internal/core/redact_test.go
@@ -1,0 +1,102 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package core
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/config"
+)
+
+func writeTemp(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestRedactFile_WritesRedactedCopyWithoutRawValues(t *testing.T) {
+	in := t.TempDir()
+	out := t.TempDir()
+	// Reserved documentation values.
+	src := writeTemp(t, in, "leak.txt", "card 5500-0000-0000-0004 email jordan@example.com\n")
+
+	res, err := RedactFile(RedactConfig{
+		FilePath:  src,
+		OutputDir: out,
+		Strategy:  "format_preserving",
+		Checks:    []string{"all"},
+		Config:    config.LoadConfigOrDefault(""),
+		LogWriter: io.Discard,
+	})
+	if err != nil {
+		t.Fatalf("RedactFile error: %v", err)
+	}
+	if res.RedactedFilePath == "" {
+		t.Fatal("expected a redacted file path")
+	}
+	if res.RedactionCount == 0 {
+		t.Error("expected at least one redaction")
+	}
+
+	data, err := os.ReadFile(res.RedactedFilePath)
+	if err != nil {
+		t.Fatalf("redacted file not readable: %v", err)
+	}
+	content := string(data)
+	if strings.Contains(content, "5500-0000-0000-0004") {
+		t.Errorf("redacted output still contains raw card number:\n%s", content)
+	}
+	if strings.Contains(content, "jordan@example.com") {
+		t.Errorf("redacted output still contains raw email:\n%s", content)
+	}
+	// Output preserves the source file type.
+	if filepath.Ext(res.RedactedFilePath) != ".txt" {
+		t.Errorf("expected .txt output, got %s", res.RedactedFilePath)
+	}
+}
+
+func TestRedactFile_CleanFileIsCopiedThrough(t *testing.T) {
+	in := t.TempDir()
+	out := t.TempDir()
+	src := writeTemp(t, in, "clean.txt", "nothing sensitive here\n")
+
+	res, err := RedactFile(RedactConfig{
+		FilePath:  src,
+		OutputDir: out,
+		Config:    config.LoadConfigOrDefault(""),
+		LogWriter: io.Discard,
+	})
+	if err != nil {
+		t.Fatalf("RedactFile error: %v", err)
+	}
+	if _, err := os.Stat(res.RedactedFilePath); err != nil {
+		t.Errorf("expected a passed-through copy for a clean file: %v", err)
+	}
+}
+
+func TestRedactFile_DefaultsToFormatPreserving(t *testing.T) {
+	in := t.TempDir()
+	out := t.TempDir()
+	src := writeTemp(t, in, "e.txt", "email jordan@example.com\n")
+
+	res, err := RedactFile(RedactConfig{
+		FilePath:  src,
+		OutputDir: out,
+		Config:    config.LoadConfigOrDefault(""),
+		LogWriter: io.Discard,
+	})
+	if err != nil {
+		t.Fatalf("RedactFile error: %v", err)
+	}
+	if res.Strategy != "format_preserving" {
+		t.Errorf("expected default strategy format_preserving, got %q", res.Strategy)
+	}
+}


### PR DESCRIPTION
## What

Adds `core.RedactFile` — scan a single file and write a redacted copy of the **same file type** (plaintext/CSV/JSON, PDF, Office, image-metadata) using the existing format-aware redactors.

Also extracts `core.NewDefaultRedactionManager` as the **single source of truth** for redaction setup (manager config + registering the default redactors) and switches `cmd/main.go` to use it — removing duplicated wiring that previously lived in both the CLI and the redaction path.

## Why

`core.ScanFile` intentionally leaves redaction to the caller (it passes a nil redaction manager). In-process embedders (e.g. a Lambda handler or sidecar) that want redacted output had to re-implement the manager setup `cmd/main.go` performs. `RedactFile` gives them a one-call library entry point.

## Behavior

- A redacted `.docx` stays a `.docx`, a `.pdf` stays a `.pdf`; image redaction strips EXIF/GPS metadata — the output is a real file of the same type.
- Clean files (no findings) are copied through, so callers always get an output path.
- Strategy defaults to `format_preserving`; `simple` and `synthetic` are also accepted.

## Tests

- Redacted output contains no raw values; clean-file passthrough; default-strategy behavior.
- CLI redaction path verified end-to-end (unchanged output).