### PR TITLE
test(goldencorpus): lock context-decoy behavior for original + PERSON_NAME validators

### DIFF
--- a/internal/goldencorpus/corpus.go
+++ b/internal/goldencorpus/corpus.go
@@ -183,6 +183,42 @@ var Cases = []Case{
 			"5 people way too many for the room\n" +
 			"3 items in way of progress\n",
 	},
+	{
+		Name: "context_decoys_original",
+		Description: "Real-context vs decoy-context pairs for the ORIGINAL validators (SSN, " +
+			"PHONE, CREDIT_CARD, EMAIL): the same shaped value framed as PII on one line and " +
+			"as a part number / error code / SKU on another. Locks CURRENT context-scoring " +
+			"behavior including known warts — e.g. SSN-shaped part numbers today score the " +
+			"same as real SSNs (no context discrimination). A future context-scoring change " +
+			"must show up here as an intentional diff, not slip through silently.",
+		Checks: []string{"SSN", "PHONE", "CREDIT_CARD", "EMAIL"},
+		Input: "employee ssn 449-87-4100 on file\n" +
+			"part number 449-87-4100 from the catalog\n" +
+			"requisition 526-33-8210 approved for shipment\n" +
+			"call us at 212-555-0142 today\n" +
+			"error code 212-555-0142 in the diagnostics log\n" +
+			"SKU 313-555-0175 restocked\n",
+	},
+	{
+		Name: "context_decoys_personname",
+		Description: "Multi-line document (PERSON_NAME is document-length sensitive) mixing " +
+			"real person references with decoy name-shaped strings: geographic features " +
+			"(Jordan River), products (Lincoln Continental), and companies (Amazon Web " +
+			"Services) that share surface shape with person names. Locks CURRENT " +
+			"disambiguation behavior, whatever it is, so future name-context changes " +
+			"surface as intentional diffs.",
+		Checks: []string{"PERSON_NAME"},
+		Input: "Contact Maria Delgado for approval\n" +
+			"the Jordan River flows north\n" +
+			"Please forward the report to James Whitfield by Friday\n" +
+			"Lincoln Continental parked outside\n" +
+			"Sarah Okonkwo will present the quarterly results\n" +
+			"Amazon Web Services launched\n" +
+			"Schedule a review with Daniel Moreau next week\n" +
+			"the Hudson Valley orchard shipped apples\n" +
+			"Priya Raghavan approved the budget request\n" +
+			"Ford Mustang sales rose sharply\n",
+	},
 }
 
 // FileCase is one file-based corpus entry. Unlike Case (which scans an in-memory

--- a/internal/goldencorpus/testdata/golden/context_decoys_original.csv
+++ b/internal/goldencorpus/testdata/golden/context_decoys_original.csv
@@ -1,0 +1,7 @@
+Filename,Type,Confidence Level,Confidence %,Line Number,Text
+<golden:context_decoys_original>,PHONE,HIGH,100.0,4,212-555-0142
+<golden:context_decoys_original>,PHONE,MEDIUM,65.0,5,212-555-0142
+<golden:context_decoys_original>,PHONE,MEDIUM,65.0,6,313-555-0175
+<golden:context_decoys_original>,SSN,HIGH,100.0,1,449-87-4100
+<golden:context_decoys_original>,SSN,HIGH,100.0,2,449-87-4100
+<golden:context_decoys_original>,SSN,HIGH,100.0,3,526-33-8210

--- a/internal/goldencorpus/testdata/golden/context_decoys_original.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/context_decoys_original.gitlab-sast.json
@@ -1,0 +1,186 @@
+{
+  "remediations": [],
+  "scan": {
+    "analyzer": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "end_time": "<TIMESTAMP>",
+    "scanner": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "start_time": "<TIMESTAMP>",
+    "status": "success",
+    "type": "sast"
+  },
+  "version": "15.0.4",
+  "vulnerabilities": [
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected phone number in this file.\n\n**Location:** <golden:context_decoys_original> (line 4)\n**Confidence:** HIGH (100.0%)\n**Detected by:** phone validator\n\n**Context:**\n```\ncall us at 212-555-0142 today\n```\n\n**Additional Information:**\n- context_impact: 15\n- source: preprocessed_content\n\n**Remediation:**\nRemove phone numbers or replace with example numbers (e.g., 555-0123).",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "PHONE"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "phone"
+        }
+      ],
+      "location": {
+        "end_line": 4,
+        "file": "<golden:context_decoys_original>",
+        "start_line": 4
+      },
+      "message": "Phone number detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Phone Number Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected phone number in this file.\n\n**Location:** <golden:context_decoys_original> (line 5)\n**Confidence:** MEDIUM (65.0%)\n**Detected by:** phone validator\n\n**Context:**\n```\nerror code 212-555-0142 in the diagnostics log\n```\n\n**Additional Information:**\n- context_impact: -20\n- source: preprocessed_content\n\n**Remediation:**\nRemove phone numbers or replace with example numbers (e.g., 555-0123).",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "PHONE"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "phone"
+        }
+      ],
+      "location": {
+        "end_line": 5,
+        "file": "<golden:context_decoys_original>",
+        "start_line": 5
+      },
+      "message": "Phone number detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Phone Number Detected",
+      "severity": "High"
+    },
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected phone number in this file.\n\n**Location:** <golden:context_decoys_original> (line 6)\n**Confidence:** MEDIUM (65.0%)\n**Detected by:** phone validator\n\n**Context:**\n```\nSKU 313-555-0175 restocked\n```\n\n**Additional Information:**\n- context_impact: -20\n- source: preprocessed_content\n\n**Remediation:**\nRemove phone numbers or replace with example numbers (e.g., 555-0123).",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "PHONE"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "phone"
+        }
+      ],
+      "location": {
+        "end_line": 6,
+        "file": "<golden:context_decoys_original>",
+        "start_line": 6
+      },
+      "message": "Phone number detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Phone Number Detected",
+      "severity": "High"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <golden:context_decoys_original> (line 1)\n**Confidence:** HIGH (100.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\nemployee ssn 449-87-4100 on file\n```\n\n**Additional Information:**\n- context_impact: 50\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "SSN"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "ssn"
+        }
+      ],
+      "location": {
+        "end_line": 1,
+        "file": "<golden:context_decoys_original>",
+        "start_line": 1
+      },
+      "message": "Social Security Number detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Social Security Number Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <golden:context_decoys_original> (line 2)\n**Confidence:** HIGH (100.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\npart number 449-87-4100 from the catalog\n```\n\n**Additional Information:**\n- context_impact: 15\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "SSN"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "ssn"
+        }
+      ],
+      "location": {
+        "end_line": 2,
+        "file": "<golden:context_decoys_original>",
+        "start_line": 2
+      },
+      "message": "Social Security Number detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Social Security Number Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <golden:context_decoys_original> (line 3)\n**Confidence:** HIGH (100.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\nrequisition 526-33-8210 approved for shipment\n```\n\n**Additional Information:**\n- context_impact: 15\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "SSN"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "ssn"
+        }
+      ],
+      "location": {
+        "end_line": 3,
+        "file": "<golden:context_decoys_original>",
+        "start_line": 3
+      },
+      "message": "Social Security Number detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Social Security Number Detected",
+      "severity": "Critical"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/context_decoys_original.json.json
+++ b/internal/goldencorpus/testdata/golden/context_decoys_original.json.json
@@ -1,0 +1,238 @@
+{
+  "results": [
+    {
+      "confidence": 100,
+      "confidence_level": "HIGH",
+      "filename": "<golden:context_decoys_original>",
+      "line_number": 4,
+      "metadata": {
+        "clean_number": "2125550142",
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 15,
+        "country": "US/CA",
+        "format": "XXX-XXX-XXXX",
+        "original_confidence": 100,
+        "original_file": "<golden:context_decoys_original>",
+        "pattern_name": "US_Dashed",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "not_repeating": true,
+          "not_sequential": true,
+          "not_ssn_pattern": true,
+          "not_test_number": false,
+          "not_timestamp": true,
+          "reasonable_length": true,
+          "valid_country": true,
+          "valid_digits": true,
+          "valid_format": true
+        },
+        "validation_path": "document"
+      },
+      "text": "212-555-0142",
+      "type": "PHONE",
+      "validator": "phone"
+    },
+    {
+      "confidence": 100,
+      "confidence_level": "HIGH",
+      "filename": "<golden:context_decoys_original>",
+      "line_number": 1,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 50,
+        "original_confidence": 100,
+        "original_file": "<golden:context_decoys_original>",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "format": true,
+          "not_common_pattern": true,
+          "not_repeating": true,
+          "not_sequential": true,
+          "not_test_number": true,
+          "valid_area": true
+        },
+        "validation_path": "document"
+      },
+      "text": "449-87-4100",
+      "type": "SSN",
+      "validator": "ssn"
+    },
+    {
+      "confidence": 100,
+      "confidence_level": "HIGH",
+      "filename": "<golden:context_decoys_original>",
+      "line_number": 2,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 15,
+        "original_confidence": 100,
+        "original_file": "<golden:context_decoys_original>",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "format": true,
+          "not_common_pattern": true,
+          "not_repeating": true,
+          "not_sequential": true,
+          "not_test_number": true,
+          "valid_area": true
+        },
+        "validation_path": "document"
+      },
+      "text": "449-87-4100",
+      "type": "SSN",
+      "validator": "ssn"
+    },
+    {
+      "confidence": 100,
+      "confidence_level": "HIGH",
+      "filename": "<golden:context_decoys_original>",
+      "line_number": 3,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 15,
+        "original_confidence": 100,
+        "original_file": "<golden:context_decoys_original>",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "format": true,
+          "not_common_pattern": true,
+          "not_repeating": true,
+          "not_sequential": true,
+          "not_test_number": true,
+          "valid_area": true
+        },
+        "validation_path": "document"
+      },
+      "text": "526-33-8210",
+      "type": "SSN",
+      "validator": "ssn"
+    },
+    {
+      "confidence": 65,
+      "confidence_level": "MEDIUM",
+      "filename": "<golden:context_decoys_original>",
+      "line_number": 5,
+      "metadata": {
+        "clean_number": "2125550142",
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": -20,
+        "country": "US/CA",
+        "format": "XXX-XXX-XXXX",
+        "original_confidence": 65,
+        "original_file": "<golden:context_decoys_original>",
+        "pattern_name": "US_Dashed",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "not_repeating": true,
+          "not_sequential": true,
+          "not_ssn_pattern": true,
+          "not_test_number": false,
+          "not_timestamp": true,
+          "reasonable_length": true,
+          "valid_country": true,
+          "valid_digits": true,
+          "valid_format": true
+        },
+        "validation_path": "document"
+      },
+      "text": "212-555-0142",
+      "type": "PHONE",
+      "validator": "phone"
+    },
+    {
+      "confidence": 65,
+      "confidence_level": "MEDIUM",
+      "filename": "<golden:context_decoys_original>",
+      "line_number": 6,
+      "metadata": {
+        "clean_number": "3135550175",
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": -20,
+        "country": "US/CA",
+        "format": "XXX-XXX-XXXX",
+        "original_confidence": 65,
+        "original_file": "<golden:context_decoys_original>",
+        "pattern_name": "US_Dashed",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "not_repeating": true,
+          "not_sequential": true,
+          "not_ssn_pattern": true,
+          "not_test_number": false,
+          "not_timestamp": true,
+          "reasonable_length": true,
+          "valid_country": true,
+          "valid_digits": true,
+          "valid_format": true
+        },
+        "validation_path": "document"
+      },
+      "text": "313-555-0175",
+      "type": "PHONE",
+      "validator": "phone"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/context_decoys_original.junit.xml
+++ b/internal/goldencorpus/testdata/golden/context_decoys_original.junit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
+  <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
+    <testcase name="&lt;golden:context_decoys_original&gt;" classname="security-scan" time="0.001">
+      <failure message="6 security findings detected" type="SECURITY_FINDINGS">Line 4: PHONE detected with 100.0% confidence (HIGH)&#xA;Match: 212-555-0142&#xA;Validator: phone&#xA;Line 1: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 2: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 3: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 526-33-8210&#xA;Validator: ssn&#xA;Line 6: PHONE detected with 65.0% confidence (MEDIUM)&#xA;Match: 313-555-0175&#xA;Validator: phone&#xA;Line 5: PHONE detected with 65.0% confidence (MEDIUM)&#xA;Match: 212-555-0142&#xA;Validator: phone</failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/internal/goldencorpus/testdata/golden/context_decoys_original.redact_format_preserving.txt
+++ b/internal/goldencorpus/testdata/golden/context_decoys_original.redact_format_preserving.txt
@@ -1,0 +1,14 @@
+=== REDACTED ===
+employee ssn ***-**-4100 on file
+part number ***-**-4100 from the catalog
+requisition ***-**-8210 approved for shipment
+call us at ***-***-0142 today
+error code ***-***-0142 in the diagnostics log
+SKU ***-***-0175 restocked
+=== FINDINGS (sorted) ===
+type=PHONE line=4 conf=high match=212-555-0142
+type=PHONE line=5 conf=medium match=212-555-0142
+type=PHONE line=6 conf=medium match=313-555-0175
+type=SSN line=1 conf=high match=449-87-4100
+type=SSN line=2 conf=high match=449-87-4100
+type=SSN line=3 conf=high match=526-33-8210

