### PR TITLE
fix(release): brew formula install rename, PyPI idempotence, brews rationale

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -287,6 +287,12 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: python-package/dist/
           verbose: true
+          # A re-pushed tag (e.g. re-cut release after a goreleaser failure)
+          # re-runs this job; PyPI filenames are immutable, so a duplicate
+          # upload otherwise fails the whole run with "400 File already
+          # exists" even though nothing is wrong. skip-existing makes tag
+          # re-pushes idempotent while still failing on genuine errors.
+          skip-existing: true
 
 
 
@@ -325,6 +331,12 @@ jobs:
         with:
           packages-dir: python-package/dist/
           verbose: true
+          # A re-pushed tag (e.g. re-cut release after a goreleaser failure)
+          # re-runs this job; PyPI filenames are immutable, so a duplicate
+          # upload otherwise fails the whole run with "400 File already
+          # exists" even though nothing is wrong. skip-existing makes tag
+          # re-pushes idempotent while still failing on genuine errors.
+          skip-existing: true
 
       - name: Create summary
         env:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -134,3 +134,9 @@ jobs:
         with:
           packages-dir: python-package/dist/
           verbose: true
+          # A re-pushed tag (e.g. re-cut release after a goreleaser failure)
+          # re-runs this job; PyPI filenames are immutable, so a duplicate
+          # upload otherwise fails the whole run with "400 File already
+          # exists" even though nothing is wrong. skip-existing makes tag
+          # re-pushes idempotent while still failing on genuine errors.
+          skip-existing: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -132,6 +132,14 @@ release:
 # Users install with:
 #   brew tap awslabs/ferret-scan https://github.com/awslabs/ferret-scan
 #   brew install awslabs/ferret-scan/ferret-scan
+#
+# NOTE: `brews` is deprecated in goreleaser v2 in favor of `homebrew_casks`,
+# but casks are macOS-ONLY and this tap deliberately serves Linux (linuxbrew)
+# users too — the README advertises "Homebrew (macOS/Linux)". Migrating would
+# silently drop Linux support. `brews` remains functional for all of v2 (CI
+# pins "~> v2" and runs --skip=validate, so the deprecation warning cannot
+# fail a release). Revisit only when planning the goreleaser v3 upgrade:
+# https://goreleaser.com/deprecations#brews
 brews:
   - name: ferret-scan
     # ids filters by ARCHIVE id, not build id ("binaries" wraps the
@@ -153,8 +161,11 @@ brews:
     description: "Find and redact sensitive data before it leaks — PII, secrets, credit cards, metadata"
     license: "Apache-2.0"
     skip_upload: auto
-    install: |
-      bin.install "ferret-scan"
+    # No custom install block: with binary-format archives the downloaded
+    # file is named by archives.name_template (ferret-scan_2.1.0_darwin_arm64),
+    # NOT "ferret-scan". goreleaser's generated default install renames it
+    # (bin.install "<asset>" => "ferret-scan"); the previous hand-written
+    # `bin.install "ferret-scan"` hit Errno::ENOENT on every brew install.
     test: |
       assert_match version.to_s, shell_output("#{bin}/ferret-scan --version")
       (testpath / "test.txt").write "card 5500-0000-0000-0004\n"

--- a/HomebrewFormula/ferret-scan.rb
+++ b/HomebrewFormula/ferret-scan.rb
@@ -14,7 +14,7 @@ class FerretScan < Formula
       sha256 "68b49d8a943ec307077da105bf71641f9ead124ece910c3081fb629710428df1"
 
       define_method(:install) do
-        bin.install "ferret-scan"
+        bin.install "ferret-scan_2.1.0_darwin_amd64" => "ferret-scan"
       end
     end
     if Hardware::CPU.arm?
@@ -22,7 +22,7 @@ class FerretScan < Formula
       sha256 "0aa3929320509aad5aab69d5fa193469964e0fa1b60008b7a0016ab20bfd9574"
 
       define_method(:install) do
-        bin.install "ferret-scan"
+        bin.install "ferret-scan_2.1.0_darwin_arm64" => "ferret-scan"
       end
     end
   end
@@ -32,14 +32,14 @@ class FerretScan < Formula
       url "https://github.com/awslabs/ferret-scan/releases/download/v2.1.0/ferret-scan_2.1.0_linux_amd64"
       sha256 "2ed3afeaea014fe3f1fb4c0d4d77033f6c6e0e6b8260c01eb8e91e948621c241"
       define_method(:install) do
-        bin.install "ferret-scan"
+        bin.install "ferret-scan_2.1.0_linux_amd64" => "ferret-scan"
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
       url "https://github.com/awslabs/ferret-scan/releases/download/v2.1.0/ferret-scan_2.1.0_linux_arm64"
       sha256 "177694468f6ab903840edf7a46247cb1bbeda448f5ad0e492ce8c3f7ab337e01"
       define_method(:install) do
-        bin.install "ferret-scan"
+        bin.install "ferret-scan_2.1.0_linux_arm64" => "ferret-scan"
       end
     end
   end


### PR DESCRIPTION
Three fixes from the v2.1.0 release shakeout:

## 1. Homebrew formula is currently uninstallable (user-reported)
\`\`\`
==> Upgrading awslabs/ferret-scan/ferret-scan 2.0.2 -> 2.1.0
Error: Errno::ENOENT: No such file or directory - ferret-scan
\`\`\`
With **binary-format archives**, the asset brew downloads is named by `archives.name_template` (`ferret-scan_2.1.0_darwin_arm64`) — but our custom `install:` block ran `bin.install "ferret-scan"`, a file that doesn't exist in the staging dir. Fix: drop the custom block so goreleaser emits its default **rename** form (`bin.install "<asset>" => "ferret-scan"`, verified via snapshot dry-run), **and** hand-fix the committed v2.1.0 formula identically so `brew upgrade` works the moment this merges — no waiting for the next release tag.

## 2. PyPI publish now idempotent (`skip-existing: true`, all 3 publish steps)
The re-pushed v2.1.0 tag re-ran the publish job; PyPI filenames are immutable, so the duplicate upload failed the run with `400 File already exists` despite nothing being wrong (run 29868997919). Tag re-pushes no longer produce false-alarm red X's; genuine errors still fail.

## 3. `brews` deprecation: documented as deliberate, not migrated
The suggested `homebrew_casks` replacement is **macOS-only**; this tap deliberately serves linuxbrew users (README advertises "Homebrew (macOS/Linux)"). Migrating would silently drop Linux support. `brews` remains functional throughout goreleaser v2 (CI pins `~> v2`); revisit at v3. Rationale is now a comment in the config so the warning doesn't tempt a well-meaning migration later.