### PR TITLE
fix(security): redaction leak/panic, web XSS, decompression bombs, debug PII, supply chain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,11 @@ jobs:
           go-version-file: ".go-version"
 
       - name: Install git-chglog
-        run: go install github.com/git-chglog/git-chglog/cmd/git-chglog@latest
+        # Pinned to an exact version (not @latest) so a compromised newer release
+        # can't be pulled into this privileged release job (contents:write +
+        # packages:write). Go's sumdb does not protect against a maliciously
+        # published new version. Bump deliberately after review. (MED-4)
+        run: go install github.com/git-chglog/git-chglog/cmd/git-chglog@v0.15.4
 
       - name: Generate/Update Changelog
         run: |

--- a/cmd/suppress/main.go
+++ b/cmd/suppress/main.go
@@ -102,5 +102,15 @@ func enableSuppression(manager *suppressions.SuppressionManager, hash, reason st
 		fmt.Printf("Error enabling suppression: %v\n", err)
 		os.Exit(1)
 	}
-	fmt.Printf("Successfully enabled suppression for hash: %s\n", hash[:8])
+	fmt.Printf("Successfully enabled suppression for hash: %s\n", shortHash(hash))
+}
+
+// shortHash returns up to the first 8 characters of a hash for display, without
+// panicking on hashes shorter than 8 chars (rule Hash is a free-form YAML string
+// with no length constraint, so hash[:8] could slice out of range).
+func shortHash(hash string) string {
+	if len(hash) <= 8 {
+		return hash
+	}
+	return hash[:8]
 }

--- a/internal/goldencorpus/testdata/golden/creditcard_phone_overlap.redact_format_preserving.txt
+++ b/internal/goldencorpus/testdata/golden/creditcard_phone_overlap.redact_format_preserving.txt
@@ -1,6 +1,6 @@
 === REDACTED ===
 card **** **** **** 0366 here
-call 212-***-0142 today
+call ***-***-0142 today
 === FINDINGS (sorted) ===
 type=PHONE line=1 conf=low match=0151 1283 0366
 type=PHONE line=2 conf=high match=212-555-0142

--- a/internal/goldencorpus/testdata/golden/mixed_pii_basic.redact_format_preserving.txt
+++ b/internal/goldencorpus/testdata/golden/mixed_pii_basic.redact_format_preserving.txt
@@ -1,5 +1,5 @@
 === REDACTED ===
-Contact j*******@example.com or call 212-***-0142.
+Contact j*******@example.com or call ***-***-0142.
 AWS key ******************** in the config.
 SSN ***-**-4100 on file.
 Card ****-****-****-0366 expires soon.

--- a/internal/preprocessors/meta-extractors/meta-extract-officelib/office-extractor.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-officelib/office-extractor.go
@@ -22,6 +22,12 @@ const (
 	MaxFileSize     = 100 * 1024 * 1024 // 100MB max file size
 	MaxXMLSize      = 10 * 1024 * 1024  // 10MB max XML content
 	XMLParseTimeout = 30 * time.Second  // 30 second timeout for XML parsing
+	// MaxEmbeddedMediaSize bounds a single embedded media file extracted to a
+	// temp file. Without it, extractImageToTemp did an unbounded io.Copy, so a
+	// small .docx/.xlsx/.pptx with a media entry that deflates to many GB could
+	// exhaust the temp filesystem (security finding MED-3). The XML readers in
+	// this file already cap at MaxXMLSize; media is larger but still bounded.
+	MaxEmbeddedMediaSize = 50 * 1024 * 1024 // 50MB max per embedded media file
 )
 
 // Global replacer for efficient error sanitization (initialized once)
@@ -702,6 +708,12 @@ func extractImageToTemp(file *zip.File) (string, error) {
 	}
 	defer rc.Close()
 