--- a/internal/goldencorpus/testdata/golden/context_decoys_original.redact_simple.txt
+++ b/internal/goldencorpus/testdata/golden/context_decoys_original.redact_simple.txt
@@ -1,0 +1,14 @@
+=== REDACTED ===
+employee ssn [SSN-REDACTED] on file
+part number [SSN-REDACTED] from the catalog
+requisition [SSN-REDACTED] approved for shipment
+call us at [PHONE-REDACTED] today
+error code [PHONE-REDACTED] in the diagnostics log
+SKU [PHONE-REDACTED] restocked
+=== FINDINGS (sorted) ===
+type=PHONE line=4 conf=high match=212-555-0142
+type=PHONE line=5 conf=medium match=212-555-0142
+type=PHONE line=6 conf=medium match=313-555-0175
+type=SSN line=1 conf=high match=449-87-4100
+type=SSN line=2 conf=high match=449-87-4100
+type=SSN line=3 conf=high match=526-33-8210

--- a/internal/goldencorpus/testdata/golden/context_decoys_original.sarif.json
+++ b/internal/goldencorpus/testdata/golden/context_decoys_original.sarif.json
@@ -1,0 +1,457 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/refs/heads/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:context_decoys_original>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "call us at \ncall us at 212-555-0142 today\n today"
+                  },
+                  "startLine": 4
+                },
+                "region": {
+                  "endColumn": 24,
+                  "snippet": {
+                    "text": "call us at 212-555-0142 today"
+                  },
+                  "startColumn": 12,
+                  "startLine": 4
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Phone Number Detected in <golden:context_decoys_original> at line 4 (confidence: 100.0% - HIGH). Matched text: '212-555-0142'"
+          },
+          "properties": {
+            "confidence": 100,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "clean_number": "2125550142",
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 15,
+              "country": "US/CA",
+              "format": "XXX-XXX-XXXX",
+              "original_confidence": 100,
+              "original_file": "<golden:context_decoys_original>",
+              "pattern_name": "US_Dashed",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "not_repeating": true,
+                "not_sequential": true,
+                "not_ssn_pattern": true,
+                "not_test_number": false,
+                "not_timestamp": true,
+                "reasonable_length": true,
+                "valid_country": true,
+                "valid_digits": true,
+                "valid_format": true
+              },
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "call"
+            ],
+            "validator": "phone"
+          },
+          "rank": 75,
+          "ruleId": "PHONE"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:context_decoys_original>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "error code \nerror code 212-555-0142 in the diagnostics log\n in the diagnostics log"
+                  },
+                  "startLine": 5
+                },
+                "region": {
+                  "endColumn": 24,
+                  "snippet": {
+                    "text": "error code 212-555-0142 in the diagnostics log"
+                  },
+                  "startColumn": 12,
+                  "startLine": 5
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Phone Number Detected in <golden:context_decoys_original> at line 5 (confidence: 65.0% - MEDIUM). Matched text: '212-555-0142'"
+          },
+          "properties": {
+            "confidence": 65,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "clean_number": "2125550142",
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": -20,
+              "country": "US/CA",
+              "format": "XXX-XXX-XXXX",
+              "original_confidence": 65,
+              "original_file": "<golden:context_decoys_original>",
+              "pattern_name": "US_Dashed",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "not_repeating": true,
+                "not_sequential": true,
+                "not_ssn_pattern": true,
+                "not_test_number": false,
+                "not_timestamp": true,
+                "reasonable_length": true,
+                "valid_country": true,
+                "valid_digits": true,
+                "valid_format": true
+              },
+              "validation_path": "document"
+            },
+            "validator": "phone"
+          },
+          "rank": 57.5,
+          "ruleId": "PHONE"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:context_decoys_original>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "SKU \nSKU 313-555-0175 restocked\n restocked"
+                  },
+                  "startLine": 6
+                },
+                "region": {
+                  "endColumn": 17,
+                  "snippet": {
+                    "text": "SKU 313-555-0175 restocked"
+                  },
+                  "startColumn": 5,
+                  "startLine": 6
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Phone Number Detected in <golden:context_decoys_original> at line 6 (confidence: 65.0% - MEDIUM). Matched text: '313-555-0175'"
+          },
+          "properties": {
+            "confidence": 65,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "clean_number": "3135550175",
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": -20,
+              "country": "US/CA",
+              "format": "XXX-XXX-XXXX",
+              "original_confidence": 65,
+              "original_file": "<golden:context_decoys_original>",
+              "pattern_name": "US_Dashed",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "not_repeating": true,
+                "not_sequential": true,
+                "not_ssn_pattern": true,
+                "not_test_number": false,
+                "not_timestamp": true,
+                "reasonable_length": true,
+                "valid_country": true,
+                "valid_digits": true,
+                "valid_format": true
+              },
+              "validation_path": "document"
+            },
+            "validator": "phone"
+          },
+          "rank": 57.5,
+          "ruleId": "PHONE"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:context_decoys_original>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "employee ssn \nemployee ssn 449-87-4100 on file\n on file"
+                  },
+                  "startLine": 1
+                },
+                "region": {
+                  "endColumn": 25,
+                  "snippet": {
+                    "text": "employee ssn 449-87-4100 on file"
+                  },
+                  "startColumn": 14,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Social Security Number Detected in <golden:context_decoys_original> at line 1 (confidence: 100.0% - HIGH). Matched text: '449-87-4100'"
+          },
+          "properties": {
+            "confidence": 100,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 50,
+              "original_confidence": 100,
+              "original_file": "<golden:context_decoys_original>",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "digits": true,
+                "format": true,
+                "not_common_pattern": true,
+                "not_repeating": true,
+                "not_sequential": true,
+                "not_test_number": true,
+                "valid_area": true
+              },
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "ssn"
+            ],
+            "validator": "ssn"
+          },
+          "rank": 100,
+          "ruleId": "SSN"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:context_decoys_original>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "part number \npart number 449-87-4100 from the catalog\n from the catalog"
+                  },
+                  "startLine": 2
+                },
+                "region": {
+                  "endColumn": 24,
+                  "snippet": {
+                    "text": "part number 449-87-4100 from the catalog"
+                  },
+                  "startColumn": 13,
+                  "startLine": 2
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Social Security Number Detected in <golden:context_decoys_original> at line 2 (confidence: 100.0% - HIGH). Matched text: '449-87-4100'"
+          },
+          "properties": {
+            "confidence": 100,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 15,
+              "original_confidence": 100,
+              "original_file": "<golden:context_decoys_original>",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "digits": true,
+                "format": true,
+                "not_common_pattern": true,
+                "not_repeating": true,
+                "not_sequential": true,
+                "not_test_number": true,
+                "valid_area": true
+              },
+              "validation_path": "document"
+            },
+            "validator": "ssn"
+          },
+          "rank": 100,
+          "ruleId": "SSN"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:context_decoys_original>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "requisition \nrequisition 526-33-8210 approved for shipment\n approved for shipment"
+                  },
+                  "startLine": 3
+                },
+                "region": {
+                  "endColumn": 24,
+                  "snippet": {
+                    "text": "requisition 526-33-8210 approved for shipment"
+                  },
+                  "startColumn": 13,
+                  "startLine": 3
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Social Security Number Detected in <golden:context_decoys_original> at line 3 (confidence: 100.0% - HIGH). Matched text: '526-33-8210'"
+          },
+          "properties": {
+            "confidence": 100,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 15,
+              "original_confidence": 100,
+              "original_file": "<golden:context_decoys_original>",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "digits": true,
+                "format": true,
+                "not_common_pattern": true,
+                "not_repeating": true,
+                "not_sequential": true,
+                "not_test_number": true,
+                "valid_area": true
+              },
+              "validation_path": "document"
+            },
+            "validator": "ssn"
+          },
+          "rank": 100,
+          "ruleId": "SSN"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/awslabs/ferret-scan",
+          "name": "Ferret Scan",
+          "rules": [
+            {
+              "fullDescription": {
+                "text": "A phone number was detected in the scanned content. Phone numbers can be considered personally identifiable information (PII) depending on context and jurisdiction."
+              },
+              "help": {
+                "text": "Phone numbers may be considered PII under various privacy regulations. Evaluate whether this phone number should be present in the code. If it's for testing purposes, use clearly fake numbers (e.g., 555-0100 to 555-0199 in North America). For production use, store phone numbers in secure configuration systems with appropriate access controls."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/PHONE.md",
+              "id": "PHONE",
+              "shortDescription": {
+                "text": "Phone Number Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "A Social Security Number (SSN) pattern was detected in the scanned content. SSNs are highly sensitive personally identifiable information (PII) that must be protected under various regulations."
+              },
+              "help": {
+                "text": "Social Security Numbers are protected under numerous regulations including GDPR, HIPAA, and various state privacy laws. SSNs should never be stored in source code, configuration files, or logs. Remove this SSN immediately and ensure it is stored in a secure, encrypted system with appropriate access controls. Consider implementing tokenization or other data protection mechanisms."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/SSN.md",
+              "id": "SSN",
+              "shortDescription": {
+                "text": "Social Security Number Detected"
+              }
+            }
+          ],
+          "semanticVersion": "0.0.0-development",
+          "version": "0.0.0-development"
+        }
+      },
+      "versionControlProvenance": [
+        {
+          "mappedTo": {
+            "uriBaseId": "%SRCROOT%"
+          },
+          "repositoryUri": "https://github.com/awslabs/ferret-scan",
+          "revisionId": "0.0.0-development"
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/internal/goldencorpus/testdata/golden/context_decoys_original.txt
+++ b/internal/goldencorpus/testdata/golden/context_decoys_original.txt
@@ -1,0 +1,8 @@
+LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH        FILE
+--------------------------------------------------------------------------------------
+[HIGH  ] phone        PHONE                 100.00% line     4 212-555-0142 <golden:context_decoys_original>
+[HIGH  ] ssn          SSN                   100.00% line     1 449-87-4100  <golden:context_decoys_original>
+[HIGH  ] ssn          SSN                   100.00% line     2 449-87-4100  <golden:context_decoys_original>
+[HIGH  ] ssn          SSN                   100.00% line     3 526-33-8210  <golden:context_decoys_original>
+[MEDIUM] phone        PHONE                  65.00% line     5 212-555-0142 <golden:context_decoys_original>
+[MEDIUM] phone        PHONE                  65.00% line     6 313-555-0175 <golden:context_decoys_original>

--- a/internal/goldencorpus/testdata/golden/context_decoys_original.yaml
+++ b/internal/goldencorpus/testdata/golden/context_decoys_original.yaml
@@ -1,0 +1,205 @@
+results:
+    - text: 212-555-0142
+      line_number: 4
+      type: PHONE
+      confidence: 100
+      confidence_level: HIGH
+      filename: <golden:context_decoys_original>
+      validator: phone
+      metadata:
+        clean_number: "2125550142"
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 15
+        country: US/CA
+        format: XXX-XXX-XXXX
+        original_confidence: 100
+        original_file: <golden:context_decoys_original>
+        pattern_name: US_Dashed
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            not_repeating: true
+            not_sequential: true
+            not_ssn_pattern: true
+            not_test_number: false
+            not_timestamp: true
+            reasonable_length: true
+            valid_country: true
+            valid_digits: true
+            valid_format: true
+        validation_path: document
+    - text: 449-87-4100
+      line_number: 1
+      type: SSN
+      confidence: 100
+      confidence_level: HIGH
+      filename: <golden:context_decoys_original>
+      validator: ssn
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 50
+        original_confidence: 100
+        original_file: <golden:context_decoys_original>
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            format: true
+            not_common_pattern: true
+            not_repeating: true
+            not_sequential: true
+            not_test_number: true
+            valid_area: true
+        validation_path: document
+    - text: 449-87-4100
+      line_number: 2
+      type: SSN
+      confidence: 100
+      confidence_level: HIGH
+      filename: <golden:context_decoys_original>
+      validator: ssn
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 15
+        original_confidence: 100
+        original_file: <golden:context_decoys_original>
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            format: true
+            not_common_pattern: true
+            not_repeating: true
+            not_sequential: true
+            not_test_number: true
+            valid_area: true
+        validation_path: document
+    - text: 526-33-8210
+      line_number: 3
+      type: SSN
+      confidence: 100
+      confidence_level: HIGH
+      filename: <golden:context_decoys_original>
+      validator: ssn
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 15
+        original_confidence: 100
+        original_file: <golden:context_decoys_original>
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            format: true
+            not_common_pattern: true
+            not_repeating: true
+            not_sequential: true
+            not_test_number: true
+            valid_area: true
+        validation_path: document
+    - text: 212-555-0142
+      line_number: 5
+      type: PHONE
+      confidence: 65
+      confidence_level: MEDIUM
+      filename: <golden:context_decoys_original>
+      validator: phone
+      metadata:
+        clean_number: "2125550142"
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: -20
+        country: US/CA
+        format: XXX-XXX-XXXX
+        original_confidence: 65
+        original_file: <golden:context_decoys_original>
+        pattern_name: US_Dashed
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            not_repeating: true
+            not_sequential: true
+            not_ssn_pattern: true
+            not_test_number: false
+            not_timestamp: true
+            reasonable_length: true
+            valid_country: true
+            valid_digits: true
+            valid_format: true
+        validation_path: document
+    - text: 313-555-0175
+      line_number: 6
+      type: PHONE
+      confidence: 65
+      confidence_level: MEDIUM
+      filename: <golden:context_decoys_original>
+      validator: phone
+      metadata:
+        clean_number: "3135550175"
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: -20
+        country: US/CA
+        format: XXX-XXX-XXXX
+        original_confidence: 65
+        original_file: <golden:context_decoys_original>
+        pattern_name: US_Dashed
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            not_repeating: true
+            not_sequential: true
+            not_ssn_pattern: true
+            not_test_number: false
+            not_timestamp: true
+            reasonable_length: true
+            valid_country: true
+            valid_digits: true
+            valid_format: true
+        validation_path: document

--- a/internal/goldencorpus/testdata/golden/context_decoys_personname.csv
+++ b/internal/goldencorpus/testdata/golden/context_decoys_personname.csv
@@ -1,0 +1,7 @@
+Filename,Type,Confidence Level,Confidence %,Line Number,Text
+<golden:context_decoys_personname>,PERSON_NAME,MEDIUM,80.0,1,Contact Maria Delgado
+<golden:context_decoys_personname>,PERSON_NAME,HIGH,92.0,3,James Whitfield
+<golden:context_decoys_personname>,PERSON_NAME,MEDIUM,67.0,4,Lincoln Continental
+<golden:context_decoys_personname>,PERSON_NAME,MEDIUM,67.0,5,Sarah Okonkwo
+<golden:context_decoys_personname>,PERSON_NAME,HIGH,92.0,7,Daniel Moreau
+<golden:context_decoys_personname>,PERSON_NAME,MEDIUM,67.0,9,Priya Raghavan

--- a/internal/goldencorpus/testdata/golden/context_decoys_personname.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/context_decoys_personname.gitlab-sast.json
@@ -1,0 +1,186 @@
+{
+  "remediations": [],
+  "scan": {
+    "analyzer": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "end_time": "<TIMESTAMP>",
+    "scanner": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "start_time": "<TIMESTAMP>",
+    "status": "success",
+    "type": "sast"
+  },
+  "version": "15.0.4",
+  "vulnerabilities": [
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected sensitive data (person name) in this file.\n\n**Location:** <golden:context_decoys_personname> (line 1)\n**Confidence:** MEDIUM (80.0%)\n**Detected by:** PERSON_NAME validator\n\n**Matched value:**\n```\nContact Maria Delgado\n```\n\n**Additional Information:**\n- context_impact: 12\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "PERSON_NAME"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "PERSON_NAME"
+        }
+      ],
+      "location": {
+        "end_line": 1,
+        "file": "<golden:context_decoys_personname>",
+        "start_line": 1
+      },
+      "message": "Sensitive data (person name) detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Person Name Detected",
+      "severity": "High"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected sensitive data (person name) in this file.\n\n**Location:** <golden:context_decoys_personname> (line 3)\n**Confidence:** HIGH (92.0%)\n**Detected by:** PERSON_NAME validator\n\n**Matched value:**\n```\nJames Whitfield\n```\n\n**Additional Information:**\n- context_impact: 0\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "PERSON_NAME"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "PERSON_NAME"
+        }
+      ],
+      "location": {
+        "end_line": 3,
+        "file": "<golden:context_decoys_personname>",
+        "start_line": 3
+      },
+      "message": "Sensitive data (person name) detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Person Name Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected sensitive data (person name) in this file.\n\n**Location:** <golden:context_decoys_personname> (line 4)\n**Confidence:** MEDIUM (67.0%)\n**Detected by:** PERSON_NAME validator\n\n**Matched value:**\n```\nLincoln Continental\n```\n\n**Additional Information:**\n- context_impact: 0\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "PERSON_NAME"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "PERSON_NAME"
+        }
+      ],
+      "location": {
+        "end_line": 4,
+        "file": "<golden:context_decoys_personname>",
+        "start_line": 4
+      },
+      "message": "Sensitive data (person name) detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Person Name Detected",
+      "severity": "High"
+    },
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected sensitive data (person name) in this file.\n\n**Location:** <golden:context_decoys_personname> (line 5)\n**Confidence:** MEDIUM (67.0%)\n**Detected by:** PERSON_NAME validator\n\n**Matched value:**\n```\nSarah Okonkwo\n```\n\n**Additional Information:**\n- context_impact: 0\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "PERSON_NAME"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "PERSON_NAME"
+        }
+      ],
+      "location": {
+        "end_line": 5,
+        "file": "<golden:context_decoys_personname>",
+        "start_line": 5
+      },
+      "message": "Sensitive data (person name) detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Person Name Detected",
+      "severity": "High"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected sensitive data (person name) in this file.\n\n**Location:** <golden:context_decoys_personname> (line 7)\n**Confidence:** HIGH (92.0%)\n**Detected by:** PERSON_NAME validator\n\n**Matched value:**\n```\nDaniel Moreau\n```\n\n**Additional Information:**\n- context_impact: 0\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "PERSON_NAME"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "PERSON_NAME"
+        }
+      ],
+      "location": {
+        "end_line": 7,
+        "file": "<golden:context_decoys_personname>",
+        "start_line": 7
+      },
+      "message": "Sensitive data (person name) detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Person Name Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected sensitive data (person name) in this file.\n\n**Location:** <golden:context_decoys_personname> (line 9)\n**Confidence:** MEDIUM (67.0%)\n**Detected by:** PERSON_NAME validator\n\n**Matched value:**\n```\nPriya Raghavan\n```\n\n**Additional Information:**\n- context_impact: 0\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "PERSON_NAME"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "PERSON_NAME"
+        }
+      ],
+      "location": {
+        "end_line": 9,
+        "file": "<golden:context_decoys_personname>",
+        "start_line": 9
+      },
+      "message": "Sensitive data (person name) detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Person Name Detected",
+      "severity": "High"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/context_decoys_personname.json.json
+++ b/internal/goldencorpus/testdata/golden/context_decoys_personname.json.json
@@ -1,0 +1,381 @@
+{
+  "results": [
+    {
+      "confidence": 92,
+      "confidence_level": "HIGH",
+      "filename": "<golden:context_decoys_personname>",
+      "line_number": 3,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "Retail",
+        "context_impact": 0,
+        "context_keywords": null,
+        "cultural_context": [
+          "western",
+          "english",
+          "european"
+        ],
+        "name_components": {
+          "Cultural": [
+            "western",
+            "english",
+            "european"
+          ],
+          "FirstName": "James",
+          "FullName": "James Whitfield",
+          "LastName": "Whitfield",
+          "MiddleName": "",
+          "Pattern": "basic_western_name",
+          "Suffix": "",
+          "Title": ""
+        },
+        "original_confidence": 92,
+        "pattern": "basic_western_name",
+        "pattern_priority": 5,
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "validation_checks": {
+          "both_names_known": true,
+          "has_known_name_component": true,
+          "has_middle_name": false,
+          "has_suffix": false,
+          "has_title": false,
+          "known_first_name": true,
+          "known_last_name": true,
+          "not_business_name": true,
+          "not_technical_term": true,
+          "not_test_data": true,
+          "proper_case": true,
+          "reasonable_length": true,
+          "valid_pattern": true
+        },
+        "validation_path": "document"
+      },
+      "text": "James Whitfield",
+      "type": "PERSON_NAME",
+      "validator": "PERSON_NAME"
+    },
+    {
+      "confidence": 92,
+      "confidence_level": "HIGH",
+      "filename": "<golden:context_decoys_personname>",
+      "line_number": 7,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "Retail",
+        "context_impact": 0,
+        "context_keywords": null,
+        "cultural_context": [
+          "western",
+          "english",
+          "european"
+        ],
+        "name_components": {
+          "Cultural": [
+            "western",
+            "english",
+            "european"
+          ],
+          "FirstName": "Daniel",
+          "FullName": "Daniel Moreau",
+          "LastName": "Moreau",
+          "MiddleName": "",
+          "Pattern": "basic_western_name",
+          "Suffix": "",
+          "Title": ""
+        },
+        "original_confidence": 92,
+        "pattern": "basic_western_name",
+        "pattern_priority": 5,
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "validation_checks": {
+          "both_names_known": true,
+          "has_known_name_component": true,
+          "has_middle_name": false,
+          "has_suffix": false,
+          "has_title": false,
+          "known_first_name": true,
+          "known_last_name": true,
+          "not_business_name": true,
+          "not_technical_term": true,
+          "not_test_data": true,
+          "proper_case": true,
+          "reasonable_length": true,
+          "valid_pattern": true
+        },
+        "validation_path": "document"
+      },
+      "text": "Daniel Moreau",
+      "type": "PERSON_NAME",
+      "validator": "PERSON_NAME"
+    },
+    {
+      "confidence": 80,
+      "confidence_level": "MEDIUM",
+      "filename": "<golden:context_decoys_personname>",
+      "line_number": 1,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "Retail",
+        "context_impact": 12,
+        "context_keywords": [
+          "+contact"
+        ],
+        "cultural_context": [
+          "western",
+          "hispanic",
+          "compound"
+        ],
+        "name_components": {
+          "Cultural": [
+            "western",
+            "hispanic",
+            "compound"
+          ],
+          "FirstName": "Contact",
+          "FullName": "Contact Maria Delgado",
+          "LastName": "Delgado",
+          "MiddleName": "Maria",
+          "Pattern": "three_part_name",
+          "Suffix": "",
+          "Title": ""
+        },
+        "original_confidence": 80,
+        "pattern": "three_part_name",
+        "pattern_priority": 6,
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "validation_checks": {
+          "both_names_known": false,
+          "has_known_name_component": true,
+          "has_middle_name": true,
+          "has_suffix": false,
+          "has_title": false,
+          "known_first_name": false,
+          "known_last_name": true,
+          "not_business_name": true,
+          "not_technical_term": true,
+          "not_test_data": true,
+          "proper_case": true,
+          "reasonable_length": true,
+          "valid_pattern": true
+        },
+        "validation_path": "document"
+      },
+      "text": "Contact Maria Delgado",
+      "type": "PERSON_NAME",
+      "validator": "PERSON_NAME"
+    },
+    {
+      "confidence": 67,
+      "confidence_level": "MEDIUM",
+      "filename": "<golden:context_decoys_personname>",
+      "line_number": 4,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "Retail",
+        "context_impact": 0,
+        "context_keywords": [
+          "-inc",
+          "-park"
+        ],
+        "cultural_context": [
+          "western",
+          "english",
+          "european"
+        ],
+        "name_components": {
+          "Cultural": [
+            "western",
+            "english",
+            "european"
+          ],
+          "FirstName": "Lincoln",
+          "FullName": "Lincoln Continental",
+          "LastName": "Continental",
+          "MiddleName": "",
+          "Pattern": "basic_western_name",
+          "Suffix": "",
+          "Title": ""
+        },
+        "original_confidence": 67,
+        "pattern": "basic_western_name",
+        "pattern_priority": 5,
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "validation_checks": {
+          "both_names_known": false,
+          "has_known_name_component": true,
+          "has_middle_name": false,
+          "has_suffix": false,
+          "has_title": false,
+          "known_first_name": true,
+          "known_last_name": false,
+          "not_business_name": true,
+          "not_technical_term": true,
+          "not_test_data": true,
+          "proper_case": true,
+          "reasonable_length": true,
+          "valid_pattern": true
+        },
+        "validation_path": "document"
+      },
+      "text": "Lincoln Continental",
+      "type": "PERSON_NAME",
+      "validator": "PERSON_NAME"
+    },
+    {
+      "confidence": 67,
+      "confidence_level": "MEDIUM",
+      "filename": "<golden:context_decoys_personname>",
+      "line_number": 5,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "Retail",
+        "context_impact": 0,
+        "context_keywords": null,
+        "cultural_context": [
+          "western",
+          "english",
+          "european"
+        ],
+        "name_components": {
+          "Cultural": [
+            "western",
+            "english",
+            "european"
+          ],
+          "FirstName": "Sarah",
+          "FullName": "Sarah Okonkwo",
+          "LastName": "Okonkwo",
+          "MiddleName": "",
+          "Pattern": "basic_western_name",
+          "Suffix": "",
+          "Title": ""
+        },
+        "original_confidence": 67,
+        "pattern": "basic_western_name",
+        "pattern_priority": 5,
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "validation_checks": {
+          "both_names_known": false,
+          "has_known_name_component": true,
+          "has_middle_name": false,
+          "has_suffix": false,
+          "has_title": false,
+          "known_first_name": true,
+          "known_last_name": false,
+          "not_business_name": true,
+          "not_technical_term": true,
+          "not_test_data": true,
+          "proper_case": true,
+          "reasonable_length": true,
+          "valid_pattern": true
+        },
+        "validation_path": "document"
+      },
+      "text": "Sarah Okonkwo",
+      "type": "PERSON_NAME",
+      "validator": "PERSON_NAME"
+    },
+    {
+      "confidence": 67,
+      "confidence_level": "MEDIUM",
+      "filename": "<golden:context_decoys_personname>",
+      "line_number": 9,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "Retail",
+        "context_impact": 0,
+        "context_keywords": null,
+        "cultural_context": [
+          "western",
+          "english",
+          "european"
+        ],
+        "name_components": {
+          "Cultural": [
+            "western",
+            "english",
+            "european"
+          ],
+          "FirstName": "Priya",
+          "FullName": "Priya Raghavan",
+          "LastName": "Raghavan",
+          "MiddleName": "",
+          "Pattern": "basic_western_name",
+          "Suffix": "",
+          "Title": ""
+        },
+        "original_confidence": 67,
+        "pattern": "basic_western_name",
+        "pattern_priority": 5,
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "validation_checks": {
+          "both_names_known": false,
+          "has_known_name_component": true,
+          "has_middle_name": false,
+          "has_suffix": false,
+          "has_title": false,
+          "known_first_name": true,
+          "known_last_name": false,
+          "not_business_name": true,
+          "not_technical_term": true,
+          "not_test_data": true,
+          "proper_case": true,
+          "reasonable_length": true,
+          "valid_pattern": true
+        },
+        "validation_path": "document"
+      },
+      "text": "Priya Raghavan",
+      "type": "PERSON_NAME",
+      "validator": "PERSON_NAME"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/context_decoys_personname.junit.xml
+++ b/internal/goldencorpus/testdata/golden/context_decoys_personname.junit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
+  <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
+    <testcase name="&lt;golden:context_decoys_personname&gt;" classname="security-scan" time="0.001">
+      <failure message="6 security findings detected" type="SECURITY_FINDINGS">Line 3: PERSON_NAME detected with 92.0% confidence (HIGH)&#xA;Match: James Whitfield&#xA;Validator: PERSON_NAME&#xA;Line 7: PERSON_NAME detected with 92.0% confidence (HIGH)&#xA;Match: Daniel Moreau&#xA;Validator: PERSON_NAME&#xA;Line 1: PERSON_NAME detected with 80.0% confidence (MEDIUM)&#xA;Match: Contact Maria Delgado&#xA;Validator: PERSON_NAME&#xA;Line 5: PERSON_NAME detected with 67.0% confidence (MEDIUM)&#xA;Match: Sarah Okonkwo&#xA;Validator: PERSON_NAME&#xA;Line 4: PERSON_NAME detected with 67.0% confidence (MEDIUM)&#xA;Match: Lincoln Continental&#xA;Validator: PERSON_NAME&#xA;Line 9: PERSON_NAME detected with 67.0% confidence (MEDIUM)&#xA;Match: Priya Raghavan&#xA;Validator: PERSON_NAME</failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/internal/goldencorpus/testdata/golden/context_decoys_personname.redact_format_preserving.txt
+++ b/internal/goldencorpus/testdata/golden/context_decoys_personname.redact_format_preserving.txt
@@ -1,0 +1,18 @@
+=== REDACTED ===
+********************* for approval
+the Jordan River flows north
+Please forward the report to *************** by Friday
+******************* parked outside
+************* will present the quarterly results
+Amazon Web Services launched
+Schedule a review with ************* next week
+the Hudson Valley orchard shipped apples
+************** approved the budget request
+Ford Mustang sales rose sharply
+=== FINDINGS (sorted) ===
+type=PERSON_NAME line=1 conf=medium match=Contact Maria Delgado
+type=PERSON_NAME line=3 conf=high match=James Whitfield
+type=PERSON_NAME line=4 conf=medium match=Lincoln Continental
+type=PERSON_NAME line=5 conf=medium match=Sarah Okonkwo
+type=PERSON_NAME line=7 conf=high match=Daniel Moreau
+type=PERSON_NAME line=9 conf=medium match=Priya Raghavan

