### PR TITLE
fix(release): brews.ids must reference the archive id, not the build id

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -134,8 +134,12 @@ release:
 #   brew install awslabs/ferret-scan/ferret-scan
 brews:
   - name: ferret-scan
+    # ids filters by ARCHIVE id, not build id ("binaries" wraps the
+    # ferret-scan-cli build). Referencing the build id here matched zero
+    # archives and failed the v2.1.0 release with "no linux/macos archives
+    # found ... ids=[ferret-scan-cli]".
     ids:
-      - ferret-scan-cli
+      - binaries
     repository:
       owner: awslabs
       name: ferret-scan


### PR DESCRIPTION
## What broke
The v2.1.0 Release workflow (run 29868107847) failed in the goreleaser job:
```
⨯ release failed error=no linux/macos archives found matching goos=[darwin linux] goarch=[amd64 arm64 arm] ... ids=[ferret-scan-cli]
```

## Root cause
`brews[].ids` filters by **archive** id, but the config referenced the **build** id (`ferret-scan-cli`). The only archive is `binaries` (added with the Homebrew tap in #143's follow-up, first exercised by this tag — the tap config had never run through a real release before). Zero archives matched → the homebrew pipe aborted the entire release after the six binaries were built but **before any assets were uploaded**, which is why v2.1.0 currently has only the PyPI wheels attached.

## Fix + verification
One line: `ids: [ferret-scan-cli]` → `ids: [binaries]`, with a comment so the build-id/archive-id distinction doesn't bite again. Verified locally with `goreleaser release --snapshot --clean --skip publish` — full pipeline succeeds and writes `HomebrewFormula/ferret-scan.rb` with per-platform URLs + sha256s.

## After merge
The v2.1.0 tag needs to be re-pointed at the fixed commit (the workflow checks out the tag, so re-running the failed job would use the broken config). Procedure in PR comments.

## Note
`brews` is deprecated in goreleaser v2 (warning only; CI runs `--skip=validate`). Migration to the replacement property is deliberate follow-up, not mixed into this release-blocking fix.