### PR TITLE
fix: restore main's gates after the #152–#158 merge train

### DIFF
--- a/internal/goldencorpus/testdata/golden/context_decoys_original.csv
+++ b/internal/goldencorpus/testdata/golden/context_decoys_original.csv
@@ -3,5 +3,5 @@ Filename,Type,Confidence Level,Confidence %,Line Number,Text
 <golden:context_decoys_original>,PHONE,MEDIUM,65.0,5,212-555-0142
 <golden:context_decoys_original>,PHONE,MEDIUM,65.0,6,313-555-0175
 <golden:context_decoys_original>,SSN,HIGH,100.0,1,449-87-4100
-<golden:context_decoys_original>,SSN,HIGH,100.0,2,449-87-4100
-<golden:context_decoys_original>,SSN,HIGH,100.0,3,526-33-8210
+<golden:context_decoys_original>,SSN,MEDIUM,60.0,2,449-87-4100
+<golden:context_decoys_original>,SSN,MEDIUM,60.0,3,526-33-8210

--- a/internal/goldencorpus/testdata/golden/context_decoys_original.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/context_decoys_original.gitlab-sast.json
@@ -107,7 +107,7 @@
     {
       "category": "sast",
       "confidence": "High",
-      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <golden:context_decoys_original> (line 1)\n**Confidence:** HIGH (100.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\nemployee ssn 449-87-4100 on file\n```\n\n**Additional Information:**\n- context_impact: 50\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
+      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <golden:context_decoys_original> (line 1)\n**Confidence:** HIGH (100.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\nemployee ssn 449-87-4100 on file\n```\n\n**Additional Information:**\n- context_impact: 45\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {
@@ -132,8 +132,8 @@
     },
     {
       "category": "sast",
-      "confidence": "High",
-      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <golden:context_decoys_original> (line 2)\n**Confidence:** HIGH (100.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\npart number 449-87-4100 from the catalog\n```\n\n**Additional Information:**\n- context_impact: 15\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <golden:context_decoys_original> (line 2)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\npart number 449-87-4100 from the catalog\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {
@@ -152,14 +152,14 @@
         "file": "<golden:context_decoys_original>",
         "start_line": 2
       },
-      "message": "Social Security Number detected: [HIDDEN] (confidence: HIGH)",
+      "message": "Social Security Number detected: [HIDDEN] (confidence: MEDIUM)",
       "name": "Social Security Number Detected",
-      "severity": "Critical"
+      "severity": "High"
     },
     {
       "category": "sast",
-      "confidence": "High",
-      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <golden:context_decoys_original> (line 3)\n**Confidence:** HIGH (100.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\nrequisition 526-33-8210 approved for shipment\n```\n\n**Additional Information:**\n- context_impact: 15\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <golden:context_decoys_original> (line 3)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\nrequisition 526-33-8210 approved for shipment\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {
@@ -178,9 +178,9 @@
         "file": "<golden:context_decoys_original>",
         "start_line": 3
       },
-      "message": "Social Security Number detected: [HIDDEN] (confidence: HIGH)",
+      "message": "Social Security Number detected: [HIDDEN] (confidence: MEDIUM)",
       "name": "Social Security Number Detected",
-      "severity": "Critical"
+      "severity": "High"
     }
   ]
 }

--- a/internal/goldencorpus/testdata/golden/context_decoys_original.json.json
+++ b/internal/goldencorpus/testdata/golden/context_decoys_original.json.json
@@ -52,7 +52,7 @@
         "context_confidence": 1,
         "context_doctype": "Unknown",
         "context_domain": "HR_Payroll",
-        "context_impact": 50,
+        "context_impact": 45,
         "original_confidence": 100,
         "original_file": "<golden:context_decoys_original>",
         "semantic_context": {
@@ -75,78 +75,6 @@
         "validation_path": "document"
       },
       "text": "449-87-4100",
-      "type": "SSN",
-      "validator": "ssn"
-    },
-    {
-      "confidence": 100,
-      "confidence_level": "HIGH",
-      "filename": "<golden:context_decoys_original>",
-      "line_number": 2,
-      "metadata": {
-        "confidence_adjustment": 0,
-        "context_confidence": 1,
-        "context_doctype": "Unknown",
-        "context_domain": "HR_Payroll",
-        "context_impact": 15,
-        "original_confidence": 100,
-        "original_file": "<golden:context_decoys_original>",
-        "semantic_context": {
-          "FinancialData": 0,
-          "MedicalData": 0,
-          "PersonalData": 0,
-          "Production": 0,
-          "TestData": 0
-        },
-        "source": "preprocessed_content",
-        "validation_checks": {
-          "digits": true,
-          "format": true,
-          "not_common_pattern": true,
-          "not_repeating": true,
-          "not_sequential": true,
-          "not_test_number": true,
-          "valid_area": true
-        },
-        "validation_path": "document"
-      },
-      "text": "449-87-4100",
-      "type": "SSN",
-      "validator": "ssn"
-    },
-    {
-      "confidence": 100,
-      "confidence_level": "HIGH",
-      "filename": "<golden:context_decoys_original>",
-      "line_number": 3,
-      "metadata": {
-        "confidence_adjustment": 0,
-        "context_confidence": 1,
-        "context_doctype": "Unknown",
-        "context_domain": "HR_Payroll",
-        "context_impact": 15,
-        "original_confidence": 100,
-        "original_file": "<golden:context_decoys_original>",
-        "semantic_context": {
-          "FinancialData": 0,
-          "MedicalData": 0,
-          "PersonalData": 0,
-          "Production": 0,
-          "TestData": 0
-        },
-        "source": "preprocessed_content",
-        "validation_checks": {
-          "digits": true,
-          "format": true,
-          "not_common_pattern": true,
-          "not_repeating": true,
-          "not_sequential": true,
-          "not_test_number": true,
-          "valid_area": true
-        },
-        "validation_path": "document"
-      },
-      "text": "526-33-8210",
       "type": "SSN",
       "validator": "ssn"
     },