--- a/internal/goldencorpus/testdata/golden/context_decoys_personname.redact_simple.txt
+++ b/internal/goldencorpus/testdata/golden/context_decoys_personname.redact_simple.txt
@@ -1,0 +1,18 @@
+=== REDACTED ===
+[PERSON-NAME-REDACTED] for approval
+the Jordan River flows north
+Please forward the report to [PERSON-NAME-REDACTED] by Friday
+[PERSON-NAME-REDACTED] parked outside
+[PERSON-NAME-REDACTED] will present the quarterly results
+Amazon Web Services launched
+Schedule a review with [PERSON-NAME-REDACTED] next week
+the Hudson Valley orchard shipped apples
+[PERSON-NAME-REDACTED] approved the budget request
+Ford Mustang sales rose sharply
+=== FINDINGS (sorted) ===
+type=PERSON_NAME line=1 conf=medium match=Contact Maria Delgado
+type=PERSON_NAME line=3 conf=high match=James Whitfield
+type=PERSON_NAME line=4 conf=medium match=Lincoln Continental
+type=PERSON_NAME line=5 conf=medium match=Sarah Okonkwo
+type=PERSON_NAME line=7 conf=high match=Daniel Moreau
+type=PERSON_NAME line=9 conf=medium match=Priya Raghavan

