### PR TITLE
feat(validators): expand address/DL/OTP coverage + fix OTP O(n²) DoS

### DIFF
--- a/internal/goldencorpus/corpus.go
+++ b/internal/goldencorpus/corpus.go
@@ -165,6 +165,27 @@ var Cases = []Case{
 			"deliver to 742 evergreen terrace, springfield, il 62704\n",
 	},
 	{
+		Name: "validator_coverage_expansion",
+		Description: "Formats added in the coverage-expansion pass: military APO/FPO (PSC/Unit + " +
+			"Box + APO/FPO/DPO + AA/AE/AP + ZIP), rural routes (full and Box-anchored short " +
+			"forms), apostrophe/hyphen street names, NJ (1L+14D) and WI (1L+13D) licenses, and " +
+			"lowercase base32 OTP secrets (keyword-gated, word-guarded). Decoy lines lock the " +
+			"guards: RR-as-abbreviation stays LOW, APO-as-word and prose apostrophes stay out, " +
+			"lowercase English prose is not a secret.",
+		Checks: []string{"PHYSICAL_ADDRESS", "DRIVERS_LICENSE", "OTP"},
+		Input: "mail to PSC 1523, Box 25, APO AE 09009 promptly\n" +
+			"mailing Rural Route 3 Box 88, Roanoke, VA 24012\n" +
+			"send to 123 O'Brien St, Boston, MA 02101\n" +
+			"deliver 456 King-Smith Rd today\n" +
+			"new jersey driver license D12345678901234 on record\n" +
+			"wisconsin dl J1234567890123 verified\n" +
+			"2fa secret: jbswy3dpehpk3pxp lowercase\n" +
+			"The package weighs RR 4 lbs on the scale\n" +
+			"APO is an abbreviation for Apollo\n" +
+			"123 O' clock reading on the dial\n" +
+			"the authentication protocol requires base configuration\n",
+	},
+	{
 		Name: "new_validators_decoys",
 		Description: "Shape-valid values in PII-contradicting context for the new validators' " +
 			"broadest patterns: SSN-shaped and date-shaped tokens near DL keywords, a version " +

--- a/internal/goldencorpus/testdata/golden/new_validators_display_formats.json.json
+++ b/internal/goldencorpus/testdata/golden/new_validators_display_formats.json.json
@@ -1,19 +1,18 @@
 {
   "results": [
     {
-      "confidence": 80,
-      "confidence_level": "MEDIUM",
+      "confidence": 95,
+      "confidence_level": "HIGH",
       "filename": "<golden:new_validators_display_formats>",
-      "line_number": 2,
+      "line_number": 1,
       "metadata": {
         "confidence_adjustment": 0,
         "context_confidence": 0.5,
         "context_doctype": "Unknown",
         "context_domain": "Healthcare",
-        "context_impact": -5,
-        "country": "DE",
-        "normalized": "DE89370400440532013000",
-        "original_confidence": 80,
+        "context_impact": 20,
+        "normalized": "1EG4TE5MK73",
+        "original_confidence": 95,
         "semantic_context": {
           "FinancialData": 0,
           "MedicalData": 0,
@@ -21,11 +20,38 @@
           "Production": 0,
           "TestData": 0
         },
+        "subtype": "MBI",
         "validation_path": "document"
       },
-      "text": "DE89 3704 0044 0532 0130 00",
-      "type": "IBAN",
-      "validator": "bank_account"
+      "text": "1EG4-TE5-MK73",
+      "type": "MEDICARE_MBI",
+      "validator": "medicalid"
+    },
+    {
+      "confidence": 95,
+      "confidence_level": "HIGH",
+      "filename": "<golden:new_validators_display_formats>",
+      "line_number": 6,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0.5,
+        "context_doctype": "Unknown",
+        "context_domain": "Healthcare",
+        "original_confidence": 95,
+        "original_file": "<golden:new_validators_display_formats>",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_path": "document"
+      },
+      "text": "123 42nd Street",
+      "type": "US_STREET_ADDRESS",
+      "validator": "physical_address"
     },
     {
       "confidence": 90,
@@ -124,95 +150,6 @@
       "validator": "dob"
     },
     {
-      "confidence": 70,
-      "confidence_level": "MEDIUM",
-      "filename": "<golden:new_validators_display_formats>",
-      "line_number": 3,
-      "metadata": {
-        "confidence_adjustment": 0,
-        "context_confidence": 0.5,
-        "context_doctype": "Unknown",
-        "context_domain": "Healthcare",
-        "context_impact": 65,
-        "format": "IL_1L11D",
-        "normalized": "D12345678901",
-        "original_confidence": 70,
-        "original_file": "<golden:new_validators_display_formats>",
-        "semantic_context": {
-          "FinancialData": 0,
-          "MedicalData": 0,
-          "PersonalData": 0,
-          "Production": 0,
-          "TestData": 0
-        },
-        "source": "preprocessed_content",
-        "validation_checks": {
-          "format_match": true,
-          "has_dl_context": false,
-          "not_all_same": true,
-          "not_all_zeros": true,
-          "not_sequential": false
-        },
-        "validation_path": "document"
-      },
-      "text": "D123-4567-8901",
-      "type": "DRIVERS_LICENSE",
-      "validator": "driverslicense"
-    },
-    {
-      "confidence": 95,
-      "confidence_level": "HIGH",
-      "filename": "<golden:new_validators_display_formats>",
-      "line_number": 1,
-      "metadata": {
-        "confidence_adjustment": 0,
-        "context_confidence": 0.5,
-        "context_doctype": "Unknown",
-        "context_domain": "Healthcare",
-        "context_impact": 20,
-        "normalized": "1EG4TE5MK73",
-        "original_confidence": 95,
-        "semantic_context": {
-          "FinancialData": 0,
-          "MedicalData": 0,
-          "PersonalData": 0,
-          "Production": 0,
-          "TestData": 0
-        },
-        "subtype": "MBI",
-        "validation_path": "document"
-      },
-      "text": "1EG4-TE5-MK73",
-      "type": "MEDICARE_MBI",
-      "validator": "medicalid"
-    },
-    {
-      "confidence": 95,
-      "confidence_level": "HIGH",
-      "filename": "<golden:new_validators_display_formats>",
-      "line_number": 6,
-      "metadata": {
-        "confidence_adjustment": 0,
-        "context_confidence": 0.5,
-        "context_doctype": "Unknown",
-        "context_domain": "Healthcare",
-        "original_confidence": 95,
-        "original_file": "<golden:new_validators_display_formats>",
-        "semantic_context": {
-          "FinancialData": 0,
-          "MedicalData": 0,
-          "PersonalData": 0,
-          "Production": 0,
-          "TestData": 0
-        },
-        "source": "preprocessed_content",
-        "validation_path": "document"
-      },
-      "text": "123 42nd Street",
-      "type": "US_STREET_ADDRESS",
-      "validator": "physical_address"
-    },
-    {
       "confidence": 90,
       "confidence_level": "HIGH",
       "filename": "<golden:new_validators_display_formats>",
@@ -264,6 +201,69 @@
       "text": "742 evergreen terrace",
       "type": "US_STREET_ADDRESS",
       "validator": "physical_address"
+    },
+    {
+      "confidence": 80,
+      "confidence_level": "MEDIUM",
+      "filename": "<golden:new_validators_display_formats>",
+      "line_number": 2,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0.5,
+        "context_doctype": "Unknown",
+        "context_domain": "Healthcare",
+        "context_impact": -5,
+        "country": "DE",
+        "normalized": "DE89370400440532013000",
+        "original_confidence": 80,
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "validation_path": "document"
+      },
+      "text": "DE89 3704 0044 0532 0130 00",
+      "type": "IBAN",
+      "validator": "bank_account"
+    },
+    {
+      "confidence": 70,
+      "confidence_level": "MEDIUM",
+      "filename": "<golden:new_validators_display_formats>",
+      "line_number": 3,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0.5,
+        "context_doctype": "Unknown",
+        "context_domain": "Healthcare",
+        "context_impact": 65,
+        "format": "IL_1L11D",
+        "normalized": "D12345678901",
+        "original_confidence": 70,
+        "original_file": "<golden:new_validators_display_formats>",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "format_match": true,
+          "has_dl_context": false,
+          "not_all_same": true,
+          "not_all_zeros": true,
+          "not_sequential": false
+        },
+        "validation_path": "document"
+      },
+      "text": "D123-4567-8901",
+      "type": "DRIVERS_LICENSE",
+      "validator": "driverslicense"
     }
   ]
 }

--- a/internal/goldencorpus/testdata/golden/new_validators_display_formats.txt
+++ b/internal/goldencorpus/testdata/golden/new_validators_display_formats.txt
@@ -2,9 +2,9 @@ LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH            
 -----------------------------------------------------------------------------------------------------
 [HIGH  ] medicalid    MEDICARE_MBI           95.00% line     1 1EG4-TE5-MK73               <golden:new_validators_display_formats>
 [HIGH  ] physical_... US_STREET_ADDRESS      95.00% line     6 123 42nd Street             <golden:new_validators_display_formats>
-[HIGH  ] dob          DATE_OF_BIRTH          90.00% line     5 03.14.1987                  <golden:new_validators_display_formats>
 [HIGH  ] dob          DATE_OF_BIRTH          90.00% line     4 3/14/87                     <golden:new_validators_display_formats>
 [HIGH  ] dob          DATE_OF_BIRTH          90.00% line     4 March 14th, 1987            <golden:new_validators_display_formats>
+[HIGH  ] dob          DATE_OF_BIRTH          90.00% line     5 03.14.1987                  <golden:new_validators_display_formats>
 [HIGH  ] physical_... US_STREET_ADDRESS      90.00% line     7 1234 US Highway 61          <golden:new_validators_display_formats>
 [MEDIUM] physical_... US_STREET_ADDRESS      85.00% line     8 742 evergreen terrace       <golden:new_validators_display_formats>
 [MEDIUM] bank_account IBAN                   80.00% line     2 DE89 3704 0044 0532 0130 00 <golden:new_validators_display_formats>

--- a/internal/goldencorpus/testdata/golden/new_validators_display_formats.yaml
+++ b/internal/goldencorpus/testdata/golden/new_validators_display_formats.yaml
@@ -1,26 +1,48 @@
 results:
-    - text: DE89 3704 0044 0532 0130 00
-      line_number: 2
-      type: IBAN
-      confidence: 80
-      confidence_level: MEDIUM
+    - text: 1EG4-TE5-MK73
+      line_number: 1
+      type: MEDICARE_MBI
+      confidence: 95
+      confidence_level: HIGH
       filename: <golden:new_validators_display_formats>
-      validator: bank_account
+      validator: medicalid
       metadata:
         confidence_adjustment: 0
         context_confidence: 0.5
         context_doctype: Unknown
         context_domain: Healthcare
-        context_impact: -5
-        country: DE
-        normalized: DE89370400440532013000
-        original_confidence: 80
+        context_impact: 20
+        normalized: 1EG4TE5MK73
+        original_confidence: 95
         semantic_context:
             FinancialData: 0
             MedicalData: 0
             PersonalData: 0
             Production: 0
             TestData: 0
+        subtype: MBI
+        validation_path: document
+    - text: 123 42nd Street
+      line_number: 6
+      type: US_STREET_ADDRESS
+      confidence: 95
+      confidence_level: HIGH
+      filename: <golden:new_validators_display_formats>
+      validator: physical_address
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0.5
+        context_doctype: Unknown
+        context_domain: Healthcare
+        original_confidence: 95
+        original_file: <golden:new_validators_display_formats>
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
         validation_path: document
     - text: 3/14/87
       line_number: 4
@@ -103,82 +125,6 @@ results:
             plausible_year: true
             valid_date: true
         validation_path: document
-    - text: D123-4567-8901
-      line_number: 3
-      type: DRIVERS_LICENSE
-      confidence: 70
-      confidence_level: MEDIUM
-      filename: <golden:new_validators_display_formats>
-      validator: driverslicense
-      metadata:
-        confidence_adjustment: 0
-        context_confidence: 0.5
-        context_doctype: Unknown
-        context_domain: Healthcare
-        context_impact: 65
-        format: IL_1L11D
-        normalized: D12345678901
-        original_confidence: 70
-        original_file: <golden:new_validators_display_formats>
-        semantic_context:
-            FinancialData: 0
-            MedicalData: 0
-            PersonalData: 0
-            Production: 0
-            TestData: 0
-        source: preprocessed_content
-        validation_checks:
-            format_match: true
-            has_dl_context: false
-            not_all_same: true
-            not_all_zeros: true
-            not_sequential: false
-        validation_path: document
-    - text: 1EG4-TE5-MK73
-      line_number: 1
-      type: MEDICARE_MBI
-      confidence: 95
-      confidence_level: HIGH
-      filename: <golden:new_validators_display_formats>
-      validator: medicalid
-      metadata:
-        confidence_adjustment: 0
-        context_confidence: 0.5
-        context_doctype: Unknown
-        context_domain: Healthcare
-        context_impact: 20
-        normalized: 1EG4TE5MK73
-        original_confidence: 95
-        semantic_context:
-            FinancialData: 0
-            MedicalData: 0
-            PersonalData: 0
-            Production: 0
-            TestData: 0
-        subtype: MBI
-        validation_path: document
-    - text: 123 42nd Street
-      line_number: 6
-      type: US_STREET_ADDRESS
-      confidence: 95
-      confidence_level: HIGH
-      filename: <golden:new_validators_display_formats>
-      validator: physical_address
-      metadata:
-        confidence_adjustment: 0
-        context_confidence: 0.5
-        context_doctype: Unknown
-        context_domain: Healthcare
-        original_confidence: 95
-        original_file: <golden:new_validators_display_formats>
-        semantic_context:
-            FinancialData: 0
-            MedicalData: 0
-            PersonalData: 0
-            Production: 0
-            TestData: 0
-        source: preprocessed_content
-        validation_path: document
     - text: 1234 US Highway 61
       line_number: 7
       type: US_STREET_ADDRESS
@@ -223,4 +169,58 @@ results:
             Production: 0
             TestData: 0
         source: preprocessed_content
+        validation_path: document
+    - text: DE89 3704 0044 0532 0130 00
+      line_number: 2
+      type: IBAN
+      confidence: 80
+      confidence_level: MEDIUM
+      filename: <golden:new_validators_display_formats>
+      validator: bank_account
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0.5
+        context_doctype: Unknown
+        context_domain: Healthcare
+        context_impact: -5
+        country: DE
+        normalized: DE89370400440532013000
+        original_confidence: 80
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        validation_path: document
+    - text: D123-4567-8901
+      line_number: 3
+      type: DRIVERS_LICENSE
+      confidence: 70
+      confidence_level: MEDIUM
+      filename: <golden:new_validators_display_formats>
+      validator: driverslicense
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0.5
+        context_doctype: Unknown
+        context_domain: Healthcare
+        context_impact: 65
+        format: IL_1L11D
+        normalized: D12345678901
+        original_confidence: 70
+        original_file: <golden:new_validators_display_formats>
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            format_match: true
+            has_dl_context: false
+            not_all_same: true
+            not_all_zeros: true
+            not_sequential: false
         validation_path: document

--- a/internal/goldencorpus/testdata/golden/validator_coverage_expansion.csv
+++ b/internal/goldencorpus/testdata/golden/validator_coverage_expansion.csv
@@ -1,0 +1,9 @@
+Filename,Type,Confidence Level,Confidence %,Line Number,Text
+<golden:validator_coverage_expansion>,DRIVERS_LICENSE,MEDIUM,85.0,5,D12345678901234
+<golden:validator_coverage_expansion>,DRIVERS_LICENSE,MEDIUM,70.0,6,J1234567890123
+<golden:validator_coverage_expansion>,OTP_SECRET,MEDIUM,85.0,7,jbswy3dpehpk3pxp
+<golden:validator_coverage_expansion>,US_MILITARY_ADDRESS,HIGH,95.0,1,"PSC 1523, Box 25, APO AE 09009"
+<golden:validator_coverage_expansion>,US_RURAL_ROUTE,HIGH,90.0,2,Rural Route 3 Box 88
+<golden:validator_coverage_expansion>,US_RURAL_ROUTE,LOW,40.0,8,RR 4
+<golden:validator_coverage_expansion>,US_STREET_ADDRESS,HIGH,95.0,3,123 O'Brien St
+<golden:validator_coverage_expansion>,US_STREET_ADDRESS,HIGH,90.0,4,456 King-Smith Rd