@@ -233,6 +161,78 @@
       "text": "313-555-0175",
       "type": "PHONE",
       "validator": "phone"
+    },
+    {
+      "confidence": 60,
+      "confidence_level": "MEDIUM",
+      "filename": "<golden:context_decoys_original>",
+      "line_number": 2,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 0,
+        "original_confidence": 60,
+        "original_file": "<golden:context_decoys_original>",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "format": true,
+          "not_common_pattern": true,
+          "not_repeating": true,
+          "not_sequential": true,
+          "not_test_number": true,
+          "valid_area": true
+        },
+        "validation_path": "document"
+      },
+      "text": "449-87-4100",
+      "type": "SSN",
+      "validator": "ssn"
+    },
+    {
+      "confidence": 60,
+      "confidence_level": "MEDIUM",
+      "filename": "<golden:context_decoys_original>",
+      "line_number": 3,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 0,
+        "original_confidence": 60,
+        "original_file": "<golden:context_decoys_original>",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "format": true,
+          "not_common_pattern": true,
+          "not_repeating": true,
+          "not_sequential": true,
+          "not_test_number": true,
+          "valid_area": true
+        },
+        "validation_path": "document"
+      },
+      "text": "526-33-8210",
+      "type": "SSN",
+      "validator": "ssn"
     }
   ]
 }

--- a/internal/goldencorpus/testdata/golden/context_decoys_original.junit.xml
+++ b/internal/goldencorpus/testdata/golden/context_decoys_original.junit.xml
@@ -2,7 +2,7 @@
 <testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
   <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
     <testcase name="&lt;golden:context_decoys_original&gt;" classname="security-scan" time="0.001">
-      <failure message="6 security findings detected" type="SECURITY_FINDINGS">Line 4: PHONE detected with 100.0% confidence (HIGH)&#xA;Match: 212-555-0142&#xA;Validator: phone&#xA;Line 1: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 2: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 3: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 526-33-8210&#xA;Validator: ssn&#xA;Line 6: PHONE detected with 65.0% confidence (MEDIUM)&#xA;Match: 313-555-0175&#xA;Validator: phone&#xA;Line 5: PHONE detected with 65.0% confidence (MEDIUM)&#xA;Match: 212-555-0142&#xA;Validator: phone</failure>
+      <failure message="6 security findings detected" type="SECURITY_FINDINGS">Line 4: PHONE detected with 100.0% confidence (HIGH)&#xA;Match: 212-555-0142&#xA;Validator: phone&#xA;Line 1: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 6: PHONE detected with 65.0% confidence (MEDIUM)&#xA;Match: 313-555-0175&#xA;Validator: phone&#xA;Line 5: PHONE detected with 65.0% confidence (MEDIUM)&#xA;Match: 212-555-0142&#xA;Validator: phone&#xA;Line 2: SSN detected with 60.0% confidence (MEDIUM)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 3: SSN detected with 60.0% confidence (MEDIUM)&#xA;Match: 526-33-8210&#xA;Validator: ssn</failure>
     </testcase>
   </testsuite>
 </testsuites>

