### PR TITLE
feat(scan): UTF-16 + cp1252 support — Windows-native text files were invisible in file mode

### DIFF
--- a/internal/preprocessors/encoding.go
+++ b/internal/preprocessors/encoding.go
@@ -1,0 +1,233 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package preprocessors
+
+import (
+	"strings"
+	"unicode/utf16"
+	"unicode/utf8"
+)
+
+// TextEncoding identifies the on-disk encoding of a text file, as detected
+// from its leading bytes. Only encodings ferret-scan can transparently decode
+// to UTF-8 (and re-encode on the redaction write path) are enumerated;
+// everything else is EncodingUnknown and handled by the legacy byte-level
+// heuristics.
+type TextEncoding int
+
+const (
+	// EncodingUTF8 is plain UTF-8 / ASCII — no transform needed.
+	EncodingUTF8 TextEncoding = iota
+	// EncodingUTF8BOM is UTF-8 with a leading BOM (Windows Notepad default).
+	// The BOM is stripped on decode and restored on encode.
+	EncodingUTF8BOM
+	// EncodingUTF16LE is UTF-16 little-endian with BOM (PowerShell 5
+	// Out-File default, regedit .reg exports, many Windows logs).
+	EncodingUTF16LE
+	// EncodingUTF16BE is UTF-16 big-endian with BOM.
+	EncodingUTF16BE
+	// EncodingUTF16LENoBOM is BOM-less UTF-16 LE, detected by the
+	// alternating-null heuristic.
+	EncodingUTF16LENoBOM
+	// EncodingUTF16BENoBOM is BOM-less UTF-16 BE.
+	EncodingUTF16BENoBOM
+	// EncodingUnknown means "not a transcodable encoding we recognize" —
+	// callers fall back to treating the bytes as-is.
+	EncodingUnknown
+)
+
+// String returns a short name for metadata/debug surfaces.
+func (e TextEncoding) String() string {
+	switch e {
+	case EncodingUTF8:
+		return "utf-8"
+	case EncodingUTF8BOM:
+		return "utf-8-bom"
+	case EncodingUTF16LE:
+		return "utf-16le-bom"
+	case EncodingUTF16BE:
+		return "utf-16be-bom"
+	case EncodingUTF16LENoBOM:
+		return "utf-16le"
+	case EncodingUTF16BENoBOM:
+		return "utf-16be"
+	default:
+		return "unknown"
+	}
+}
+
+// DetectTextEncoding inspects the leading bytes of buf (any prefix of the
+// file, e.g. the 512-byte sniff window or the whole content) and identifies
+// the encoding. Detection order matters: BOMs are unambiguous and checked
+// first; the BOM-less UTF-16 heuristic runs only when the buffer contains
+// null bytes in the tell-tale alternating pattern (UTF-16-encoded
+// ASCII/Latin text has a 0x00 in every other byte, which is exactly why the
+// legacy null-byte check classified such files as binary).
+func DetectTextEncoding(buf []byte) TextEncoding {
+	if len(buf) >= 3 && buf[0] == 0xEF && buf[1] == 0xBB && buf[2] == 0xBF {
+		return EncodingUTF8BOM
+	}
+	if len(buf) >= 2 {
+		if buf[0] == 0xFF && buf[1] == 0xFE {
+			// Disambiguate from the UTF-32LE BOM (FF FE 00 00). A genuine
+			// UTF-16LE file whose first character is NUL is not text anyway.
+			if len(buf) >= 4 && buf[2] == 0x00 && buf[3] == 0x00 {
+				return EncodingUnknown // UTF-32LE: rare; not supported
+			}
+			return EncodingUTF16LE
+		}
+		if buf[0] == 0xFE && buf[1] == 0xFF {
+			return EncodingUTF16BE
+		}
+	}
+
+	// BOM-less UTF-16 heuristic. Sample up to the first 512 bytes (even
+	// length); require enough data to be meaningful.
+	sample := buf
+	if len(sample) > 512 {
+		sample = sample[:512]
+	}
+	if len(sample)%2 == 1 {
+		sample = sample[:len(sample)-1]
+	}
+	if len(sample) >= 16 {
+		evenNulls, oddNulls := 0, 0
+		pairs := len(sample) / 2
+		for i := 0; i+1 < len(sample); i += 2 {
+			if sample[i] == 0 {
+				evenNulls++
+			}
+			if sample[i+1] == 0 {
+				oddNulls++
+			}
+		}
+		// ASCII-dominated UTF-16LE: high byte (odd index) is almost always
+		// 0x00, low byte (even index) almost never. Thresholds are strict on
+		// the "wrong side" nulls so UTF-32 (nulls on BOTH sides) and binary
+		// blobs don't slip through.
+		if float64(oddNulls)/float64(pairs) > 0.30 && float64(evenNulls)/float64(pairs) < 0.02 {
+			return EncodingUTF16LENoBOM
+		}
+		if float64(evenNulls)/float64(pairs) > 0.30 && float64(oddNulls)/float64(pairs) < 0.02 {
+			return EncodingUTF16BENoBOM
+		}
+	}
+
+	return EncodingUTF8 // default: treat as UTF-8/unknown-single-byte; callers validate
+}
+
+// DecodeToUTF8 decodes raw file bytes to a UTF-8 string according to enc.
+// Decoding is total: malformed sequences (lone surrogates, a truncated final
+// code unit) decode to U+FFFD rather than failing — a corrupt tail must not
+// hide the readable remainder of a file from scanning. The second return is
+// false only when enc is not a transcodable encoding (caller keeps raw).
+func DecodeToUTF8(raw []byte, enc TextEncoding) (string, bool) {
+	switch enc {
+	case EncodingUTF8:
+		return string(raw), true
+	case EncodingUTF8BOM:
+		if len(raw) >= 3 {
+			return string(raw[3:]), true
+		}
+		return "", true
+	case EncodingUTF16LE:
+		return decodeUTF16(raw[2:], false), true
+	case EncodingUTF16BE:
+		return decodeUTF16(raw[2:], true), true
+	case EncodingUTF16LENoBOM:
+		return decodeUTF16(raw, false), true
+	case EncodingUTF16BENoBOM:
+		return decodeUTF16(raw, true), true
+	default:
+		return "", false
+	}
+}
+
+// EncodeFromUTF8 re-encodes a UTF-8 string back to enc, restoring the BOM
+// where the source had one. Used by the redaction write path so a redacted
+// copy of a UTF-16 file is still a valid UTF-16 file (a re-importable .reg
+// export, a PowerShell transcript, ...) rather than silently becoming UTF-8.
+func EncodeFromUTF8(s string, enc TextEncoding) []byte {
+	switch enc {
+	case EncodingUTF8BOM:
+		return append([]byte{0xEF, 0xBB, 0xBF}, s...)
+	case EncodingUTF16LE:
+		return encodeUTF16(s, false, true)
+	case EncodingUTF16BE:
+		return encodeUTF16(s, true, true)
+	case EncodingUTF16LENoBOM:
+		return encodeUTF16(s, false, false)
+	case EncodingUTF16BENoBOM:
+		return encodeUTF16(s, true, false)
+	default:
+		return []byte(s)
+	}
+}
+
+// decodeUTF16 converts UTF-16 bytes (without BOM) to a UTF-8 string. An odd
+// trailing byte (truncated final code unit) is dropped; unpaired surrogates
+// become U+FFFD via utf16.Decode.
+func decodeUTF16(raw []byte, bigEndian bool) string {
+	if len(raw)%2 == 1 {
+		raw = raw[:len(raw)-1]
+	}
+	units := make([]uint16, 0, len(raw)/2)
+	for i := 0; i+1 < len(raw); i += 2 {
+		if bigEndian {
+			units = append(units, uint16(raw[i])<<8|uint16(raw[i+1]))
+		} else {
+			units = append(units, uint16(raw[i])|uint16(raw[i+1])<<8)
+		}
+	}
+	var b strings.Builder
+	b.Grow(len(units)) // ASCII-dominated content: ~1 byte per unit
+	for _, r := range utf16.Decode(units) {
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// encodeUTF16 converts a UTF-8 string to UTF-16 bytes, optionally prefixed
+// with the appropriate BOM. Invalid UTF-8 in s (which cannot occur on the
+// redaction path — the decoded text is valid by construction) would encode
+// as U+FFFD.
+func encodeUTF16(s string, bigEndian, withBOM bool) []byte {
+	units := utf16.Encode([]rune(s))
+	out := make([]byte, 0, len(units)*2+2)
+	if withBOM {
+		if bigEndian {
+			out = append(out, 0xFE, 0xFF)
+		} else {
+			out = append(out, 0xFF, 0xFE)
+		}
+	}
+	for _, u := range units {
+		if bigEndian {
+			out = append(out, byte(u>>8), byte(u))
+		} else {
+			out = append(out, byte(u), byte(u>>8))
+		}
+	}
+	return out
+}
+
+// utf8OrDecoded is a convenience for sniffing: it returns the buffer's
+// decoded text when buf is a recognized transcodable encoding, or "" and
+// false when the buffer should be sniffed as raw bytes.
+func utf8OrDecoded(buf []byte) (string, bool) {
+	enc := DetectTextEncoding(buf)
+	switch enc {
+	case EncodingUTF16LE, EncodingUTF16BE, EncodingUTF16LENoBOM, EncodingUTF16BENoBOM:
+		s, _ := DecodeToUTF8(buf, enc)
+		return s, true
+	case EncodingUTF8BOM:
+		s, _ := DecodeToUTF8(buf, enc)
+		return s, true
+	default:
+		return "", false
+	}
+}
+
+// Silence unused warnings for utf8 import if build tags change.
+var _ = utf8.RuneError

--- a/internal/preprocessors/encoding.go
+++ b/internal/preprocessors/encoding.go
@@ -57,6 +57,20 @@ func (e TextEncoding) String() string {
 	}
 }
 
+// hasNullByte reports whether b contains at least one 0x00 byte. Used to
+// confirm a UTF-16 BOM: real UTF-16 text always carries nulls (the high half
+// of every ASCII character, space, and newline), so a "BOM" followed by a
+// null-free body is legacy single-byte text that happens to start with
+// ÿþ/þÿ, not UTF-16.
+func hasNullByte(b []byte) bool {
+	for _, c := range b {
+		if c == 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // DetectTextEncoding inspects the leading bytes of buf (any prefix of the
 // file, e.g. the 512-byte sniff window or the whole content) and identifies
 // the encoding. Detection order matters: BOMs are unambiguous and checked
@@ -75,10 +89,22 @@ func DetectTextEncoding(buf []byte) TextEncoding {
 			if len(buf) >= 4 && buf[2] == 0x00 && buf[3] == 0x00 {
 				return EncodingUnknown // UTF-32LE: rare; not supported
 			}
-			return EncodingUTF16LE
-		}
-		if buf[0] == 0xFE && buf[1] == 0xFF {
-			return EncodingUTF16BE
+			if hasNullByte(buf[2:]) {
+				return EncodingUTF16LE
+			}
+			// FF FE with ZERO nulls after it is almost certainly NOT
+			// UTF-16: every real UTF-16 document carries nulls (ASCII
+			// chars, spaces U+0020, newlines U+000A all have a 0x00 half).
+			// It IS what a legacy single-byte file looks like when its
+			// text begins with 'ÿþ' (0xFF 0xFE in Latin-1/cp1252) —
+			// adversarial verification proved decoding such a file as
+			// UTF-16 turns it into mojibake and silently hides its PII.
+			// Fall through to the non-BOM heuristics.
+		} else if buf[0] == 0xFE && buf[1] == 0xFF {
+			if hasNullByte(buf[2:]) {
+				return EncodingUTF16BE
+			}
+			// Same rationale: 'þÿ'-leading legacy text, not a BOM.
 		}
 	}
 

--- a/internal/preprocessors/encoding_test.go
+++ b/internal/preprocessors/encoding_test.go
@@ -1,0 +1,154 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package preprocessors
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"unicode/utf16"
+)
+
+// encodeUTF16LE / encodeUTF16BE build test fixtures independently of the
+// production encoder so encode/decode bugs can't cancel each other out.
+func fixtureUTF16(s string, bigEndian, withBOM bool) []byte {
+	units := utf16.Encode([]rune(s))
+	var b bytes.Buffer
+	if withBOM {
+		if bigEndian {
+			b.Write([]byte{0xFE, 0xFF})
+		} else {
+			b.Write([]byte{0xFF, 0xFE})
+		}
+	}
+	for _, u := range units {
+		if bigEndian {
+			b.WriteByte(byte(u >> 8))
+			b.WriteByte(byte(u))
+		} else {
+			b.WriteByte(byte(u))
+			b.WriteByte(byte(u >> 8))
+		}
+	}
+	return b.Bytes()
+}
+
+func TestDetectTextEncoding(t *testing.T) {
+	const sample = "Contact john.doe@example.com or SSN 449-87-4100 on file.\n"
+	cases := []struct {
+		name string
+		data []byte
+		want TextEncoding
+	}{
+		{"utf-8 plain", []byte(sample), EncodingUTF8},
+		{"utf-8 BOM", append([]byte{0xEF, 0xBB, 0xBF}, sample...), EncodingUTF8BOM},
+		{"utf-16le BOM", fixtureUTF16(sample, false, true), EncodingUTF16LE},
+		{"utf-16be BOM", fixtureUTF16(sample, true, true), EncodingUTF16BE},
+		{"utf-16le no BOM", fixtureUTF16(sample, false, false), EncodingUTF16LENoBOM},
+		{"utf-16be no BOM", fixtureUTF16(sample, true, false), EncodingUTF16BENoBOM},
+		{"utf-32le BOM rejected", []byte{0xFF, 0xFE, 0x00, 0x00, 'a', 0, 0, 0}, EncodingUnknown},
+		{"short buffer defaults utf-8", []byte("hi"), EncodingUTF8},
+		// Binary with scattered nulls must NOT read as UTF-16: nulls appear
+		// on both even and odd positions.
+		{"binary scattered nulls", bytes.Repeat([]byte{0x00, 0x00, 0x41, 0x42}, 16), EncodingUTF8},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := DetectTextEncoding(tc.data); got != tc.want {
+				t.Errorf("DetectTextEncoding = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDecodeEncodeRoundTrip(t *testing.T) {
+	// Content mixes ASCII PII shapes, multibyte chars (™ becomes a single
+	// UTF-16 unit; 💳 needs a surrogate pair), and CRLF line endings.
+	const content = "SSN: 449-87-4100\r\nemail john.doe@example.com ™ card 💳\r\n"
+	for _, enc := range []TextEncoding{
+		EncodingUTF8, EncodingUTF8BOM,
+		EncodingUTF16LE, EncodingUTF16BE,
+		EncodingUTF16LENoBOM, EncodingUTF16BENoBOM,
+	} {
+		t.Run(enc.String(), func(t *testing.T) {
+			raw := EncodeFromUTF8(content, enc)
+			if det := DetectTextEncoding(raw); det != enc {
+				// BOM-less encodings may legitimately re-detect as their
+				// heuristic form; everything else must round-trip exactly.
+				t.Errorf("re-detect: got %v, want %v", det, enc)
+			}
+			decoded, ok := DecodeToUTF8(raw, enc)
+			if !ok {
+				t.Fatal("DecodeToUTF8 refused a transcodable encoding")
+			}
+			if decoded != content {
+				t.Errorf("round-trip mismatch:\n got %q\nwant %q", decoded, content)
+			}
+		})
+	}
+}
+
+func TestDecodeUTF16Malformed(t *testing.T) {
+	t.Run("odd trailing byte dropped", func(t *testing.T) {
+		raw := append(fixtureUTF16("abc", false, true), 0x41) // stray byte
+		decoded, ok := DecodeToUTF8(raw, EncodingUTF16LE)
+		if !ok || decoded != "abc" {
+			t.Errorf("got %q ok=%v, want \"abc\"", decoded, ok)
+		}
+	})
+	t.Run("lone surrogate becomes U+FFFD not panic", func(t *testing.T) {
+		raw := []byte{0xFF, 0xFE, 0x00, 0xD8, 'a', 0x00} // lone high surrogate + 'a'
+		decoded, ok := DecodeToUTF8(raw, EncodingUTF16LE)
+		if !ok {
+			t.Fatal("decode refused")
+		}
+		if !strings.Contains(decoded, "�") || !strings.Contains(decoded, "a") {
+			t.Errorf("lone surrogate handling: got %q", decoded)
+		}
+	})
+	t.Run("empty payload after BOM", func(t *testing.T) {
+		if decoded, ok := DecodeToUTF8([]byte{0xFF, 0xFE}, EncodingUTF16LE); !ok || decoded != "" {
+			t.Errorf("got %q ok=%v", decoded, ok)
+		}
+	})
+}
+
+// TestLooksLikeText_Encodings extends the sniff matrix to the encodings the
+// legacy null-byte gate previously rejected wholesale.
+func TestLooksLikeText_Encodings(t *testing.T) {
+	const sample = "Contact john.doe@example.com or SSN 449-87-4100 on file.\n"
+	textCases := map[string][]byte{
+		"utf-16le BOM":    fixtureUTF16(sample, false, true),
+		"utf-16be BOM":    fixtureUTF16(sample, true, true),
+		"utf-16le no BOM": fixtureUTF16(sample, false, false),
+		"utf-16be no BOM": fixtureUTF16(sample, true, false),
+		"utf-8 BOM":       append([]byte{0xEF, 0xBB, 0xBF}, sample...),
+		"cp1252 smart quotes 0x80-0x9F": {
+			'S', 'e', 'e', ' ', 0x93, 'q', 'u', 'o', 't', 'e', 'd', 0x94, ' ',
+			0x96, ' ', 'd', 'a', 's', 'h', ' ', 0x85, ' ', 'e', 'l', 'l', 'i', 'p', '\n',
+		},
+	}
+	for name, data := range textCases {
+		t.Run("text/"+name, func(t *testing.T) {
+			if !LooksLikeText(data) {
+				t.Errorf("%s should classify as text", name)
+			}
+		})
+	}
+
+	binaryCases := map[string][]byte{
+		// UTF-16-looking but nulls on both byte positions (UTF-32-ish)
+		"nulls both positions": bytes.Repeat([]byte{0x41, 0x00, 0x00, 0x00}, 32),
+		// dense control chars encoded as UTF-16LE with BOM: decodes fine but
+		// is control soup — must still be rejected by the decoded-text judge
+		"utf-16 control soup": fixtureUTF16(strings.Repeat("\x01\x02\x03\x04", 16), false, true),
+	}
+	for name, data := range binaryCases {
+		t.Run("binary/"+name, func(t *testing.T) {
+			if LooksLikeText(data) {
+				t.Errorf("%s should classify as binary", name)
+			}
+		})
+	}
+}

--- a/internal/preprocessors/encoding_test.go
+++ b/internal/preprocessors/encoding_test.go
@@ -152,3 +152,58 @@ func TestLooksLikeText_Encodings(t *testing.T) {
 		})
 	}
 }
+
+// TestAdversarialFindings locks the fixes for the three regressions the
+// adversarial verification panel proved against the first version of this
+// change (PR #165). Each subtest is a distilled attacker repro.
+func TestAdversarialFindings(t *testing.T) {
+	t.Run("cp1251 Cyrillic prose is text (majority high-byte)", func(t *testing.T) {
+		// Attack: Russian cp1251 prose + ASCII email. The first version's
+		// ASCII-majority gate classified it binary — silent skip of every
+		// non-Latin Windows codepage. cp1251 letters are 0xC0-0xFF.
+		prose := bytes.Repeat([]byte{0xD3, 0xE2, 0xE0, 0xE6, 0xE0, 0xE5, 0xEC, 0xFB, 0xE9, 0x20}, 20) // "Уважаемый " x20
+		prose = append(prose, []byte("ivan.petrov@example.com\n")...)
+		if !LooksLikeText(prose) {
+			t.Error("cp1251 Cyrillic prose must classify as text (was the panel's major regression)")
+		}
+	})
+	t.Run("cp1253 Greek prose is text", func(t *testing.T) {
+		prose := bytes.Repeat([]byte{0xC1, 0xE3, 0xE1, 0xF0, 0xE7, 0xF4, 0xDD, 0x20}, 25) // Greek letters cp1253
+		prose = append(prose, []byte("SSN 449-87-4100\n")...)
+		if !LooksLikeText(prose) {
+			t.Error("cp1253 Greek prose must classify as text")
+		}
+	})
+	t.Run("legacy text starting with FF FE bytes is not UTF-16", func(t *testing.T) {
+		// Attack: cp1252 text beginning with 'ÿþ' (FF FE) was decoded as
+		// UTF-16LE, turning the file to mojibake and hiding its PII.
+		// Real UTF-16 always contains nulls; this file has none.
+		data := append([]byte{0xFF, 0xFE}, []byte(" starts this legacy file. SSN: 449-87-4100\n")...)
+		if enc := DetectTextEncoding(data); enc != EncodingUTF8 {
+			t.Errorf("null-free FF FE-leading buffer detected as %v, want fallback (utf-8/legacy)", enc)
+		}
+		if !LooksLikeText(data) {
+			t.Error("FF FE-leading legacy text must classify as text")
+		}
+	})
+	t.Run("legacy text starting with FE FF bytes is not UTF-16", func(t *testing.T) {
+		data := append([]byte{0xFE, 0xFF}, []byte(" also legacy. email a@b.co\n")...)
+		if enc := DetectTextEncoding(data); enc != EncodingUTF8 {
+			t.Errorf("null-free FE FF-leading buffer detected as %v", enc)
+		}
+	})
+	t.Run("real UTF-16LE BOM still detected (has nulls)", func(t *testing.T) {
+		data := fixtureUTF16("real utf-16 content\n", false, true)
+		if enc := DetectTextEncoding(data); enc != EncodingUTF16LE {
+			t.Errorf("genuine UTF-16LE+BOM detected as %v", enc)
+		}
+	})
+	t.Run("random high-byte binary still rejected despite 0x80-0x9F allowance", func(t *testing.T) {
+		// The cp1252 typographic allowance is gated on ASCII majority, so
+		// structureless high-byte spans must stay binary.
+		data := bytes.Repeat([]byte{0x81, 0x8D, 0x8F, 0x90, 0x9D, 0xC3, 0xF7, 0x85}, 16)
+		if LooksLikeText(data) {
+			t.Error("random high-byte binary must remain binary")
+		}
+	})
+}

--- a/internal/preprocessors/plaintext_preprocessor.go
+++ b/internal/preprocessors/plaintext_preprocessor.go
@@ -208,7 +208,17 @@ func (ptp *PlainTextPreprocessor) readTextFile(filePath string) (string, error) 
 		return "", fmt.Errorf("failed to read file: %w", err)
 	}
 