--- a/internal/goldencorpus/testdata/golden/context_decoys_personname.sarif.json
+++ b/internal/goldencorpus/testdata/golden/context_decoys_personname.sarif.json
@@ -1,0 +1,515 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/refs/heads/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:context_decoys_personname>"
+                },
+                "region": {
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Person Name Detected in <golden:context_decoys_personname> at line 1 (confidence: 80.0% - MEDIUM). Matched text: 'Contact Maria Delgado'"
+          },
+          "properties": {
+            "confidence": 80,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "Retail",
+              "context_impact": 12,
+              "context_keywords": [
+                "+contact"
+              ],
+              "cultural_context": [
+                "western",
+                "hispanic",
+                "compound"
+              ],
+              "name_components": {
+                "Cultural": [
+                  "western",
+                  "hispanic",
+                  "compound"
+                ],
+                "FirstName": "Contact",
+                "FullName": "Contact Maria Delgado",
+                "LastName": "Delgado",
+                "MiddleName": "Maria",
+                "Pattern": "three_part_name",
+                "Suffix": "",
+                "Title": ""
+              },
+              "original_confidence": 80,
+              "pattern": "three_part_name",
+              "pattern_priority": 6,
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "validation_checks": {
+                "both_names_known": false,
+                "has_known_name_component": true,
+                "has_middle_name": true,
+                "has_suffix": false,
+                "has_title": false,
+                "known_first_name": false,
+                "known_last_name": true,
+                "not_business_name": true,
+                "not_technical_term": true,
+                "not_test_data": true,
+                "proper_case": true,
+                "reasonable_length": true,
+                "valid_pattern": true
+              },
+              "validation_path": "document"
+            },
+            "validator": "PERSON_NAME"
+          },
+          "rank": 70,
+          "ruleId": "PERSON_NAME"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:context_decoys_personname>"
+                },
+                "region": {
+                  "startLine": 3
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Person Name Detected in <golden:context_decoys_personname> at line 3 (confidence: 92.0% - HIGH). Matched text: 'James Whitfield'"
+          },
+          "properties": {
+            "confidence": 92,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "Retail",
+              "context_impact": 0,
+              "context_keywords": null,
+              "cultural_context": [
+                "western",
+                "english",
+                "european"
+              ],
+              "name_components": {
+                "Cultural": [
+                  "western",
+                  "english",
+                  "european"
+                ],
+                "FirstName": "James",
+                "FullName": "James Whitfield",
+                "LastName": "Whitfield",
+                "MiddleName": "",
+                "Pattern": "basic_western_name",
+                "Suffix": "",
+                "Title": ""
+              },
+              "original_confidence": 92,
+              "pattern": "basic_western_name",
+              "pattern_priority": 5,
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "validation_checks": {
+                "both_names_known": true,
+                "has_known_name_component": true,
+                "has_middle_name": false,
+                "has_suffix": false,
+                "has_title": false,
+                "known_first_name": true,
+                "known_last_name": true,
+                "not_business_name": true,
+                "not_technical_term": true,
+                "not_test_data": true,
+                "proper_case": true,
+                "reasonable_length": true,
+                "valid_pattern": true
+              },
+              "validation_path": "document"
+            },
+            "validator": "PERSON_NAME"
+          },
+          "rank": 76,
+          "ruleId": "PERSON_NAME"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:context_decoys_personname>"
+                },
+                "region": {
+                  "startLine": 4
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Person Name Detected in <golden:context_decoys_personname> at line 4 (confidence: 67.0% - MEDIUM). Matched text: 'Lincoln Continental'"
+          },
+          "properties": {
+            "confidence": 67,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "Retail",
+              "context_impact": 0,
+              "context_keywords": [
+                "-inc",
+                "-park"
+              ],
+              "cultural_context": [
+                "western",
+                "english",
+                "european"
+              ],
+              "name_components": {
+                "Cultural": [
+                  "western",
+                  "english",
+                  "european"
+                ],
+                "FirstName": "Lincoln",
+                "FullName": "Lincoln Continental",
+                "LastName": "Continental",
+                "MiddleName": "",
+                "Pattern": "basic_western_name",
+                "Suffix": "",
+                "Title": ""
+              },
+              "original_confidence": 67,
+              "pattern": "basic_western_name",
+              "pattern_priority": 5,
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "validation_checks": {
+                "both_names_known": false,
+                "has_known_name_component": true,
+                "has_middle_name": false,
+                "has_suffix": false,
+                "has_title": false,
+                "known_first_name": true,
+                "known_last_name": false,
+                "not_business_name": true,
+                "not_technical_term": true,
+                "not_test_data": true,
+                "proper_case": true,
+                "reasonable_length": true,
+                "valid_pattern": true
+              },
+              "validation_path": "document"
+            },
+            "validator": "PERSON_NAME"
+          },
+          "rank": 63.5,
+          "ruleId": "PERSON_NAME"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:context_decoys_personname>"
+                },
+                "region": {
+                  "startLine": 5
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Person Name Detected in <golden:context_decoys_personname> at line 5 (confidence: 67.0% - MEDIUM). Matched text: 'Sarah Okonkwo'"
+          },
+          "properties": {
+            "confidence": 67,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "Retail",
+              "context_impact": 0,
+              "context_keywords": null,
+              "cultural_context": [
+                "western",
+                "english",
+                "european"
+              ],
+              "name_components": {
+                "Cultural": [
+                  "western",
+                  "english",
+                  "european"
+                ],
+                "FirstName": "Sarah",
+                "FullName": "Sarah Okonkwo",
+                "LastName": "Okonkwo",
+                "MiddleName": "",
+                "Pattern": "basic_western_name",
+                "Suffix": "",
+                "Title": ""
+              },
+              "original_confidence": 67,
+              "pattern": "basic_western_name",
+              "pattern_priority": 5,
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "validation_checks": {
+                "both_names_known": false,
+                "has_known_name_component": true,
+                "has_middle_name": false,
+                "has_suffix": false,
+                "has_title": false,
+                "known_first_name": true,
+                "known_last_name": false,
+                "not_business_name": true,
+                "not_technical_term": true,
+                "not_test_data": true,
+                "proper_case": true,
+                "reasonable_length": true,
+                "valid_pattern": true
+              },
+              "validation_path": "document"
+            },
+            "validator": "PERSON_NAME"
+          },
+          "rank": 63.5,
+          "ruleId": "PERSON_NAME"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:context_decoys_personname>"
+                },
+                "region": {
+                  "startLine": 7
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Person Name Detected in <golden:context_decoys_personname> at line 7 (confidence: 92.0% - HIGH). Matched text: 'Daniel Moreau'"
+          },
+          "properties": {
+            "confidence": 92,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "Retail",
+              "context_impact": 0,
+              "context_keywords": null,
+              "cultural_context": [
+                "western",
+                "english",
+                "european"
+              ],
+              "name_components": {
+                "Cultural": [
+                  "western",
+                  "english",
+                  "european"
+                ],
+                "FirstName": "Daniel",
+                "FullName": "Daniel Moreau",
+                "LastName": "Moreau",
+                "MiddleName": "",
+                "Pattern": "basic_western_name",
+                "Suffix": "",
+                "Title": ""
+              },
+              "original_confidence": 92,
+              "pattern": "basic_western_name",
+              "pattern_priority": 5,
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "validation_checks": {
+                "both_names_known": true,
+                "has_known_name_component": true,
+                "has_middle_name": false,
+                "has_suffix": false,
+                "has_title": false,
+                "known_first_name": true,
+                "known_last_name": true,
+                "not_business_name": true,
+                "not_technical_term": true,
+                "not_test_data": true,
+                "proper_case": true,
+                "reasonable_length": true,
+                "valid_pattern": true
+              },
+              "validation_path": "document"
+            },
+            "validator": "PERSON_NAME"
+          },
+          "rank": 76,
+          "ruleId": "PERSON_NAME"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:context_decoys_personname>"
+                },
+                "region": {
+                  "startLine": 9
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Person Name Detected in <golden:context_decoys_personname> at line 9 (confidence: 67.0% - MEDIUM). Matched text: 'Priya Raghavan'"
+          },
+          "properties": {
+            "confidence": 67,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "Retail",
+              "context_impact": 0,
+              "context_keywords": null,
+              "cultural_context": [
+                "western",
+                "english",
+                "european"
+              ],
+              "name_components": {
+                "Cultural": [
+                  "western",
+                  "english",
+                  "european"
+                ],
+                "FirstName": "Priya",
+                "FullName": "Priya Raghavan",
+                "LastName": "Raghavan",
+                "MiddleName": "",
+                "Pattern": "basic_western_name",
+                "Suffix": "",
+                "Title": ""
+              },
+              "original_confidence": 67,
+              "pattern": "basic_western_name",
+              "pattern_priority": 5,
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "validation_checks": {
+                "both_names_known": false,
+                "has_known_name_component": true,
+                "has_middle_name": false,
+                "has_suffix": false,
+                "has_title": false,
+                "known_first_name": true,
+                "known_last_name": false,
+                "not_business_name": true,
+                "not_technical_term": true,
+                "not_test_data": true,
+                "proper_case": true,
+                "reasonable_length": true,
+                "valid_pattern": true
+              },
+              "validation_path": "document"
+            },
+            "validator": "PERSON_NAME"
+          },
+          "rank": 63.5,
+          "ruleId": "PERSON_NAME"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/awslabs/ferret-scan",
+          "name": "Ferret Scan",
+          "rules": [
+            {
+              "fullDescription": {
+                "text": "A person's name was detected in the scanned content. Names are considered personally identifiable information (PII) under various privacy regulations."
+              },
+              "help": {
+                "text": "Person names are considered PII under GDPR, CCPA, and other privacy regulations. Evaluate whether this name should be present in the code. If it's test data, use clearly fictional names or anonymized identifiers. For production use, ensure names are stored securely with appropriate access controls and data retention policies."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/PERSON_NAME.md",
+              "id": "PERSON_NAME",
+              "shortDescription": {
+                "text": "Person Name Detected"
+              }
+            }
+          ],
+          "semanticVersion": "0.0.0-development",
+          "version": "0.0.0-development"
+        }
+      },
+      "versionControlProvenance": [
+        {
+          "mappedTo": {
+            "uriBaseId": "%SRCROOT%"
+          },
+          "repositoryUri": "https://github.com/awslabs/ferret-scan",
+          "revisionId": "0.0.0-development"
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/internal/goldencorpus/testdata/golden/context_decoys_personname.txt
+++ b/internal/goldencorpus/testdata/golden/context_decoys_personname.txt
@@ -1,0 +1,8 @@
+LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH                 FILE
+-----------------------------------------------------------------------------------------------
+[HIGH  ] PERSON_NAME  PERSON_NAME            92.00% line     3 James Whitfield       <golden:context_decoys_personname>
+[HIGH  ] PERSON_NAME  PERSON_NAME            92.00% line     7 Daniel Moreau         <golden:context_decoys_personname>
+[MEDIUM] PERSON_NAME  PERSON_NAME            80.00% line     1 Contact Maria Delgado <golden:context_decoys_personname>
+[MEDIUM] PERSON_NAME  PERSON_NAME            67.00% line     4 Lincoln Continental   <golden:context_decoys_personname>
+[MEDIUM] PERSON_NAME  PERSON_NAME            67.00% line     5 Sarah Okonkwo         <golden:context_decoys_personname>
+[MEDIUM] PERSON_NAME  PERSON_NAME            67.00% line     9 Priya Raghavan        <golden:context_decoys_personname>

--- a/internal/goldencorpus/testdata/golden/context_decoys_personname.yaml
+++ b/internal/goldencorpus/testdata/golden/context_decoys_personname.yaml
@@ -1,0 +1,328 @@
+results:
+    - text: James Whitfield
+      line_number: 3
+      type: PERSON_NAME
+      confidence: 92
+      confidence_level: HIGH
+      filename: <golden:context_decoys_personname>
+      validator: PERSON_NAME
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: Retail
+        context_impact: 0
+        context_keywords: []
+        cultural_context:
+            - western
+            - english
+            - european
+        name_components:
+            fullname: James Whitfield
+            title: ""
+            firstname: James
+            middlename: ""
+            lastname: Whitfield
+            suffix: ""
+            pattern: basic_western_name
+            cultural:
+                - western
+                - english
+                - european
+        original_confidence: 92
+        pattern: basic_western_name
+        pattern_priority: 5
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        validation_checks:
+            both_names_known: true
+            has_known_name_component: true
+            has_middle_name: false
+            has_suffix: false
+            has_title: false
+            known_first_name: true
+            known_last_name: true
+            not_business_name: true
+            not_technical_term: true
+            not_test_data: true
+            proper_case: true
+            reasonable_length: true
+            valid_pattern: true
+        validation_path: document
+    - text: Daniel Moreau
+      line_number: 7
+      type: PERSON_NAME
+      confidence: 92
+      confidence_level: HIGH
+      filename: <golden:context_decoys_personname>
+      validator: PERSON_NAME
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: Retail
+        context_impact: 0
+        context_keywords: []
+        cultural_context:
+            - western
+            - english
+            - european
+        name_components:
+            fullname: Daniel Moreau
+            title: ""
+            firstname: Daniel
+            middlename: ""
+            lastname: Moreau
+            suffix: ""
+            pattern: basic_western_name
+            cultural:
+                - western
+                - english
+                - european
+        original_confidence: 92
+        pattern: basic_western_name
+        pattern_priority: 5
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        validation_checks:
+            both_names_known: true
+            has_known_name_component: true
+            has_middle_name: false
+            has_suffix: false
+            has_title: false
+            known_first_name: true
+            known_last_name: true
+            not_business_name: true
+            not_technical_term: true
+            not_test_data: true
+            proper_case: true
+            reasonable_length: true
+            valid_pattern: true
+        validation_path: document
+    - text: Contact Maria Delgado
+      line_number: 1
+      type: PERSON_NAME
+      confidence: 80
+      confidence_level: MEDIUM
+      filename: <golden:context_decoys_personname>
+      validator: PERSON_NAME
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: Retail
+        context_impact: 12
+        context_keywords:
+            - +contact
+        cultural_context:
+            - western
+            - hispanic
+            - compound
+        name_components:
+            fullname: Contact Maria Delgado
+            title: ""
+            firstname: Contact
+            middlename: Maria
+            lastname: Delgado
+            suffix: ""
+            pattern: three_part_name
+            cultural:
+                - western
+                - hispanic
+                - compound
+        original_confidence: 80
+        pattern: three_part_name
+        pattern_priority: 6
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        validation_checks:
+            both_names_known: false
+            has_known_name_component: true
+            has_middle_name: true
+            has_suffix: false
+            has_title: false
+            known_first_name: false
+            known_last_name: true
+            not_business_name: true
+            not_technical_term: true
+            not_test_data: true
+            proper_case: true
+            reasonable_length: true
+            valid_pattern: true
+        validation_path: document
+    - text: Lincoln Continental
+      line_number: 4
+      type: PERSON_NAME
+      confidence: 67
+      confidence_level: MEDIUM
+      filename: <golden:context_decoys_personname>
+      validator: PERSON_NAME
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: Retail
+        context_impact: 0
+        context_keywords:
+            - -inc
+            - -park
+        cultural_context:
+            - western
+            - english
+            - european
+        name_components:
+            fullname: Lincoln Continental
+            title: ""
+            firstname: Lincoln
+            middlename: ""
+            lastname: Continental
+            suffix: ""
+            pattern: basic_western_name
+            cultural:
+                - western
+                - english
+                - european
+        original_confidence: 67
+        pattern: basic_western_name
+        pattern_priority: 5
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        validation_checks:
+            both_names_known: false
+            has_known_name_component: true
+            has_middle_name: false
+            has_suffix: false
+            has_title: false
+            known_first_name: true
+            known_last_name: false
+            not_business_name: true
+            not_technical_term: true
+            not_test_data: true
+            proper_case: true
+            reasonable_length: true
+            valid_pattern: true
+        validation_path: document
+    - text: Sarah Okonkwo
+      line_number: 5
+      type: PERSON_NAME
+      confidence: 67
+      confidence_level: MEDIUM
+      filename: <golden:context_decoys_personname>
+      validator: PERSON_NAME
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: Retail
+        context_impact: 0
+        context_keywords: []
+        cultural_context:
+            - western
+            - english
+            - european
+        name_components:
+            fullname: Sarah Okonkwo
+            title: ""
+            firstname: Sarah
+            middlename: ""
+            lastname: Okonkwo
+            suffix: ""
+            pattern: basic_western_name
+            cultural:
+                - western
+                - english
+                - european
+        original_confidence: 67
+        pattern: basic_western_name
+        pattern_priority: 5
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        validation_checks:
+            both_names_known: false
+            has_known_name_component: true
+            has_middle_name: false
+            has_suffix: false
+            has_title: false
+            known_first_name: true
+            known_last_name: false
+            not_business_name: true
+            not_technical_term: true
+            not_test_data: true
+            proper_case: true
+            reasonable_length: true
+            valid_pattern: true
+        validation_path: document
+    - text: Priya Raghavan
+      line_number: 9
+      type: PERSON_NAME
+      confidence: 67
+      confidence_level: MEDIUM
+      filename: <golden:context_decoys_personname>
+      validator: PERSON_NAME
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: Retail
+        context_impact: 0
+        context_keywords: []
+        cultural_context:
+            - western
+            - english
+            - european
+        name_components:
+            fullname: Priya Raghavan
+            title: ""
+            firstname: Priya
+            middlename: ""
+            lastname: Raghavan
+            suffix: ""
+            pattern: basic_western_name
+            cultural:
+                - western
+                - english
+                - european
+        original_confidence: 67
+        pattern: basic_western_name
+        pattern_priority: 5
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        validation_checks:
+            both_names_known: false
+            has_known_name_component: true
+            has_middle_name: false
+            has_suffix: false
+            has_title: false
+            known_first_name: true
+            known_last_name: false
+            not_business_name: true
+            not_technical_term: true
+            not_test_data: true
+            proper_case: true
+            reasonable_length: true
+            valid_pattern: true
+        validation_path: document

--- a/internal/goldencorpus/testdata/golden/new_validators_display_formats.json.json
+++ b/internal/goldencorpus/testdata/golden/new_validators_display_formats.json.json
@@ -1,19 +1,18 @@
 {
   "results": [
     {
-      "confidence": 80,
-      "confidence_level": "MEDIUM",
+      "confidence": 95,
+      "confidence_level": "HIGH",
       "filename": "<golden:new_validators_display_formats>",
-      "line_number": 2,
+      "line_number": 1,
       "metadata": {
         "confidence_adjustment": 0,
         "context_confidence": 0.5,
         "context_doctype": "Unknown",
         "context_domain": "Healthcare",
-        "context_impact": -5,
-        "country": "DE",
-        "normalized": "DE89370400440532013000",
-        "original_confidence": 80,
+        "context_impact": 20,
+        "normalized": "1EG4TE5MK73",
+        "original_confidence": 95,
         "semantic_context": {
           "FinancialData": 0,
           "MedicalData": 0,
@@ -21,11 +20,38 @@
           "Production": 0,
           "TestData": 0
         },
+        "subtype": "MBI",
         "validation_path": "document"
       },
-      "text": "DE89 3704 0044 0532 0130 00",
-      "type": "IBAN",
-      "validator": "bank_account"
+      "text": "1EG4-TE5-MK73",
+      "type": "MEDICARE_MBI",
+      "validator": "medicalid"
+    },
+    {
+      "confidence": 95,
+      "confidence_level": "HIGH",
+      "filename": "<golden:new_validators_display_formats>",
+      "line_number": 6,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0.5,
+        "context_doctype": "Unknown",
+        "context_domain": "Healthcare",
+        "original_confidence": 95,
+        "original_file": "<golden:new_validators_display_formats>",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_path": "document"
+      },
+      "text": "123 42nd Street",
+      "type": "US_STREET_ADDRESS",
+      "validator": "physical_address"
     },
     {
       "confidence": 90,
@@ -124,95 +150,6 @@
       "validator": "dob"
     },
     {
-      "confidence": 70,
-      "confidence_level": "MEDIUM",
-      "filename": "<golden:new_validators_display_formats>",
-      "line_number": 3,
-      "metadata": {
-        "confidence_adjustment": 0,
-        "context_confidence": 0.5,
-        "context_doctype": "Unknown",
-        "context_domain": "Healthcare",
-        "context_impact": 65,
-        "format": "IL_1L11D",
-        "normalized": "D12345678901",
-        "original_confidence": 70,
-        "original_file": "<golden:new_validators_display_formats>",
-        "semantic_context": {
-          "FinancialData": 0,
-          "MedicalData": 0,
-          "PersonalData": 0,
-          "Production": 0,
-          "TestData": 0
-        },
-        "source": "preprocessed_content",
-        "validation_checks": {
-          "format_match": true,
-          "has_dl_context": false,
-          "not_all_same": true,
-          "not_all_zeros": true,
-          "not_sequential": false
-        },
-        "validation_path": "document"
-      },
-      "text": "D123-4567-8901",
-      "type": "DRIVERS_LICENSE",
-      "validator": "driverslicense"
-    },
-    {
-      "confidence": 95,
-      "confidence_level": "HIGH",
-      "filename": "<golden:new_validators_display_formats>",
-      "line_number": 1,
-      "metadata": {
-        "confidence_adjustment": 0,
-        "context_confidence": 0.5,
-        "context_doctype": "Unknown",
-        "context_domain": "Healthcare",
-        "context_impact": 20,
-        "normalized": "1EG4TE5MK73",
-        "original_confidence": 95,
-        "semantic_context": {
-          "FinancialData": 0,
-          "MedicalData": 0,
-          "PersonalData": 0,
-          "Production": 0,
-          "TestData": 0
-        },
-        "subtype": "MBI",
-        "validation_path": "document"
-      },
-      "text": "1EG4-TE5-MK73",
-      "type": "MEDICARE_MBI",
-      "validator": "medicalid"
-    },
-    {
-      "confidence": 95,
-      "confidence_level": "HIGH",
-      "filename": "<golden:new_validators_display_formats>",
-      "line_number": 6,
-      "metadata": {
-        "confidence_adjustment": 0,
-        "context_confidence": 0.5,
-        "context_doctype": "Unknown",
-        "context_domain": "Healthcare",
-        "original_confidence": 95,
-        "original_file": "<golden:new_validators_display_formats>",
-        "semantic_context": {
-          "FinancialData": 0,
-          "MedicalData": 0,
-          "PersonalData": 0,
-          "Production": 0,
-          "TestData": 0
-        },
-        "source": "preprocessed_content",
-        "validation_path": "document"
-      },
-      "text": "123 42nd Street",
-      "type": "US_STREET_ADDRESS",
-      "validator": "physical_address"
-    },
-    {
       "confidence": 90,
       "confidence_level": "HIGH",
       "filename": "<golden:new_validators_display_formats>",
@@ -264,6 +201,69 @@
       "text": "742 evergreen terrace",
       "type": "US_STREET_ADDRESS",
       "validator": "physical_address"
+    },
+    {
+      "confidence": 80,
+      "confidence_level": "MEDIUM",
+      "filename": "<golden:new_validators_display_formats>",
+      "line_number": 2,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0.5,
+        "context_doctype": "Unknown",
+        "context_domain": "Healthcare",
+        "context_impact": -5,
+        "country": "DE",
+        "normalized": "DE89370400440532013000",
+        "original_confidence": 80,
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "validation_path": "document"
+      },
+      "text": "DE89 3704 0044 0532 0130 00",
+      "type": "IBAN",
+      "validator": "bank_account"
+    },
+    {
+      "confidence": 70,
+      "confidence_level": "MEDIUM",
+      "filename": "<golden:new_validators_display_formats>",
+      "line_number": 3,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0.5,
+        "context_doctype": "Unknown",
+        "context_domain": "Healthcare",
+        "context_impact": 65,
+        "format": "IL_1L11D",
+        "normalized": "D12345678901",
+        "original_confidence": 70,
+        "original_file": "<golden:new_validators_display_formats>",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "format_match": true,
+          "has_dl_context": false,
+          "not_all_same": true,
+          "not_all_zeros": true,
+          "not_sequential": false
+        },
+        "validation_path": "document"
+      },
+      "text": "D123-4567-8901",
+      "type": "DRIVERS_LICENSE",
+      "validator": "driverslicense"
     }
   ]
 }