--- a/internal/goldencorpus/testdata/golden/context_decoys_original.redact_format_preserving.txt
+++ b/internal/goldencorpus/testdata/golden/context_decoys_original.redact_format_preserving.txt
@@ -10,5 +10,5 @@ type=PHONE line=4 conf=high match=212-555-0142
 type=PHONE line=5 conf=medium match=212-555-0142
 type=PHONE line=6 conf=medium match=313-555-0175
 type=SSN line=1 conf=high match=449-87-4100
-type=SSN line=2 conf=high match=449-87-4100
-type=SSN line=3 conf=high match=526-33-8210
+type=SSN line=2 conf=medium match=449-87-4100
+type=SSN line=3 conf=medium match=526-33-8210

--- a/internal/goldencorpus/testdata/golden/context_decoys_original.redact_simple.txt
+++ b/internal/goldencorpus/testdata/golden/context_decoys_original.redact_simple.txt
@@ -10,5 +10,5 @@ type=PHONE line=4 conf=high match=212-555-0142
 type=PHONE line=5 conf=medium match=212-555-0142
 type=PHONE line=6 conf=medium match=313-555-0175
 type=SSN line=1 conf=high match=449-87-4100
-type=SSN line=2 conf=high match=449-87-4100
-type=SSN line=3 conf=high match=526-33-8210
+type=SSN line=2 conf=medium match=449-87-4100
+type=SSN line=3 conf=medium match=526-33-8210

--- a/internal/goldencorpus/testdata/golden/context_decoys_original.sarif.json
+++ b/internal/goldencorpus/testdata/golden/context_decoys_original.sarif.json
@@ -249,7 +249,7 @@
               "context_confidence": 1,
               "context_doctype": "Unknown",
               "context_domain": "HR_Payroll",
-              "context_impact": 50,
+              "context_impact": 45,
               "original_confidence": 100,
               "original_file": "<golden:context_decoys_original>",
               "semantic_context": {
@@ -305,18 +305,18 @@
             }
           ],
           "message": {
-            "text": "Social Security Number Detected in <golden:context_decoys_original> at line 2 (confidence: 100.0% - HIGH). Matched text: '449-87-4100'"
+            "text": "Social Security Number Detected in <golden:context_decoys_original> at line 2 (confidence: 60.0% - MEDIUM). Matched text: '449-87-4100'"
           },
           "properties": {
-            "confidence": 100,
-            "confidenceLevel": "HIGH",
+            "confidence": 60,
+            "confidenceLevel": "MEDIUM",
             "metadata": {
               "confidence_adjustment": 0,
               "context_confidence": 1,
               "context_doctype": "Unknown",
               "context_domain": "HR_Payroll",
-              "context_impact": 15,
-              "original_confidence": 100,
+              "context_impact": 0,
+              "original_confidence": 60,
               "original_file": "<golden:context_decoys_original>",
               "semantic_context": {
                 "FinancialData": 0,
@@ -339,7 +339,7 @@
             },
             "validator": "ssn"
           },
-          "rank": 100,
+          "rank": 80,
           "ruleId": "SSN"
         },
         {
@@ -368,18 +368,18 @@
             }
           ],
           "message": {
-            "text": "Social Security Number Detected in <golden:context_decoys_original> at line 3 (confidence: 100.0% - HIGH). Matched text: '526-33-8210'"
+            "text": "Social Security Number Detected in <golden:context_decoys_original> at line 3 (confidence: 60.0% - MEDIUM). Matched text: '526-33-8210'"
           },
           "properties": {
-            "confidence": 100,
-            "confidenceLevel": "HIGH",
+            "confidence": 60,
+            "confidenceLevel": "MEDIUM",
             "metadata": {
               "confidence_adjustment": 0,
               "context_confidence": 1,
               "context_doctype": "Unknown",
               "context_domain": "HR_Payroll",
-              "context_impact": 15,
-              "original_confidence": 100,
+              "context_impact": 0,
+              "original_confidence": 60,
               "original_file": "<golden:context_decoys_original>",
               "semantic_context": {
                 "FinancialData": 0,
@@ -402,7 +402,7 @@
             },
             "validator": "ssn"
           },
-          "rank": 100,
+          "rank": 80,
           "ruleId": "SSN"
         }
       ],