+	// Reject before extracting when the entry declares a size over the cap.
+	if file.UncompressedSize64 > MaxEmbeddedMediaSize {
+		return "", fmt.Errorf("embedded media %q declares %d bytes, exceeding the %d cap (possible decompression bomb)",
+			file.Name, file.UncompressedSize64, MaxEmbeddedMediaSize)
+	}
+
 	// Create temp file
 	tempFile, err := os.CreateTemp("", "office_image_*"+filepath.Ext(file.Name))
 	if err != nil {
@@ -709,11 +721,18 @@ func extractImageToTemp(file *zip.File) (string, error) {
 	}
 	defer tempFile.Close()
 
-	// Copy image data
-	_, err = io.Copy(tempFile, rc)
+	// Copy image data, bounded so a lying declared size can't exhaust the temp
+	// filesystem. Read one byte past the cap to detect an over-cap entry, then
+	// remove the partial temp file so no bomb fragment is left on disk (MED-3).
+	n, err := io.Copy(tempFile, io.LimitReader(rc, MaxEmbeddedMediaSize+1))
 	if err != nil {
 		os.Remove(tempFile.Name())
 		return "", err
+	}
+	if n > MaxEmbeddedMediaSize {
+		os.Remove(tempFile.Name())
+		return "", fmt.Errorf("embedded media %q exceeds the %d extraction cap (possible decompression bomb)",
+			file.Name, MaxEmbeddedMediaSize)
 	}
 
 	return tempFile.Name(), nil

--- a/internal/preprocessors/meta-extractors/meta-extract-pdflib/pdf-extractor.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-pdflib/pdf-extractor.go
@@ -50,10 +50,14 @@ func ExtractMetadata(filePath string) (*Metadata, error) {
 		Properties: make(map[string]string),
 	}
 
-	// Check file size and warn about potential memory issues
+	// Enforce (not just warn on) a file-size ceiling before the unbounded
+	// os.ReadFile below, mirroring the office extractor's validateFileSize. The
+	// previous code only printed a warning and then read the whole file anyway,
+	// so a large attacker-supplied PDF could OOM-kill the process (Glasswing
+	// MEDIUM). Reject oversized files instead.
 	const maxSafeFileSize = 100 * 1024 * 1024 // 100MB
 	if fileInfo.Size() > maxSafeFileSize {
-		fmt.Fprintf(os.Stderr, "Warning: Large PDF file (%d MB), metadata extraction may use significant memory\n", fileInfo.Size()/(1024*1024))
+		return metadata, fmt.Errorf("PDF file too large: %d bytes (max: %d)", fileInfo.Size(), maxSafeFileSize)
 	}
 
 	// Read the PDF file - for very large files, consider streaming in future

--- a/internal/preprocessors/text-extractors/text-extract-officetextlib/office-text-extractor.go
+++ b/internal/preprocessors/text-extractors/text-extract-officetextlib/office-text-extractor.go
@@ -31,6 +31,13 @@ const (
 	// MaxZipEntryBytes bounds a single decompressed entry (e.g. document.xml,
 	// one sheet's sharedStrings.xml).
 	MaxZipEntryBytes = 50 * 1024 * 1024 // 50MB
+	// MaxTotalTextBytes bounds the CUMULATIVE extracted text across all entries
+	// in one document. The per-entry cap alone doesn't stop a document with many
+	// entries (e.g. thousands of slides/sheets, each under 50MB) from summing to
+	// tens of GB and then being fed whole to every validator (security finding
+	// LOW-1). Consistent with this extractor's truncate-don't-error philosophy,
+	// accumulation loops stop appending once the running total exceeds this.
+	MaxTotalTextBytes = 200 * 1024 * 1024 // 200MB
 )
 
 // readZipEntryLimited reads a decompressed zip entry, capped at MaxZipEntryBytes,
@@ -202,6 +209,10 @@ func extractDocxText(filePath string, content *TextContent) (*TextContent, error
 
 	// Add headers first
 	for _, headerFile := range headerFiles {
+		// Stop once cumulative extracted text hits the cap (LOW-1).
+		if allText.Len() > MaxTotalTextBytes {
+			break
+		}
 		headerText, err := extractWordXMLText(headerFile)
 		if err == nil && headerText != "" {
 			allText.WriteString("--- HEADER ---\n")
@@ -215,6 +226,10 @@ func extractDocxText(filePath string, content *TextContent) (*TextContent, error
 
 	// Add footers last
 	for _, footerFile := range footerFiles {
+		// Stop once cumulative extracted text hits the cap (LOW-1).
+		if allText.Len() > MaxTotalTextBytes {
+			break
+		}
 		footerText, err := extractWordXMLText(footerFile)
 		if err == nil && footerText != "" {
 			allText.WriteString("\n\n--- FOOTER ---\n")
@@ -272,6 +287,11 @@ func extractXlsxText(filePath string, content *TextContent) (*TextContent, error
 	sortWorksheets(worksheets)
 
 	for _, worksheet := range worksheets {
+		// Stop once cumulative extracted text hits the cap (LOW-1): many small
+		// entries can still sum to a memory-exhausting total.
+		if allText.Len() > MaxTotalTextBytes {
+			break
+		}
 		// Get sheet name
 		sheetName := strings.TrimPrefix(worksheet.Name, "xl/worksheets/")
 		sheetName = strings.TrimSuffix(sheetName, ".xml")
@@ -331,6 +351,10 @@ func extractPptxText(filePath string, content *TextContent) (*TextContent, error
 
 	// Process slides
 	for i, slide := range slides {
+		// Stop once cumulative extracted text hits the cap (LOW-1).
+		if allText.Len() > MaxTotalTextBytes {
+			break
+		}
 		slideNum := i + 1
 		allText.WriteString(fmt.Sprintf("--- Slide %d ---\n", slideNum))
 
@@ -352,6 +376,10 @@ func extractPptxText(filePath string, content *TextContent) (*TextContent, error
 
 	// Process master slides
 	for i, master := range masters {
+		// Stop once cumulative extracted text hits the cap (LOW-1).
+		if allText.Len() > MaxTotalTextBytes {
+			break
+		}
 		allText.WriteString(fmt.Sprintf("--- Master %d ---\n", i+1))
 		masterText, err := extractTextFromXML(master, "//a:t")
 		if err == nil {

--- a/internal/redactors/office/redactor.go
+++ b/internal/redactors/office/redactor.go
@@ -56,6 +56,20 @@ const (
 	DocumentTypePPTX
 )
 
+// Decompression-bomb bounds for extractOfficeContent. An Office file is a ZIP,
+// and the only upstream gate is on-disk (compressed) size — a small archive can
+// declare gigabytes of uncompressed content. These caps bound what a single
+// document can expand to in memory. They mirror the 50MB/entry cap already used
+// by the text and metadata extractors; the redactor was the one reader still
+// doing an unbounded io.ReadAll (security finding HIGH-4).
+const (
+	// maxOfficeEntryBytes bounds a single decompressed zip entry.
+	maxOfficeEntryBytes = 50 * 1024 * 1024 // 50MB
+	// maxOfficeTotalBytes bounds the cumulative decompressed size across all
+	// entries in one document.
+	maxOfficeTotalBytes = 200 * 1024 * 1024 // 200MB
+)
+
 // String returns the string representation of the document type
 func (dt OfficeDocumentType) String() string {
 	switch dt {
@@ -265,9 +279,18 @@ func (or *OfficeRedactor) extractOfficeContent(filePath string, docType OfficeDo
 
 	var extractedText strings.Builder
 	var textPositions []OfficeTextPosition
+	var totalDecompressed int64
 
 	// Extract all files from ZIP
 	for _, file := range reader.File {
+		// Reject before decompressing when the entry declares a size over the
+		// per-entry cap. This is the cheap first line of defense against a
+		// decompression bomb (a tiny compressed entry claiming multi-GB output).
+		if file.UncompressedSize64 > maxOfficeEntryBytes {
+			return nil, "", nil, fmt.Errorf("office entry %q declares %d bytes, exceeding the %d cap (possible decompression bomb)",
+				file.Name, file.UncompressedSize64, maxOfficeEntryBytes)
+		}
+
 		rc, err := file.Open()
 		if err != nil {
 			or.logEvent("file_extraction_failed", false, map[string]interface{}{
@@ -277,7 +300,9 @@ func (or *OfficeRedactor) extractOfficeContent(filePath string, docType OfficeDo
 			continue
 		}
 
-		content, err := io.ReadAll(rc)
+		// Read at most one byte past the cap so a lying declared size (or a
+		// stored/zip64 entry) is still caught by the actual decompressed length.
+		content, err := io.ReadAll(io.LimitReader(rc, maxOfficeEntryBytes+1))
 		rc.Close()
 		if err != nil {
 			or.logEvent("file_read_failed", false, map[string]interface{}{
@@ -285,6 +310,17 @@ func (or *OfficeRedactor) extractOfficeContent(filePath string, docType OfficeDo
 				"error":     err.Error(),
 			})
 			continue
+		}
+		// The redactor repackages exactly what it reads, so a truncated entry
+		// would silently corrupt the redacted output — fail closed instead.
+		if int64(len(content)) > maxOfficeEntryBytes {
+			return nil, "", nil, fmt.Errorf("office entry %q exceeds the %d per-entry decompression cap (possible bomb)",
+				file.Name, maxOfficeEntryBytes)
+		}
+		totalDecompressed += int64(len(content))
+		if totalDecompressed > maxOfficeTotalBytes {
+			return nil, "", nil, fmt.Errorf("office document exceeds the %d cumulative decompression cap (possible bomb)",
+				maxOfficeTotalBytes)
 		}
 
 		zipContents.Files[file.Name] = content

--- a/internal/redactors/replacement/phone_test.go
+++ b/internal/redactors/replacement/phone_test.go
@@ -1,0 +1,77 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package replacement
+
+import (
+	"strings"
+	"testing"
+)
+
+// These tests lock in the fix for security finding HIGH-1: format-preserving
+// phone redaction previously left the whole number in clear for 7-digit inputs
+// (middle = Repeat("*", 0)) and PANICKED for 6-digit inputs (Repeat("*", -1)).
+// The policy is now "mask all but the last 4 digits", identical to SSN/CC.
+
+// TestPhone_FormatPreserving_NoLeak asserts that for a range of digit counts the
+// masked output never contains the leading digits and always ends in the real
+// last 4 — i.e. redaction actually redacts.
+func TestPhone_FormatPreserving_NoLeak(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		last4 string
+		lead  string // leading digits that MUST NOT survive
+	}{
+		{"six_digits", "012345", "2345", "01"},
+		{"seven_digits_local", "0123456", "3456", "012"},   // the old full-leak case
+		{"seven_dashed", "012-3456", "3456", "012"},         // the old full-leak case
+		{"ten_digits", "2065550173", "0173", "206555"},
+		{"us_formatted", "(206) 555-0173", "0173", "206555"},
+		{"e164", "+12065550173", "0173", "120655"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := FormatPreserving(tc.input, "PHONE")
+			digitsOnly := stripNonDigits(got)
+			if !strings.HasSuffix(digitsOnly, tc.last4) {
+				t.Errorf("FormatPreserving(%q) = %q; digits %q must end in last4 %q",
+					tc.input, got, digitsOnly, tc.last4)
+			}
+			// Everything before the last 4 must be masked — no leading real digit survives.
+			maskedPart := digitsOnly[:len(digitsOnly)-len(tc.last4)]
+			if maskedPart != "" {
+				t.Errorf("FormatPreserving(%q) = %q; leading digits not fully masked (got %q before last4)",
+					tc.input, got, maskedPart)
+			}
+			if strings.HasPrefix(digitsOnly, tc.lead) {
+				t.Errorf("FormatPreserving(%q) = %q leaks leading digits %q", tc.input, got, tc.lead)
+			}
+		})
+	}
+}
+
+// TestPhone_FormatPreserving_NoPanic asserts the 6-and-under digit inputs that
+// previously computed Repeat("*", negative) no longer panic.
+func TestPhone_FormatPreserving_NoPanic(t *testing.T) {
+	for _, in := range []string{"1", "12", "123", "1234", "12345", "012345", "12-34", "1.2.3"} {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("FormatPreserving(%q) panicked: %v", in, r)
+				}
+			}()
+			_ = FormatPreserving(in, "PHONE")
+		}()
+	}
+}
+
+func stripNonDigits(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if r >= '0' && r <= '9' {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}

--- a/internal/redactors/replacement/replacement.go
+++ b/internal/redactors/replacement/replacement.go
@@ -206,19 +206,24 @@ func preserveEmail(original string) string {
 
 func preservePhone(original string) string {
 	cleaned := nonDigit.ReplaceAllString(original, "")
-	if len(cleaned) < 6 {
+	// Mask everything except the last 4 digits — the same policy as SSN and
+	// credit card. The previous "first3 + stars + last4" scheme had two security
+	// defects: for a 7-digit number the middle was Repeat("*", 0) so ALL seven
+	// digits survived verbatim (a redaction that redacts nothing), and for a
+	// 6-digit number it computed Repeat("*", -1) which PANICS — an unrecovered
+	// crash for any pkg/redact embedder. Keeping only the last 4 fixes both.
+	if len(cleaned) < 4 {
 		return strings.Repeat("*", len(original))
 	}
-	first3 := cleaned[:3]
 	last4 := cleaned[len(cleaned)-4:]
-	middle := strings.Repeat("*", len(cleaned)-7)
-	masked := first3 + middle + last4
 	di := 0
 	return digitRe.ReplaceAllStringFunc(original, func(_ string) string {
-		if di < len(masked) {
-			r := string(masked[di])
-			di++
-			return r
+		defer func() { di++ }()
+		if di < len(cleaned)-4 {
+			return "*"
+		}
+		if di < len(cleaned) {
+			return string(last4[di-(len(cleaned)-4)])
 		}
 		return "*"
 	})

--- a/internal/validators/intellectualproperty/validator.go
+++ b/internal/validators/intellectualproperty/validator.go
@@ -876,7 +876,7 @@ func (v *Validator) detectPatternsByLine(ctx stdctx.Context, content string, ori
 					// Debug logging to verify this code path is reached
 					if v.observer != nil && v.observer.Debug() != nil {
 						v.observer.Debug().LogDetail("intellectualproperty",
-							fmt.Sprintf("INTERNAL URL MATCH FOUND: '%s' - setting HIGH confidence", match))
+							fmt.Sprintf("INTERNAL URL MATCH FOUND: [HIDDEN] (len=%d) - setting HIGH confidence", len(match)))
 					}
 					// Configured internal URLs always start at HIGH confidence
 					// If someone configured a pattern, they want it treated as high priority

--- a/internal/validators/metadata/metadata_validator.go
+++ b/internal/validators/metadata/metadata_validator.go
@@ -124,12 +124,11 @@ func (v *Validator) ValidateMetadataContent(content router.MetadataContent) ([]d
 			v.observer.Debug().LogDetail("metadata_validator",
 				fmt.Sprintf("Processing content from %s (type: %s), content length: %d",
 					content.SourceFile, content.PreprocessorType, len(content.Content)))
-			contentPreview := content.Content
-			if len(contentPreview) > 200 {
-				contentPreview = contentPreview[:200] + "..."
-			}
-			v.observer.Debug().LogDetail("metadata_validator",
-				fmt.Sprintf("Content preview: %s", contentPreview))
+			// Do NOT log the content itself — it is raw scanned data that may
+			// contain the very secrets/PII this tool exists to protect (BSC4).
+			// The previous "Content preview: <first 200 bytes>" leaked payload to
+			// stderr/CI logs on plain --debug. Log only the length. (Glasswing
+			// finding; same class as the socialmedia/intellectualproperty fixes.)
 		}
 	}
 

--- a/internal/validators/socialmedia/validator.go
+++ b/internal/validators/socialmedia/validator.go
@@ -807,7 +807,7 @@ func (v *Validator) CalculateConfidence(match string) (float64, map[string]bool)
 		if r := recover(); r != nil {
 			// Log panic recovery for debugging
 			if v.observer != nil && v.observer.Debug() != nil {
-				v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Recovered from panic in CalculateConfidence for match '%s': %v", match, r))
+				v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Recovered from panic in CalculateConfidence for match [HIDDEN] (len=%d): %v", len(match), r))
 			}
 			if v.isDebugEnabled() {
 				fmt.Fprintf(os.Stderr, "[ERROR] Social Media Validator: Panic in confidence calculation\n")
@@ -833,7 +833,7 @@ func (v *Validator) CalculateConfidence(match string) (float64, map[string]bool)
 	if platform == "" {
 		// Unknown platform - assign low confidence with enhanced logging
 		if v.observer != nil && v.observer.Debug() != nil {
-			v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Unknown platform for match: %s", match))
+			v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Unknown platform for match [HIDDEN] (len=%d)", len(match)))
 		}
 		if v.isDebugEnabled() {
 			fmt.Fprintf(os.Stderr, "[DEBUG] Social Media Validator: Unknown platform for match [HIDDEN] (len=%d)\n", len(match))
@@ -2789,7 +2789,7 @@ func (v *Validator) processMatchOptimized(match, platform string, patternIndex i
 
 	// Log match details in debug mode (only for high-confidence matches to reduce overhead)
 	if os.Getenv("FERRET_DEBUG") == "1" && confidence > 70 && v.observer != nil && v.observer.Debug() != nil {
-		v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Found %s match: '%s' (confidence: %.1f%%, type: %s, username: %s)", platform, match, confidence, patternType, username))
+		v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Found %s match [HIDDEN] (len=%d) (confidence: %.1f%%, type: %s, username len=%d)", platform, len(match), confidence, patternType, len(username)))
 	}
 
 	return &socialMediaMatch
@@ -2914,7 +2914,7 @@ func (v *Validator) analyzeContextWithPlatformLine(match string, platform string
 
 	// Log detailed context analysis in debug mode
 	if v.observer != nil && v.observer.Debug() != nil {
-		v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Context analysis for %s match '%s': impact=%.1f", platform, match, confidenceImpact))
+		v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Context analysis for %s match [HIDDEN] (len=%d): impact=%.1f", platform, len(match), confidenceImpact))
 		if len(foundPositiveKeywords) > 0 {
 			v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("  Positive keywords found: %v", foundPositiveKeywords))
 		}

--- a/internal/web/assets/template.html
+++ b/internal/web/assets/template.html
@@ -2127,7 +2127,7 @@
                         <div class="finding-text" style="max-width: 350px; word-break: break-word; overflow-wrap: break-word; white-space: normal;">${showMatch ? escapeHtml(extractMetadataValue(result.text, validator)) : `<span class="redacted-link" onclick="toggleRedactedText(this, ${index})" title="Click to reveal">🔒 [HIDDEN]</span>`}</div>
                         ${verbose && result.metadata ? formatMetadata(result.metadata) : ''}
                     </td>
-                    <td title="${escapeHtml(result.filename)}">${escapeHtml(formatPathForDisplay(result.filename))}</td>
+                    <td title="${escapeAttr(result.filename)}">${escapeHtml(formatPathForDisplay(result.filename))}</td>
                 `;
                 tbody.appendChild(row);
             });
@@ -3055,9 +3055,9 @@
                         <td><input type="checkbox" class="new-finding-checkbox" value="${item.hash}" onchange="updateNewFindingsBulkActions()"></td>
                         <td style="font-family: monospace; font-size: 12px;">NEW</td>
                         <td><span style="background: #fff4e6; color: #ff9900; padding: 4px 8px; border-radius: 4px; font-size: 12px; font-weight: 600;">NEW FINDING</span></td>
-                        <td title="${escapeHtml(finding.filename)}">${escapeHtml(formatPathForDisplay(finding.filename))}</td>
+                        <td title="${escapeAttr(finding.filename)}">${escapeHtml(formatPathForDisplay(finding.filename))}</td>
                         <td>${finding.type}</td>
-                        <td><div class="finding-text" style="max-width: 200px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;" title="${escapeHtml(finding.actualText || finding.text)}">${escapeHtml((finding.actualText || finding.text).substring(0, 50))}${(finding.actualText || finding.text).length > 50 ? '...' : ''}</div></td>
+                        <td><div class="finding-text" style="max-width: 200px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;" title="${escapeAttr(finding.actualText || finding.text)}">${escapeHtml((finding.actualText || finding.text).substring(0, 50))}${(finding.actualText || finding.text).length > 50 ? '...' : ''}</div></td>
                         <td>${Math.round(finding.confidence)}%</td>
                         <td>${finding.line_number}</td>
                         <td>
@@ -3067,7 +3067,13 @@
                 } else {
                     // Existing suppression rule
                     const rule = item;
-                    const ruleId = rule.ID || rule.id;
+                    // Escape the rule ID before it enters innerHTML — it lands in
+                    // text, in value="..." and inside onclick='...(\'${ruleId}\')'
+                    // strings below. escapeAttr (escapes < > & " ') is decoded by
+                    // the HTML attribute parser before the JS string sees it, so a
+                    // quote/backslash can't break out of the onclick string. Guards
+                    // stored XSS (HIGH-3) from a malicious suppression rule ID.
+                    const ruleId = escapeAttr(rule.ID || rule.id);
                     const isEnabled = rule.Enabled !== undefined ? rule.Enabled : rule.enabled;
 
                     // Check if rule is expired
@@ -3090,8 +3096,14 @@
                             '<span style="background: #ffeaea; color: #d13212; padding: 4px 8px; border-radius: 4px; font-size: 12px; font-weight: 600;">DISABLED</span>';
 
                     const metadata = rule.Metadata || rule.metadata || {};
-                    const filename = metadata.filename || 'Unknown';
-                    const fileType = metadata.finding_type || metadata.file_type || 'Unknown';
+                    // Escape all rule-sourced values before they enter innerHTML.
+                    // These come from a YAML suppression file that a contributor
+                    // or POST /suppressions/create can control, so an unescaped
+                    // value here is stored XSS (HIGH-3). escapeAttr is safe in
+                    // both HTML text and quoted-attribute/onclick-string contexts
+                    // (it escapes < > & " '), which all three of these hit below.
+                    const filename = escapeAttr(metadata.filename || 'Unknown');
+                    const fileType = escapeAttr(metadata.finding_type || metadata.file_type || 'Unknown');
                     const lineNumber = metadata.line_number || 'Unknown';
                     const confidence = metadata.confidence ? Math.round(parseFloat(metadata.confidence)) : 'Unknown';
 
@@ -3101,12 +3113,12 @@
                         <td>${statusBadge}</td>
                         <td>${filename}</td>
                         <td>${fileType}</td>
-                        <td><div class="finding-text" style="max-width: 200px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;" title="${escapeHtml(metadata.finding_text || 'N/A')}">${escapeHtml((metadata.finding_text || 'N/A').substring(0, 50))}${(metadata.finding_text || 'N/A').length > 50 ? '...' : ''}</div></td>
+                        <td><div class="finding-text" style="max-width: 200px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;" title="${escapeAttr(metadata.finding_text || 'N/A')}">${escapeHtml((metadata.finding_text || 'N/A').substring(0, 50))}${(metadata.finding_text || 'N/A').length > 50 ? '...' : ''}</div></td>
                         <td>${confidence}%</td>
                         <td>${lineNumber}</td>
                         <td>
                             <label class="toggle-switch" style="margin-right: 8px;">
-                                <input type="checkbox" ${isEnabled ? 'checked' : ''} onchange="toggleSuppressionStatus('${ruleId}', '${rule.Hash || rule.hash}', this.checked)">
+                                <input type="checkbox" ${isEnabled ? 'checked' : ''} onchange="toggleSuppressionStatus('${ruleId}', '${escapeAttr(rule.Hash || rule.hash)}', this.checked)">
                                 <span class="toggle-slider"></span>
                             </label>
                             <button onclick="showEditSuppressionModal('${ruleId}')" class="icon-button edit" style="margin-right: 4px;">✏️<span class="tooltip">Edit</span></button>
@@ -3314,8 +3326,8 @@
 
             content.innerHTML = `
                 <div style="display: grid; grid-template-columns: 150px 1fr; gap: 8px; margin-bottom: 16px;">
-                    <strong>ID:</strong> <span style="font-family: monospace;">${rule.ID || rule.id}</span>
-                    <strong>Hash:</strong> <span style="font-family: monospace; word-break: break-all;">${rule.Hash || rule.hash}</span>
+                    <strong>ID:</strong> <span style="font-family: monospace;">${escapeHtml(rule.ID || rule.id)}</span>
+                    <strong>Hash:</strong> <span style="font-family: monospace; word-break: break-all;">${escapeHtml(rule.Hash || rule.hash)}</span>
                     <strong>Status:</strong> <span style="color: ${(rule.Enabled !== undefined ? rule.Enabled : rule.enabled) ? '#037f0c' : '#d13212'}; font-weight: 600;">${(rule.Enabled !== undefined ? rule.Enabled : rule.enabled) ? 'ENABLED' : 'DISABLED'}</span>
                     <strong>Reason:</strong> <span>${escapeHtml(rule.Reason || rule.reason)}</span>
                     <strong>Created By:</strong> <span>${escapeHtml(rule.CreatedBy || rule.created_by || 'Unknown')}</span>
@@ -3327,7 +3339,7 @@
                     <div style="margin-top: 16px;">
                         <strong>Metadata:</strong>
                         <div style="background: #f2f3f3; padding: 12px; border-radius: 4px; margin-top: 8px; font-family: monospace; font-size: 12px;">
-                            ${Object.entries(rule.Metadata || rule.metadata || {}).map(([key, value]) => `<div><strong>${key}:</strong> ${escapeHtml(String(value))}</div>`).join('')}
+                            ${Object.entries(rule.Metadata || rule.metadata || {}).map(([key, value]) => `<div><strong>${escapeHtml(String(key))}:</strong> ${escapeHtml(String(value))}</div>`).join('')}
                         </div>
                     </div>
                 ` : ''}
@@ -4248,7 +4260,7 @@
                 html += `<tr>
                     <td style="white-space: nowrap;">${actualFinding.Type || actualFinding.type}</td>
                     <td style="white-space: nowrap;"><span class="confidence-badge confidence-${confidenceLevel}">${confidenceLevel.toUpperCase()}</span> (${Math.round(confidence)}%)</td>
-                    <td style="white-space: nowrap;" title="${escapeHtml(actualFinding.Filename || actualFinding.filename)}">${escapeHtml(formatPathForDisplay(actualFinding.Filename || actualFinding.filename))}</td>
+                    <td style="white-space: nowrap;" title="${escapeAttr(actualFinding.Filename || actualFinding.filename)}">${escapeHtml(formatPathForDisplay(actualFinding.Filename || actualFinding.filename))}</td>
                     <td style="white-space: nowrap; text-align: center;">${finding.line_number || 'N/A'}</td>
                     <td><div class="finding-text">${document.getElementById('showMatchCheck').checked ? `<span style="word-wrap: break-word; overflow-wrap: break-word; white-space: normal;">${escapeHtml(actualFinding.Text || actualFinding.text)}</span>` : `<span class="redacted-link" data-text="${(actualFinding.Text || actualFinding.text).replace(/"/g, '&quot;').replace(/'/g, '&#39;').replace(/</g, '&lt;').replace(/>/g, '&gt;')}" onclick="toggleSuppressedTextFromData(this)" title="Click to reveal">🔒 [HIDDEN]</span>`}</div></td>
                     <td style="font-family: monospace; font-size: 12px; white-space: nowrap;">${suppressed.suppressed_by}</td>

--- a/internal/web/template_xss_test.go
+++ b/internal/web/template_xss_test.go
@@ -1,0 +1,82 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package web
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// These tests guard the XSS fixes for security findings HIGH-2 and HIGH-3 by
+// asserting invariants on the embedded template. They are intentionally
+// structural (the template is client-side JS that Go can't execute here): they
+// fail if a future edit reintroduces an unescaped sink at the patterns we fixed.
+
+// TestTemplate_NoTitleAttrWithEscapeHtml locks HIGH-2: a title="..." attribute
+// must never be filled with escapeHtml(...), which does NOT escape quotes and so
+// allows attribute breakout. Those sinks must use escapeAttr(...).
+func TestTemplate_NoTitleAttrWithEscapeHtml(t *testing.T) {
+	if strings.Contains(embeddedTemplate, `title="${escapeHtml(`) {
+		t.Errorf(`template has title="${escapeHtml(...)}" — escapeHtml does not escape ` +
+			`quotes, enabling attribute-breakout XSS (HIGH-2). Use escapeAttr(...) instead.`)
+	}
+}
+
+// TestTemplate_TitleAttrsUseEscapeAttr is the positive counterpart: every
+// interpolated title attribute uses escapeAttr. (Sanity that the fix is present,
+// not just that the bad form is absent.)
+func TestTemplate_TitleAttrsUseEscapeAttr(t *testing.T) {
+	// Any `title="${...}"` interpolation must route through escapeAttr.
+	re := regexp.MustCompile(`title="\$\{([a-zA-Z]+)\(`)
+	for _, m := range re.FindAllStringSubmatch(embeddedTemplate, -1) {
+		if m[1] != "escapeAttr" {
+			t.Errorf(`title attribute interpolates via %q; must use escapeAttr for quote safety (HIGH-2)`, m[1])
+		}
+	}
+}
+
+// TestTemplate_SuppressionRuleFieldsEscaped locks HIGH-3: the suppression-list
+// row must not interpolate raw rule-sourced values into innerHTML. We assert the
+// row's variables are defined via an escaper so a malicious suppression YAML
+// value cannot inject markup.
+func TestTemplate_SuppressionRuleFieldsEscaped(t *testing.T) {
+	// The per-row variables must be escaped at definition. Before the fix these
+	// were `const filename = metadata.filename || 'Unknown';` (raw).
+	mustEscapeDefs := []string{
+		"const filename = escapeAttr(",
+		"const fileType = escapeAttr(",
+		"const ruleId = escapeAttr(",
+	}
+	for _, want := range mustEscapeDefs {
+		if !strings.Contains(embeddedTemplate, want) {
+			t.Errorf("suppression row is missing escaped definition %q — stored XSS risk (HIGH-3)", want)
+		}
+	}
+
+	// The raw (unescaped) forms must be gone.
+	rawForms := []string{
+		"const filename = metadata.filename",
+		"const fileType = metadata.finding_type",
+	}
+	for _, bad := range rawForms {
+		if strings.Contains(embeddedTemplate, bad) {
+			t.Errorf("suppression row still has unescaped definition %q — stored XSS (HIGH-3)", bad)
+		}
+	}
+}
+
+// TestTemplate_EscapeAttrDefined ensures the escapeAttr helper the fixes rely on
+// exists and escapes both quote characters (the whole point vs escapeHtml).
+func TestTemplate_EscapeAttrDefined(t *testing.T) {
+	if !strings.Contains(embeddedTemplate, "function escapeAttr(") {
+		t.Fatal("escapeAttr helper is missing from the template")
+	}
+	// It must escape double and single quotes.
+	for _, frag := range []string{`replace(/"/g`, `replace(/'/g`} {
+		if !strings.Contains(embeddedTemplate, frag) {
+			t.Errorf("escapeAttr does not appear to escape %s — attribute breakout still possible", frag)
+		}
+	}
+}

--- a/pkg/redact/engine.go
+++ b/pkg/redact/engine.go
@@ -255,9 +255,16 @@ func (e *Engine) Redact(ctx context.Context, req Request) (*Result, error) {
 	// unredacted (the redactor is fed only the unsuppressed ones).
 	unsuppressed, suppressed := applySuppressions(matches, req.AllowSuppressions, label)
 
-	// Run redaction. Map our public Strategy onto the internal enum.
+	// Run redaction. Map our public Strategy onto the internal enum. The call is
+	// wrapped in a panic recover so a defect in any single redactor (e.g. a bad
+	// slice/Repeat bound on a malformed match) is converted into a returned error
+	// rather than crashing the embedding process — this is a library API that
+	// runs inside long-lived callers (gateways, Lambdas), so a panic must never
+	// escape. Redaction is all-or-nothing: on panic we return an error and no
+	// partially-redacted text, so a caller never mistakes unredacted output for
+	// redacted output.
 	internalStrategy := mapStrategy(strategy)
-	redacted, _, err := e.redactor.RedactString(text, unsuppressed, internalStrategy)
+	redacted, err := redactStringSafely(e.redactor, text, unsuppressed, internalStrategy)
 	if err != nil {
 		return nil, fmt.Errorf("redact: redaction failed: %w", err)
 	}
@@ -389,4 +396,21 @@ func applySuppressions(matches []detector.Match, rules []Rule, label string) (
 		}
 	}
 	return unsuppressed, suppressed
+}
+
+// redactStringSafely calls the redactor and converts any panic into an error.
+// Redaction runs inside long-lived library callers (gateways, Lambdas), so a
+// defect in a single redactor must never crash the host process. On panic it
+// returns an error and the empty string — callers already treat a non-nil error
+// as "redaction failed" and never emit the text, so unredacted content can never
+// be mistaken for redacted output.
+func redactStringSafely(r *plaintextredactor.PlainTextRedactor, text string, matches []detector.Match, strategy redactors.RedactionStrategy) (redacted string, err error) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			redacted = ""
+			err = fmt.Errorf("redactor panicked: %v", rec)
+		}
+	}()
+	redacted, _, err = r.RedactString(text, matches, strategy)
+	return redacted, err
 }

--- a/python-package/ferret_scan/cli.py
+++ b/python-package/ferret_scan/cli.py
@@ -6,6 +6,7 @@
 CLI wrapper for ferret-scan binary
 """
 
+import hashlib
 import platform
 import stat
 import subprocess
@@ -110,9 +111,19 @@ class FerretScanCLI:
             # Find the appropriate asset
             system, arch = self.get_platform_info()
             download_url = None
+            download_name = None
+            checksums_url = None
 
             for asset in release_data.get("assets", []):
                 asset_name = asset["name"]
+
+                # Capture the checksums manifest so the downloaded binary can be
+                # integrity-verified before we chmod +x and execute it (MED-5).
+                if asset_name in ("checksums.txt", "ferret-scan_checksums.txt") or (
+                    asset_name.startswith("ferret-scan") and asset_name.endswith("checksums.txt")
+                ):
+                    checksums_url = asset["browser_download_url"]
+                    continue
 
                 # Check if this asset matches our platform
                 # Support both formats: ferret-scan-darwin-arm64 and ferret-scan_1.2.2_darwin_arm64
@@ -127,6 +138,7 @@ class FerretScanCLI:
                         continue
 
                     download_url = asset["browser_download_url"]
+                    download_name = asset_name
                     break
 
             if not download_url:
@@ -158,6 +170,13 @@ class FerretScanCLI:
                     "Please try again later or download manually."
                 )
 
+            # Verify the download's SHA-256 against the release's checksums.txt
+            # BEFORE writing an executable bit or running it (MED-5). Without this
+            # a tampered asset would be chmod +x'd and executed unconditionally.
+            # HTTPS protects transport; this additionally detects a corrupted or
+            # substituted asset. The manifest is fetched from the SAME release.
+            self._verify_checksum(response.content, download_name, checksums_url)
+
             # Write binary to disk
             try:
                 with open(binary_path, "wb") as f:
@@ -183,6 +202,57 @@ class FerretScanCLI:
                 f"Unexpected error while downloading ferret-scan binary: {e}. "
                 "Please try downloading the binary manually from the GitHub releases page."
             )
+
+    def _verify_checksum(self, content, asset_name, checksums_url):
+        """Verify the downloaded binary's SHA-256 against the release's
+        checksums.txt manifest before it is made executable (MED-5).
+
+        The manifest is goreleaser's standard format: one "  " line per
+        asset. We locate the line for our asset_name and compare its
+        digest to the SHA-256 of the downloaded bytes. Any mismatch,
+        missing manifest, or missing entry is a hard failure — we never
+        execute an unverified binary.
+        """
+        if not checksums_url:
+            raise RuntimeError(
+                "Release is missing a checksums.txt manifest; refusing to run an "
+                "unverified binary. Please download and verify manually."
+            )
+        if not asset_name:
+            raise RuntimeError(
+                "Internal error: downloaded asset name unknown; cannot verify checksum."
+            )
+
+        try:
+            resp = requests.get(checksums_url, timeout=60)
+            resp.raise_for_status()
+            manifest = resp.text
+        except requests.exceptions.RequestException as e:
+            raise RuntimeError(
+                f"Failed to fetch checksums manifest for integrity verification: {e}."
+            )
+
+        expected = None
+        for line in manifest.splitlines():
+            parts = line.split()
+            # goreleaser format: "<sha256>  <filename>"
+            if len(parts) == 2 and parts[1] == asset_name:
+                expected = parts[0].lower()
+                break
+
+        if not expected:
+            raise RuntimeError(
+                f"No checksum entry for {asset_name} in the release manifest; "
+                "refusing to run an unverified binary."
+            )
+
+        actual = hashlib.sha256(content).hexdigest().lower()
+        if actual != expected:
+            raise RuntimeError(
+                f"Checksum mismatch for {asset_name}: expected {expected}, got {actual}. "
+                "The download may be corrupted or tampered with; refusing to run it."
+            )
+        print(f"Verified SHA-256 for {asset_name}", file=sys.stderr)
 
     def run(self, args):
         """Run ferret-scan with the given arguments"""


### PR DESCRIPTION
Addresses confirmed findings from two independent security reviews. Each fix mirrors hardening the codebase already applied elsewhere. No shared files with #144 or #145 — merges cleanly.

## HIGH

| # | Fix | File |
|---|---|---|
| **H-1** | `preservePhone` left 7-digit numbers fully in clear and **panicked** on 6-digit (`Repeat("*",-1)`). Now masks all-but-last-4 like SSN/CC. `pkg/redact` wrapped in panic-recover so a redactor defect returns an error, not a process crash. | replacement.go, engine.go |
| **H-2** | 5 `title="${escapeHtml(...)}"` sinks → `escapeAttr` (escapeHtml doesn't escape quotes → attribute-breakout XSS). | template.html |
| **H-3** | Suppression-list `innerHTML` sinks (ruleId/filename/fileType/Hash/ID/metadata-key) interpolated raw from YAML → escaped. | template.html |
| **H-4** | Office redactor unbounded `io.ReadAll` per zip entry → per-entry (50MB) + cumulative (200MB) caps, fail-closed. | office/redactor.go |

## MEDIUM / LOW

- **MED-1**: `--debug` logged raw matched values in socialmedia (×4), intellectualproperty (×1), **metadata content preview (×1)** → `[HIDDEN] (len=%d)` (BSC4).
- **MED-3**: Office embedded-image extraction unbounded `io.Copy` → `io.LimitReader` + reject + remove partial temp file.
- **MED-4**: pin `git-chglog@v0.15.4` in the privileged release workflow (was `@latest`).
- **MED-5**: PyPI wrapper verifies downloaded binary SHA-256 against release `checksums.txt` before `chmod +x` / exec.
- **LOW-1**: Office text extractor cumulative decompression budget (bounds zip entry-count amplification).
- suppress CLI: guard `hash[:8]` against short hashes (slice-bounds panic).
- PDF extractor: enforce the 100MB ceiling (was warn-only then unbounded read).

## Deferred to follow-up issues (larger design changes)

- **CSP `unsafe-inline`** — needs ~90 inline handlers refactored to `addEventListener`; H-2/H-3 already close the injection points it would escalate.
- **CWD config auto-discovery** — a committed `config.yaml` can weaken checks; fix is a warn-on-narrowing + schema-validate, changing config-load semantics.
- **Web endpoint auth** — documented opt-in posture (loopback default; `0.0.0.0` only in container mode with printed warning); real fix is an auth feature.
- **AWS Secret Access Key detection** — the secret half is never detected/redacted; fix is a new secrets-validator pattern needing FP testing.

## Tests
- [x] All 41 packages pass
- [x] Golden corpus regenerated (phone now `***-***-0142`, was leaking area code `212-***-0142`)
- [x] Web tests + `-race` clean
- [x] New regression tests: `phone_test.go` (leak+panic), `template_xss_test.go` (XSS sinks)