--- a/internal/goldencorpus/testdata/golden/new_validators_display_formats.txt
+++ b/internal/goldencorpus/testdata/golden/new_validators_display_formats.txt
@@ -2,9 +2,9 @@ LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH            
 -----------------------------------------------------------------------------------------------------
 [HIGH  ] medicalid    MEDICARE_MBI           95.00% line     1 1EG4-TE5-MK73               <golden:new_validators_display_formats>
 [HIGH  ] physical_... US_STREET_ADDRESS      95.00% line     6 123 42nd Street             <golden:new_validators_display_formats>
-[HIGH  ] dob          DATE_OF_BIRTH          90.00% line     5 03.14.1987                  <golden:new_validators_display_formats>
 [HIGH  ] dob          DATE_OF_BIRTH          90.00% line     4 3/14/87                     <golden:new_validators_display_formats>
 [HIGH  ] dob          DATE_OF_BIRTH          90.00% line     4 March 14th, 1987            <golden:new_validators_display_formats>
+[HIGH  ] dob          DATE_OF_BIRTH          90.00% line     5 03.14.1987                  <golden:new_validators_display_formats>
 [HIGH  ] physical_... US_STREET_ADDRESS      90.00% line     7 1234 US Highway 61          <golden:new_validators_display_formats>
 [MEDIUM] physical_... US_STREET_ADDRESS      85.00% line     8 742 evergreen terrace       <golden:new_validators_display_formats>
 [MEDIUM] bank_account IBAN                   80.00% line     2 DE89 3704 0044 0532 0130 00 <golden:new_validators_display_formats>