--- a/internal/goldencorpus/testdata/golden/context_decoys_original.txt
+++ b/internal/goldencorpus/testdata/golden/context_decoys_original.txt
@@ -2,7 +2,7 @@ LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH        FILE
 --------------------------------------------------------------------------------------
 [HIGH  ] phone        PHONE                 100.00% line     4 212-555-0142 <golden:context_decoys_original>
 [HIGH  ] ssn          SSN                   100.00% line     1 449-87-4100  <golden:context_decoys_original>
-[HIGH  ] ssn          SSN                   100.00% line     2 449-87-4100  <golden:context_decoys_original>
-[HIGH  ] ssn          SSN                   100.00% line     3 526-33-8210  <golden:context_decoys_original>
 [MEDIUM] phone        PHONE                  65.00% line     5 212-555-0142 <golden:context_decoys_original>
 [MEDIUM] phone        PHONE                  65.00% line     6 313-555-0175 <golden:context_decoys_original>
+[MEDIUM] ssn          SSN                    60.00% line     2 449-87-4100  <golden:context_decoys_original>
+[MEDIUM] ssn          SSN                    60.00% line     3 526-33-8210  <golden:context_decoys_original>

--- a/internal/goldencorpus/testdata/golden/context_decoys_original.yaml
+++ b/internal/goldencorpus/testdata/golden/context_decoys_original.yaml
@@ -48,69 +48,7 @@ results:
         context_confidence: 1
         context_doctype: Unknown
         context_domain: HR_Payroll
-        context_impact: 50
-        original_confidence: 100
-        original_file: <golden:context_decoys_original>
-        semantic_context:
-            FinancialData: 0
-            MedicalData: 0
-            PersonalData: 0
-            Production: 0
-            TestData: 0
-        source: preprocessed_content
-        validation_checks:
-            digits: true
-            format: true
-            not_common_pattern: true
-            not_repeating: true
-            not_sequential: true
-            not_test_number: true
-            valid_area: true
-        validation_path: document
-    - text: 449-87-4100
-      line_number: 2
-      type: SSN
-      confidence: 100
-      confidence_level: HIGH
-      filename: <golden:context_decoys_original>
-      validator: ssn
-      metadata:
-        confidence_adjustment: 0
-        context_confidence: 1
-        context_doctype: Unknown
-        context_domain: HR_Payroll
-        context_impact: 15
-        original_confidence: 100
-        original_file: <golden:context_decoys_original>
-        semantic_context:
-            FinancialData: 0
-            MedicalData: 0
-            PersonalData: 0
-            Production: 0
-            TestData: 0
-        source: preprocessed_content
-        validation_checks:
-            digits: true
-            format: true
-            not_common_pattern: true
-            not_repeating: true
-            not_sequential: true
-            not_test_number: true
-            valid_area: true
-        validation_path: document
-    - text: 526-33-8210
-      line_number: 3
-      type: SSN
-      confidence: 100
-      confidence_level: HIGH
-      filename: <golden:context_decoys_original>
-      validator: ssn
-      metadata:
-        confidence_adjustment: 0
-        context_confidence: 1
-        context_doctype: Unknown
-        context_domain: HR_Payroll
-        context_impact: 15
+        context_impact: 45
         original_confidence: 100
         original_file: <golden:context_decoys_original>
         semantic_context:
@@ -202,4 +140,66 @@ results:
             valid_country: true
             valid_digits: true
             valid_format: true
