### PR TITLE
fix(text): make pre-commit hint accurate when --show-match is active

### DIFF
--- a/internal/formatters/text/formatter.go
+++ b/internal/formatters/text/formatter.go
@@ -868,7 +868,7 @@ func (f *Formatter) formatPrecommitOutput(matches []detector.Match, suppressedMa
 	// Add resolution guidance if there are findings
 	if len(matches) > 0 {
 		builder.WriteString("\n")
-		builder.WriteString(f.getPrecommitResolutionGuidance(matches))
+		builder.WriteString(f.getPrecommitResolutionGuidance(matches, options))
 	}
 
 	return builder.String()
@@ -919,13 +919,18 @@ func (f *Formatter) getPrecommitIssueDescription(match detector.Match) string {
 }
 
 // getPrecommitResolutionGuidance provides actionable guidance for resolving issues
-func (f *Formatter) getPrecommitResolutionGuidance(matches []detector.Match) string {
+func (f *Formatter) getPrecommitResolutionGuidance(matches []detector.Match, options formatters.FormatterOptions) string {
 	var guidance strings.Builder
 
 	guidance.WriteString("Resolution options:\n")
 	guidance.WriteString("1. Remove or redact the sensitive data\n")
 	guidance.WriteString("2. Add suppression rules if data is intentional (run `ferret-scan --help` for the suppression flags, or see https://github.com/awslabs/ferret-scan)\n")
-	guidance.WriteString("3. Use --show-match flag to see exact matches for review (otherwise shows [HIDDEN])\n")
+	// Only suggest --show-match when it is not already in effect: suggesting a
+	// flag the operator has already passed is misleading. When ShowMatch is on,
+	// the per-finding "match:" lines above already show the exact values.
+	if !options.ShowMatch {
+		guidance.WriteString("3. Use --show-match flag to see exact matches for review (otherwise shows [HIDDEN])\n")
+	}
 
 	// Check if there are high confidence findings that should block
 	hasHighConfidence := false

--- a/internal/formatters/text/formatter_test.go
+++ b/internal/formatters/text/formatter_test.go
@@ -135,3 +135,49 @@ func TestTextFormatter_PrecommitHonorsShowMatch(t *testing.T) {
 		t.Errorf("pre-commit --show-match should reveal the matched value:\n%s", shown)
 	}
 }
+
+// TestTextFormatter_PrecommitGuidanceHintMatchesState is a regression test for
+// the misleading resolution hint: pre-commit guidance unconditionally said
+// "Use --show-match flag to see exact matches", even when the operator had
+// already passed --show-match (the values were already on screen). The hint
+// must appear only when ShowMatch is off, i.e. only when following it would
+// actually change the output.
+func TestTextFormatter_PrecommitGuidanceHintMatchesState(t *testing.T) {
+	const secret = "4929-3813-3266-4295"
+	matches := []detector.Match{{
+		Text:       secret,
+		LineNumber: 2,
+		Type:       "CREDIT_CARD",
+		Confidence: 100,
+		Filename:   "cards.tsv",
+		Validator:  "creditcard",
+	}}
+	levels := map[string]bool{"high": true, "medium": true, "low": true}
+	const hint = "Use --show-match flag"
+
+	// ShowMatch off: values are [HIDDEN], so the hint is actionable — show it.
+	hidden, err := NewFormatter().Format(matches, nil, formatters.FormatterOptions{
+		PrecommitMode: true, ShowMatch: false, NoColor: true, ConfidenceLevel: levels,
+	})
+	if err != nil {
+		t.Fatalf("Format error: %v", err)
+	}
+	if !strings.Contains(hidden, hint) {
+		t.Errorf("pre-commit guidance should suggest --show-match when it is off:\n%s", hidden)
+	}
+
+	// ShowMatch on: values are already shown; suggesting the flag is misleading.
+	shown, err := NewFormatter().Format(matches, nil, formatters.FormatterOptions{
+		PrecommitMode: true, ShowMatch: true, NoColor: true, ConfidenceLevel: levels,
+	})
+	if err != nil {
+		t.Fatalf("Format error: %v", err)
+	}
+	if strings.Contains(shown, hint) {
+		t.Errorf("pre-commit guidance must not suggest --show-match when it is already on:\n%s", shown)
+	}
+	// The remaining guidance is still present in both states.
+	if !strings.Contains(shown, "Resolution options:") || !strings.Contains(hidden, "Resolution options:") {
+		t.Errorf("resolution guidance header should be present in both states")
+	}
+}


### PR DESCRIPTION
## Summary
The pre-commit guidance unconditionally said "Use --show-match flag to see exact matches" even when `--show-match` was already on — misleading. This makes the hint conditional: it appears only when the flag is off. Pre-commit's reveal behavior itself (printing match text when ShowMatch is true) was already wired; only the hint was broken.

One of three --show-match reveal gaps identified by an earlier audit. The remaining two (JUnit suppressed findings never reveal, gitlab-sast lacks FullLine fallback) will be addressed in follow-up PRs.

## Test plan
- Added test for both hint states (flag on → hint absent, flag off → hint present)
- Golden corpus unchanged (goldens generate without --show-match)