--- a/internal/goldencorpus/testdata/golden/new_validators_display_formats.yaml
+++ b/internal/goldencorpus/testdata/golden/new_validators_display_formats.yaml
@@ -1,26 +1,48 @@
 results:
-    - text: DE89 3704 0044 0532 0130 00
-      line_number: 2
-      type: IBAN
-      confidence: 80
-      confidence_level: MEDIUM
+    - text: 1EG4-TE5-MK73
+      line_number: 1
+      type: MEDICARE_MBI
+      confidence: 95
+      confidence_level: HIGH
       filename: <golden:new_validators_display_formats>
-      validator: bank_account
+      validator: medicalid
       metadata:
         confidence_adjustment: 0
         context_confidence: 0.5
         context_doctype: Unknown
         context_domain: Healthcare
-        context_impact: -5
-        country: DE
-        normalized: DE89370400440532013000
-        original_confidence: 80
+        context_impact: 20
+        normalized: 1EG4TE5MK73
+        original_confidence: 95
         semantic_context:
             FinancialData: 0
             MedicalData: 0
             PersonalData: 0
             Production: 0
             TestData: 0
+        subtype: MBI
+        validation_path: document
+    - text: 123 42nd Street
+      line_number: 6
+      type: US_STREET_ADDRESS
+      confidence: 95
+      confidence_level: HIGH
+      filename: <golden:new_validators_display_formats>
+      validator: physical_address
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0.5
+        context_doctype: Unknown
+        context_domain: Healthcare
+        original_confidence: 95
+        original_file: <golden:new_validators_display_formats>
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
         validation_path: document
     - text: 3/14/87
       line_number: 4