+        validation_path: document
+    - text: 449-87-4100
+      line_number: 2
+      type: SSN
+      confidence: 60
+      confidence_level: MEDIUM
+      filename: <golden:context_decoys_original>
+      validator: ssn
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 0
+        original_confidence: 60
+        original_file: <golden:context_decoys_original>
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            format: true
+            not_common_pattern: true
+            not_repeating: true
+            not_sequential: true
+            not_test_number: true
+            valid_area: true
+        validation_path: document
+    - text: 526-33-8210
+      line_number: 3
+      type: SSN
+      confidence: 60
+      confidence_level: MEDIUM
+      filename: <golden:context_decoys_original>
+      validator: ssn
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 0
+        original_confidence: 60
+        original_file: <golden:context_decoys_original>
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            format: true
+            not_common_pattern: true
+            not_repeating: true
+            not_sequential: true
+            not_test_number: true
+            valid_area: true
         validation_path: document

--- a/internal/validators/ssn/validator.go
+++ b/internal/validators/ssn/validator.go
@@ -1099,17 +1099,21 @@ func (v *Validator) isTabularData(line, match string) bool {
 	// holding a single bare SSN self-counts as two "structured elements" and
 	// EVERY SSN line gets the +15 tabular boost — which is what flattened all
 	// context discrimination (real vs decoy context both re-clamped to 100).
+	//
+	// Both index slices are sorted by start offset (FindAllStringIndex returns
+	// left-to-right, non-overlapping), so a two-pointer merge walk keeps this
+	// O(dates + ssns). The first version nested the span test — O(dates×ssns),
+	// which on a 1MB single line of ~87K SSNs (the DoS regression shape) is
+	// ~7.6 billion comparisons and pushed the perf test from ~2s to ~180s.
+	si := 0
 	for _, d := range reDate.FindAllStringIndex(line, -1) {
-		inSSN := false
-		for _, s := range ssnSpans {
-			if d[0] >= s[0] && d[1] <= s[1] {
-				inSSN = true
-				break
-			}
+		for si < len(ssnSpans) && ssnSpans[si][1] < d[1] {
+			si++
 		}
-		if !inSSN {
-			structuredElements++
+		if si < len(ssnSpans) && d[0] >= ssnSpans[si][0] && d[1] <= ssnSpans[si][1] {
+			continue // date is the tail of an SSN token
 		}
+		structuredElements++
 	}
 
 	// If multiple structured elements, likely tabular data

--- a/pkg/scan/testdata/golden/aws_key.redact.txt
+++ b/pkg/scan/testdata/golden/aws_key.redact.txt
@@ -1,2 +1,2 @@
 AWS_ACCESS_KEY_ID=********************
-AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+AWS_SECRET_ACCESS_KEY=****************************************

--- a/pkg/scan/testdata/golden/aws_key.scan.txt
+++ b/pkg/scan/testdata/golden/aws_key.scan.txt
@@ -1,1 +1,2 @@
 [MEDIUM] AWS_ACCESS_KEY (line 1, conf 84%, likely_real) val="AKIAIOSFODNN7EXAMPLE"
+[MEDIUM] AWS_SECRET_ACCESS_KEY (line 2, conf 65%, likely_real) val="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"


### PR DESCRIPTION
Main's Go Tests workflow is red on all three OSes since the merge train landed (run 29864922893). Three independent causes, all fixed here:

## 1. SSN perf: O(dates × ssns) nested loop → 180s timeout
The `isTabularData` date-exclusion I added in #155 nested a span test. Fine on real lines; on the 1MB single-line DoS-regression fixture (~87K SSNs, each of whose tails also parses as a date) it's ~7.6B comparisons — CI runners blew the 30s ceiling at 180s+. Now a two-pointer merge walk over the two sorted `FindAllStringIndex` slices: **O(dates + ssns), perf test 3.8s locally**. Zero behavior change (context-discrimination + full validator suites pass unchanged).

## 2. `context_decoys_original` goldens — the predicted #154 × #155 collision
Called out in the merge-order recommendation: #154 locked SSN decoys at the pre-fix **100 HIGH**, #155 changed exactly that to **60 MEDIUM**. Each PR was green alone; together the snapshot no longer matched. Regenerated — the decoy case now locks the *fixed* behavior, which is what it exists to document.

## 3. `pkg/scan` aws_key goldens — #157 regeneration gap
#157 regenerated `internal/goldencorpus` but missed `pkg/scan`'s separate golden set. Regenerated: the AWS secret key now appears **detected (65 MEDIUM) and redacted** in the public-API snapshots too.

## Verification
Full `go test ./...` green locally — all 48 packages, including the previously failing goldencorpus, ssn, and pkg/scan.