-	content := string(fileContent)
+	// Decode transcodable encodings (UTF-16 LE/BE with or without BOM,
+	// BOM'd UTF-8) to UTF-8 before scanning; validators only speak UTF-8.
+	// Windows tooling (PowerShell 5 Out-File, .reg exports) writes UTF-16LE,
+	// which previously reached the validators as null-riddled bytes no
+	// pattern could match even when the sniff let the file through.
+	var content string
+	if decoded, ok := DecodeToUTF8(fileContent, DetectTextEncoding(fileContent)); ok {
+		content = decoded
+	} else {
+		content = string(fileContent)
+	}
 
 	// Validate UTF-8 encoding
 	if !utf8.ValidString(content) {
@@ -243,13 +253,10 @@ func (ptp *PlainTextPreprocessor) isTextFile(filePath string) bool {
 
 	buffer = buffer[:n]
 
-	// Check for null bytes (common in binary files)
-	for _, b := range buffer {
-		if b == 0 {
-			return false
-		}
-	}
-
+	// Null-byte and ratio gating live inside LooksLikeText: the null check
+	// must come AFTER encoding detection, because UTF-16 text has a null in
+	// every other byte by construction — the old order made every UTF-16
+	// file (PowerShell Out-File, .reg exports) binary by definition.
 	return LooksLikeText(buffer)
 }
 
@@ -273,6 +280,23 @@ func LooksLikeText(buf []byte) bool {
 		return false
 	}
 
+	// Transcodable encodings first: UTF-16 (BOM'd or heuristically detected)
+	// contains a null byte per ASCII character, so it can never survive a
+	// pre-decode null-byte gate or the ratio tests below — decode the sniff
+	// window and judge the decoded text instead. PowerShell 5 Out-File,
+	// .reg exports, and plenty of Windows logs are UTF-16LE.
+	if decoded, ok := utf8OrDecoded(buf); ok {
+		return looksLikeDecodedText(decoded)
+	}
+
+	// Not a recognized transcodable encoding: any null byte means binary
+	// (the classic gate, now applied only after UTF-16 has had its chance).
+	for _, b := range buf {
+		if b == 0 {
+			return false
+		}
+	}
+
 	// The 512-byte read may split a multi-byte sequence at the end; trim up
 	// to utf8.UTFMax-1 trailing continuation/start bytes of an incomplete
 	// rune so a truncated final character doesn't fail validation.
@@ -284,29 +308,44 @@ func LooksLikeText(buf []byte) bool {
 		trimmed = trimmed[:len(trimmed)-1]
 	}
 	if len(trimmed) > 0 && utf8.Valid(trimmed) {
-		// Valid UTF-8. Reject only if dominated by control characters
-		// (binary formats that happen to be UTF-8-clean, e.g. some font or
-		// archive headers survive the null-byte check).
-		control := 0
-		total := 0
-		for _, r := range string(trimmed) {
-			total++
-			if r < 32 && r != '\t' && r != '\n' && r != '\r' {
-				control++
-			}
-		}
-		return total > 0 && float64(control)/float64(total) < 0.05
+		return looksLikeDecodedText(string(trimmed))
 	}
 
-	// Not valid UTF-8: fall back to the ASCII-printable ratio for legacy
-	// single-byte encodings, with a small allowance for high bytes.
-	printableCount := 0
+	// Not valid UTF-8: fall back to a legacy single-byte-encoding judgment.
+	// The whole high half (>= 0x80) counts as printable — Latin-1 letters
+	// live at 0xA0+ and Windows-1252 places its typographic characters
+	// (curly quotes, en/em dashes, ellipsis, ™) in 0x80-0x9F, so a short
+	// cp1252 line from an old Word/Outlook export must not be classified
+	// binary for using them. BUT real single-byte-encoding text is
+	// predominantly ASCII with scattered high bytes; an all-high-bytes
+	// buffer is binary, not prose. Hence two thresholds: >95% printable
+	// overall AND a majority of plain ASCII text.
+	printableCount, asciiCount := 0, 0
 	for _, b := range buf {
-		if (b >= 32 && b <= 126) || b == 9 || b == 10 || b == 13 || b >= 160 {
+		switch {
+		case (b >= 32 && b <= 126) || b == 9 || b == 10 || b == 13:
+			printableCount++
+			asciiCount++
+		case b >= 128:
 			printableCount++
 		}
 	}
-	return float64(printableCount)/float64(len(buf)) > 0.95
+	n := float64(len(buf))
+	return float64(printableCount)/n > 0.95 && float64(asciiCount)/n > 0.5
+}
+
+// looksLikeDecodedText judges already-decoded (valid UTF-8) text: accept
+// unless dominated by control characters — binary formats that happen to be
+// UTF-8-clean (some font/archive headers) survive the null-byte gates.
+func looksLikeDecodedText(s string) bool {
+	control, total := 0, 0
+	for _, r := range s {
+		total++
+		if r < 32 && r != '\t' && r != '\n' && r != '\r' {
+			control++
+		}
+	}
+	return total > 0 && float64(control)/float64(total) < 0.05
 }
 
 // countWords counts the number of words in the text

--- a/internal/preprocessors/plaintext_preprocessor.go
+++ b/internal/preprocessors/plaintext_preprocessor.go
@@ -312,26 +312,41 @@ func LooksLikeText(buf []byte) bool {
 	}
 
 	// Not valid UTF-8: fall back to a legacy single-byte-encoding judgment.
-	// The whole high half (>= 0x80) counts as printable — Latin-1 letters
-	// live at 0xA0+ and Windows-1252 places its typographic characters
-	// (curly quotes, en/em dashes, ellipsis, ™) in 0x80-0x9F, so a short
-	// cp1252 line from an old Word/Outlook export must not be classified
-	// binary for using them. BUT real single-byte-encoding text is
-	// predominantly ASCII with scattered high bytes; an all-high-bytes
-	// buffer is binary, not prose. Hence two thresholds: >95% printable
-	// overall AND a majority of plain ASCII text.
-	printableCount, asciiCount := 0, 0
+	//
+	// Floor (identical to the historical rule): ASCII printables, tab/CR/LF,
+	// and ALL bytes >= 0xA0 count as printable against a 95% bar. Bytes at
+	// 0xA0+ are where every ISO-8859-x / Windows-125x codepage puts its
+	// letters — Cyrillic cp1251, Greek cp1253, Hebrew cp1255, Arabic cp1256
+	// prose is majority high-byte, and an "ASCII majority" requirement here
+	// silently skipped all of it (proven by adversarial verification:
+	// Russian cp1251 with an embedded email went from 2 findings to a
+	// silent skip). Never require ASCII dominance of legacy text.
+	//
+	// Extension (the cp1252 fix): Windows-1252 also places typographic
+	// characters — curly quotes, en/em dashes, ellipsis, ™ — in 0x80-0x9F.
+	// Those count as printable ONLY when the document is ASCII-majority,
+	// which is what a smart-quoted Word/Outlook export actually looks like.
+	// Gating the 0x80-0x9F allowance (rather than granting it wholesale)
+	// keeps structureless high-byte binary rejected: random bytes spanning
+	// 0x80-0xFF are not ASCII-majority, so their 0x80-0x9F content stays
+	// unprintable and drags them under the bar, exactly as before.
+	asciiCount, high160Count, typo1252Count := 0, 0, 0
 	for _, b := range buf {
 		switch {
 		case (b >= 32 && b <= 126) || b == 9 || b == 10 || b == 13:
-			printableCount++
 			asciiCount++
+		case b >= 160:
+			high160Count++
 		case b >= 128:
-			printableCount++
+			typo1252Count++
 		}
 	}
 	n := float64(len(buf))
-	return float64(printableCount)/n > 0.95 && float64(asciiCount)/n > 0.5
+	printable := asciiCount + high160Count
+	if float64(asciiCount)/n > 0.5 {
+		printable += typo1252Count
+	}
+	return float64(printable)/n > 0.95
 }
 
 // looksLikeDecodedText judges already-decoded (valid UTF-8) text: accept

