### PR TITLE
docs: fix BIN redaction examples + speed up demo animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ That last command turns sensitive values into masked-but-shaped output:
 
 | Before | After (`--enable-redaction`) |
 |---|---|
-| `card 5500-0000-0000-0004 from jordan@example.com` | `card 5500-****-****-0004 from j*****@example.com` |
+| `card 5500-0000-0000-0004 from jordan@example.com` | `card ****-****-****-0004 from j*****@example.com` |
 
 Sensitive values are masked while the shape of the data survives — so downstream tooling, tests, and log pipelines keep working. (Examples here use reserved documentation values.)
 

--- a/docs/images/demo.svg
+++ b/docs/images/demo.svg
@@ -30,22 +30,23 @@
     .b2{animation:b2 18s infinite}.b3{animation:b3 18s infinite}
     .c2{animation:c2 18s infinite}
 
-    /* Act 1 — staggered fade-in, all clear together at 44% */
-    @keyframes a1{0%{opacity:0}3%{opacity:0}4.2%{opacity:1}44%{opacity:1}45.2%{opacity:0}100%{opacity:0}}
-    @keyframes a2{0%{opacity:0}8%{opacity:0}9.2%{opacity:1}44%{opacity:1}45.2%{opacity:0}100%{opacity:0}}
-    @keyframes a3{0%{opacity:0}12%{opacity:0}13.2%{opacity:1}44%{opacity:1}45.2%{opacity:0}100%{opacity:0}}
-    @keyframes a4{0%{opacity:0}15%{opacity:0}16.2%{opacity:1}44%{opacity:1}45.2%{opacity:0}100%{opacity:0}}
-    @keyframes a5{0%{opacity:0}18%{opacity:0}19.2%{opacity:1}44%{opacity:1}45.2%{opacity:0}100%{opacity:0}}
-    @keyframes a6{0%{opacity:0}21%{opacity:0}22.2%{opacity:1}44%{opacity:1}45.2%{opacity:0}100%{opacity:0}}
-    @keyframes a7{0%{opacity:0}24%{opacity:0}25.2%{opacity:1}44%{opacity:1}45.2%{opacity:0}100%{opacity:0}}
-    @keyframes c1{0%{opacity:0}30%{opacity:0}31.2%{opacity:1}44%{opacity:1}45.2%{opacity:0}100%{opacity:0}}
+    /* Act 1 — command appears, then ALL results slam in simultaneously
+       (instant burst), hold for a long reading pause before clearing */
+    @keyframes a1{0%{opacity:0}3%{opacity:0}3.5%{opacity:1}46%{opacity:1}47%{opacity:0}100%{opacity:0}}
+    @keyframes a2{0%{opacity:0}5%{opacity:0}5.3%{opacity:1}46%{opacity:1}47%{opacity:0}100%{opacity:0}}
+    @keyframes a3{0%{opacity:0}5.3%{opacity:0}5.6%{opacity:1}46%{opacity:1}47%{opacity:0}100%{opacity:0}}
+    @keyframes a4{0%{opacity:0}5.6%{opacity:0}5.9%{opacity:1}46%{opacity:1}47%{opacity:0}100%{opacity:0}}
+    @keyframes a5{0%{opacity:0}5.9%{opacity:0}6.2%{opacity:1}46%{opacity:1}47%{opacity:0}100%{opacity:0}}
+    @keyframes a6{0%{opacity:0}6.2%{opacity:0}6.5%{opacity:1}46%{opacity:1}47%{opacity:0}100%{opacity:0}}
+    @keyframes a7{0%{opacity:0}6.5%{opacity:0}6.8%{opacity:1}46%{opacity:1}47%{opacity:0}100%{opacity:0}}
+    @keyframes c1{0%{opacity:0}9%{opacity:0}9.3%{opacity:1}46%{opacity:1}47%{opacity:0}100%{opacity:0}}
 