--- a/internal/goldencorpus/testdata/golden/validator_coverage_expansion.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/validator_coverage_expansion.gitlab-sast.json
@@ -1,0 +1,238 @@
+{
+  "remediations": [],
+  "scan": {
+    "analyzer": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "end_time": "<TIMESTAMP>",
+    "scanner": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "start_time": "<TIMESTAMP>",
+    "status": "success",
+    "type": "sast"
+  },
+  "version": "15.0.4",
+  "vulnerabilities": [
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected sensitive data (drivers license) in this file.\n\n**Location:** <golden:validator_coverage_expansion> (line 5)\n**Confidence:** MEDIUM (85.0%)\n**Detected by:** driverslicense validator\n\n**Context:**\n```\nnew jersey driver license D12345678901234 on record\n```\n\n**Additional Information:**\n- context_impact: 80\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "DRIVERS_LICENSE"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "driverslicense"
+        }
+      ],
+      "location": {
+        "end_line": 5,
+        "file": "<golden:validator_coverage_expansion>",
+        "start_line": 5
+      },
+      "message": "Sensitive data (drivers license) detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Drivers License Detected",
+      "severity": "High"
+    },
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected sensitive data (drivers license) in this file.\n\n**Location:** <golden:validator_coverage_expansion> (line 6)\n**Confidence:** MEDIUM (70.0%)\n**Detected by:** driverslicense validator\n\n**Context:**\n```\nwisconsin dl J1234567890123 verified\n```\n\n**Additional Information:**\n- context_impact: 65\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "DRIVERS_LICENSE"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "driverslicense"
+        }
+      ],
+      "location": {
+        "end_line": 6,
+        "file": "<golden:validator_coverage_expansion>",
+        "start_line": 6
+      },
+      "message": "Sensitive data (drivers license) detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Drivers License Detected",
+      "severity": "High"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected sensitive data (otp secret) in this file.\n\n**Location:** <golden:validator_coverage_expansion> (line 7)\n**Confidence:** MEDIUM (85.0%)\n**Detected by:** otp validator\n\n**Context:**\n```\n2fa secret: jbswy3dpehpk3pxp lowercase\n```\n\n**Additional Information:**\n- context_impact: 30\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "OTP_SECRET"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "otp"
+        }
+      ],
+      "location": {
+        "end_line": 7,
+        "file": "<golden:validator_coverage_expansion>",
+        "start_line": 7
+      },
+      "message": "Sensitive data (otp secret) detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Otp Secret Detected",
+      "severity": "High"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected sensitive data (us military address) in this file.\n\n**Location:** <golden:validator_coverage_expansion> (line 1)\n**Confidence:** HIGH (95.0%)\n**Detected by:** physical_address validator\n\n**Context:**\n```\nmail to PSC 1523, Box 25, APO AE 09009 promptly\n```\n\n**Additional Information:**\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "US_MILITARY_ADDRESS"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "physical_address"
+        }
+      ],
+      "location": {
+        "end_line": 1,
+        "file": "<golden:validator_coverage_expansion>",
+        "start_line": 1
+      },
+      "message": "Sensitive data (us military address) detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Us Military Address Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected sensitive data (us rural route) in this file.\n\n**Location:** <golden:validator_coverage_expansion> (line 2)\n**Confidence:** HIGH (90.0%)\n**Detected by:** physical_address validator\n\n**Context:**\n```\nmailing Rural Route 3 Box 88, Roanoke, VA 24012\n```\n\n**Additional Information:**\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "US_RURAL_ROUTE"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "physical_address"
+        }
+      ],
+      "location": {
+        "end_line": 2,
+        "file": "<golden:validator_coverage_expansion>",
+        "start_line": 2
+      },
+      "message": "Sensitive data (us rural route) detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Us Rural Route Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
+      "confidence": "Low",
+      "description": "Ferret Scan detected sensitive data (us rural route) in this file.\n\n**Location:** <golden:validator_coverage_expansion> (line 8)\n**Confidence:** LOW (40.0%)\n**Detected by:** physical_address validator\n\n**Context:**\n```\nThe package weighs RR 4 lbs on the scale\n```\n\n**Additional Information:**\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "US_RURAL_ROUTE"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "physical_address"
+        }
+      ],
+      "location": {
+        "end_line": 8,
+        "file": "<golden:validator_coverage_expansion>",
+        "start_line": 8
+      },
+      "message": "Sensitive data (us rural route) detected: [HIDDEN] (confidence: LOW)",
+      "name": "Us Rural Route Detected",
+      "severity": "Medium"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected sensitive data (us street address) in this file.\n\n**Location:** <golden:validator_coverage_expansion> (line 3)\n**Confidence:** HIGH (95.0%)\n**Detected by:** physical_address validator\n\n**Context:**\n```\nsend to 123 O'Brien St, Boston, MA 02101\n```\n\n**Additional Information:**\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "US_STREET_ADDRESS"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "physical_address"
+        }
+      ],
+      "location": {
+        "end_line": 3,
+        "file": "<golden:validator_coverage_expansion>",
+        "start_line": 3
+      },
+      "message": "Sensitive data (us street address) detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Us Street Address Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected sensitive data (us street address) in this file.\n\n**Location:** <golden:validator_coverage_expansion> (line 4)\n**Confidence:** HIGH (90.0%)\n**Detected by:** physical_address validator\n\n**Context:**\n```\ndeliver 456 King-Smith Rd today\n```\n\n**Additional Information:**\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "US_STREET_ADDRESS"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "physical_address"
+        }
+      ],
+      "location": {
+        "end_line": 4,
+        "file": "<golden:validator_coverage_expansion>",
+        "start_line": 4
+      },
+      "message": "Sensitive data (us street address) detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Us Street Address Detected",
+      "severity": "Critical"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/validator_coverage_expansion.json.json
+++ b/internal/goldencorpus/testdata/golden/validator_coverage_expansion.json.json
@@ -1,0 +1,237 @@
+{
+  "results": [
+    {
+      "confidence": 95,
+      "confidence_level": "HIGH",
+      "filename": "<golden:validator_coverage_expansion>",
+      "line_number": 1,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0,
+        "context_doctype": "Unknown",
+        "context_domain": "Unknown",
+        "original_confidence": 95,
+        "original_file": "<golden:validator_coverage_expansion>",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_path": "document"
+      },
+      "text": "PSC 1523, Box 25, APO AE 09009",
+      "type": "US_MILITARY_ADDRESS",
+      "validator": "physical_address"
+    },
+    {
+      "confidence": 95,
+      "confidence_level": "HIGH",
+      "filename": "<golden:validator_coverage_expansion>",
+      "line_number": 3,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0,
+        "context_doctype": "Unknown",
+        "context_domain": "Unknown",
+        "original_confidence": 95,
+        "original_file": "<golden:validator_coverage_expansion>",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_path": "document"
+      },
+      "text": "123 O'Brien St",
+      "type": "US_STREET_ADDRESS",
+      "validator": "physical_address"
+    },
+    {
+      "confidence": 90,
+      "confidence_level": "HIGH",
+      "filename": "<golden:validator_coverage_expansion>",
+      "line_number": 2,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0,
+        "context_doctype": "Unknown",
+        "context_domain": "Unknown",
+        "original_confidence": 90,
+        "original_file": "<golden:validator_coverage_expansion>",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_path": "document"
+      },
+      "text": "Rural Route 3 Box 88",
+      "type": "US_RURAL_ROUTE",
+      "validator": "physical_address"
+    },
+    {
+      "confidence": 90,
+      "confidence_level": "HIGH",
+      "filename": "<golden:validator_coverage_expansion>",
+      "line_number": 4,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0,
+        "context_doctype": "Unknown",
+        "context_domain": "Unknown",
+        "original_confidence": 90,
+        "original_file": "<golden:validator_coverage_expansion>",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_path": "document"
+      },
+      "text": "456 King-Smith Rd",
+      "type": "US_STREET_ADDRESS",
+      "validator": "physical_address"
+    },
+    {
+      "confidence": 85,
+      "confidence_level": "MEDIUM",
+      "filename": "<golden:validator_coverage_expansion>",
+      "line_number": 5,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0,
+        "context_doctype": "Unknown",
+        "context_domain": "Unknown",
+        "context_impact": 80,
+        "format": "NJ_1L14D",
+        "original_confidence": 85,
+        "original_file": "<golden:validator_coverage_expansion>",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "format_match": true,
+          "has_dl_context": false,
+          "not_all_same": true,
+          "not_all_zeros": true,
+          "not_sequential": false
+        },
+        "validation_path": "document"
+      },
+      "text": "D12345678901234",
+      "type": "DRIVERS_LICENSE",
+      "validator": "driverslicense"
+    },
+    {
+      "confidence": 85,
+      "confidence_level": "MEDIUM",
+      "filename": "<golden:validator_coverage_expansion>",
+      "line_number": 7,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0,
+        "context_doctype": "Unknown",
+        "context_domain": "Unknown",
+        "context_impact": 30,
+        "original_confidence": 85,
+        "original_file": "<golden:validator_coverage_expansion>",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "format": true,
+          "not_excluded": true,
+          "valid_chars": true
+        },
+        "validation_path": "document"
+      },
+      "text": "jbswy3dpehpk3pxp",
+      "type": "OTP_SECRET",
+      "validator": "otp"
+    },
+    {
+      "confidence": 70,
+      "confidence_level": "MEDIUM",
+      "filename": "<golden:validator_coverage_expansion>",
+      "line_number": 6,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0,
+        "context_doctype": "Unknown",
+        "context_domain": "Unknown",
+        "context_impact": 65,
+        "format": "WI_1L13D",
+        "original_confidence": 70,
+        "original_file": "<golden:validator_coverage_expansion>",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "format_match": true,
+          "has_dl_context": false,
+          "not_all_same": true,
+          "not_all_zeros": true,
+          "not_sequential": false
+        },
+        "validation_path": "document"
+      },
+      "text": "J1234567890123",
+      "type": "DRIVERS_LICENSE",
+      "validator": "driverslicense"
+    },
+    {
+      "confidence": 40,
+      "confidence_level": "LOW",
+      "filename": "<golden:validator_coverage_expansion>",
+      "line_number": 8,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0,
+        "context_doctype": "Unknown",
+        "context_domain": "Unknown",
+        "original_confidence": 40,
+        "original_file": "<golden:validator_coverage_expansion>",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "short_form": true,
+        "source": "preprocessed_content",
+        "validation_path": "document"
+      },
+      "text": "RR 4",
+      "type": "US_RURAL_ROUTE",
+      "validator": "physical_address"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/validator_coverage_expansion.junit.xml
+++ b/internal/goldencorpus/testdata/golden/validator_coverage_expansion.junit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
+  <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
+    <testcase name="&lt;golden:validator_coverage_expansion&gt;" classname="security-scan" time="0.001">
+      <failure message="8 security findings detected" type="SECURITY_FINDINGS">Line 1: US_MILITARY_ADDRESS detected with 95.0% confidence (HIGH)&#xA;Match: PSC 1523, Box 25, APO AE 09009&#xA;Validator: physical_address&#xA;Line 3: US_STREET_ADDRESS detected with 95.0% confidence (HIGH)&#xA;Match: 123 O&#39;Brien St&#xA;Validator: physical_address&#xA;Line 2: US_RURAL_ROUTE detected with 90.0% confidence (HIGH)&#xA;Match: Rural Route 3 Box 88&#xA;Validator: physical_address&#xA;Line 4: US_STREET_ADDRESS detected with 90.0% confidence (HIGH)&#xA;Match: 456 King-Smith Rd&#xA;Validator: physical_address&#xA;Line 5: DRIVERS_LICENSE detected with 85.0% confidence (MEDIUM)&#xA;Match: D12345678901234&#xA;Validator: driverslicense&#xA;Line 7: OTP_SECRET detected with 85.0% confidence (MEDIUM)&#xA;Match: jbswy3dpehpk3pxp&#xA;Validator: otp&#xA;Line 6: DRIVERS_LICENSE detected with 70.0% confidence (MEDIUM)&#xA;Match: J1234567890123&#xA;Validator: driverslicense&#xA;Line 8: US_RURAL_ROUTE detected with 40.0% confidence (LOW)&#xA;Match: RR 4&#xA;Validator: physical_address</failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/internal/goldencorpus/testdata/golden/validator_coverage_expansion.redact_format_preserving.txt
+++ b/internal/goldencorpus/testdata/golden/validator_coverage_expansion.redact_format_preserving.txt
@@ -1,0 +1,21 @@
+=== REDACTED ===
+mail to ****************************** promptly
+mailing ********************, Roanoke, VA 24012
+send to **************, Boston, MA 02101
+deliver ***************** today
+new jersey driver license *************** on record
+wisconsin dl ************** verified
+2fa secret: **************** lowercase
+The package weighs **** lbs on the scale
+APO is an abbreviation for Apollo
+123 O' clock reading on the dial
+the authentication protocol requires base configuration
+=== FINDINGS (sorted) ===
+type=DRIVERS_LICENSE line=5 conf=medium match=D12345678901234
+type=DRIVERS_LICENSE line=6 conf=medium match=J1234567890123
+type=OTP_SECRET line=7 conf=medium match=jbswy3dpehpk3pxp
+type=US_MILITARY_ADDRESS line=1 conf=high match=PSC 1523, Box 25, APO AE 09009
+type=US_RURAL_ROUTE line=2 conf=high match=Rural Route 3 Box 88
+type=US_RURAL_ROUTE line=8 conf=low match=RR 4
+type=US_STREET_ADDRESS line=3 conf=high match=123 O'Brien St
+type=US_STREET_ADDRESS line=4 conf=high match=456 King-Smith Rd