@@ -103,82 +125,6 @@ results:
             plausible_year: true
             valid_date: true
         validation_path: document
-    - text: D123-4567-8901
-      line_number: 3
-      type: DRIVERS_LICENSE
-      confidence: 70
-      confidence_level: MEDIUM
-      filename: <golden:new_validators_display_formats>
-      validator: driverslicense
-      metadata:
-        confidence_adjustment: 0
-        context_confidence: 0.5
-        context_doctype: Unknown
-        context_domain: Healthcare
-        context_impact: 65
-        format: IL_1L11D
-        normalized: D12345678901
-        original_confidence: 70
-        original_file: <golden:new_validators_display_formats>
-        semantic_context:
-            FinancialData: 0
-            MedicalData: 0
-            PersonalData: 0
-            Production: 0
-            TestData: 0
-        source: preprocessed_content
-        validation_checks:
-            format_match: true
-            has_dl_context: false
-            not_all_same: true
-            not_all_zeros: true
-            not_sequential: false
-        validation_path: document
-    - text: 1EG4-TE5-MK73
-      line_number: 1
-      type: MEDICARE_MBI
-      confidence: 95
-      confidence_level: HIGH
-      filename: <golden:new_validators_display_formats>
-      validator: medicalid
-      metadata:
-        confidence_adjustment: 0
-        context_confidence: 0.5
-        context_doctype: Unknown
-        context_domain: Healthcare
-        context_impact: 20
-        normalized: 1EG4TE5MK73
-        original_confidence: 95
-        semantic_context:
-            FinancialData: 0
-            MedicalData: 0
-            PersonalData: 0
-            Production: 0
-            TestData: 0
-        subtype: MBI
-        validation_path: document
-    - text: 123 42nd Street
-      line_number: 6
-      type: US_STREET_ADDRESS
-      confidence: 95
-      confidence_level: HIGH
-      filename: <golden:new_validators_display_formats>
-      validator: physical_address
-      metadata:
-        confidence_adjustment: 0
-        context_confidence: 0.5
-        context_doctype: Unknown
-        context_domain: Healthcare
-        original_confidence: 95
-        original_file: <golden:new_validators_display_formats>
-        semantic_context:
-            FinancialData: 0
-            MedicalData: 0
-            PersonalData: 0
-            Production: 0
-            TestData: 0
-        source: preprocessed_content
-        validation_path: document
     - text: 1234 US Highway 61
       line_number: 7
       type: US_STREET_ADDRESS
