### PR TITLE
chore(brew): add Homebrew formula + goreleaser auto-publish

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -101,6 +101,12 @@ release:
     pip install ferret-scan
     ```
 
+    #### macOS (Homebrew)
+    ```bash
+    brew tap awslabs/ferret-scan https://github.com/awslabs/ferret-scan
+    brew install awslabs/ferret-scan/ferret-scan
+    ```
+
     #### Alternative: Download Binary
     Download the binary for your platform from the assets below if you prefer not to use pip.
 
@@ -121,6 +127,36 @@ release:
 
     **Full Changelog**: https://github.com/awslabs/ferret-scan/compare/{{ .PreviousTag }}...{{ .Tag }}
 
+# Homebrew tap (self-hosted in this repo under HomebrewFormula/).
+# On every release, goreleaser updates the formula with the new version + sha256.
+# Users install with:
+#   brew tap awslabs/ferret-scan https://github.com/awslabs/ferret-scan
+#   brew install awslabs/ferret-scan/ferret-scan
+brews:
+  - name: ferret-scan
+    ids:
+      - ferret-scan-cli
+    repository:
+      owner: awslabs
+      name: ferret-scan
+      branch: main
+    directory: HomebrewFormula
+    commit_author:
+      name: goreleaser[bot]
+      email: goreleaser[bot]@users.noreply.github.com
+    commit_msg_template: "chore(brew): update ferret-scan formula to {{ .Tag }}"
+    homepage: "https://github.com/awslabs/ferret-scan"
+    description: "Find and redact sensitive data before it leaks — PII, secrets, credit cards, metadata"
+    license: "Apache-2.0"
+    skip_upload: auto
+    install: |
+      bin.install "ferret-scan"
+    test: |
+      assert_match version.to_s, shell_output("#{bin}/ferret-scan --version")
+      (testpath / "test.txt").write "card 5500-0000-0000-0004\n"
+      output = shell_output("#{bin}/ferret-scan --file #{testpath}/test.txt 2>&1")
+      assert_match "creditcard", output
+
 # Docker builds are handled by .github/workflows/docker-multiarch.yml
 # (multi-arch build + push to ECR Public and GHCR), not by GoReleaser.
-# GoReleaser here focuses on binary + PyPI releases only.
+# GoReleaser here focuses on binary + PyPI + Homebrew releases.

--- a/HomebrewFormula/ferret-scan.rb
+++ b/HomebrewFormula/ferret-scan.rb
@@ -1,0 +1,43 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+class FerretScan < Formula
+  desc "Find and redact sensitive data before it leaks — PII, secrets, credit cards, metadata"
+  homepage "https://github.com/awslabs/ferret-scan"
+  version "2.0.2"
+  license "Apache-2.0"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/awslabs/ferret-scan/releases/download/v#{version}/ferret-scan_#{version}_darwin_arm64"
+      sha256 "b1fe68f551cdd305f83089ed35569d58a7a07c1df17656fa3762066977905e76"
+    else
+      url "https://github.com/awslabs/ferret-scan/releases/download/v#{version}/ferret-scan_#{version}_darwin_amd64"
+      sha256 "a4e0aeda37a898f53bb874b422f31f0af5302171a2e065b8e0a4a27f2e5fc2b2"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "https://github.com/awslabs/ferret-scan/releases/download/v#{version}/ferret-scan_#{version}_linux_arm64"
+      sha256 ""  # populated by goreleaser on release
+    else
+      url "https://github.com/awslabs/ferret-scan/releases/download/v#{version}/ferret-scan_#{version}_linux_amd64"
+      sha256 ""  # populated by goreleaser on release
+    end
+  end
+
+  def install
+    # The download IS the precompiled binary — just install it directly.
+    binary_name = Dir["ferret-scan*"].first || "ferret-scan"
+    bin.install binary_name => "ferret-scan"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/ferret-scan --version")
+
+    (testpath / "test.txt").write "card 5500-0000-0000-0004\n"
+    output = shell_output("#{bin}/ferret-scan --file #{testpath}/test.txt 2>&1")
+    assert_match "creditcard", output
+  end
+end

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE.txt)
 [![Go](https://img.shields.io/badge/Go-1.26-00ADD8?logo=go&logoColor=white)](go.mod)
 [![PyPI](https://img.shields.io/pypi/v/ferret-scan?logo=pypi&logoColor=white&label=PyPI)](https://pypi.org/project/ferret-scan/)
+[![Homebrew](https://img.shields.io/badge/Homebrew-ferret--scan-FBB040?logo=homebrew&logoColor=white)](https://github.com/awslabs/ferret-scan#install)
 [![ECR Public](https://img.shields.io/badge/ECR%20Public-ferret--scan-FF9900?logo=amazonaws&logoColor=white)](https://gallery.ecr.aws/awslabs/ferret-scan)
+[![GitHub stars](https://img.shields.io/github/stars/awslabs/ferret-scan?style=social)](https://github.com/awslabs/ferret-scan)
 
 ![ferret-scan demo](docs/images/demo.svg)
 
@@ -59,6 +61,7 @@ Pick whichever fits your workflow — all are first-class.
 
 | Method | Command |
 |---|---|
+| **Homebrew** (macOS/Linux) | `brew tap awslabs/ferret-scan https://github.com/awslabs/ferret-scan && brew install awslabs/ferret-scan/ferret-scan` |
 | **pip** (CLI + pre-commit) | `pip install ferret-scan` |
 | **Docker** | `docker pull public.ecr.aws/awslabs/ferret-scan:latest` |
 | **From source** (Go 1.26.5) | `git clone https://github.com/awslabs/ferret-scan.git && cd ferret-scan && go build ./cmd` |


### PR DESCRIPTION
## Summary

- Add a Homebrew formula (`HomebrewFormula/ferret-scan.rb`) that installs the
  **prebuilt binary** from GitHub Releases — no Go, no build tools, zero
  dependencies, installs in ~1 second.
- Add a `brews:` section to `.goreleaser.yml` so every tagged release
  auto-updates the formula (sha256 + version).
- Add Homebrew as the first install method in `README.md`.

## Install (once merged)

```bash
brew tap awslabs/ferret-scan https://github.com/awslabs/ferret-scan
brew install awslabs/ferret-scan/ferret-scan
```

## Tested locally

```
$ brew install awslabs/ferret-scan/ferret-scan
🍺  /opt/homebrew/Cellar/ferret-scan/2.0.2: 4 files, 13.4MB, built in 1 second

$ ferret-scan --version
ferret-scan 2.0.2

$ brew deps awslabs/ferret-scan/ferret-scan
(nothing)
```

## Test plan

- [x] `ruby -c HomebrewFormula/ferret-scan.rb` — syntax valid
- [x] `brew install` from local tap — downloads prebuilt binary, runs, version matches
- [x] `brew deps` — zero dependencies (no Go required)
- [x] Formula test block runs: `--version` + scan detects a credit card
- [ ] goreleaser dry-run confirms `brews:` section generates a valid formula