-    /* Act 2 — begins only after Act 1 has cleared, all clear at 96% */
-    @keyframes b0{0%{opacity:0}49%{opacity:0}50.2%{opacity:1}96%{opacity:1}97.2%{opacity:0}100%{opacity:0}}
-    @keyframes b1{0%{opacity:0}54%{opacity:0}55.2%{opacity:1}96%{opacity:1}97.2%{opacity:0}100%{opacity:0}}
-    @keyframes b2{0%{opacity:0}60%{opacity:0}61.2%{opacity:1}96%{opacity:1}97.2%{opacity:0}100%{opacity:0}}
-    @keyframes b3{0%{opacity:0}66%{opacity:0}67.2%{opacity:1}96%{opacity:1}97.2%{opacity:0}100%{opacity:0}}
-    @keyframes c2{0%{opacity:0}72%{opacity:0}73.2%{opacity:1}96%{opacity:1}97.2%{opacity:0}100%{opacity:0}}
+    /* Act 2 — same: command, then input+output slam in together, hold */
+    @keyframes b0{0%{opacity:0}51%{opacity:0}51.3%{opacity:1}96%{opacity:1}97%{opacity:0}100%{opacity:0}}
+    @keyframes b1{0%{opacity:0}52%{opacity:0}52.3%{opacity:1}96%{opacity:1}97%{opacity:0}100%{opacity:0}}
+    @keyframes b2{0%{opacity:0}52.3%{opacity:0}52.6%{opacity:1}96%{opacity:1}97%{opacity:0}100%{opacity:0}}
+    @keyframes b3{0%{opacity:0}52.6%{opacity:0}52.9%{opacity:1}96%{opacity:1}97%{opacity:0}100%{opacity:0}}
+    @keyframes c2{0%{opacity:0}55%{opacity:0}55.3%{opacity:1}96%{opacity:1}97%{opacity:0}100%{opacity:0}}
 
     .cursor { fill: #7ee787; animation: blink 1s steps(1) infinite; }
     @keyframes blink { 50% { opacity: 0; } }
@@ -69,19 +70,19 @@
     <text x="40" y="132" class="dim">──────────────────────────────────────────────────────────────────────</text>
   </g>
   <g class="fx a3">
-    <text x="40" y="158" class="txt"><tspan class="high">[HIGH  ]</tspan> <tspan class="val">secrets      AWS_ACCESS_KEY    100.00%  line 3 </tspan><tspan class="dim">[HIDDEN]</tspan><tspan class="val">   ticket.txt</tspan></text>
+    <text x="40" y="158" class="txt"><tspan class="high">[HIGH  ]</tspan> <tspan class="val">ssn          SSN               100.00%  line 4 </tspan><tspan class="dim">[HIDDEN]</tspan><tspan class="val">   ticket.txt</tspan></text>
   </g>
   <g class="fx a4">
-    <text x="40" y="180" class="txt"><tspan class="high">[HIGH  ]</tspan> <tspan class="val">ssn          SSN               100.00%  line 4 </tspan><tspan class="dim">[HIDDEN]</tspan><tspan class="val">   ticket.txt</tspan></text>
+    <text x="40" y="180" class="txt"><tspan class="high">[HIGH  ]</tspan> <tspan class="val">secrets      AWS_ACCESS_KEY     96.00%  line 3 </tspan><tspan class="dim">[HIDDEN]</tspan><tspan class="val">   ticket.txt</tspan></text>
   </g>
   <g class="fx a5">
-    <text x="40" y="202" class="txt"><tspan class="high">[HIGH  ]</tspan> <tspan class="val">email        BUSINESS          100.00%  line 1 </tspan><tspan class="dim">[HIDDEN]</tspan><tspan class="val">   ticket.txt</tspan></text>
+    <text x="40" y="202" class="txt"><tspan class="med">[MEDIUM]</tspan> <tspan class="val">phone        PHONE              82.00%  line 4 </tspan><tspan class="dim">[HIDDEN]</tspan><tspan class="val">   ticket.txt</tspan></text>
   </g>
   <g class="fx a6">
-    <text x="40" y="224" class="txt"><tspan class="med">[MEDIUM]</tspan> <tspan class="val">creditcard   MASTERCARD         88.00%  line 2 </tspan><tspan class="dim">[HIDDEN]</tspan><tspan class="val">   ticket.txt</tspan></text>
+    <text x="40" y="224" class="txt"><tspan class="low">[LOW   ]</tspan> <tspan class="val">email        BUSINESS           48.00%  line 1 </tspan><tspan class="dim">[HIDDEN]</tspan><tspan class="val">   ticket.txt</tspan></text>
   </g>
   <g class="fx a7">
-    <text x="40" y="246" class="txt"><tspan class="low">[LOW   ]</tspan> <tspan class="val">phone        PHONE              52.00%  line 4 </tspan><tspan class="dim">[HIDDEN]</tspan><tspan class="val">   ticket.txt</tspan></text>
+    <text x="40" y="246" class="txt"><tspan class="low">[LOW   ]</tspan> <tspan class="val">creditcard   MASTERCARD         15.00%  line 2 </tspan><tspan class="dim">[HIDDEN]</tspan><tspan class="val">   ticket.txt</tspan></text>
   </g>
   <g class="fx c1">
     <text x="40" y="300" class="caption">Values stay hidden by default. Confidence is context-aware — not just regex.</text>
@@ -97,7 +98,7 @@
   </g>
   <g class="fx b2">
     <text x="40" y="160" class="prompt" font-size="13">out ▸</text>
-    <text x="92" y="160" class="txt" font-size="14"><tspan class="kept">card 5500-</tspan><tspan class="mask">****-****</tspan><tspan class="kept">-0004  key </tspan><tspan class="mask">********************</tspan><tspan class="kept">  j</tspan><tspan class="mask">*****</tspan><tspan class="kept">@example.com</tspan></text>
+    <text x="92" y="160" class="txt" font-size="14"><tspan class="kept">card </tspan><tspan class="mask">****-****-****</tspan><tspan class="kept">-0004  key </tspan><tspan class="mask">********************</tspan><tspan class="kept">  j</tspan><tspan class="mask">*****</tspan><tspan class="kept">@example.com</tspan></text>
   </g>
   <g class="fx b3">
     <text x="40" y="200" class="dim" font-size="13">redacted bytes → stdout · findings → stderr · format-preserving, structure intact</text>

--- a/docs/user-guides/README-Stdin.md
+++ b/docs/user-guides/README-Stdin.md
@@ -94,7 +94,7 @@ The combination `--stdin --enable-redaction` is the gateway pattern. All three p
 | Strategy | Example output |
 |---|---|
 | `simple` | `card [CREDIT-CARD-REDACTED] email [EMAIL-REDACTED]` |
-| `format_preserving` | `card 5500-****-****-0004 email a****@example.com` |
+| `format_preserving` | `card ****-****-****-0004 email a****@example.com` |
 | `synthetic` | `card 5555-7344-3408-4176 email 5c0sq@example.com` |
 
 ```bash

--- a/examples/lambda-redact/README.md
+++ b/examples/lambda-redact/README.md
@@ -103,7 +103,7 @@ Content-Type: application/json
 Content-Type: application/json
 
 {
-  "redacted": "card 5500-****-****-0004 from a****@example.com",
+  "redacted": "card ****-****-****-0004 from a****@example.com",
   "request_id": "req-abc-123",
   "duration_ms": 12
 }
@@ -127,7 +127,7 @@ flag enabled:
 
 ```json
 {
-  "redacted": "card 5500-****-****-0004 from a****@example.com",
+  "redacted": "card ****-****-****-0004 from a****@example.com",
   "findings_by_type": {"MASTERCARD": 1, "EMAIL": 1},
   "request_id": "req-abc-123",
   "duration_ms": 12

--- a/pkg/redact/types.go
+++ b/pkg/redact/types.go
@@ -18,7 +18,7 @@ const (
 	Simple Strategy = iota
 
 	// FormatPreserving keeps the same length and structural format as the
-	// original (e.g. "5500-****-****-0004"). Best for callers that need
+	// original (e.g. "****-****-****-0004"). Best for callers that need
 	// the byte length and surrounding structure unchanged downstream.
 	FormatPreserving
 


### PR DESCRIPTION
## Summary

The engine now masks the BIN in credit card redaction (`****-****-****-0004`,
not `5500-****-****-0004`). This PR updates all documentation and the animated
SVG demo to match the actual v2.0.2 output.

## Changes

- **README.md** — redaction example table fixed
- **docs/images/demo.svg** — ACT 2 output corrected; ACT 1 confidence scores
  match current engine; animation timing reworked so results appear in a
  near-instant burst (~54ms between lines) then hold for reading
- **docs/user-guides/README-Stdin.md** — strategy table example fixed
- **examples/lambda-redact/README.md** — lambda output example fixed
- **pkg/redact/types.go** — `FormatPreserving` doc comment example fixed

## Verified

```bash
$ echo "card 5500-0000-0000-0004 from jordan@example.com" | ferret-scan --stdin --enable-redaction
card ****-****-****-0004 from j*****@example.com
```

Demo SVG output matches this exactly.