@@ -223,4 +169,58 @@ results:
             Production: 0
             TestData: 0
         source: preprocessed_content
+        validation_path: document
+    - text: DE89 3704 0044 0532 0130 00
+      line_number: 2
+      type: IBAN
+      confidence: 80
+      confidence_level: MEDIUM
+      filename: <golden:new_validators_display_formats>
+      validator: bank_account
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0.5
+        context_doctype: Unknown
+        context_domain: Healthcare
+        context_impact: -5
+        country: DE
+        normalized: DE89370400440532013000
+        original_confidence: 80
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        validation_path: document
+    - text: D123-4567-8901
+      line_number: 3
+      type: DRIVERS_LICENSE
+      confidence: 70
+      confidence_level: MEDIUM
+      filename: <golden:new_validators_display_formats>
+      validator: driverslicense
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0.5
+        context_doctype: Unknown
+        context_domain: Healthcare
+        context_impact: 65
+        format: IL_1L11D
+        normalized: D12345678901
+        original_confidence: 70
+        original_file: <golden:new_validators_display_formats>
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            format_match: true
+            has_dl_context: false
+            not_all_same: true
+            not_all_zeros: true
+            not_sequential: false
         validation_path: document


### PR DESCRIPTION
## Summary
Adds two golden corpus cases that LOCK the current context-handling behavior (including warts) of the original validators when presented with shape-valid values in PII-contradicting context:

- **context_decoys_original**: SSN/PHONE/CREDIT_CARD/EMAIL real-context and decoy-context pairs. Confirms the SSN context gap: part-number and requisition decoys both score 100 HIGH indistinguishably from real SSNs. Phone decoys (error codes) correctly land at 65 MEDIUM. This locks the status quo so future SSN context-penalty work shows as intentional golden diffs.
- **context_decoys_personname**: An 8-line multi-document mixing real person names with decoy name-shaped strings (rivers, car models, companies). Locks the PERSON_NAME document-length and context-discrimination behavior.

**No validator code changes** — snapshot-only PR.

## Findings from experiments (not committed, informational)
The SSN validator has ZERO context discrimination: both real and decoy contexts produce identical 100 HIGH scores. DOB has the strongest context handling (decoys → 5 LOW). PERSON_NAME requires a minimum document length of ~5 lines to fire at all — confirmed as the document-length sensitivity bug noted in memory.