--- a/internal/goldencorpus/testdata/golden/validator_coverage_expansion.redact_simple.txt
+++ b/internal/goldencorpus/testdata/golden/validator_coverage_expansion.redact_simple.txt
@@ -1,0 +1,21 @@
+=== REDACTED ===
+mail to [US_MILITARY_ADDRESS-REDACTED] promptly
+mailing [US_RURAL_ROUTE-REDACTED], Roanoke, VA 24012
+send to [US_STREET_ADDRESS-REDACTED], Boston, MA 02101
+deliver [US_STREET_ADDRESS-REDACTED] today
+new jersey driver license [DRIVERS_LICENSE-REDACTED] on record
+wisconsin dl [DRIVERS_LICENSE-REDACTED] verified
+2fa secret: [OTP_SECRET-REDACTED] lowercase
+The package weighs [US_RURAL_ROUTE-REDACTED] lbs on the scale
+APO is an abbreviation for Apollo
+123 O' clock reading on the dial
+the authentication protocol requires base configuration
+=== FINDINGS (sorted) ===
+type=DRIVERS_LICENSE line=5 conf=medium match=D12345678901234
+type=DRIVERS_LICENSE line=6 conf=medium match=J1234567890123
+type=OTP_SECRET line=7 conf=medium match=jbswy3dpehpk3pxp
+type=US_MILITARY_ADDRESS line=1 conf=high match=PSC 1523, Box 25, APO AE 09009
+type=US_RURAL_ROUTE line=2 conf=high match=Rural Route 3 Box 88
+type=US_RURAL_ROUTE line=8 conf=low match=RR 4
+type=US_STREET_ADDRESS line=3 conf=high match=123 O'Brien St
+type=US_STREET_ADDRESS line=4 conf=high match=456 King-Smith Rd

