### PR TITLE
ci: brew formula smoke tests — PR-time and release-time

### DIFF
--- a/.github/workflows/brew-smoke.yml
+++ b/.github/workflows/brew-smoke.yml
@@ -1,0 +1,76 @@
+# Smoke test for the committed Homebrew formula (HomebrewFormula/ferret-scan.rb).
+#
+# Why this exists: the v2.1.0 formula shipped broken (Errno::ENOENT — the
+# install block referenced a filename that doesn't exist in binary archives,
+# fixed in PR #161) because the brew install path was never exercised in CI.
+#
+# What this tests: the formula as committed on this ref, which pins the
+# PREVIOUS release's download URLs and sha256s. That still catches the whole
+# class of install-block bugs (bad rename, bad URL, bad checksum, Ruby syntax)
+# before they are baked into .goreleaser.yml's brews template for the next
+# release. The freshly generated formula for a NEW release is smoke-tested by
+# the brew-smoke job in release.yml.
+#
+# Note on triggers: goreleaser's bot commits the regenerated formula to main
+# with the workflow-provided GITHUB_TOKEN, and GITHUB_TOKEN-authored pushes do
+# NOT trigger push workflows — so the push trigger below only fires on
+# human-authored formula changes. Release-time coverage lives in release.yml.
+
+name: Brew Formula Smoke Test
+
+on:
+  pull_request:
+    branches: [main, master]
+    paths:
+      - "HomebrewFormula/**"
+      - ".goreleaser.yml"
+      - ".github/workflows/brew-smoke.yml"
+  push:
+    branches: [main, master]
+    paths:
+      - "HomebrewFormula/**"
+      - ".github/workflows/brew-smoke.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  brew-smoke:
+    name: brew install + smoke (macos)
+    runs-on: macos-latest
+    timeout-minutes: 15
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+      HOMEBREW_NO_INSTALL_CLEANUP: "1"
+      HOMEBREW_NO_ENV_HINTS: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install formula from a throwaway local tap
+        # Modern Homebrew rejects `brew install --formula ./file.rb`
+        # ("Homebrew requires formulae to be in a tap"), so stage the formula
+        # in a local tap first. `--no-git` keeps tap-new offline and avoids
+        # needing a git identity on the runner.
+        run: |
+          set -euo pipefail
+          brew tap-new local/smoke --no-git
+          cp HomebrewFormula/ferret-scan.rb "$(brew --repository local/smoke)/Formula/"
+          brew install local/smoke/ferret-scan
+
+      - name: Run formula test block
+        run: brew test local/smoke/ferret-scan
+
+      - name: Smoke test installed binary
+        run: |
+          set -euo pipefail
+          ferret-scan --version
+          ferret-scan --version | grep -E '^ferret-scan [0-9]+\.[0-9]+\.[0-9]+'
+          out="$(echo "card 5500-0000-0000-0004" | ferret-scan --stdin 2>&1)" || {
+            echo "$out"
+            echo "ferret-scan --stdin exited non-zero" >&2
+            exit 1
+          }
+          echo "$out"
+          echo "$out" | grep -i creditcard

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Upload generated Homebrew formula
+        # Hands the freshly generated formula to the brew-smoke job below.
+        # goreleaser writes it under dist/homebrew/ even when skip_upload
+        # (prerelease) prevents committing it to main, so prereleases get
+        # smoke-tested too.
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: homebrew-formula
+          # goreleaser layout under dist/homebrew/ varies by version
+          # (flat vs Formula/ subdir); upload the whole directory and let
+          # the smoke job locate ferret-scan.rb with find.
+          path: dist/homebrew/
+          if-no-files-found: error
+          retention-days: 7
+
 
 
       - name: Run GoReleaser (Snapshot)
@@ -85,3 +101,61 @@ jobs:
           name: snapshot-binaries
           path: dist/*
           retention-days: 7
+
+  # Smoke test the formula goreleaser JUST generated, against the release
+  # assets it JUST uploaded. This is the check that would have caught the
+  # v2.1.0 Errno::ENOENT install-block bug (PR #161) before users hit it.
+  # Runs after the release exists so the formula's download URLs resolve.
+  # If it fails, the release is already published — treat a red brew-smoke
+  # as "pull the formula/fix forward immediately", not as a gate.
+  brew-smoke:
+    name: brew install + smoke (macos)
+    needs: goreleaser
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: macos-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+      HOMEBREW_NO_INSTALL_CLEANUP: "1"
+      HOMEBREW_NO_ENV_HINTS: "1"
+    steps:
+      - name: Download generated Homebrew formula
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: homebrew-formula
+          path: formula-artifact
+
+      - name: Install formula from a throwaway local tap
+        # Modern Homebrew rejects installing a bare .rb path ("Homebrew
+        # requires formulae to be in a tap"), so stage the generated formula
+        # in a local tap. `--no-git` keeps tap-new offline and avoids
+        # needing a git identity on the runner.
+        run: |
+          set -euo pipefail
+          formula="$(find formula-artifact -name 'ferret-scan.rb' -print -quit)"
+          if [ -z "$formula" ]; then
+            echo "generated formula not found in artifact" >&2
+            find formula-artifact -type f >&2
+            exit 1
+          fi
+          brew tap-new local/smoke --no-git
+          cp "$formula" "$(brew --repository local/smoke)/Formula/"
+          brew install local/smoke/ferret-scan
+
+      - name: Run formula test block
+        run: brew test local/smoke/ferret-scan
+
+      - name: Smoke test installed binary
+        run: |
+          set -euo pipefail
+          ferret-scan --version
+          ferret-scan --version | grep -E '^ferret-scan [0-9]+\.[0-9]+\.[0-9]+'
+          out="$(echo "card 5500-0000-0000-0004" | ferret-scan --stdin 2>&1)" || {
+            echo "$out"
+            echo "ferret-scan --stdin exited non-zero" >&2
+            exit 1
+          }
+          echo "$out"
+          echo "$out" | grep -i creditcard


### PR DESCRIPTION
Closes the loop on the v2.1.0 formula breakage (#161): the brew install path was the only distribution channel never exercised in CI, which is why `Errno::ENOENT` shipped to users. Two complementary checks:

## A. PR-time (`brew-smoke.yml`, new)
- macos-latest; installs the **committed** formula via a throwaway local tap, runs the formula's own `brew test` block, then `--version` + a stdin credit-card scan
- Paths-filtered to `HomebrewFormula/**` / `.goreleaser.yml` — near-zero cost on normal PRs
- Tests against the *previous* release's assets (documented in the header) — still catches the whole install-block bug class (bad rename, bad URL, bad checksum, Ruby syntax) before it's templated into the next release

## B. Release-time (`release.yml`, additions)
- goreleaser job uploads `dist/homebrew/` as an artifact; a new `brew-smoke` job (needs: goreleaser, tag refs only) installs the **freshly generated** formula against the **just-uploaded** assets — the exact check that would have caught v2.1.0 before any user did
- Covers prereleases too (`skip_upload: auto` means those never take the push-to-main path)

## Notable implementation findings
- Modern Homebrew **rejects** `brew install --formula ./file.rb` ("requires formulae to be in a tap") — both jobs stage via `brew tap-new local/smoke --no-git`. Verified end-to-end locally against the real v2.1.0 formula and release assets.
- A push-to-main-triggered workflow would **silently never fire** for the goreleaser bot's formula commits (GITHUB_TOKEN-authored pushes don't trigger push workflows) — hence the in-release.yml wiring; the push trigger remains only for human formula edits, with a comment explaining this.
- actionlint clean; actions SHA-pinned per repo convention; minimal permissions blocks.