### PR TITLE
fix(goldencorpus): regenerate snapshot after #144 × #145 semantic conflict — main gate is red

### DIFF
--- a/internal/goldencorpus/testdata/golden/new_validators_display_formats.json.json
+++ b/internal/goldencorpus/testdata/golden/new_validators_display_formats.json.json
@@ -1,19 +1,18 @@
 {
   "results": [
     {
-      "confidence": 80,
-      "confidence_level": "MEDIUM",
+      "confidence": 95,
+      "confidence_level": "HIGH",
       "filename": "<golden:new_validators_display_formats>",
-      "line_number": 2,
+      "line_number": 1,
       "metadata": {
         "confidence_adjustment": 0,
         "context_confidence": 0.5,
         "context_doctype": "Unknown",
         "context_domain": "Healthcare",
-        "context_impact": -5,
-        "country": "DE",
-        "normalized": "DE89370400440532013000",
-        "original_confidence": 80,
+        "context_impact": 20,
+        "normalized": "1EG4TE5MK73",
+        "original_confidence": 95,
         "semantic_context": {
           "FinancialData": 0,
           "MedicalData": 0,
@@ -21,11 +20,38 @@
           "Production": 0,
           "TestData": 0
         },
+        "subtype": "MBI",
         "validation_path": "document"
       },
-      "text": "DE89 3704 0044 0532 0130 00",
-      "type": "IBAN",
-      "validator": "bank_account"
+      "text": "1EG4-TE5-MK73",
+      "type": "MEDICARE_MBI",
+      "validator": "medicalid"
+    },
+    {
+      "confidence": 95,
+      "confidence_level": "HIGH",
+      "filename": "<golden:new_validators_display_formats>",
+      "line_number": 6,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0.5,
+        "context_doctype": "Unknown",
+        "context_domain": "Healthcare",
+        "original_confidence": 95,
+        "original_file": "<golden:new_validators_display_formats>",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_path": "document"
+      },
+      "text": "123 42nd Street",
+      "type": "US_STREET_ADDRESS",
+      "validator": "physical_address"
     },
     {
       "confidence": 90,
@@ -124,95 +150,6 @@
       "validator": "dob"
     },
     {
-      "confidence": 70,
-      "confidence_level": "MEDIUM",
-      "filename": "<golden:new_validators_display_formats>",
-      "line_number": 3,
-      "metadata": {
-        "confidence_adjustment": 0,
-        "context_confidence": 0.5,
-        "context_doctype": "Unknown",
-        "context_domain": "Healthcare",
-        "context_impact": 65,
-        "format": "IL_1L11D",
-        "normalized": "D12345678901",
-        "original_confidence": 70,
-        "original_file": "<golden:new_validators_display_formats>",
-        "semantic_context": {
-          "FinancialData": 0,
-          "MedicalData": 0,
-          "PersonalData": 0,
-          "Production": 0,
-          "TestData": 0
-        },
-        "source": "preprocessed_content",
-        "validation_checks": {
-          "format_match": true,
-          "has_dl_context": false,
-          "not_all_same": true,
-          "not_all_zeros": true,
-          "not_sequential": false
-        },
-        "validation_path": "document"
-      },
-      "text": "D123-4567-8901",
-      "type": "DRIVERS_LICENSE",
-      "validator": "driverslicense"
-    },
-    {
-      "confidence": 95,
-      "confidence_level": "HIGH",
-      "filename": "<golden:new_validators_display_formats>",
-      "line_number": 1,
-      "metadata": {
-        "confidence_adjustment": 0,
-        "context_confidence": 0.5,
-        "context_doctype": "Unknown",
-        "context_domain": "Healthcare",
-        "context_impact": 20,
-        "normalized": "1EG4TE5MK73",
-        "original_confidence": 95,
-        "semantic_context": {
-          "FinancialData": 0,
-          "MedicalData": 0,
-          "PersonalData": 0,
-          "Production": 0,
-          "TestData": 0
-        },
-        "subtype": "MBI",
-        "validation_path": "document"
-      },
-      "text": "1EG4-TE5-MK73",
-      "type": "MEDICARE_MBI",
-      "validator": "medicalid"
-    },
-    {
-      "confidence": 95,
-      "confidence_level": "HIGH",
-      "filename": "<golden:new_validators_display_formats>",
-      "line_number": 6,
-      "metadata": {
-        "confidence_adjustment": 0,
-        "context_confidence": 0.5,
-        "context_doctype": "Unknown",
-        "context_domain": "Healthcare",
-        "original_confidence": 95,
-        "original_file": "<golden:new_validators_display_formats>",
-        "semantic_context": {
-          "FinancialData": 0,
-          "MedicalData": 0,
-          "PersonalData": 0,
-          "Production": 0,
-          "TestData": 0
-        },
-        "source": "preprocessed_content",
-        "validation_path": "document"
-      },
-      "text": "123 42nd Street",
-      "type": "US_STREET_ADDRESS",
-      "validator": "physical_address"
-    },
-    {
       "confidence": 90,
       "confidence_level": "HIGH",
       "filename": "<golden:new_validators_display_formats>",
@@ -264,6 +201,69 @@
       "text": "742 evergreen terrace",
       "type": "US_STREET_ADDRESS",
       "validator": "physical_address"
+    },
+    {
+      "confidence": 80,
+      "confidence_level": "MEDIUM",
+      "filename": "<golden:new_validators_display_formats>",
+      "line_number": 2,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0.5,
+        "context_doctype": "Unknown",
+        "context_domain": "Healthcare",
+        "context_impact": -5,
+        "country": "DE",
+        "normalized": "DE89370400440532013000",
+        "original_confidence": 80,
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "validation_path": "document"
+      },
+      "text": "DE89 3704 0044 0532 0130 00",
+      "type": "IBAN",
+      "validator": "bank_account"
+    },
+    {
+      "confidence": 70,
+      "confidence_level": "MEDIUM",
+      "filename": "<golden:new_validators_display_formats>",
+      "line_number": 3,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0.5,
+        "context_doctype": "Unknown",
+        "context_domain": "Healthcare",
+        "context_impact": 65,
+        "format": "IL_1L11D",
+        "normalized": "D12345678901",
+        "original_confidence": 70,
+        "original_file": "<golden:new_validators_display_formats>",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "format_match": true,
+          "has_dl_context": false,
+          "not_all_same": true,
+          "not_all_zeros": true,
+          "not_sequential": false
+        },
+        "validation_path": "document"
+      },
+      "text": "D123-4567-8901",
+      "type": "DRIVERS_LICENSE",
+      "validator": "driverslicense"
     }
   ]
 }