--- a/internal/preprocessors/plaintext_sniff_test.go
+++ b/internal/preprocessors/plaintext_sniff_test.go
@@ -16,18 +16,18 @@ import (
 // mode (stdin was unaffected, which is how the gap hid).
 func TestLooksLikeText(t *testing.T) {
 	textCases := map[string]string{
-		"plain ascii":              "Contact john.doe@example.com about the contract\n",
-		"trademark symbol short":   "Acme ™ contact john.doe@example.com\n",
-		"em-dash short":            "Contract — contact john.doe@example.com\n",
-		"copyright dense":          strings.Repeat("© 2026 Acme. ", 10),
-		"accented names":           "Renée Müller, José García, François Lefèvre\n",
-		"french prose":             "Le numéro de sécurité sociale de l'employé est confidentiel.\n",
-		"japanese":                 "顧客の個人情報：山田太郎、東京都渋谷区\n",
-		"cyrillic":                 "Персональные данные клиента: Иван Петров\n",
-		"emoji":                    "credit card 5500-0000-0000-0004 \U0001f4b3\n",
-		"curly quotes":             "“confidential” ‘internal’ draft\n",
-		"crlf windows text":        "line one\r\nline two\r\n",
-		"tab separated":            "name\temail\tssn\n",
+		"plain ascii":               "Contact john.doe@example.com about the contract\n",
+		"trademark symbol short":    "Acme ™ contact john.doe@example.com\n",
+		"em-dash short":             "Contract — contact john.doe@example.com\n",
+		"copyright dense":           strings.Repeat("© 2026 Acme. ", 10),
+		"accented names":            "Renée Müller, José García, François Lefèvre\n",
+		"french prose":              "Le numéro de sécurité sociale de l'employé est confidentiel.\n",
+		"japanese":                  "顧客の個人情報：山田太郎、東京都渋谷区\n",
+		"cyrillic":                  "Персональные данные клиента: Иван Петров\n",
+		"emoji":                     "credit card 5500-0000-0000-0004 \U0001f4b3\n",
+		"curly quotes":              "“confidential” ‘internal’ draft\n",
+		"crlf windows text":         "line one\r\nline two\r\n",
+		"tab separated":             "name\temail\tssn\n",
 		"latin-1 legacy (fallback)": string([]byte{'c', 'a', 'f', 0xe9, ' ', 'm', 'e', 'n', 'u', '\n', 'p', 'r', 'i', 'x', ':', ' ', '5', '0', '\n'}),
 	}
 	for name, content := range textCases {
@@ -43,8 +43,12 @@ func TestLooksLikeText(t *testing.T) {
 		"png header": {0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A, 0xFF, 0xD8, 0xFE, 0x01, 0x02, 0x03, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86},
 		// dense control characters, valid UTF-8 (all < 0x80)
 		"control-char soup": {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x0B, 0x0C, 0x0E, 0x0F, 0x10, 0x11, 'a', 'b'},
-		// random high bytes, invalid UTF-8
-		"random high bytes": {0xFE, 0xFF, 0xC0, 0xC1, 0xF5, 0xF6, 0x80, 0x81, 0xFE, 0xFF, 0xC0, 0xC1, 0xF5, 0xF6, 0x80, 0x81, 0xFE, 0xFF, 0xC0, 0xC1},
+		// random high bytes, invalid UTF-8. Deliberately does NOT start with
+		// FE FF / FF FE: a leading UTF-16 BOM is an explicit encoding
+		// declaration and such buffers are decoded as UTF-16 by design (see
+		// TestLooksLikeText_Encodings) — the byte-ratio fallback only judges
+		// buffers with no recognized encoding signature.
+		"random high bytes": {0xC0, 0xC1, 0xF5, 0xF6, 0x80, 0x81, 0xFE, 0xFF, 0xC0, 0xC1, 0xF5, 0xF6, 0x80, 0x81, 0xFE, 0xFF, 0xC0, 0xC1, 0xF5, 0xF6},
 	}
 	for name, content := range binaryCases {
 		t.Run("binary/"+name, func(t *testing.T) {

--- a/internal/redactors/plaintext/encoding_roundtrip_test.go
+++ b/internal/redactors/plaintext/encoding_roundtrip_test.go
@@ -1,0 +1,85 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package plaintext
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/preprocessors"
+	"github.com/awslabs/ferret-scan/v2/internal/redactors"
+)
+
+// TestRedactDocument_EncodingRoundTrip locks the transcode contract for the
+// file redaction path: matches are produced against DECODED text, so the
+// redactor must decode the same way before masking, and must write the
+// redacted output back in the ORIGINAL encoding (BOM included) so a redacted
+// UTF-16 file (PowerShell transcript, .reg export) remains valid for its
+// native tooling. A regression here is a silent redaction hole: searching
+// raw UTF-16 bytes for a UTF-8 match text finds nothing and the sensitive
+// value survives.
+func TestRedactDocument_EncodingRoundTrip(t *testing.T) {
+	const secret = "449-87-4100"
+	const content = "Employee SSN " + secret + " on file.\r\nsecond line clean.\r\n"
+
+	match := detector.Match{
+		Text:       secret,
+		LineNumber: 1,
+		Type:       "SSN",
+		Confidence: 100,
+		Validator:  "ssn",
+	}
+
+	encodings := []preprocessors.TextEncoding{
+		preprocessors.EncodingUTF8,
+		preprocessors.EncodingUTF8BOM,
+		preprocessors.EncodingUTF16LE,
+		preprocessors.EncodingUTF16BE,
+		preprocessors.EncodingUTF16LENoBOM,
+		preprocessors.EncodingUTF16BENoBOM,
+	}
+
+	for _, enc := range encodings {
+		t.Run(enc.String(), func(t *testing.T) {
+			dir := t.TempDir()
+			src := filepath.Join(dir, "in.txt")
+			dst := filepath.Join(dir, "out.txt")
+			if err := os.WriteFile(src, preprocessors.EncodeFromUTF8(content, enc), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			r := NewPlainTextRedactor(nil, nil)
+			if _, err := r.RedactDocument(src, dst, []detector.Match{match}, redactors.RedactionSimple); err != nil {
+				t.Fatalf("RedactDocument: %v", err)
+			}
+
+			raw, err := os.ReadFile(dst)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Output must still BE the original encoding.
+			if got := preprocessors.DetectTextEncoding(raw); got != enc {
+				t.Errorf("output encoding = %v, want %v", got, enc)
+			}
+
+			decoded, ok := preprocessors.DecodeToUTF8(raw, enc)
+			if !ok {
+				t.Fatal("output not decodable")
+			}
+			if strings.Contains(decoded, secret) {
+				t.Errorf("SECRET SURVIVED redaction in %v output", enc)
+			}
+			if !strings.Contains(decoded, "REDACTED") {
+				t.Errorf("no redaction marker in output: %q", decoded)
+			}
+			if !strings.Contains(decoded, "second line clean.") {
+				t.Errorf("non-sensitive content damaged: %q", decoded)
+			}
+		})
+	}
+}

--- a/internal/redactors/plaintext/redactor.go
+++ b/internal/redactors/plaintext/redactor.go
@@ -133,8 +133,17 @@ func (ptr *PlainTextRedactor) RedactDocument(originalPath string, outputPath str
 		return nil, fmt.Errorf("failed to read original file: %w", err)
 	}
 
-	// Convert to string for processing
-	originalText := string(content)
+	// Decode transcodable encodings (UTF-16 with/without BOM, BOM'd UTF-8)
+	// to UTF-8 for redaction — matches were produced against the DECODED
+	// text by the preprocessor, so redacting the raw bytes would never find
+	// them (UTF-16 interleaves nulls through every match). The original
+	// encoding is restored on write so a redacted .reg export or PowerShell
+	// transcript remains a valid file in its native encoding.
+	encoding := preprocessors.DetectTextEncoding(content)
+	originalText, ok := preprocessors.DecodeToUTF8(content, encoding)
+	if !ok {
+		originalText = string(content)
+	}
 
 	// Perform redaction
 	redactedText, redactionMap, err := ptr.redactText(originalText, matches, strategy)
@@ -150,11 +159,13 @@ func (ptr *PlainTextRedactor) RedactDocument(originalPath string, outputPath str
 		}
 	}
 
-	// Write redacted content to output file with secure permissions.
+	// Write redacted content to output file with secure permissions,
+	// re-encoded to the ORIGINAL file's encoding (BOM restored) so a
+	// redacted UTF-16 file stays valid in its native tooling.
 	// #nosec G703 -- outputPath is operator-controlled (--redaction-output-dir
 	// + mirrored input filename); CLI-only path. Web mode hard-codes
 	// EnableRedaction: false so this is unreachable from the HTTP boundary.
-	err = os.WriteFile(outputPath, []byte(redactedText), 0600)
+	err = os.WriteFile(outputPath, preprocessors.EncodeFromUTF8(redactedText, encoding), 0600)
 	if err != nil {
 		return nil, fmt.Errorf("failed to write redacted file: %w", err)
 	}
@@ -477,6 +488,22 @@ func (ptr *PlainTextRedactor) RedactString(content string, matches []detector.Ma
 	return ptr.redactText(content, matches, strategy)
 }
 
+// readFileHead returns up to n leading bytes of the file at path — enough
+// for encoding detection without re-reading potentially 100MB of content.
+func readFileHead(path string, n int) ([]byte, error) {
+	f, err := os.Open(path) // #nosec G304 -- path is the scan target the operator supplied
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	buf := make([]byte, n)
+	read, err := f.Read(buf)
+	if read == 0 && err != nil {
+		return nil, err
+	}
+	return buf[:read], nil
+}
+
 // RedactContent implements ContentRedactor interface for efficient content-based redaction
 func (ptr *PlainTextRedactor) RedactContent(content *preprocessors.ProcessedContent, outputPath string, matches []detector.Match, strategy redactors.RedactionStrategy) (*redactors.RedactionResult, error) {
 	var finishTiming func(bool, map[string]interface{})
@@ -510,8 +537,20 @@ func (ptr *PlainTextRedactor) RedactContent(content *preprocessors.ProcessedCont
 		}
 	}
 
+	// content.Text is the preprocessor's DECODED UTF-8; if the source file
+	// was a transcodable encoding (UTF-16, BOM'd UTF-8), re-encode the
+	// redacted text so the output stays valid in its native tooling — a
+	// redacted .reg export or PowerShell transcript must not silently
+	// become UTF-8. The original's leading bytes identify the encoding.
+	outputBytes := []byte(redactedText)
+	if head, rerr := readFileHead(content.OriginalPath, 512); rerr == nil {
+		if enc := preprocessors.DetectTextEncoding(head); enc != preprocessors.EncodingUTF8 {
+			outputBytes = preprocessors.EncodeFromUTF8(redactedText, enc)
+		}
+	}
+
 	// Write redacted content to output file with secure permissions
-	err = os.WriteFile(outputPath, []byte(redactedText), 0600)
+	err = os.WriteFile(outputPath, outputBytes, 0600)
 	if err != nil {
 		return nil, fmt.Errorf("failed to write redacted file: %w", err)
 	}

--- a/internal/router/file_router.go
+++ b/internal/router/file_router.go
@@ -389,13 +389,10 @@ func isTextFile(filePath string) (bool, error) {
 
 	buffer = buffer[:n]
 
-	// Check for null bytes
-	for _, b := range buffer {
-		if b == 0 {
-			return false, nil
-		}
-	}
-
+	// Null-byte gating happens inside LooksLikeText, after encoding
+	// detection — UTF-16 text carries a null per ASCII character, so a
+	// pre-decode null check would (and previously did) classify every
+	// UTF-16 file as binary.
 	// UTF-8-aware sniff shared with the plaintext preprocessor: the previous
 	// ASCII-byte-ratio copy here silently classified short lines containing
 	// any multi-byte character (™, em-dash, accents, non-Latin scripts) as


### PR DESCRIPTION
Follow-up to #164, closing the two Windows-encoding gaps found while testing it. Both verified **pre-existing** (reproduced on the pre-#164 binary).

## 1. UTF-16 was binary *by definition*
UTF-16-encoded ASCII carries a null byte in every other position — and both sniff sites rejected any null-bearing file before considering encoding. **Every PowerShell 5 `Out-File` transcript, regedit `.reg` export, and UTF-16 Windows log was silently invisible to all validators in file mode.**

Sniffing alone can't fix it (validators would receive null-riddled bytes no regex matches), so this adds a transcode layer (`internal/preprocessors/encoding.go`):
- **Detection**: BOMs (UTF-8, UTF-16 LE/BE) + a BOM-less UTF-16 heuristic (alternating-null pattern, strict wrong-side thresholds so UTF-32/binary don't slip through; UTF-32 BOM explicitly rejected)
- **Sniff**: transcodable encodings are decoded and judged as text *before* the null gate
- **Read path**: decodes to UTF-8 so validators see real text
- **Redaction — the critical half**: matches are produced against *decoded* text, so masking raw bytes would silently skip every match. Both redaction entry points (`RedactDocument`, `RedactContent`) decode before masking and **re-encode the output to the original encoding, BOM included** — a redacted `.reg` export stays a valid `.reg` export.

## 2. cp1252 smart quotes (0x80–0x9F)
Windows-1252 puts curly quotes/dashes/ellipsis below the 0xA0 floor the legacy fallback allowed — short smart-quoted lines from old Word/Outlook exports classified binary. Fallback now accepts the full high half, balanced by an ASCII-majority requirement so all-high-byte binary stays excluded.

## Verification (per user requirement: "thoroughly tested for everything, including masking and exceptions")
- **Detection matrix**: email+SSN+AWS-key content detected identically across utf-8, utf-8-bom, utf-16le±bom, utf-16be±bom, cp1252
- **Redaction matrix**: simple + format-preserving strategies — zero leaks, masking confirmed, **output encoding preserved** on every variant (locked by `TestRedactDocument_EncodingRoundTrip`, 6 encodings)
- **Exceptions**: empty file, 1-byte invalid file, BOM+truncated-rune file — clean exits, no panics; lone surrogates → U+FFFD; odd trailing byte dropped
- **Suppression flow + stdin gateway**: behavior identical across encodings (verified against utf-8 control)
- **Perf**: 12.6 MB UTF-16 file scans in 4.4 s
- **~45 unit subtests** (detection, round-trip incl. surrogate-pair emoji + CRLF, malformed inputs, sniff matrix); goldens byte-identical; full `./...` green

**Deliberately not supported** (documented in-code): UTF-32 (vanishingly rare), Shift-JIS/GBK/EUC-KR (need charset detection à la chardet — big dependency; save-as-UTF-8 is the workaround)