### PR TITLE
fix(scan): UTF-8-aware text sniff — non-ASCII text files were silently skipped in file mode

### DIFF
--- a/internal/preprocessors/plaintext_preprocessor.go
+++ b/internal/preprocessors/plaintext_preprocessor.go
@@ -250,17 +250,63 @@ func (ptp *PlainTextPreprocessor) isTextFile(filePath string) bool {
 		}
 	}
 
-	// Count printable characters
+	return LooksLikeText(buffer)
+}
+
+// LooksLikeText reports whether buf (a null-free prefix of the file) is text.
+// Exported because the FileRouter maintains a second sniff site (isTextFile in
+// internal/router) that must apply identical semantics — the two copies of the
+// old byte-ratio heuristic drifted into the same UTF-8 bug independently.
+//
+// UTF-8 first: every byte of a multi-byte UTF-8 sequence is >= 0x80, so the
+// old ASCII-printable ratio counted EVERY non-ASCII character against the
+// file. A short line with a ™ (3 bytes) or an em-dash, a name with accents,
+// or any non-Latin-script document fell below the 95% bar and the file was
+// silently skipped as "binary" — a recall hole across ALL validators in file
+// mode (stdin mode never sniffs, which is how the gap hid). Genuinely binary
+// data essentially never forms long runs of valid UTF-8, so utf8.Valid is
+// both the safer and the stricter signal; the ASCII-ratio heuristic remains
+// only as the fallback for legacy single-byte encodings (Latin-1 etc.),
+// which are not valid UTF-8 but are still text someone may want scanned.
+func LooksLikeText(buf []byte) bool {
+	if len(buf) == 0 {
+		return false
+	}
+
+	// The 512-byte read may split a multi-byte sequence at the end; trim up
+	// to utf8.UTFMax-1 trailing continuation/start bytes of an incomplete
+	// rune so a truncated final character doesn't fail validation.
+	trimmed := buf
+	for i := 0; i < utf8.UTFMax-1 && len(trimmed) > 0; i++ {
+		if r, _ := utf8.DecodeLastRune(trimmed); r != utf8.RuneError {
+			break
+		}
+		trimmed = trimmed[:len(trimmed)-1]
+	}
+	if len(trimmed) > 0 && utf8.Valid(trimmed) {
+		// Valid UTF-8. Reject only if dominated by control characters
+		// (binary formats that happen to be UTF-8-clean, e.g. some font or
+		// archive headers survive the null-byte check).
+		control := 0
+		total := 0
+		for _, r := range string(trimmed) {
+			total++
+			if r < 32 && r != '\t' && r != '\n' && r != '\r' {
+				control++
+			}
+		}
+		return total > 0 && float64(control)/float64(total) < 0.05
+	}
+
+	// Not valid UTF-8: fall back to the ASCII-printable ratio for legacy
+	// single-byte encodings, with a small allowance for high bytes.
 	printableCount := 0
-	for _, b := range buffer {
-		if (b >= 32 && b <= 126) || b == 9 || b == 10 || b == 13 {
+	for _, b := range buf {
+		if (b >= 32 && b <= 126) || b == 9 || b == 10 || b == 13 || b >= 160 {
 			printableCount++
 		}
 	}
-
-	// Consider it text if more than 95% of characters are printable
-	printableRatio := float64(printableCount) / float64(len(buffer))
-	return printableRatio > 0.95
+	return float64(printableCount)/float64(len(buf)) > 0.95
 }
 
 // countWords counts the number of words in the text

--- a/internal/preprocessors/plaintext_sniff_test.go
+++ b/internal/preprocessors/plaintext_sniff_test.go
@@ -1,0 +1,78 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package preprocessors
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestLooksLikeText locks the UTF-8-aware text sniff. The previous heuristic
+// counted ASCII-printable BYTES (32..126) against a 95% bar, so every byte of
+// a multi-byte UTF-8 character counted as "unprintable": a short line with a
+// ™ or an em-dash, accented names, or any non-Latin-script document was
+// classified binary and the file silently skipped by every validator in file
+// mode (stdin was unaffected, which is how the gap hid).
+func TestLooksLikeText(t *testing.T) {
+	textCases := map[string]string{
+		"plain ascii":              "Contact john.doe@example.com about the contract\n",
+		"trademark symbol short":   "Acme ™ contact john.doe@example.com\n",
+		"em-dash short":            "Contract — contact john.doe@example.com\n",
+		"copyright dense":          strings.Repeat("© 2026 Acme. ", 10),
+		"accented names":           "Renée Müller, José García, François Lefèvre\n",
+		"french prose":             "Le numéro de sécurité sociale de l'employé est confidentiel.\n",
+		"japanese":                 "顧客の個人情報：山田太郎、東京都渋谷区\n",
+		"cyrillic":                 "Персональные данные клиента: Иван Петров\n",
+		"emoji":                    "credit card 5500-0000-0000-0004 \U0001f4b3\n",
+		"curly quotes":             "“confidential” ‘internal’ draft\n",
+		"crlf windows text":        "line one\r\nline two\r\n",
+		"tab separated":            "name\temail\tssn\n",
+		"latin-1 legacy (fallback)": string([]byte{'c', 'a', 'f', 0xe9, ' ', 'm', 'e', 'n', 'u', '\n', 'p', 'r', 'i', 'x', ':', ' ', '5', '0', '\n'}),
+	}
+	for name, content := range textCases {
+		t.Run("text/"+name, func(t *testing.T) {
+			if !LooksLikeText([]byte(content)) {
+				t.Errorf("%s should be classified as text; content=%q", name, content[:min(len(content), 60)])
+			}
+		})
+	}
+
+	binaryCases := map[string][]byte{
+		// PNG header (no null in first 8 bytes; invalid UTF-8)
+		"png header": {0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A, 0xFF, 0xD8, 0xFE, 0x01, 0x02, 0x03, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86},
+		// dense control characters, valid UTF-8 (all < 0x80)
+		"control-char soup": {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x0B, 0x0C, 0x0E, 0x0F, 0x10, 0x11, 'a', 'b'},
+		// random high bytes, invalid UTF-8
+		"random high bytes": {0xFE, 0xFF, 0xC0, 0xC1, 0xF5, 0xF6, 0x80, 0x81, 0xFE, 0xFF, 0xC0, 0xC1, 0xF5, 0xF6, 0x80, 0x81, 0xFE, 0xFF, 0xC0, 0xC1},
+	}
+	for name, content := range binaryCases {
+		t.Run("binary/"+name, func(t *testing.T) {
+			if LooksLikeText(content) {
+				t.Errorf("%s should be classified as binary", name)
+			}
+		})
+	}
+
+	t.Run("split multibyte rune at 512-byte boundary", func(t *testing.T) {
+		// A buffer ending mid-™ (0xE2 0x84 0xA2 truncated to 0xE2 0x84) must
+		// still classify as text — the read window can split a rune.
+		buf := append([]byte(strings.Repeat("legal notice ™ ", 20)), 0xE2, 0x84)
+		if !LooksLikeText(buf) {
+			t.Error("buffer ending in a truncated UTF-8 rune should still be text")
+		}
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		if LooksLikeText(nil) || LooksLikeText([]byte{}) {
+			t.Error("empty buffer is not text")
+		}
+	})
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/router/file_router.go
+++ b/internal/router/file_router.go
@@ -396,16 +396,11 @@ func isTextFile(filePath string) (bool, error) {
 		}
 	}
 
-	// Check printable ratio
-	printableCount := 0
-	for _, b := range buffer {
-		if (b >= 32 && b <= 126) || b == 9 || b == 10 || b == 13 {
-			printableCount++
-		}
-	}
-
-	printableRatio := float64(printableCount) / float64(len(buffer))
-	return printableRatio > 0.95, nil
+	// UTF-8-aware sniff shared with the plaintext preprocessor: the previous
+	// ASCII-byte-ratio copy here silently classified short lines containing
+	// any multi-byte character (™, em-dash, accents, non-Latin scripts) as
+	// binary, skipping the file for every validator in file mode.
+	return preprocessors.LooksLikeText(buffer), nil
 }
 
 func generateRequestID() string {


### PR DESCRIPTION
## The bug (found while probing IP consolidation edge cases)
Both text-vs-binary sniff sites — the plaintext preprocessor's `isTextFile` and the FileRouter's independent copy — counted **ASCII-printable bytes** (32–126 + tab/CR/LF) against a **95% bar**. Every byte of a multi-byte UTF-8 character is ≥ 0x80, so each non-ASCII character counted fully against the file.

Result: a short line containing a `™` (3 bytes), an em-dash, accented names, or **any non-Latin-script content** was classified *binary* and the file **silently skipped by every validator in file mode** — no warning, nothing even at `--confidence all`.

Why it stayed hidden: stdin mode never sniffs (so gateway/pipe usage always worked), and long ASCII-dominated lines dilute the ratio (so typical English documents worked). The gap was precisely: smallish files with modest non-ASCII density — i.e., **real-world PII documents**: names with accents, French/German/Japanese text, curly-quoted prose.

## Verified before → after (file mode, EMAIL/SSN/IP checks)
| Content | before | after |
|---|---|---|
| `Acme ™ contact john.doe@example.com` | **0 findings** | 1 (EMAIL) |
| `Contract — contact john.doe@example.com` | **0** | 1 (EMAIL) |
| Copyright + ™ legal notice | **0** | 1 (IP, conf 99) |
| French prose + SSN | **0** | 1 (SSN) |
| Japanese + email | **0** | 1 (EMAIL) |
| PNG bytes as `.txt` (control) | 0 | 0 ✓ |

## The fix
One shared `preprocessors.LooksLikeText`, both call sites delegating (the two copies had drifted into the same bug independently):
- **Valid UTF-8 ⇒ text** (genuinely binary data essentially never forms valid UTF-8), with tolerance for a multi-byte rune truncated at the 512-byte read window, unless >5% control characters (catches UTF-8-clean binary headers)
- **Non-UTF-8 ⇒ legacy fallback**: the printable-ratio test retained for single-byte encodings (Latin-1 café menus still scan), with high-byte allowance

## Verification
- 19 unit subtests: 13 text shapes (incl. Japanese, Cyrillic, emoji, curly quotes, Latin-1 fallback, split-rune boundary), 3 binary shapes, edge cases
- Golden corpus: zero snapshot changes; full `go test ./...` green
- Recall-only change: strictly widens what gets scanned; binary exclusion intact