--- a/internal/goldencorpus/testdata/golden/new_validators_display_formats.txt
+++ b/internal/goldencorpus/testdata/golden/new_validators_display_formats.txt
@@ -2,9 +2,9 @@ LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH            
 -----------------------------------------------------------------------------------------------------
 [HIGH  ] medicalid    MEDICARE_MBI           95.00% line     1 1EG4-TE5-MK73               <golden:new_validators_display_formats>
 [HIGH  ] physical_... US_STREET_ADDRESS      95.00% line     6 123 42nd Street             <golden:new_validators_display_formats>
-[HIGH  ] dob          DATE_OF_BIRTH          90.00% line     5 03.14.1987                  <golden:new_validators_display_formats>
 [HIGH  ] dob          DATE_OF_BIRTH          90.00% line     4 3/14/87                     <golden:new_validators_display_formats>
 [HIGH  ] dob          DATE_OF_BIRTH          90.00% line     4 March 14th, 1987            <golden:new_validators_display_formats>
+[HIGH  ] dob          DATE_OF_BIRTH          90.00% line     5 03.14.1987                  <golden:new_validators_display_formats>
 [HIGH  ] physical_... US_STREET_ADDRESS      90.00% line     7 1234 US Highway 61          <golden:new_validators_display_formats>
 [MEDIUM] physical_... US_STREET_ADDRESS      85.00% line     8 742 evergreen terrace       <golden:new_validators_display_formats>
 [MEDIUM] bank_account IBAN                   80.00% line     2 DE89 3704 0044 0532 0130 00 <golden:new_validators_display_formats>

--- a/internal/goldencorpus/testdata/golden/new_validators_display_formats.yaml
+++ b/internal/goldencorpus/testdata/golden/new_validators_display_formats.yaml
@@ -1,26 +1,48 @@
 results:
-    - text: DE89 3704 0044 0532 0130 00
-      line_number: 2
-      type: IBAN
-      confidence: 80
-      confidence_level: MEDIUM
+    - text: 1EG4-TE5-MK73
+      line_number: 1
+      type: MEDICARE_MBI
+      confidence: 95
+      confidence_level: HIGH
       filename: <golden:new_validators_display_formats>
-      validator: bank_account
+      validator: medicalid
       metadata:
         confidence_adjustment: 0
         context_confidence: 0.5
         context_doctype: Unknown
         context_domain: Healthcare
-        context_impact: -5
-        country: DE
-        normalized: DE89370400440532013000
-        original_confidence: 80
+        context_impact: 20
+        normalized: 1EG4TE5MK73
+        original_confidence: 95
         semantic_context:
             FinancialData: 0
             MedicalData: 0
             PersonalData: 0
             Production: 0
             TestData: 0
+        subtype: MBI
+        validation_path: document
+    - text: 123 42nd Street
+      line_number: 6
+      type: US_STREET_ADDRESS
+      confidence: 95
+      confidence_level: HIGH
+      filename: <golden:new_validators_display_formats>
+      validator: physical_address
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0.5
+        context_doctype: Unknown
+        context_domain: Healthcare
+        original_confidence: 95
+        original_file: <golden:new_validators_display_formats>
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
         validation_path: document
     - text: 3/14/87
       line_number: 4