--- a/internal/goldencorpus/testdata/golden/validator_coverage_expansion.sarif.json
+++ b/internal/goldencorpus/testdata/golden/validator_coverage_expansion.sarif.json
@@ -1,0 +1,567 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/refs/heads/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:validator_coverage_expansion>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "new jersey driver license \nnew jersey driver license D12345678901234 on record\n on record"
+                  },
+                  "startLine": 5
+                },
+                "region": {
+                  "endColumn": 42,
+                  "snippet": {
+                    "text": "new jersey driver license D12345678901234 on record"
+                  },
+                  "startColumn": 27,
+                  "startLine": 5
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "DRIVERS_LICENSE Detected in <golden:validator_coverage_expansion> at line 5 (confidence: 85.0% - MEDIUM). Matched text: 'D12345678901234'"
+          },
+          "properties": {
+            "confidence": 85,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 0,
+              "context_doctype": "Unknown",
+              "context_domain": "Unknown",
+              "context_impact": 80,
+              "format": "NJ_1L14D",
+              "original_confidence": 85,
+              "original_file": "<golden:validator_coverage_expansion>",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "format_match": true,
+                "has_dl_context": false,
+                "not_all_same": true,
+                "not_all_zeros": true,
+                "not_sequential": false
+              },
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "driver",
+              "license",
+              "driver license"
+            ],
+            "validator": "driverslicense"
+          },
+          "rank": 67.5,
+          "ruleId": "DRIVERS_LICENSE"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:validator_coverage_expansion>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "wisconsin dl \nwisconsin dl J1234567890123 verified\n verified"
+                  },
+                  "startLine": 6
+                },
+                "region": {
+                  "endColumn": 28,
+                  "snippet": {
+                    "text": "wisconsin dl J1234567890123 verified"
+                  },
+                  "startColumn": 14,
+                  "startLine": 6
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "DRIVERS_LICENSE Detected in <golden:validator_coverage_expansion> at line 6 (confidence: 70.0% - MEDIUM). Matched text: 'J1234567890123'"
+          },
+          "properties": {
+            "confidence": 70,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 0,
+              "context_doctype": "Unknown",
+              "context_domain": "Unknown",
+              "context_impact": 65,
+              "format": "WI_1L13D",
+              "original_confidence": 70,
+              "original_file": "<golden:validator_coverage_expansion>",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "format_match": true,
+                "has_dl_context": false,
+                "not_all_same": true,
+                "not_all_zeros": true,
+                "not_sequential": false
+              },
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "dl"
+            ],
+            "validator": "driverslicense"
+          },
+          "rank": 60,
+          "ruleId": "DRIVERS_LICENSE"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:validator_coverage_expansion>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "2fa secret: \n2fa secret: jbswy3dpehpk3pxp lowercase\n lowercase"
+                  },
+                  "startLine": 7
+                },
+                "region": {
+                  "endColumn": 29,
+                  "snippet": {
+                    "text": "2fa secret: jbswy3dpehpk3pxp lowercase"
+                  },
+                  "startColumn": 13,
+                  "startLine": 7
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "OTP_SECRET Detected in <golden:validator_coverage_expansion> at line 7 (confidence: 85.0% - MEDIUM). Matched text: 'jbswy3dpehpk3pxp'"
+          },
+          "properties": {
+            "confidence": 85,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 0,
+              "context_doctype": "Unknown",
+              "context_domain": "Unknown",
+              "context_impact": 30,
+              "original_confidence": 85,
+              "original_file": "<golden:validator_coverage_expansion>",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "format": true,
+                "not_excluded": true,
+                "valid_chars": true
+              },
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "2fa",
+              "secret"
+            ],
+            "validator": "otp"
+          },
+          "rank": 67.5,
+          "ruleId": "OTP_SECRET"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:validator_coverage_expansion>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "mail to \nmail to PSC 1523, Box 25, APO AE 09009 promptly\n promptly"
+                  },
+                  "startLine": 1
+                },
+                "region": {
+                  "endColumn": 39,
+                  "snippet": {
+                    "text": "mail to PSC 1523, Box 25, APO AE 09009 promptly"
+                  },
+                  "startColumn": 9,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "US_MILITARY_ADDRESS Detected in <golden:validator_coverage_expansion> at line 1 (confidence: 95.0% - HIGH). Matched text: 'PSC 1523, Box 25, APO AE 09009'"
+          },
+          "properties": {
+            "confidence": 95,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 0,
+              "context_doctype": "Unknown",
+              "context_domain": "Unknown",
+              "original_confidence": 95,
+              "original_file": "<golden:validator_coverage_expansion>",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "mail to"
+            ],
+            "validator": "physical_address"
+          },
+          "rank": 72.5,
+          "ruleId": "US_MILITARY_ADDRESS"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:validator_coverage_expansion>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "mailing \nmailing Rural Route 3 Box 88, Roanoke, VA 24012\n, Roanoke, VA 24012"
+                  },
+                  "startLine": 2
+                },
+                "region": {
+                  "endColumn": 29,
+                  "snippet": {
+                    "text": "mailing Rural Route 3 Box 88, Roanoke, VA 24012"
+                  },
+                  "startColumn": 9,
+                  "startLine": 2
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "US_RURAL_ROUTE Detected in <golden:validator_coverage_expansion> at line 2 (confidence: 90.0% - HIGH). Matched text: 'Rural Route 3 Box 88'"
+          },
+          "properties": {
+            "confidence": 90,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 0,
+              "context_doctype": "Unknown",
+              "context_domain": "Unknown",
+              "original_confidence": 90,
+              "original_file": "<golden:validator_coverage_expansion>",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "mailing"
+            ],
+            "validator": "physical_address"
+          },
+          "rank": 70,
+          "ruleId": "US_RURAL_ROUTE"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:validator_coverage_expansion>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "The package weighs \nThe package weighs RR 4 lbs on the scale\n lbs on the scale"
+                  },
+                  "startLine": 8
+                },
+                "region": {
+                  "endColumn": 24,
+                  "snippet": {
+                    "text": "The package weighs RR 4 lbs on the scale"
+                  },
+                  "startColumn": 20,
+                  "startLine": 8
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "US_RURAL_ROUTE Detected in <golden:validator_coverage_expansion> at line 8 (confidence: 40.0% - LOW). Matched text: 'RR 4'"
+          },
+          "properties": {
+            "confidence": 40,
+            "confidenceLevel": "LOW",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 0,
+              "context_doctype": "Unknown",
+              "context_domain": "Unknown",
+              "original_confidence": 40,
+              "original_file": "<golden:validator_coverage_expansion>",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "short_form": true,
+              "source": "preprocessed_content",
+              "validation_path": "document"
+            },
+            "validator": "physical_address"
+          },
+          "rank": 45,
+          "ruleId": "US_RURAL_ROUTE"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:validator_coverage_expansion>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "send to \nsend to 123 O'Brien St, Boston, MA 02101\n, Boston, MA 02101"
+                  },
+                  "startLine": 3
+                },
+                "region": {
+                  "endColumn": 23,
+                  "snippet": {
+                    "text": "send to 123 O'Brien St, Boston, MA 02101"
+                  },
+                  "startColumn": 9,
+                  "startLine": 3
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "US_STREET_ADDRESS Detected in <golden:validator_coverage_expansion> at line 3 (confidence: 95.0% - HIGH). Matched text: '123 O'Brien St'"
+          },
+          "properties": {
+            "confidence": 95,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 0,
+              "context_doctype": "Unknown",
+              "context_domain": "Unknown",
+              "original_confidence": 95,
+              "original_file": "<golden:validator_coverage_expansion>",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "send to"
+            ],
+            "validator": "physical_address"
+          },
+          "rank": 72.5,
+          "ruleId": "US_STREET_ADDRESS"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:validator_coverage_expansion>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "deliver \ndeliver 456 King-Smith Rd today\n today"
+                  },
+                  "startLine": 4
+                },
+                "region": {
+                  "endColumn": 26,
+                  "snippet": {
+                    "text": "deliver 456 King-Smith Rd today"
+                  },
+                  "startColumn": 9,
+                  "startLine": 4
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "US_STREET_ADDRESS Detected in <golden:validator_coverage_expansion> at line 4 (confidence: 90.0% - HIGH). Matched text: '456 King-Smith Rd'"
+          },
+          "properties": {
+            "confidence": 90,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 0,
+              "context_doctype": "Unknown",
+              "context_domain": "Unknown",
+              "original_confidence": 90,
+              "original_file": "<golden:validator_coverage_expansion>",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "deliver"
+            ],
+            "validator": "physical_address"
+          },
+          "rank": 70,
+          "ruleId": "US_STREET_ADDRESS"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/awslabs/ferret-scan",
+          "name": "Ferret Scan",
+          "rules": [
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type DRIVERS_LICENSE was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/DRIVERS_LICENSE.md",
+              "id": "DRIVERS_LICENSE",
+              "shortDescription": {
+                "text": "DRIVERS_LICENSE Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type OTP_SECRET was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/OTP_SECRET.md",
+              "id": "OTP_SECRET",
+              "shortDescription": {
+                "text": "OTP_SECRET Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type US_MILITARY_ADDRESS was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/US_MILITARY_ADDRESS.md",
+              "id": "US_MILITARY_ADDRESS",
+              "shortDescription": {
+                "text": "US_MILITARY_ADDRESS Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type US_RURAL_ROUTE was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/US_RURAL_ROUTE.md",
+              "id": "US_RURAL_ROUTE",
+              "shortDescription": {
+                "text": "US_RURAL_ROUTE Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type US_STREET_ADDRESS was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/US_STREET_ADDRESS.md",
+              "id": "US_STREET_ADDRESS",
+              "shortDescription": {
+                "text": "US_STREET_ADDRESS Detected"
+              }
+            }
+          ],
+          "semanticVersion": "0.0.0-development",
+          "version": "0.0.0-development"
+        }
+      },
+      "versionControlProvenance": [
+        {
+          "mappedTo": {
+            "uriBaseId": "%SRCROOT%"
+          },
+          "repositoryUri": "https://github.com/awslabs/ferret-scan",
+          "revisionId": "0.0.0-development"
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/internal/goldencorpus/testdata/golden/validator_coverage_expansion.txt
+++ b/internal/goldencorpus/testdata/golden/validator_coverage_expansion.txt
@@ -1,0 +1,10 @@
+LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH                          FILE
+--------------------------------------------------------------------------------------------------------
+[HIGH  ] physical_... US_MILITARY_ADDRESS    95.00% line     1 PSC 1523, Box 25, APO AE 09009 <golden:validator_coverage_expansion>
+[HIGH  ] physical_... US_STREET_ADDRESS      95.00% line     3 123 O'Brien St                 <golden:validator_coverage_expansion>
+[HIGH  ] physical_... US_RURAL_ROUTE         90.00% line     2 Rural Route 3 Box 88           <golden:validator_coverage_expansion>
+[HIGH  ] physical_... US_STREET_ADDRESS      90.00% line     4 456 King-Smith Rd              <golden:validator_coverage_expansion>
+[MEDIUM] driversli... DRIVERS_LICENSE        85.00% line     5 D12345678901234                <golden:validator_coverage_expansion>
+[MEDIUM] otp          OTP_SECRET             85.00% line     7 jbswy3dpehpk3pxp               <golden:validator_coverage_expansion>
+[MEDIUM] driversli... DRIVERS_LICENSE        70.00% line     6 J1234567890123                 <golden:validator_coverage_expansion>
+[LOW   ] physical_... US_RURAL_ROUTE         40.00% line     8 RR 4                           <golden:validator_coverage_expansion>

--- a/internal/goldencorpus/testdata/golden/validator_coverage_expansion.yaml
+++ b/internal/goldencorpus/testdata/golden/validator_coverage_expansion.yaml
@@ -1,0 +1,199 @@
+results:
+    - text: PSC 1523, Box 25, APO AE 09009
+      line_number: 1
+      type: US_MILITARY_ADDRESS
+      confidence: 95
+      confidence_level: HIGH
+      filename: <golden:validator_coverage_expansion>
+      validator: physical_address
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0
+        context_doctype: Unknown
+        context_domain: Unknown
+        original_confidence: 95
+        original_file: <golden:validator_coverage_expansion>
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_path: document
+    - text: 123 O'Brien St
+      line_number: 3
+      type: US_STREET_ADDRESS
+      confidence: 95
+      confidence_level: HIGH
+      filename: <golden:validator_coverage_expansion>
+      validator: physical_address
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0
+        context_doctype: Unknown
+        context_domain: Unknown
+        original_confidence: 95
+        original_file: <golden:validator_coverage_expansion>
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_path: document
+    - text: Rural Route 3 Box 88
+      line_number: 2
+      type: US_RURAL_ROUTE
+      confidence: 90
+      confidence_level: HIGH
+      filename: <golden:validator_coverage_expansion>
+      validator: physical_address
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0
+        context_doctype: Unknown
+        context_domain: Unknown
+        original_confidence: 90
+        original_file: <golden:validator_coverage_expansion>
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_path: document
+    - text: 456 King-Smith Rd
+      line_number: 4
+      type: US_STREET_ADDRESS
+      confidence: 90
+      confidence_level: HIGH
+      filename: <golden:validator_coverage_expansion>
+      validator: physical_address
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0
+        context_doctype: Unknown
+        context_domain: Unknown
+        original_confidence: 90
+        original_file: <golden:validator_coverage_expansion>
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_path: document
+    - text: D12345678901234
+      line_number: 5
+      type: DRIVERS_LICENSE
+      confidence: 85
+      confidence_level: MEDIUM
+      filename: <golden:validator_coverage_expansion>
+      validator: driverslicense
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0
+        context_doctype: Unknown
+        context_domain: Unknown
+        context_impact: 80
+        format: NJ_1L14D
+        original_confidence: 85
+        original_file: <golden:validator_coverage_expansion>
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            format_match: true
+            has_dl_context: false
+            not_all_same: true
+            not_all_zeros: true
+            not_sequential: false
+        validation_path: document
+    - text: jbswy3dpehpk3pxp
+      line_number: 7
+      type: OTP_SECRET
+      confidence: 85
+      confidence_level: MEDIUM
+      filename: <golden:validator_coverage_expansion>
+      validator: otp
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0
+        context_doctype: Unknown
+        context_domain: Unknown
+        context_impact: 30
+        original_confidence: 85
+        original_file: <golden:validator_coverage_expansion>
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            format: true
+            not_excluded: true
+            valid_chars: true
+        validation_path: document
+    - text: J1234567890123
+      line_number: 6
+      type: DRIVERS_LICENSE
+      confidence: 70
+      confidence_level: MEDIUM
+      filename: <golden:validator_coverage_expansion>
+      validator: driverslicense
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0
+        context_doctype: Unknown
+        context_domain: Unknown
+        context_impact: 65
+        format: WI_1L13D
+        original_confidence: 70
+        original_file: <golden:validator_coverage_expansion>
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            format_match: true
+            has_dl_context: false
+            not_all_same: true
+            not_all_zeros: true
+            not_sequential: false
+        validation_path: document
+    - text: RR 4
+      line_number: 8
+      type: US_RURAL_ROUTE
+      confidence: 40
+      confidence_level: LOW
+      filename: <golden:validator_coverage_expansion>
+      validator: physical_address
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0
+        context_doctype: Unknown
+        context_domain: Unknown
+        original_confidence: 40
+        original_file: <golden:validator_coverage_expansion>
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        short_form: true
+        source: preprocessed_content
+        validation_path: document

--- a/internal/validators/address/validator.go
+++ b/internal/validators/address/validator.go
@@ -27,11 +27,15 @@ var (
 		`Path|Glen|Hollow|Meadow|Summit|Vista`
 
 	// streetNameWord matches one word of a street name. A word either starts
-	// with a letter ("Main", "Evergreen") or is an ordinal number ("42nd",
-	// "5th") — the ordinal form is what makes numbered streets in NYC-style
-	// grid cities ("123 42nd Street") detectable. Bare numbers are NOT street
-	// name words (that would make "500 300 Blvd" ambiguous with measurements).
-	streetNameWord = `(?:[A-Za-z][A-Za-z0-9]*|\d{1,4}(?:st|nd|rd|th|ST|ND|RD|TH))`
+	// with a letter ("Main", "Evergreen", "O'Brien", "King-Smith") or is an
+	// ordinal number ("42nd", "5th") — the ordinal form is what makes numbered
+	// streets in NYC-style grid cities ("123 42nd Street") detectable. Internal
+	// apostrophes and hyphens are allowed (Irish/hyphenated names) but the word
+	// must end with an alphanumeric character — no trailing punctuation. Single
+	// letters also match (e.g. the "D" in "D Street"). Bare numbers are NOT
+	// street name words (that would make "500 300 Blvd" ambiguous with
+	// measurements).
+	streetNameWord = `(?:[A-Za-z][A-Za-z0-9'\-]*[A-Za-z0-9]|[A-Za-z]|\d{1,4}(?:st|nd|rd|th|ST|ND|RD|TH))`
 
 	// reStreetAddress matches a US street address: number + street name + street type.
 	// Requires at least a street number, one or more name words, and a recognized
@@ -96,6 +100,31 @@ var (
 			`\s+(` + streetSuffixAlt + `)` +
 			`\.?` + // optional trailing dot
 			`\b`,
+	)
+
+	// reRuralRoute matches US rural route / highway contract route addresses.
+	// Full forms ("Rural Route 3", "Star Route 1 Box 88") are unambiguous;
+	// abbreviated forms ("RR 4", "HC 72") require the "Box NNN" continuation
+	// or external address context to avoid false positives. Case-insensitive.
+	reRuralRoute = regexp.MustCompile(
+		`(?i)\b(?:` +
+			`(?:Rural\s+Route|Star\s+Route)\s+\d{1,4}(?:\s*,?\s*Box\s+\d{1,6})?` +
+			`|(?:RR|R\.R\.|HC)\s+\d{1,4}\s*,?\s*Box\s+\d{1,6}` +
+			`)\b`,
+	)
+
+	// reRuralRouteShort matches abbreviated rural-route forms WITHOUT the Box
+	// continuation (e.g. "RR 4", "HC 72"). These need positive address context
+	// (ZIP, state, mailing keyword) to reach actionable confidence.
+	reRuralRouteShort = regexp.MustCompile(
+		`(?i)\b(?:RR|R\.R\.|HC)\s+\d{1,4}\b`,
+	)
+
+	// reAPOAddress matches US military mail addresses: PSC/CMR/Unit + number,
+	// optional Box, followed by APO/FPO/DPO + military state code + ZIP.
+	// The compound structure is extremely specific (near-zero FP).
+	reAPOAddress = regexp.MustCompile(
+		`(?i)\b(?:PSC|CMR|Unit)\s+\d{1,5}(?:\s*,?\s*Box\s+\d{1,6})?\s*,?\s*(?:APO|FPO|DPO)\s+(?:AA|AE|AP)\s+\d{5}(?:-\d{4})?\b`,
 	)
 
 	// False positive patterns
@@ -262,6 +291,122 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 				Text:       matchText,
 				LineNumber: lineNum + 1,
 				Type:       "PO_BOX",
+				Confidence: confidence,
+				Filename:   originalPath,
+				Validator:  "physical_address",
+				Context:    contextInfo,
+				Metadata: map[string]any{
+					"source":        "preprocessed_content",
+					"original_file": originalPath,
+				},
+			})
+		}
+
+		// Detect rural route addresses (RR N Box N, HC N Box N, Rural Route N, Star Route N).
+		ruralMatches := reRuralRoute.FindAllStringIndex(line, -1)
+		var ruralConfidence float64
+		if len(ruralMatches) > 0 {
+			ruralConfidence = v.calculateRuralRouteConfidence(line, lines, lineNum) - negativePenalty
+		}
+		for i, loc := range ruralMatches {
+			if execguard.LineLoopCancelled(ctx, i) {
+				return matches, ctx.Err()
+			}
+			matchText := line[loc[0]:loc[1]]
+
+			confidence := ruralConfidence
+			if confidence <= 0 {
+				continue
+			}
+			if confidence > 100 {
+				confidence = 100
+			}
+
+			contextInfo := v.buildContextInfo(line, loc[0], len(matchText), linePositiveKeywords, lineNegativeKeywords)
+
+			matches = append(matches, detector.Match{
+				Text:       matchText,
+				LineNumber: lineNum + 1,
+				Type:       "US_RURAL_ROUTE",
+				Confidence: confidence,
+				Filename:   originalPath,
+				Validator:  "physical_address",
+				Context:    contextInfo,
+				Metadata: map[string]any{
+					"source":        "preprocessed_content",
+					"original_file": originalPath,
+				},
+			})
+		}
+
+		// Short-form rural routes (RR 4, HC 72) without Box — only match when
+		// the full-form regex above did NOT already match and positive address
+		// context is present on this or adjacent lines.
+		if len(ruralMatches) == 0 {
+			ruralShortMatches := reRuralRouteShort.FindAllStringIndex(line, -1)
+			var ruralShortConfidence float64
+			if len(ruralShortMatches) > 0 {
+				ruralShortConfidence = v.calculateRuralRouteShortConfidence(line, lines, lineNum) - negativePenalty
+			}
+			for i, loc := range ruralShortMatches {
+				if execguard.LineLoopCancelled(ctx, i) {
+					return matches, ctx.Err()
+				}
+				matchText := line[loc[0]:loc[1]]
+
+				confidence := ruralShortConfidence
+				if confidence <= 0 {
+					continue
+				}
+				if confidence > 100 {
+					confidence = 100
+				}
+
+				contextInfo := v.buildContextInfo(line, loc[0], len(matchText), linePositiveKeywords, lineNegativeKeywords)
+
+				matches = append(matches, detector.Match{
+					Text:       matchText,
+					LineNumber: lineNum + 1,
+					Type:       "US_RURAL_ROUTE",
+					Confidence: confidence,
+					Filename:   originalPath,
+					Validator:  "physical_address",
+					Context:    contextInfo,
+					Metadata: map[string]any{
+						"source":        "preprocessed_content",
+						"original_file": originalPath,
+						"short_form":    true,
+					},
+				})
+			}
+		}
+
+		// Detect military APO/FPO/DPO addresses.
+		apoMatches := reAPOAddress.FindAllStringIndex(line, -1)
+		var apoConfidence float64
+		if len(apoMatches) > 0 {
+			apoConfidence = v.calculateAPOConfidence(line, lines, lineNum) - negativePenalty
+		}
+		for i, loc := range apoMatches {
+			if execguard.LineLoopCancelled(ctx, i) {
+				return matches, ctx.Err()
+			}
+			matchText := line[loc[0]:loc[1]]
+
+			confidence := apoConfidence
+			if confidence <= 0 {
+				continue
+			}
+			if confidence > 100 {
+				confidence = 100
+			}
+
+			contextInfo := v.buildContextInfo(line, loc[0], len(matchText), linePositiveKeywords, lineNegativeKeywords)
+
+			matches = append(matches, detector.Match{
+				Text:       matchText,
+				LineNumber: lineNum + 1,
+				Type:       "US_MILITARY_ADDRESS",
 				Confidence: confidence,
 				Filename:   originalPath,
 				Validator:  "physical_address",
@@ -504,6 +649,72 @@ func (v *Validator) calculatePOBoxConfidence(line string, lines []string, lineNu
 	}
 
 	// Positive keyword boost
+	keywordBoost := v.calculateKeywordBoost(line, lines, lineNum)
+	confidence += keywordBoost
+
+	return confidence
+}
+
+// calculateRuralRouteConfidence computes confidence for a full-form rural route
+// match (contains "Box" or spells out "Rural Route" / "Star Route").
+func (v *Validator) calculateRuralRouteConfidence(line string, lines []string, lineNum int) float64 {
+	confidence := 55.0
+
+	// City/state/ZIP on same line
+	if reCityStateZip.MatchString(line) {
+		confidence += 20
+	} else {
+		adjacentContext := v.getAdjacentLines(lines, lineNum, 2)
+		if reCityStateZip.MatchString(adjacentContext) {
+			confidence += 20
+		} else if reStateAbbrev.MatchString(adjacentContext) && reZIPAlone.MatchString(adjacentContext) {
+			confidence += 15
+		} else if reZIPAlone.MatchString(adjacentContext) {
+			confidence += 10
+		}
+	}
+
+	// Positive keyword boost
+	keywordBoost := v.calculateKeywordBoost(line, lines, lineNum)
+	confidence += keywordBoost
+
+	return confidence
+}
+
+// calculateRuralRouteShortConfidence computes confidence for abbreviated rural
+// routes without the Box continuation (e.g. "RR 4", "HC 72"). These are only
+// actionable when address context is independently present.
+func (v *Validator) calculateRuralRouteShortConfidence(line string, lines []string, lineNum int) float64 {
+	confidence := 40.0
+
+	// Require city/state/ZIP or positive keyword to reach actionable threshold.
+	if reCityStateZip.MatchString(line) {
+		confidence += 20
+	} else {
+		adjacentContext := v.getAdjacentLines(lines, lineNum, 2)
+		if reCityStateZip.MatchString(adjacentContext) {
+			confidence += 20
+		} else if reStateAbbrev.MatchString(adjacentContext) && reZIPAlone.MatchString(adjacentContext) {
+			confidence += 15
+		} else if reZIPAlone.MatchString(adjacentContext) {
+			confidence += 10
+		}
+	}
+
+	// Positive keyword boost
+	keywordBoost := v.calculateKeywordBoost(line, lines, lineNum)
+	confidence += keywordBoost
+
+	return confidence
+}
+
+// calculateAPOConfidence computes confidence for a military APO/FPO/DPO match.
+// The compound pattern (PSC/CMR/Unit + APO/FPO/DPO + AA/AE/AP + ZIP) is
+// self-guarding — near-zero false positive rate — so the base is very high.
+func (v *Validator) calculateAPOConfidence(line string, lines []string, lineNum int) float64 {
+	confidence := 80.0
+
+	// Positive keyword boost (minor — pattern is already decisive)
 	keywordBoost := v.calculateKeywordBoost(line, lines, lineNum)
 	confidence += keywordBoost
 

--- a/internal/validators/driverslicense/validator.go
+++ b/internal/validators/driverslicense/validator.go
@@ -28,6 +28,12 @@ var (
 	// New York: 9 digits (also Georgia)
 	reNewYorkDL = regexp.MustCompile(`\b\d{9}\b`)
 
+	// New Jersey: 1 letter + 14 digits (15 characters total — extremely distinctive length)
+	reNewJerseyDL = regexp.MustCompile(`\b[A-Za-z]\d{14}\b`)
+
+	// Wisconsin: 1 letter + 13 digits (14 characters total — very distinctive length)
+	reWisconsinDL = regexp.MustCompile(`\b[A-Za-z]\d{13}\b`)
+
 	// Illinois: 1 letter + 11 digits
 	reIllinoisDL = regexp.MustCompile(`\b[A-Za-z]\d{11}\b`)
 
@@ -36,10 +42,14 @@ var (
 
 	// Composite pattern that matches ANY of the above formats in a single pass.
 	// Used by ValidateContentCtx for the initial line scan; hits are then
-	// classified into the specific state format in classifyMatch.
+	// classified into the specific state format in classifyMatch. Ordered
+	// longest-first so the regex engine greedily matches the full token
+	// without a shorter prefix stealing the match.
 	reAnyDL = regexp.MustCompile(
 		`\b(?:` +
 			`[A-Za-z]{2}\d{6}` + // Ohio (2 letters + 6 digits)
+			`|[A-Za-z]\d{14}` + // New Jersey (1 letter + 14 digits)
+			`|[A-Za-z]\d{13}` + // Wisconsin (1 letter + 13 digits)
 			`|[A-Za-z]\d{12}` + // Florida/Michigan (1 letter + 12 digits)
 			`|[A-Za-z]\d{11}` + // Illinois (1 letter + 11 digits)
 			`|[A-Za-z]\d{7}` + // California (1 letter + 7 digits)
@@ -48,7 +58,7 @@ var (
 			`)\b`)
 
 	// State name patterns for context detection
-	reStateName = regexp.MustCompile(`(?i)\b(?:california|texas|florida|new york|pennsylvania|illinois|ohio|georgia|north carolina|michigan|CA|TX|FL|NY|PA|IL|OH|GA|NC|MI)\b`)
+	reStateName = regexp.MustCompile(`(?i)\b(?:california|texas|florida|new york|new jersey|pennsylvania|illinois|ohio|georgia|north carolina|michigan|wisconsin|CA|TX|FL|NY|NJ|PA|IL|OH|GA|NC|MI|WI)\b`)
 
 	// Licenses are often printed with separators (e.g. "D123-4567-8901",
 	// "123 456 789"). Candidates are normalized (separators stripped) and must
@@ -130,8 +140,9 @@ func NewValidator() *Validator {
 			"work permit",
 		},
 		stateKeywords: []string{
-			"california", "texas", "florida", "new york", "pennsylvania",
-			"illinois", "ohio", "georgia", "north carolina", "michigan",
+			"california", "texas", "florida", "new york", "new jersey",
+			"pennsylvania", "illinois", "ohio", "georgia", "north carolina",
+			"michigan", "wisconsin",
 		},
 	}
 
@@ -389,8 +400,16 @@ func (v *Validator) lineHasPositiveKeyword(line string) bool {
 
 // classifyMatch determines which state DL format the match corresponds to.
 // Returns a human-readable format string or "" if no specific format is matched.
+// Ordered longest-first so that longer formats are checked before shorter ones
+// that would also match (e.g. NJ 1L+14D before FL 1L+12D).
 func (v *Validator) classifyMatch(match string) string {
 	switch {
+	case reNewJerseyDL.MatchString(match):
+		// 1 letter + 14 digits: New Jersey
+		return "NJ_1L14D"
+	case reWisconsinDL.MatchString(match):
+		// 1 letter + 13 digits: Wisconsin
+		return "WI_1L13D"
 	case reFloridaDL.MatchString(match):
 		// 1 letter + 12 digits: Florida or Michigan
 		return "FL_MI_1L12D"

--- a/internal/validators/otp/dos_test.go
+++ b/internal/validators/otp/dos_test.go
@@ -1,0 +1,70 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package otp
+
+import (
+	stdctx "context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSingleLongLine_NotQuadratic guards against the O(n^2) DoS the other
+// validators were hardened against (a 48KB single line of dense base32
+// tokens with OTP keywords took ~6.7s before the per-line context hoist).
+// The fix computes AnalyzeContext / keyword sets / positive-negative context
+// once per line and builds ContextInfo from FindAllStringIndex offsets
+// instead of re-scanning the line per match.
+func TestSingleLongLine_NotQuadratic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping DoS timing regression in -short mode")
+	}
+
+	var b strings.Builder
+	b.Grow(48*1024 + 64)
+	b.WriteString("2fa secret totp ")
+	for b.Len() < 48*1024 {
+		b.WriteString("jbswy3dpehpk3pxp krugkidrovuwg2zamjzg653o JBSWY3DPEHPK3PXP ")
+	}
+	content := b.String()
+	if strings.Contains(content, "\n") {
+		t.Fatalf("worst-case input must be a single line")
+	}
+
+	const ceiling = 2 * time.Second
+	start := time.Now()
+	matches, err := NewValidator().ValidateContent(content, "worstcase.txt")
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("ValidateContent() error = %v", err)
+	}
+	if raceEnabled {
+		t.Logf("processed %d-byte single line, %d matches (timing assertion skipped under -race)", len(content), len(matches))
+		return
+	}
+	if elapsed > ceiling {
+		t.Fatalf("ValidateContent on a %d-byte single line took %s, exceeding the %s ceiling (likely an O(n^2) regression)",
+			len(content), elapsed, ceiling)
+	}
+}
+
+// TestSingleLongLine_Cancellable verifies per-match ctx polling interrupts a
+// single pathological line promptly.
+func TestSingleLongLine_Cancellable(t *testing.T) {
+	var b strings.Builder
+	b.Grow(1<<20 + 64)
+	b.WriteString("2fa secret totp ")
+	for b.Len() < 1<<20 {
+		b.WriteString("jbswy3dpehpk3pxp krugkidrovuwg2zamjzg653o JBSWY3DPEHPK3PXP ")
+	}
+
+	ctx, cancel := stdctx.WithCancel(stdctx.Background())
+	cancel()
+
+	start := time.Now()
+	_, _ = NewValidator().ValidateContentCtx(ctx, b.String(), "cancel.txt")
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("cancelled scan took %s; per-match ctx polling not effective", elapsed)
+	}
+}

--- a/internal/validators/otp/race_off_test.go
+++ b/internal/validators/otp/race_off_test.go
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !race
+
+package otp
+
+// raceEnabled reports whether the binary was built with the race detector. The
+// race detector adds large (5-20x), variable wall-clock overhead, so the DoS
+// timing regression test uses it to skip its wall-clock ceiling (the scan still
+// runs, so -race can still detect data races in the per-line hoisted state).
+const raceEnabled = false

--- a/internal/validators/otp/race_on_test.go
+++ b/internal/validators/otp/race_on_test.go
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build race
+
+package otp
+
+// raceEnabled reports whether the binary was built with the race detector. The
+// race detector adds large (5-20x), variable wall-clock overhead, so the DoS
+// timing regression test uses it to skip its wall-clock ceiling (the scan still
+// runs, so -race can still detect data races in the per-line hoisted state).
+const raceEnabled = true

--- a/internal/validators/otp/validator.go
+++ b/internal/validators/otp/validator.go
@@ -24,6 +24,11 @@ var (
 	// We match only uppercase; CalculateConfidence normalizes to upper for validation.
 	reBase32Secret = regexp.MustCompile(`\b[A-Z2-7]{16,64}\b`)
 
+	// Lowercase base32 secrets: same charset but lowercase. Some tools/configs emit
+	// secrets in lowercase (e.g., "jbswy3dpehpk3pxp"). Matched separately and only
+	// considered when positive OTP context is present on the line.
+	reBase32SecretLower = regexp.MustCompile(`\b[a-z2-7]{16,64}\b`)
+
 	// Recovery/backup codes: groups of 4-10 alphanumeric blocks separated by dashes
 	// or spaces. We detect lines that have 2+ such blocks (a single block is too
 	// ambiguous). The typical pattern is XXXX-XXXX-XXXX or XXXXXXXX XXXXXXXX.
@@ -122,6 +127,69 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 	return v.ValidateContentCtx(stdctx.Background(), content, originalPath)
 }
 
+// otpLineContext holds the per-line invariants, computed ONCE per line.
+// AnalyzeContext ignores its match argument and only tests keyword PRESENCE
+// over BeforeText+FullLine+AfterText — and Before/After are slices of the
+// line, so its result is identical for every match on the line. The original
+// code recomputed it (plus hasPositive/hasNegativeContext and the
+// buildContextInfo keyword scans) per match, which is O(matches × line
+// length × keywords) — the single-long-line CPU-exhaustion DoS the other
+// validators were already hardened against. See the timing regression test.
+type otpLineContext struct {
+	impact  float64
+	posKW   []string
+	negKW   []string
+	hasPos  bool
+	hasNeg  bool
+	uriLocs [][]int
+}
+
+func (v *Validator) buildOTPLineContext(line string) otpLineContext {
+	return otpLineContext{
+		impact: v.AnalyzeContext("", detector.ContextInfo{FullLine: line}),
+		posKW:  v.findKeywords(line, v.positiveKeywords),
+		negKW:  v.findKeywords(line, v.negativeKeywords),
+		hasPos: v.hasPositiveContext(line),
+		hasNeg: v.hasNegativeContext(line),
+	}
+}
+
+// contextInfoAt builds the ContextInfo for a match at a known byte offset,
+// reusing the per-line keyword sets — no strings.Index re-scan, no per-match
+// keyword sweep.
+func (v *Validator) contextInfoAt(line string, start, length int, lc otpLineContext) detector.ContextInfo {
+	ci := detector.ContextInfo{
+		FullLine:         line,
+		PositiveKeywords: lc.posKW,
+		NegativeKeywords: lc.negKW,
+	}
+	from := start - 50
+	if from < 0 {
+		from = 0
+	}
+	to := start + length + 50
+	if to > len(line) {
+		to = len(line)
+	}
+	ci.BeforeText = line[from:start]
+	ci.AfterText = line[start+length : to]
+	return ci
+}
+
+// insideAnySpan reports whether [start,end) falls inside any span in locs
+// (sorted by start, as FindAllStringIndex returns them).
+func insideAnySpan(locs [][]int, start, end int) bool {
+	for _, l := range locs {
+		if l[0] > start {
+			return false
+		}
+		if end <= l[1] {
+			return true
+		}
+	}
+	return false
+}
+
 // ValidateContentCtx is the context-aware form of ValidateContent, implementing
 // cooperative cancellation via execguard.LineLoopCancelled.
 func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, originalPath string) ([]detector.Match, error) {
@@ -134,148 +202,111 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 			return matches, ctx.Err()
 		}
 
-		// Check for otpauth:// URIs
-		uriMatches := reOTPAuthURI.FindAllString(line, -1)
-		for _, uri := range uriMatches {
-			confidence, checks := v.CalculateConfidence(uri)
-			contextInfo := v.buildContextInfo(line, uri)
-			contextImpact := v.AnalyzeContext(uri, contextInfo)
-			confidence += contextImpact
+		lc := v.buildOTPLineContext(line)
 
+		// emit scores one candidate at a known offset and appends it if it
+		// survives clamping. Confidence math is identical to the original
+		// per-match path; only the redundant per-match line scans are gone.
+		emit := func(start, length int, matchType string, applyNegative bool) {
+			text := line[start : start+length]
+			confidence, checks := v.CalculateConfidence(text)
+			confidence += lc.impact
+			if applyNegative && lc.hasNeg {
+				confidence -= 30
+			}
 			confidence = v.clampConfidence(confidence)
 			if confidence <= 0 {
-				continue
+				return
 			}
-
 			matches = append(matches, detector.Match{
-				Text:       uri,
+				Text:       text,
 				LineNumber: lineNum + 1,
-				Type:       "OTPAUTH_URI",
+				Type:       matchType,
 				Confidence: confidence,
 				Filename:   originalPath,
 				Validator:  "otp",
-				Context:    contextInfo,
+				Context:    v.contextInfoAt(line, start, length, lc),
 				Metadata: map[string]any{
 					"validation_checks": checks,
-					"context_impact":    contextImpact,
+					"context_impact":    lc.impact,
 					"source":            "preprocessed_content",
 					"original_file":     originalPath,
 				},
 			})
 		}
 
-		// Check for base32 secrets (only with context keywords)
-		secretMatches := reBase32Secret.FindAllString(line, -1)
-		for _, secret := range secretMatches {
-			// Skip if already part of an otpauth URI on this line
-			if strings.Contains(line, "otpauth://") && strings.Contains(line, secret) {
-				// Check if the secret is inside the URI (as a parameter value)
-				for _, uri := range uriMatches {
-					if strings.Contains(uri, secret) {
-						goto nextSecret
-					}
+		// Check for otpauth:// URIs
+		lc.uriLocs = reOTPAuthURI.FindAllStringIndex(line, -1)
+		for i, loc := range lc.uriLocs {
+			if execguard.LineLoopCancelled(ctx, i) {
+				return matches, ctx.Err()
+			}
+			emit(loc[0], loc[1]-loc[0], "OTPAUTH_URI", false)
+		}
+
+		// Check for base32 secrets (only with context keywords — a bare
+		// base32 string is far too ambiguous on its own).
+		if lc.hasPos {
+			for i, loc := range reBase32Secret.FindAllStringIndex(line, -1) {
+				if execguard.LineLoopCancelled(ctx, i) {
+					return matches, ctx.Err()
 				}
-			}
+				secret := line[loc[0]:loc[1]]
 
-			// Base32 secrets require positive keyword context — a bare base32
-			// string is far too ambiguous on its own.
-			if !v.hasPositiveContext(line) {
-				continue
-			}
-
-			// Reject if this looks like a UUID or hex hash
-			if reUUID.MatchString(secret) || reHexHash.MatchString(secret) {
-				continue
-			}
-
-			// Reject AWS access key IDs (AKIA.../ASIA...)
-			if reAWSKeyID.MatchString(secret) {
-				continue
-			}
-
-			// Validate it is actually valid base32
-			if !v.isValidBase32(secret) {
-				continue
-			}
-
-			{
-				confidence, checks := v.CalculateConfidence(secret)
-				contextInfo := v.buildContextInfo(line, secret)
-				contextImpact := v.AnalyzeContext(secret, contextInfo)
-				confidence += contextImpact
-
-				// Apply negative keyword suppression
-				if v.hasNegativeContext(line) {
-					confidence -= 30
-				}
-
-				confidence = v.clampConfidence(confidence)
-				if confidence <= 0 {
+				// Skip if inside an otpauth URI on this line (its secret= param)
+				if insideAnySpan(lc.uriLocs, loc[0], loc[1]) {
 					continue
 				}
-
-				matches = append(matches, detector.Match{
-					Text:       secret,
-					LineNumber: lineNum + 1,
-					Type:       "OTP_SECRET",
-					Confidence: confidence,
-					Filename:   originalPath,
-					Validator:  "otp",
-					Context:    contextInfo,
-					Metadata: map[string]any{
-						"validation_checks": checks,
-						"context_impact":    contextImpact,
-						"source":            "preprocessed_content",
-						"original_file":     originalPath,
-					},
-				})
+				// Reject UUID / hex-hash / AWS-key shaped tokens
+				if reUUID.MatchString(secret) || reHexHash.MatchString(secret) || reAWSKeyID.MatchString(secret) {
+					continue
+				}
+				if !v.isValidBase32(secret) {
+					continue
+				}
+				emit(loc[0], loc[1]-loc[0], "OTP_SECRET", true)
 			}
-		nextSecret:
+
+			// Lowercase base32 secrets (some tools/configs emit lowercase).
+			// Normalized to uppercase for validation; original text reported.
+			for i, loc := range reBase32SecretLower.FindAllStringIndex(line, -1) {
+				if execguard.LineLoopCancelled(ctx, i) {
+					return matches, ctx.Err()
+				}
+				secret := line[loc[0]:loc[1]]
+
+				if insideAnySpan(lc.uriLocs, loc[0], loc[1]) {
+					continue
+				}
+				upper := strings.ToUpper(secret)
+				if reUUID.MatchString(secret) || reHexHash.MatchString(secret) {
+					continue
+				}
+				if !v.isValidBase32(upper) {
+					continue
+				}
+				// Reject uppercased forms that look like English words/patterns
+				if v.isLikelyWord(upper) {
+					continue
+				}
+				emit(loc[0], loc[1]-loc[0], "OTP_SECRET", true)
+			}
 		}
 
 		// Check for recovery/backup code blocks
-		recoveryMatches := reRecoveryCodeBlock.FindAllString(line, -1)
-		if len(recoveryMatches) >= 2 && v.hasRecoveryContext(line) {
+		recoveryLocs := reRecoveryCodeBlock.FindAllStringIndex(line, -1)
+		if len(recoveryLocs) >= 2 && v.hasRecoveryContext(line) {
 			// Multiple recovery-code-shaped blocks on the same line with context
-			for _, code := range recoveryMatches {
-				// Skip UUIDs and partial UUIDs
-				if reUUID.MatchString(code) || rePartialUUID.MatchString(code) {
+			for i, loc := range recoveryLocs {
+				if execguard.LineLoopCancelled(ctx, i) {
+					return matches, ctx.Err()
+				}
+				code := line[loc[0]:loc[1]]
+				// Skip UUIDs, partial UUIDs, and hex-only dash blocks
+				if reUUID.MatchString(code) || rePartialUUID.MatchString(code) || reHexDashBlock.MatchString(code) {
 					continue
 				}
-				// Skip hex-only dash blocks (likely partial UUIDs or hashes)
-				if reHexDashBlock.MatchString(code) {
-					continue
-				}
-
-				confidence, checks := v.CalculateConfidence(code)
-				contextInfo := v.buildContextInfo(line, code)
-				contextImpact := v.AnalyzeContext(code, contextInfo)
-				confidence += contextImpact
-
-				if v.hasNegativeContext(line) {
-					confidence -= 30
-				}
-
-				confidence = v.clampConfidence(confidence)
-				if confidence <= 0 {
-					continue
-				}
-
-				matches = append(matches, detector.Match{
-					Text:       code,
-					LineNumber: lineNum + 1,
-					Type:       "RECOVERY_CODES",
-					Confidence: confidence,
-					Filename:   originalPath,
-					Validator:  "otp",
-					Context:    contextInfo,
-					Metadata: map[string]any{
-						"validation_checks": checks,
-						"context_impact":    contextImpact,
-						"source":            "preprocessed_content",
-						"original_file":     originalPath,
-					},
-				})
+				emit(loc[0], loc[1]-loc[0], "RECOVERY_CODES", true)
 			}
 		}
 	}

--- a/internal/validators/otp/validator_test.go
+++ b/internal/validators/otp/validator_test.go
@@ -605,6 +605,77 @@ func TestOTPValidator_IsLikelyWord(t *testing.T) {
 	}
 }
 
+func TestOTPValidator_LowercaseBase32Secrets(t *testing.T) {
+	validator := NewValidator()
+
+	tests := []struct {
+		name        string
+		content     string
+		expectMatch bool
+		matchText   string
+		description string
+	}{
+		{
+			name:        "Lowercase TOTP secret with context",
+			content:     "totp secret: jbswy3dpehpk3pxp",
+			expectMatch: true,
+			matchText:   "jbswy3dpehpk3pxp",
+			description: "Lowercase base32 with TOTP keyword should match",
+		},
+		{
+			name:        "Lowercase secret with 2FA keyword",
+			content:     "2fa seed krugkidrovuwg2zamjzg653oehpk3pxp",
+			expectMatch: true,
+			matchText:   "krugkidrovuwg2zamjzg653oehpk3pxp",
+			description: "Longer lowercase base32 with 2FA context",
+		},
+		{
+			name:        "Lowercase base32 without context",
+			content:     "random data: jbswy3dpehpk3pxp here",
+			expectMatch: false,
+			description: "Lowercase base32 without OTP keywords should not match",
+		},
+		{
+			name:        "English word with OTP context but caught by isLikelyWord",
+			content:     "2fa secret: aaaaaaaaaaaaaaaa",
+			expectMatch: false,
+			description: "All-same-char pattern rejected by isLikelyWord",
+		},
+		{
+			name:        "Lowercase with negative context suppression",
+			content:     "test example totp key: jbswy3dpehpk3pxp",
+			expectMatch: false,
+			description: "Negative keywords should suppress even lowercase matches",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matches, err := validator.ValidateContent(tt.content, "test.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent() error = %v", err)
+			}
+			hasMatch := false
+			for _, m := range matches {
+				if m.Type == "OTP_SECRET" && m.Confidence > 50 {
+					hasMatch = true
+					if tt.matchText != "" && m.Text != tt.matchText {
+						t.Errorf("expected match text %q, got %q", tt.matchText, m.Text)
+					}
+					break
+				}
+			}
+			if hasMatch != tt.expectMatch {
+				t.Errorf("%s: expected match=%v, got=%v (matches=%d)",
+					tt.description, tt.expectMatch, hasMatch, len(matches))
+				for _, m := range matches {
+					t.Logf("  match: type=%s text=%q confidence=%.1f", m.Type, m.Text, m.Confidence)
+				}
+			}
+		})
+	}
+}
+
 func TestOTPValidator_SecretInsideOTPAuthURI(t *testing.T) {
 	validator := NewValidator()
 


### PR DESCRIPTION
Completes the new-validator coverage so they ship at full strength (follow-up to #144, which merged before this landed):

## New coverage
- **Military APO/FPO/DPO** addresses (`PSC 1523, Box 25, APO AE 09009`) — compound structure, near-zero FP
- **Rural/star routes** (`Rural Route 3 Box 88`, `RR 4 Box 200`); abbreviated forms without Box score LOW
- **Apostrophe/hyphen street names** (`123 O'Brien St`, `456 King-Smith Rd`)
- **NJ (1L+14D) and WI (1L+13D) licenses** — the only state formats distinctive enough to add FP-free (researched VA/NH/WA/IN and rejected as too generic)
- **Lowercase base32 OTP secrets** — keyword-gated, word-guarded on the uppercased form

## DoS fix
The OTP validator had the same O(n²) per-match line-rescan the other validators were hardened against in #144 — 6.7s on a 48KB dense single line, quadratic scaling confirmed by an adversarial probe. Context is now hoisted per-line: **0.7s** on the same probe. Adds the missing DoS timing regression tests.

## Verification
- All validator + golden corpus tests green; `go vet` clean
- 48KB pathological single-line probes: rural 0.12s, APO 0.11s, apostrophe 0.10s, lowercase-OTP 0.70s
- FP probes: `RR 4 lbs` → LOW only, `APO is an abbreviation` / `O' clock` / `king-sized` / lowercase prose → no match
- New golden case locks formats + guards; only order-only diff (equal-confidence tiebreak) in one existing snapshot