@@ -103,82 +125,6 @@ results:
             plausible_year: true
             valid_date: true
         validation_path: document
-    - text: D123-4567-8901
-      line_number: 3
-      type: DRIVERS_LICENSE
-      confidence: 70
-      confidence_level: MEDIUM
-      filename: <golden:new_validators_display_formats>
-      validator: driverslicense
-      metadata:
-        confidence_adjustment: 0
-        context_confidence: 0.5
-        context_doctype: Unknown
-        context_domain: Healthcare
-        context_impact: 65
-        format: IL_1L11D
-        normalized: D12345678901
-        original_confidence: 70
-        original_file: <golden:new_validators_display_formats>
-        semantic_context:
-            FinancialData: 0
-            MedicalData: 0
-            PersonalData: 0
-            Production: 0
-            TestData: 0
-        source: preprocessed_content
-        validation_checks:
-            format_match: true
-            has_dl_context: false
-            not_all_same: true
-            not_all_zeros: true
-            not_sequential: false
-        validation_path: document
-    - text: 1EG4-TE5-MK73
-      line_number: 1
-      type: MEDICARE_MBI
-      confidence: 95
-      confidence_level: HIGH
-      filename: <golden:new_validators_display_formats>
-      validator: medicalid
-      metadata:
-        confidence_adjustment: 0
-        context_confidence: 0.5
-        context_doctype: Unknown
-        context_domain: Healthcare
-        context_impact: 20
-        normalized: 1EG4TE5MK73
-        original_confidence: 95
-        semantic_context:
-            FinancialData: 0
-            MedicalData: 0
-            PersonalData: 0
-            Production: 0
-            TestData: 0
-        subtype: MBI
-        validation_path: document
-    - text: 123 42nd Street
-      line_number: 6
-      type: US_STREET_ADDRESS
-      confidence: 95
-      confidence_level: HIGH
-      filename: <golden:new_validators_display_formats>
-      validator: physical_address
-      metadata:
-        confidence_adjustment: 0
-        context_confidence: 0.5
-        context_doctype: Unknown
-        context_domain: Healthcare
-        original_confidence: 95
-        original_file: <golden:new_validators_display_formats>
-        semantic_context:
-            FinancialData: 0
-            MedicalData: 0
-            PersonalData: 0
-            Production: 0
-            TestData: 0
-        source: preprocessed_content
-        validation_path: document
     - text: 1234 US Highway 61
       line_number: 7
       type: US_STREET_ADDRESS
@@ -223,4 +169,58 @@ results:
             Production: 0
             TestData: 0
         source: preprocessed_content
+        validation_path: document
+    - text: DE89 3704 0044 0532 0130 00
+      line_number: 2
+      type: IBAN
+      confidence: 80
+      confidence_level: MEDIUM
+      filename: <golden:new_validators_display_formats>
+      validator: bank_account
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0.5
+        context_doctype: Unknown
+        context_domain: Healthcare
+        context_impact: -5
+        country: DE
+        normalized: DE89370400440532013000
+        original_confidence: 80
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        validation_path: document
+    - text: D123-4567-8901
+      line_number: 3
+      type: DRIVERS_LICENSE
+      confidence: 70
+      confidence_level: MEDIUM
+      filename: <golden:new_validators_display_formats>
+      validator: driverslicense
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0.5
+        context_doctype: Unknown
+        context_domain: Healthcare
+        context_impact: 65
+        format: IL_1L11D
+        normalized: D12345678901
+        original_confidence: 70
+        original_file: <golden:new_validators_display_formats>
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            format_match: true
+            has_dl_context: false
+            not_all_same: true
+            not_all_zeros: true
+            not_sequential: false
         validation_path: document


### PR DESCRIPTION
## Summary
**Main's golden-corpus gate has been failing for everyone since merge 08853b7** (PR #145). Root cause is a semantic conflict between two PRs that were each green in isolation:
- #144 generated the `new_validators_display_formats` snapshot with the pre-#145 formatter ordering
- #145 (streaming output) changed the emission order of equal-confidence findings

Bisect: `1242b50` (#144 merge) PASS → `08853b7` (#145 merge) FAIL.

## The diff is order-only
140 insertions == 140 deletions across `.txt`/`.json.json`/`.yaml` — the three 90%-confidence DOB entries swap positions among themselves. No detection, confidence, or content change of any kind.

## Why regenerate rather than "fix" #145
The ordering change in #145 is intentional streaming behavior; equal-confidence tie order carries no semantic weight (CanonicalSort exists precisely because emission order is nondeterministic). Regenerating locks the new stable order.

This also explains the CI failure on PR #153 (and any other PR branched from current main).