### PR TITLE
fix(validators): precision + recall fixes from the reranker-benchmark corpus

### DIFF
--- a/internal/goldencorpus/testdata/golden/context_decoys_original.csv
+++ b/internal/goldencorpus/testdata/golden/context_decoys_original.csv
@@ -1,7 +1,7 @@
 Filename,Type,Confidence Level,Confidence %,Line Number,Text
 <golden:context_decoys_original>,PHONE,HIGH,100.0,4,212-555-0142
-<golden:context_decoys_original>,PHONE,MEDIUM,65.0,5,212-555-0142
-<golden:context_decoys_original>,PHONE,MEDIUM,65.0,6,313-555-0175
+<golden:context_decoys_original>,PHONE,LOW,30.0,5,212-555-0142
+<golden:context_decoys_original>,PHONE,LOW,47.0,6,313-555-0175
 <golden:context_decoys_original>,SSN,HIGH,100.0,1,449-87-4100
-<golden:context_decoys_original>,SSN,MEDIUM,60.0,2,449-87-4100
-<golden:context_decoys_original>,SSN,MEDIUM,60.0,3,526-33-8210
+<golden:context_decoys_original>,SSN,LOW,55.0,2,449-87-4100
+<golden:context_decoys_original>,SSN,LOW,40.0,3,526-33-8210

--- a/internal/goldencorpus/testdata/golden/context_decoys_original.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/context_decoys_original.gitlab-sast.json
@@ -54,8 +54,8 @@
     },
     {
       "category": "sast",
-      "confidence": "Medium",
-      "description": "Ferret Scan detected phone number in this file.\n\n**Location:** <golden:context_decoys_original> (line 5)\n**Confidence:** MEDIUM (65.0%)\n**Detected by:** phone validator\n\n**Context:**\n```\nerror code 212-555-0142 in the diagnostics log\n```\n\n**Additional Information:**\n- context_impact: -20\n- source: preprocessed_content\n\n**Remediation:**\nRemove phone numbers or replace with example numbers (e.g., 555-0123).",
+      "confidence": "Low",
+      "description": "Ferret Scan detected phone number in this file.\n\n**Location:** <golden:context_decoys_original> (line 5)\n**Confidence:** LOW (30.0%)\n**Detected by:** phone validator\n\n**Context:**\n```\nerror code 212-555-0142 in the diagnostics log\n```\n\n**Additional Information:**\n- context_impact: -55\n- source: preprocessed_content\n\n**Remediation:**\nRemove phone numbers or replace with example numbers (e.g., 555-0123).",
       "id": "ferret-<HASH>",
       "identifiers": [
         {
@@ -74,14 +74,14 @@
         "file": "<golden:context_decoys_original>",
         "start_line": 5
       },
-      "message": "Phone number detected: [HIDDEN] (confidence: MEDIUM)",
+      "message": "Phone number detected: [HIDDEN] (confidence: LOW)",
       "name": "Phone Number Detected",
-      "severity": "High"
+      "severity": "Medium"
     },
     {
       "category": "sast",
-      "confidence": "Medium",
-      "description": "Ferret Scan detected phone number in this file.\n\n**Location:** <golden:context_decoys_original> (line 6)\n**Confidence:** MEDIUM (65.0%)\n**Detected by:** phone validator\n\n**Context:**\n```\nSKU 313-555-0175 restocked\n```\n\n**Additional Information:**\n- context_impact: -20\n- source: preprocessed_content\n\n**Remediation:**\nRemove phone numbers or replace with example numbers (e.g., 555-0123).",
+      "confidence": "Low",
+      "description": "Ferret Scan detected phone number in this file.\n\n**Location:** <golden:context_decoys_original> (line 6)\n**Confidence:** LOW (47.0%)\n**Detected by:** phone validator\n\n**Context:**\n```\nSKU 313-555-0175 restocked\n```\n\n**Additional Information:**\n- context_impact: -38\n- source: preprocessed_content\n\n**Remediation:**\nRemove phone numbers or replace with example numbers (e.g., 555-0123).",
       "id": "ferret-<HASH>",
       "identifiers": [
         {
@@ -100,9 +100,9 @@
         "file": "<golden:context_decoys_original>",
         "start_line": 6
       },
-      "message": "Phone number detected: [HIDDEN] (confidence: MEDIUM)",
+      "message": "Phone number detected: [HIDDEN] (confidence: LOW)",
       "name": "Phone Number Detected",
-      "severity": "High"
+      "severity": "Medium"
     },
     {
       "category": "sast",
@@ -133,7 +133,7 @@
     {
       "category": "sast",
       "confidence": "Medium",
-      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <golden:context_decoys_original> (line 2)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\npart number 449-87-4100 from the catalog\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
+      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <golden:context_decoys_original> (line 2)\n**Confidence:** LOW (55.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\npart number 449-87-4100 from the catalog\n```\n\n**Additional Information:**\n- context_impact: -15\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {
@@ -152,14 +152,14 @@
         "file": "<golden:context_decoys_original>",
         "start_line": 2
       },
-      "message": "Social Security Number detected: [HIDDEN] (confidence: MEDIUM)",
+      "message": "Social Security Number detected: [HIDDEN] (confidence: LOW)",
       "name": "Social Security Number Detected",
-      "severity": "High"
+      "severity": "Medium"
     },
     {
       "category": "sast",
-      "confidence": "Medium",
-      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <golden:context_decoys_original> (line 3)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\nrequisition 526-33-8210 approved for shipment\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
+      "confidence": "Low",
+      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <golden:context_decoys_original> (line 3)\n**Confidence:** LOW (40.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\nrequisition 526-33-8210 approved for shipment\n```\n\n**Additional Information:**\n- context_impact: -30\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {
@@ -178,9 +178,9 @@
         "file": "<golden:context_decoys_original>",
         "start_line": 3
       },
-      "message": "Social Security Number detected: [HIDDEN] (confidence: MEDIUM)",
+      "message": "Social Security Number detected: [HIDDEN] (confidence: LOW)",
       "name": "Social Security Number Detected",
-      "severity": "High"
+      "severity": "Medium"
     }
   ]
 }

--- a/internal/goldencorpus/testdata/golden/context_decoys_original.json.json
+++ b/internal/goldencorpus/testdata/golden/context_decoys_original.json.json
@@ -79,22 +79,18 @@
       "validator": "ssn"
     },
     {
-      "confidence": 65,
-      "confidence_level": "MEDIUM",
+      "confidence": 55,
+      "confidence_level": "LOW",
       "filename": "<golden:context_decoys_original>",
-      "line_number": 5,
+      "line_number": 2,
       "metadata": {
-        "clean_number": "2125550142",
         "confidence_adjustment": 0,
         "context_confidence": 1,
         "context_doctype": "Unknown",
         "context_domain": "HR_Payroll",
-        "context_impact": -20,
-        "country": "US/CA",
-        "format": "XXX-XXX-XXXX",
-        "original_confidence": 65,
+        "context_impact": -15,
+        "original_confidence": 55,
         "original_file": "<golden:context_decoys_original>",
-        "pattern_name": "US_Dashed",
         "semantic_context": {
           "FinancialData": 0,
           "MedicalData": 0,
@@ -104,25 +100,23 @@
         },
         "source": "preprocessed_content",
         "validation_checks": {
+          "digits": true,
+          "format": true,
+          "not_common_pattern": true,
           "not_repeating": true,
           "not_sequential": true,
-          "not_ssn_pattern": true,
-          "not_test_number": false,
-          "not_timestamp": true,
-          "reasonable_length": true,
-          "valid_country": true,
-          "valid_digits": true,
-          "valid_format": true
+          "not_test_number": true,
+          "valid_area": true
         },
         "validation_path": "document"
       },
-      "text": "212-555-0142",
-      "type": "PHONE",
-      "validator": "phone"
+      "text": "449-87-4100",
+      "type": "SSN",
+      "validator": "ssn"
     },
     {
-      "confidence": 65,
-      "confidence_level": "MEDIUM",
+      "confidence": 47,
+      "confidence_level": "LOW",
       "filename": "<golden:context_decoys_original>",
       "line_number": 6,
       "metadata": {
@@ -131,10 +125,10 @@
         "context_confidence": 1,
         "context_doctype": "Unknown",
         "context_domain": "HR_Payroll",
-        "context_impact": -20,
+        "context_impact": -38,
         "country": "US/CA",
         "format": "XXX-XXX-XXXX",
-        "original_confidence": 65,
+        "original_confidence": 47,
         "original_file": "<golden:context_decoys_original>",
         "pattern_name": "US_Dashed",
         "semantic_context": {
@@ -163,44 +157,8 @@
       "validator": "phone"
     },
     {
-      "confidence": 60,
-      "confidence_level": "MEDIUM",
-      "filename": "<golden:context_decoys_original>",
-      "line_number": 2,
-      "metadata": {
-        "confidence_adjustment": 0,
-        "context_confidence": 1,
-        "context_doctype": "Unknown",
-        "context_domain": "HR_Payroll",
-        "context_impact": 0,
-        "original_confidence": 60,
-        "original_file": "<golden:context_decoys_original>",
-        "semantic_context": {
-          "FinancialData": 0,
-          "MedicalData": 0,
-          "PersonalData": 0,
-          "Production": 0,
-          "TestData": 0
-        },
-        "source": "preprocessed_content",
-        "validation_checks": {
-          "digits": true,
-          "format": true,
-          "not_common_pattern": true,
-          "not_repeating": true,
-          "not_sequential": true,
-          "not_test_number": true,
-          "valid_area": true
-        },
-        "validation_path": "document"
-      },
-      "text": "449-87-4100",
-      "type": "SSN",
-      "validator": "ssn"
-    },
-    {
-      "confidence": 60,
-      "confidence_level": "MEDIUM",
+      "confidence": 40,
+      "confidence_level": "LOW",
       "filename": "<golden:context_decoys_original>",
       "line_number": 3,
       "metadata": {
@@ -208,8 +166,8 @@
         "context_confidence": 1,
         "context_doctype": "Unknown",
         "context_domain": "HR_Payroll",
-        "context_impact": 0,
-        "original_confidence": 60,
+        "context_impact": -30,
+        "original_confidence": 40,
         "original_file": "<golden:context_decoys_original>",
         "semantic_context": {
           "FinancialData": 0,
@@ -233,6 +191,48 @@
       "text": "526-33-8210",
       "type": "SSN",
       "validator": "ssn"
+    },
+    {
+      "confidence": 30,
+      "confidence_level": "LOW",
+      "filename": "<golden:context_decoys_original>",
+      "line_number": 5,
+      "metadata": {
+        "clean_number": "2125550142",
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": -55,
+        "country": "US/CA",
+        "format": "XXX-XXX-XXXX",
+        "original_confidence": 30,
+        "original_file": "<golden:context_decoys_original>",
+        "pattern_name": "US_Dashed",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "not_repeating": true,
+          "not_sequential": true,
+          "not_ssn_pattern": true,
+          "not_test_number": false,
+          "not_timestamp": true,
+          "reasonable_length": true,
+          "valid_country": true,
+          "valid_digits": true,
+          "valid_format": true
+        },
+        "validation_path": "document"
+      },
+      "text": "212-555-0142",
+      "type": "PHONE",
+      "validator": "phone"
     }
   ]
 }

--- a/internal/goldencorpus/testdata/golden/context_decoys_original.junit.xml
+++ b/internal/goldencorpus/testdata/golden/context_decoys_original.junit.xml
@@ -2,7 +2,7 @@
 <testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
   <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
     <testcase name="&lt;golden:context_decoys_original&gt;" classname="security-scan" time="0.001">
-      <failure message="6 security findings detected" type="SECURITY_FINDINGS">Line 4: PHONE detected with 100.0% confidence (HIGH)&#xA;Match: 212-555-0142&#xA;Validator: phone&#xA;Line 1: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 6: PHONE detected with 65.0% confidence (MEDIUM)&#xA;Match: 313-555-0175&#xA;Validator: phone&#xA;Line 5: PHONE detected with 65.0% confidence (MEDIUM)&#xA;Match: 212-555-0142&#xA;Validator: phone&#xA;Line 2: SSN detected with 60.0% confidence (MEDIUM)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 3: SSN detected with 60.0% confidence (MEDIUM)&#xA;Match: 526-33-8210&#xA;Validator: ssn</failure>
+      <failure message="6 security findings detected" type="SECURITY_FINDINGS">Line 4: PHONE detected with 100.0% confidence (HIGH)&#xA;Match: 212-555-0142&#xA;Validator: phone&#xA;Line 1: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 2: SSN detected with 55.0% confidence (LOW)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 6: PHONE detected with 47.0% confidence (LOW)&#xA;Match: 313-555-0175&#xA;Validator: phone&#xA;Line 3: SSN detected with 40.0% confidence (LOW)&#xA;Match: 526-33-8210&#xA;Validator: ssn&#xA;Line 5: PHONE detected with 30.0% confidence (LOW)&#xA;Match: 212-555-0142&#xA;Validator: phone</failure>
     </testcase>
   </testsuite>
 </testsuites>

--- a/internal/goldencorpus/testdata/golden/context_decoys_original.redact_format_preserving.txt
+++ b/internal/goldencorpus/testdata/golden/context_decoys_original.redact_format_preserving.txt
@@ -7,8 +7,8 @@ error code ***-***-0142 in the diagnostics log
 SKU ***-***-0175 restocked
 === FINDINGS (sorted) ===
 type=PHONE line=4 conf=high match=212-555-0142
-type=PHONE line=5 conf=medium match=212-555-0142
-type=PHONE line=6 conf=medium match=313-555-0175
+type=PHONE line=5 conf=low match=212-555-0142
+type=PHONE line=6 conf=low match=313-555-0175
 type=SSN line=1 conf=high match=449-87-4100
-type=SSN line=2 conf=medium match=449-87-4100
-type=SSN line=3 conf=medium match=526-33-8210
+type=SSN line=2 conf=low match=449-87-4100
+type=SSN line=3 conf=low match=526-33-8210

--- a/internal/goldencorpus/testdata/golden/context_decoys_original.redact_simple.txt
+++ b/internal/goldencorpus/testdata/golden/context_decoys_original.redact_simple.txt
@@ -7,8 +7,8 @@ error code [PHONE-REDACTED] in the diagnostics log
 SKU [PHONE-REDACTED] restocked
 === FINDINGS (sorted) ===
 type=PHONE line=4 conf=high match=212-555-0142
-type=PHONE line=5 conf=medium match=212-555-0142
-type=PHONE line=6 conf=medium match=313-555-0175
+type=PHONE line=5 conf=low match=212-555-0142
+type=PHONE line=6 conf=low match=313-555-0175
 type=SSN line=1 conf=high match=449-87-4100
-type=SSN line=2 conf=medium match=449-87-4100
-type=SSN line=3 conf=medium match=526-33-8210
+type=SSN line=2 conf=low match=449-87-4100
+type=SSN line=3 conf=low match=526-33-8210

--- a/internal/goldencorpus/testdata/golden/context_decoys_original.sarif.json
+++ b/internal/goldencorpus/testdata/golden/context_decoys_original.sarif.json
@@ -101,21 +101,21 @@
             }
           ],
           "message": {
-            "text": "Phone Number Detected in <golden:context_decoys_original> at line 5 (confidence: 65.0% - MEDIUM). Matched text: '212-555-0142'"
+            "text": "Phone Number Detected in <golden:context_decoys_original> at line 5 (confidence: 30.0% - LOW). Matched text: '212-555-0142'"
           },
           "properties": {
-            "confidence": 65,
-            "confidenceLevel": "MEDIUM",
+            "confidence": 30,
+            "confidenceLevel": "LOW",
             "metadata": {
               "clean_number": "2125550142",
               "confidence_adjustment": 0,
               "context_confidence": 1,
               "context_doctype": "Unknown",
               "context_domain": "HR_Payroll",
-              "context_impact": -20,
+              "context_impact": -55,
               "country": "US/CA",
               "format": "XXX-XXX-XXXX",
-              "original_confidence": 65,
+              "original_confidence": 30,
               "original_file": "<golden:context_decoys_original>",
               "pattern_name": "US_Dashed",
               "semantic_context": {
@@ -139,9 +139,12 @@
               },
               "validation_path": "document"
             },
+            "negativeKeywords": [
+              "error code"
+            ],
             "validator": "phone"
           },
-          "rank": 57.5,
+          "rank": 40,
           "ruleId": "PHONE"
         },
         {
@@ -170,21 +173,21 @@
             }
           ],
           "message": {
-            "text": "Phone Number Detected in <golden:context_decoys_original> at line 6 (confidence: 65.0% - MEDIUM). Matched text: '313-555-0175'"
+            "text": "Phone Number Detected in <golden:context_decoys_original> at line 6 (confidence: 47.0% - LOW). Matched text: '313-555-0175'"
           },
           "properties": {
-            "confidence": 65,
-            "confidenceLevel": "MEDIUM",
+            "confidence": 47,
+            "confidenceLevel": "LOW",
             "metadata": {
               "clean_number": "3135550175",
               "confidence_adjustment": 0,
               "context_confidence": 1,
               "context_doctype": "Unknown",
               "context_domain": "HR_Payroll",
-              "context_impact": -20,
+              "context_impact": -38,
               "country": "US/CA",
               "format": "XXX-XXX-XXXX",
-              "original_confidence": 65,
+              "original_confidence": 47,
               "original_file": "<golden:context_decoys_original>",
               "pattern_name": "US_Dashed",
               "semantic_context": {
@@ -208,9 +211,12 @@
               },
               "validation_path": "document"
             },
+            "negativeKeywords": [
+              "sku"
+            ],
             "validator": "phone"
           },
-          "rank": 57.5,
+          "rank": 48.5,
           "ruleId": "PHONE"
         },
         {
@@ -305,18 +311,18 @@
             }
           ],
           "message": {
-            "text": "Social Security Number Detected in <golden:context_decoys_original> at line 2 (confidence: 60.0% - MEDIUM). Matched text: '449-87-4100'"
+            "text": "Social Security Number Detected in <golden:context_decoys_original> at line 2 (confidence: 55.0% - LOW). Matched text: '449-87-4100'"
           },
           "properties": {
-            "confidence": 60,
-            "confidenceLevel": "MEDIUM",
+            "confidence": 55,
+            "confidenceLevel": "LOW",
             "metadata": {
               "confidence_adjustment": 0,
               "context_confidence": 1,
               "context_doctype": "Unknown",
               "context_domain": "HR_Payroll",
-              "context_impact": 0,
-              "original_confidence": 60,
+              "context_impact": -15,
+              "original_confidence": 55,
               "original_file": "<golden:context_decoys_original>",
               "semantic_context": {
                 "FinancialData": 0,
@@ -337,9 +343,12 @@
               },
               "validation_path": "document"
             },
+            "negativeKeywords": [
+              "part number"
+            ],
             "validator": "ssn"
           },
-          "rank": 80,
+          "rank": 77.5,
           "ruleId": "SSN"
         },
         {
@@ -368,18 +377,18 @@
             }
           ],
           "message": {
-            "text": "Social Security Number Detected in <golden:context_decoys_original> at line 3 (confidence: 60.0% - MEDIUM). Matched text: '526-33-8210'"
+            "text": "Social Security Number Detected in <golden:context_decoys_original> at line 3 (confidence: 40.0% - LOW). Matched text: '526-33-8210'"
           },
           "properties": {
-            "confidence": 60,
-            "confidenceLevel": "MEDIUM",
+            "confidence": 40,
+            "confidenceLevel": "LOW",
             "metadata": {
               "confidence_adjustment": 0,
               "context_confidence": 1,
               "context_doctype": "Unknown",
               "context_domain": "HR_Payroll",
-              "context_impact": 0,
-              "original_confidence": 60,
+              "context_impact": -30,
+              "original_confidence": 40,
               "original_file": "<golden:context_decoys_original>",
               "semantic_context": {
                 "FinancialData": 0,
@@ -400,9 +409,13 @@
               },
               "validation_path": "document"
             },
+            "negativeKeywords": [
+              "requisition",
+              "shipment"
+            ],
             "validator": "ssn"
           },
-          "rank": 80,
+          "rank": 70,
           "ruleId": "SSN"
         }
       ],

--- a/internal/goldencorpus/testdata/golden/context_decoys_original.txt
+++ b/internal/goldencorpus/testdata/golden/context_decoys_original.txt
@@ -2,7 +2,7 @@ LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH        FILE
 --------------------------------------------------------------------------------------
 [HIGH  ] phone        PHONE                 100.00% line     4 212-555-0142 <golden:context_decoys_original>
 [HIGH  ] ssn          SSN                   100.00% line     1 449-87-4100  <golden:context_decoys_original>
-[MEDIUM] phone        PHONE                  65.00% line     5 212-555-0142 <golden:context_decoys_original>
-[MEDIUM] phone        PHONE                  65.00% line     6 313-555-0175 <golden:context_decoys_original>
-[MEDIUM] ssn          SSN                    60.00% line     2 449-87-4100  <golden:context_decoys_original>
-[MEDIUM] ssn          SSN                    60.00% line     3 526-33-8210  <golden:context_decoys_original>
+[LOW   ] ssn          SSN                    55.00% line     2 449-87-4100  <golden:context_decoys_original>
+[LOW   ] phone        PHONE                  47.00% line     6 313-555-0175 <golden:context_decoys_original>
+[LOW   ] ssn          SSN                    40.00% line     3 526-33-8210  <golden:context_decoys_original>
+[LOW   ] phone        PHONE                  30.00% line     5 212-555-0142 <golden:context_decoys_original>

--- a/internal/goldencorpus/testdata/golden/context_decoys_original.yaml
+++ b/internal/goldencorpus/testdata/golden/context_decoys_original.yaml
@@ -67,25 +67,21 @@ results:
             not_test_number: true
             valid_area: true
         validation_path: document
-    - text: 212-555-0142
-      line_number: 5
-      type: PHONE
-      confidence: 65
-      confidence_level: MEDIUM
+    - text: 449-87-4100
+      line_number: 2
+      type: SSN
+      confidence: 55
+      confidence_level: LOW
       filename: <golden:context_decoys_original>
-      validator: phone
+      validator: ssn
       metadata:
-        clean_number: "2125550142"
         confidence_adjustment: 0
         context_confidence: 1
         context_doctype: Unknown
         context_domain: HR_Payroll
-        context_impact: -20
-        country: US/CA
-        format: XXX-XXX-XXXX
-        original_confidence: 65
+        context_impact: -15
+        original_confidence: 55
         original_file: <golden:context_decoys_original>
-        pattern_name: US_Dashed
         semantic_context:
             FinancialData: 0
             MedicalData: 0
@@ -94,21 +90,19 @@ results:
             TestData: 0
         source: preprocessed_content
         validation_checks:
+            digits: true
+            format: true
+            not_common_pattern: true
             not_repeating: true
             not_sequential: true
-            not_ssn_pattern: true
-            not_test_number: false
-            not_timestamp: true
-            reasonable_length: true
-            valid_country: true
-            valid_digits: true
-            valid_format: true
+            not_test_number: true
+            valid_area: true
         validation_path: document
     - text: 313-555-0175
       line_number: 6
       type: PHONE
-      confidence: 65
-      confidence_level: MEDIUM
+      confidence: 47
+      confidence_level: LOW
       filename: <golden:context_decoys_original>
       validator: phone
       metadata:
@@ -117,10 +111,10 @@ results:
         context_confidence: 1
         context_doctype: Unknown
         context_domain: HR_Payroll
-        context_impact: -20
+        context_impact: -38
         country: US/CA
         format: XXX-XXX-XXXX
-        original_confidence: 65
+        original_confidence: 47
         original_file: <golden:context_decoys_original>
         pattern_name: US_Dashed
         semantic_context:
@@ -141,11 +135,11 @@ results:
             valid_digits: true
             valid_format: true
         validation_path: document
-    - text: 449-87-4100
-      line_number: 2
+    - text: 526-33-8210
+      line_number: 3
       type: SSN
-      confidence: 60
-      confidence_level: MEDIUM
+      confidence: 40
+      confidence_level: LOW
       filename: <golden:context_decoys_original>
       validator: ssn
       metadata:
@@ -153,8 +147,8 @@ results:
         context_confidence: 1
         context_doctype: Unknown
         context_domain: HR_Payroll
-        context_impact: 0
-        original_confidence: 60
+        context_impact: -30
+        original_confidence: 40
         original_file: <golden:context_decoys_original>
         semantic_context:
             FinancialData: 0
@@ -172,21 +166,25 @@ results:
             not_test_number: true
             valid_area: true
         validation_path: document
-    - text: 526-33-8210
-      line_number: 3
-      type: SSN
-      confidence: 60
-      confidence_level: MEDIUM
+    - text: 212-555-0142
+      line_number: 5
+      type: PHONE
+      confidence: 30
+      confidence_level: LOW
       filename: <golden:context_decoys_original>
-      validator: ssn
+      validator: phone
       metadata:
+        clean_number: "2125550142"
         confidence_adjustment: 0
         context_confidence: 1
         context_doctype: Unknown
         context_domain: HR_Payroll
-        context_impact: 0
-        original_confidence: 60
+        context_impact: -55
+        country: US/CA
+        format: XXX-XXX-XXXX
+        original_confidence: 30
         original_file: <golden:context_decoys_original>
+        pattern_name: US_Dashed
         semantic_context:
             FinancialData: 0
             MedicalData: 0
@@ -195,11 +193,13 @@ results:
             TestData: 0
         source: preprocessed_content
         validation_checks:
-            digits: true
-            format: true
-            not_common_pattern: true
             not_repeating: true
             not_sequential: true
-            not_test_number: true
-            valid_area: true
+            not_ssn_pattern: true
+            not_test_number: false
+            not_timestamp: true
+            reasonable_length: true
+            valid_country: true
+            valid_digits: true
+            valid_format: true
         validation_path: document

--- a/internal/goldencorpus/testdata/golden/email_variants.csv
+++ b/internal/goldencorpus/testdata/golden/email_variants.csv
@@ -1,4 +1,4 @@
 Filename,Type,Confidence Level,Confidence %,Line Number,Text
 <golden:email_variants>,BUSINESS,HIGH,100.0,1,support@acme-corp.com
-<golden:email_variants>,BUSINESS,MEDIUM,88.0,3,no-reply@internal.example.org
+<golden:email_variants>,BUSINESS,MEDIUM,85.0,3,no-reply@internal.example.org
 <golden:email_variants>,GMAIL,HIGH,100.0,2,alice@gmail.com

--- a/internal/goldencorpus/testdata/golden/email_variants.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/email_variants.gitlab-sast.json
@@ -55,7 +55,7 @@
     {
       "category": "sast",
       "confidence": "High",
-      "description": "Ferret Scan detected sensitive data (business) in this file.\n\n**Location:** <golden:email_variants> (line 3)\n**Confidence:** MEDIUM (88.0%)\n**Detected by:** email validator\n\n**Context:**\n```\nno-reply@internal.example.org\n```\n\n**Additional Information:**\n- context_impact: -12\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "description": "Ferret Scan detected sensitive data (business) in this file.\n\n**Location:** <golden:email_variants> (line 3)\n**Confidence:** MEDIUM (85.0%)\n**Detected by:** email validator\n\n**Context:**\n```\nno-reply@internal.example.org\n```\n\n**Additional Information:**\n- context_impact: -12\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {

--- a/internal/goldencorpus/testdata/golden/email_variants.json.json
+++ b/internal/goldencorpus/testdata/golden/email_variants.json.json
@@ -83,7 +83,7 @@
       "validator": "email"
     },
     {
-      "confidence": 88,
+      "confidence": 85,
       "confidence_level": "MEDIUM",
       "filename": "<golden:email_variants>",
       "line_number": 3,
@@ -95,7 +95,7 @@
         "context_impact": -12,
         "domain": "internal.example.org",
         "email_provider": "BUSINESS",
-        "original_confidence": 88,
+        "original_confidence": 85,
         "original_file": "<golden:email_variants>",
         "semantic_context": {
           "FinancialData": 0,

--- a/internal/goldencorpus/testdata/golden/email_variants.junit.xml
+++ b/internal/goldencorpus/testdata/golden/email_variants.junit.xml
@@ -2,7 +2,7 @@
 <testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
   <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
     <testcase name="&lt;golden:email_variants&gt;" classname="security-scan" time="0.001">
-      <failure message="3 security findings detected" type="SECURITY_FINDINGS">Line 1: BUSINESS detected with 100.0% confidence (HIGH)&#xA;Match: support@acme-corp.com&#xA;Validator: email&#xA;Line 2: GMAIL detected with 100.0% confidence (HIGH)&#xA;Match: alice@gmail.com&#xA;Validator: email&#xA;Line 3: BUSINESS detected with 88.0% confidence (MEDIUM)&#xA;Match: no-reply@internal.example.org&#xA;Validator: email</failure>
+      <failure message="3 security findings detected" type="SECURITY_FINDINGS">Line 1: BUSINESS detected with 100.0% confidence (HIGH)&#xA;Match: support@acme-corp.com&#xA;Validator: email&#xA;Line 2: GMAIL detected with 100.0% confidence (HIGH)&#xA;Match: alice@gmail.com&#xA;Validator: email&#xA;Line 3: BUSINESS detected with 85.0% confidence (MEDIUM)&#xA;Match: no-reply@internal.example.org&#xA;Validator: email</failure>
     </testcase>
   </testsuite>
 </testsuites>

--- a/internal/goldencorpus/testdata/golden/email_variants.sarif.json
+++ b/internal/goldencorpus/testdata/golden/email_variants.sarif.json
@@ -88,10 +88,10 @@
             }
           ],
           "message": {
-            "text": "BUSINESS Detected in <golden:email_variants> at line 3 (confidence: 88.0% - MEDIUM). Matched text: 'no-reply@internal.example.org'"
+            "text": "BUSINESS Detected in <golden:email_variants> at line 3 (confidence: 85.0% - MEDIUM). Matched text: 'no-reply@internal.example.org'"
           },
           "properties": {
-            "confidence": 88,
+            "confidence": 85,
             "confidenceLevel": "MEDIUM",
             "metadata": {
               "confidence_adjustment": 0,
@@ -101,7 +101,7 @@
               "context_impact": -12,
               "domain": "internal.example.org",
               "email_provider": "BUSINESS",
-              "original_confidence": 88,
+              "original_confidence": 85,
               "original_file": "<golden:email_variants>",
               "semantic_context": {
                 "FinancialData": 0,
@@ -133,7 +133,7 @@
             ],
             "validator": "email"
           },
-          "rank": 69,
+          "rank": 67.5,
           "ruleId": "BUSINESS"
         },
         {

--- a/internal/goldencorpus/testdata/golden/email_variants.txt
+++ b/internal/goldencorpus/testdata/golden/email_variants.txt
@@ -2,4 +2,4 @@ LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH            
 -------------------------------------------------------------------------------------------------------
 [HIGH  ] email        BUSINESS              100.00% line     1 support@acme-corp.com         <golden:email_variants>
 [HIGH  ] email        GMAIL                 100.00% line     2 alice@gmail.com               <golden:email_variants>
-[MEDIUM] email        BUSINESS               88.00% line     3 no-reply@internal.example.org <golden:email_variants>
+[MEDIUM] email        BUSINESS               85.00% line     3 no-reply@internal.example.org <golden:email_variants>

--- a/internal/goldencorpus/testdata/golden/email_variants.yaml
+++ b/internal/goldencorpus/testdata/golden/email_variants.yaml
@@ -74,7 +74,7 @@ results:
     - text: no-reply@internal.example.org
       line_number: 3
       type: BUSINESS
-      confidence: 88
+      confidence: 85
       confidence_level: MEDIUM
       filename: <golden:email_variants>
       validator: email
@@ -86,7 +86,7 @@ results:
         context_impact: -12
         domain: internal.example.org
         email_provider: BUSINESS
-        original_confidence: 88
+        original_confidence: 85
         original_file: <golden:email_variants>
         semantic_context:
             FinancialData: 0

--- a/internal/preprocessors/plaintext_sniff_test.go
+++ b/internal/preprocessors/plaintext_sniff_test.go
@@ -16,18 +16,18 @@ import (
 // mode (stdin was unaffected, which is how the gap hid).
 func TestLooksLikeText(t *testing.T) {
 	textCases := map[string]string{
-		"plain ascii":              "Contact john.doe@example.com about the contract\n",
-		"trademark symbol short":   "Acme ™ contact john.doe@example.com\n",
-		"em-dash short":            "Contract — contact john.doe@example.com\n",
-		"copyright dense":          strings.Repeat("© 2026 Acme. ", 10),
-		"accented names":           "Renée Müller, José García, François Lefèvre\n",
-		"french prose":             "Le numéro de sécurité sociale de l'employé est confidentiel.\n",
-		"japanese":                 "顧客の個人情報：山田太郎、東京都渋谷区\n",
-		"cyrillic":                 "Персональные данные клиента: Иван Петров\n",
-		"emoji":                    "credit card 5500-0000-0000-0004 \U0001f4b3\n",
-		"curly quotes":             "“confidential” ‘internal’ draft\n",
-		"crlf windows text":        "line one\r\nline two\r\n",
-		"tab separated":            "name\temail\tssn\n",
+		"plain ascii":               "Contact john.doe@example.com about the contract\n",
+		"trademark symbol short":    "Acme ™ contact john.doe@example.com\n",
+		"em-dash short":             "Contract — contact john.doe@example.com\n",
+		"copyright dense":           strings.Repeat("© 2026 Acme. ", 10),
+		"accented names":            "Renée Müller, José García, François Lefèvre\n",
+		"french prose":              "Le numéro de sécurité sociale de l'employé est confidentiel.\n",
+		"japanese":                  "顧客の個人情報：山田太郎、東京都渋谷区\n",
+		"cyrillic":                  "Персональные данные клиента: Иван Петров\n",
+		"emoji":                     "credit card 5500-0000-0000-0004 \U0001f4b3\n",
+		"curly quotes":              "“confidential” ‘internal’ draft\n",
+		"crlf windows text":         "line one\r\nline two\r\n",
+		"tab separated":             "name\temail\tssn\n",
 		"latin-1 legacy (fallback)": string([]byte{'c', 'a', 'f', 0xe9, ' ', 'm', 'e', 'n', 'u', '\n', 'p', 'r', 'i', 'x', ':', ' ', '5', '0', '\n'}),
 	}
 	for name, content := range textCases {

--- a/internal/redactors/replacement/phone_test.go
+++ b/internal/redactors/replacement/phone_test.go
@@ -24,8 +24,8 @@ func TestPhone_FormatPreserving_NoLeak(t *testing.T) {
 		lead  string // leading digits that MUST NOT survive
 	}{
 		{"six_digits", "012345", "2345", "01"},
-		{"seven_digits_local", "0123456", "3456", "012"},   // the old full-leak case
-		{"seven_dashed", "012-3456", "3456", "012"},         // the old full-leak case
+		{"seven_digits_local", "0123456", "3456", "012"}, // the old full-leak case
+		{"seven_dashed", "012-3456", "3456", "012"},      // the old full-leak case
 		{"ten_digits", "2065550173", "0173", "206555"},
 		{"us_formatted", "(206) 555-0173", "0173", "206555"},
 		{"e164", "+12065550173", "0173", "120655"},

--- a/internal/validators/bankaccount/validator.go
+++ b/internal/validators/bankaccount/validator.go
@@ -158,7 +158,7 @@ type lineContext struct {
 	lower          string  // strings.ToLower(line), for near-match keyword probes
 	keywordImpact  float64 // AnalyzeContext result (positive/negative keyword scan)
 	strongNegative bool    // hasStrongNegativeContext(line)
-	bankingKeyword bool     // hasBankingKeywords(line)
+	bankingKeyword bool    // hasBankingKeywords(line)
 }
 
 // buildLineContext computes the per-line invariants once. AnalyzeContext is

--- a/internal/validators/creditcard/validator.go
+++ b/internal/validators/creditcard/validator.go
@@ -94,6 +94,17 @@ func NewValidator() *Validator {
 			"telephone",
 			"md5", "sha", "hash", "uuid", "guid", "crc", "checksum",
 			"version", "build", "test", "example", "fake", "mock", "sample",
+			// Synonym clusters the reranker-benchmark corpus proved walk
+			// straight past the list above: "S/N" fired at 95 where "serial"
+			// was suppressed; same for shipping/logistics and inventory
+			// wording. Whole-word matched like the rest ("s/n" matches the
+			// token, not letters inside words). Deliberately NOT included:
+			// "batch" — POS settlement receipts print "BATCH NNNN" beside a
+			// REAL card (regression-verified against the corpus), and it fired
+			// zero decoys, so it is pure false-suppression risk.
+			"s/n", "sn#", "nameplate", "waybill", "parcel",
+			"booking", "barcode", "asset", "asset tag", "sku",
+			"part", "designator", "receipt", "session", "token",
 		},
 	}
 

--- a/internal/validators/email/validator.go
+++ b/internal/validators/email/validator.go
@@ -114,6 +114,58 @@ var (
 	nameEmailPattern       = regexp.MustCompile(`[A-Z][a-z]+\s+[A-Z][a-z]+\s+[A-Za-z0-9._%+-]+@`)
 )
 
+// machineEmailCap is the maximum final confidence for machine-identifier
+// addresses (noreply@, mailer-daemon@, service accounts). They are real,
+// deliverable addresses — worth detecting and redacting — but they are not a
+// person's contact information, so they must not reach the HIGH band that
+// drives blocking decisions. 85 keeps them prominent MEDIUM findings.
+const machineEmailCap = 85.0
+
+// machineLocalParts are local-part prefixes (or exact local parts) that
+// identify automated senders rather than people. Sourced from the reranker
+// benchmark corpus, where these fired at 100 HIGH across logs, mail headers,
+// git trailers, cron configs, and monitoring identities.
+var machineLocalParts = []string{
+	"noreply", "no-reply", "no_reply", "donotreply", "do-not-reply",
+	"mailer-daemon", "postmaster", "bounce", "bounces",
+	"alerts", "alert", "notifications", "notification", "notify",
+	"automated", "auto-confirm", "auto-reply", "autoreply",
+	"svc-", "service-account", "system", "daemon", "cron", "robot", "bot@",
+}
+
+// isMachineLocalPart reports whether the email's local part identifies an
+// automated sender. An entry matches when the local part equals it exactly,
+// or continues with a machine-style separator (+ - _ or a digit: noreply2@,
+// alerts+prod@, svc-deploy@). A "." continuation does NOT match: dot-joined
+// continuations are the firstname.lastname convention, so system.smith@ is a
+// person, not a daemon.
+func isMachineLocalPart(email string) bool {
+	at := strings.IndexByte(email, '@')
+	if at <= 0 {
+		return false
+	}
+	local := strings.ToLower(email[:at])
+	for _, p := range machineLocalParts {
+		p = strings.TrimSuffix(p, "@")
+		if !strings.HasPrefix(local, p) {
+			continue
+		}
+		if len(local) == len(p) {
+			return true // exact match
+		}
+		// Entries that end in a separator (svc-) carry their boundary with
+		// them; any continuation matches.
+		if last := p[len(p)-1]; last == '-' || last == '_' {
+			return true
+		}
+		next := local[len(p)]
+		if next == '+' || next == '-' || next == '_' || (next >= '0' && next <= '9') {
+			return true
+		}
+	}
+	return false
+}
+
 // Validator implements the detector.Validator interface for detecting
 // email addresses using regex patterns and contextual analysis.
 type Validator struct {
@@ -278,6 +330,20 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 			}
 
 			confidence += contextImpact
+
+			// HARD CAP for machine-identifier local parts (noreply@,
+			// mailer-daemon@, svc-*@, ...): these are the single most common
+			// email FP in real logs and configs — they are addresses, but not
+			// a person's contact. The -15 test-pattern penalty alone is
+			// clawed back by positive context ("alert", "notification",
+			// "noreply" are themselves positive keywords) and re-clamped to
+			// 100 HIGH. Mirror the phone fictional-range cap: applied AFTER
+			// context adjustment so keyword stacking cannot raise a machine
+			// address back into HIGH. Capped at 85 (solid MEDIUM) — still
+			// detected, displayed, and redactable, never HIGH.
+			if isMachineLocalPart(match) && confidence > machineEmailCap {
+				confidence = machineEmailCap
+			}
 
 			// Ensure confidence stays within bounds
 			if confidence > 100 {

--- a/internal/validators/personname/validator.go
+++ b/internal/validators/personname/validator.go
@@ -332,12 +332,36 @@ func (v *Validator) CalculateConfidenceWithComponents(match string, components N
 
 	// EFFICIENCY FIRST: Check database matches before any expensive operations
 	// This is the authoritative source - no matches = early exit
+	// hyphenPartKnown handles compound given/family names (Soo-Jin, Jean-Luc,
+	// Mary-Kate): the full hyphenated token is rarely in the ~5K dictionary,
+	// but its parts usually are. A single part matching is enough to treat the
+	// compound as a known name component — the dictionary is the authoritative
+	// gate and these are real names it would otherwise reject outright
+	// (recall gap surfaced by the reranker-benchmark corpus generator).
+	// Requires the part be 2+ chars so a stray "A-Team" style initial can't
+	// qualify on a one-letter fragment.
+	hyphenPartKnown := func(name string, dict map[string]bool) bool {
+		if !strings.Contains(name, "-") {
+			return false
+		}
+		for _, part := range strings.Split(name, "-") {
+			if len(part) < 2 {
+				continue
+			}
+			if dict[part] || dict[v.normalizeAccents(part)] {
+				return true
+			}
+		}
+		return false
+	}
+
 	if v.firstNames != nil && len(components.FirstName) > 0 {
 		// Try both the original name and normalized version (without accents)
 		firstName := strings.ToLower(components.FirstName)
 		normalizedFirstName := v.normalizeAccents(firstName)
 
-		if v.firstNames[firstName] || v.firstNames[normalizedFirstName] {
+		if v.firstNames[firstName] || v.firstNames[normalizedFirstName] ||
+			hyphenPartKnown(firstName, v.firstNames) {
 			checks["known_first_name"] = true
 		}
 	}
@@ -347,7 +371,8 @@ func (v *Validator) CalculateConfidenceWithComponents(match string, components N
 		lastName := strings.ToLower(components.LastName)
 		normalizedLastName := v.normalizeAccents(lastName)
 
-		if v.lastNames[lastName] || v.lastNames[normalizedLastName] {
+		if v.lastNames[lastName] || v.lastNames[normalizedLastName] ||
+			hyphenPartKnown(lastName, v.lastNames) {
 			checks["known_last_name"] = true
 		}
 	}

--- a/internal/validators/phone/validator.go
+++ b/internal/validators/phone/validator.go
@@ -108,6 +108,16 @@ func NewValidator() *Validator {
 			"timestamp", "unix", "epoch", "milliseconds", "seconds", "time",
 			"created", "modified", "updated", "generated", "build", "version",
 			"revision", "commit", "hash", "checksum", "uuid", "guid",
+			// Operational/inventory vocabulary: phone-shaped tokens labeled
+			// as these scored 65-100 (displayed) in the reranker-benchmark
+			// corpus — order refs, RMAs, serials, SKUs, permits, lots, and
+			// error codes are routinely formatted XXX-XXX-XXXX. A same-line
+			// occurrence is strong evidence the number is not a phone.
+			"error code", "fault code", "order reference", "order ref",
+			"rma", "serial", "serial number", "s/n", "part no", "part number",
+			"case number", "permit", "batch", "lot", "sku", "fixture",
+			"row id", "bib number", "model", "promo code", "certificate",
+			"asset tag", "bin", "accession", "stamped", "etched",
 		},
 		knownTestPatterns: []string{
 			"555-0", "555-1", "000-000", "111-111", "222-222", "333-333",

--- a/internal/validators/ssn/validator.go
+++ b/internal/validators/ssn/validator.go
@@ -454,6 +454,18 @@ func (v *Validator) keywordInFullContext(keyword, before, after string, lc *line
 	if lc.keywordOnLine[keyword] {
 		return true
 	}
+	// A SINGLE-WORD keyword absent from the line cannot appear in
+	// before+" "+line+" "+after either: before/after are substrings of the
+	// line, and a token with no internal space can only span the synthetic
+	// " " joins if it itself contains a space. So single-word keywords are
+	// fully decided by keywordOnLine — skip the two junction scans entirely.
+	// This is the dominant per-match cost on a dense single long line
+	// (O(matches × keywords) junction scans); restricting it to the few
+	// multi-word keywords keeps behavior byte-identical while removing the
+	// bulk of the work. (Whitespace check is cheap and allocation-free.)
+	if !strings.Contains(keyword, " ") {
+		return false
+	}
 	// Scan the tiny regions around each synthetic space join. before/after are
 	// already substrings of the line, so any match not already covered above must
 	// span "before + ' ' + line" or "line + ' ' + after".

--- a/internal/validators/ssn/validator.go
+++ b/internal/validators/ssn/validator.go
@@ -124,6 +124,23 @@ func NewValidator() *Validator {
 			"555-55-5555", "666-66-6666", "777-77-7777", "888-88-8888",
 			"999-99-9999", "serial", "model", "version", "build",
 			"encoded", "numeric", "code", "hash", "uuid", "guid",
+			// Procurement/operations vocabulary: SSN-shaped tokens labeled as
+			// any of these scored 60 MEDIUM (displayed by default) in the
+			// reranker-benchmark corpus — part/lot/requisition numbers in the
+			// XXX-XX-XXXX shape are common in ERP exports. The per-keyword
+			// -15 same-line penalty pushes them below the display bar while
+			// keyword-anchored real SSNs stay at 100.
+			"part number", "part no", "requisition", "lot", "batch",
+			"work order", "invoice", "rma", "asset tag", "asset",
+			"case", "ticket", "sku", "purchase order", "docket",
+			"tracking", "shipment", "order number",
+			"po", "permit", "reservation", "grant", "bin",
+			"accession", "specimen", "contract", "txn", "transaction",
+			// "policy" is intentionally NOT listed: insurance-policy documents
+			// legitimately carry SSNs on the same line ("policy holder SSN:"),
+			// and the strong positive keywords win there anyway — verified in
+			// the regression test.
+			"policy number", "policy no",
 		},
 		invalidPatterns: []string{
 			"000", "666", "900", "901", "902", "903", "904", "905", "906", "907", "908", "909",
@@ -593,11 +610,27 @@ func (v *Validator) isEnhancedTabularData(line, value string) bool {
 	// Phone patterns
 	structuredCount += len(rePhoneEnhanced.FindAllString(line, -1))
 
-	// Date patterns
-	structuredCount += len(reDate.FindAllString(line, -1))
-
 	// SSN patterns
-	structuredCount += len(reSSNEnhanced.FindAllString(line, -1))
+	ssnSpans := reSSNEnhanced.FindAllStringIndex(line, -1)
+	structuredCount += len(ssnSpans)
+
+	// Date patterns — excluding matches INSIDE an SSN span: the tail of every
+	// XXX-XX-XXXX parses as \d{1,2}-\d{2}-\d{4}, so a line with one SSN would
+	// otherwise self-count as SSN+date. Combined with a single Title Case
+	// name ("Judge Hollis", "Nordvik Tooling") that reached the 3-element
+	// bar and awarded the +25 tabular boost to ordinary PROSE — the same
+	// self-counting bug fixed in isTabularData (#155), in its enhanced
+	// sibling. Two-pointer walk: both index slices are sorted.
+	si := 0
+	for _, d := range reDate.FindAllStringIndex(line, -1) {
+		for si < len(ssnSpans) && ssnSpans[si][1] < d[1] {
+			si++
+		}
+		if si < len(ssnSpans) && d[0] >= ssnSpans[si][0] && d[1] <= ssnSpans[si][1] {
+			continue
+		}
+		structuredCount++
+	}
 
 	// Name patterns (Title Case words)
 	structuredCount += len(reNameEnhanced.FindAllString(line, -1))


### PR DESCRIPTION
An 860-case verified real/decoy corpus — built to evaluate an ML reranker (parked; see below) — surfaced concrete per-validator blind spots as a side effect. Six were actionable and cheap; this ships them.

## Fixes

| Validator | Problem | Fix | Corpus result |
|---|---|---|---|
| **EMAIL** | `noreply@`, `mailer-daemon@`, `svc-*` scored 100 HIGH — top email FP in logs | Hard-cap machine local-parts at 85 MEDIUM, separator-aware (`system.smith@` stays HIGH) | machine senders no longer HIGH |
| **CREDIT_CARD** | negative-keyword filter is literal; synonyms bypass it (`S/N` fired where `serial` was blocked) | add proven-bypassing synonyms | 4 decoy clusters suppressed, reals stay 100 |
| **SSN** | `isEnhancedTabularData` self-counts an SSN's tail as a date → one Title-Case name gave prose a +25 "tabular" boost (same bug class as #155, in the enhanced sibling) + procurement keywords | fix self-count + keywords | 22/25 decoys → LOW, 25/25 reals HIGH |
| **PHONE** | error-code/RMA/SKU/part-number decoys shown | operational keywords | 18/25 decoys hidden, **0 TP lost** |
| **PERSON_NAME** | hyphenated names (Jean-Luc, Ji-Soo, Mary-Kate) rejected — full token misses the dictionary | check hyphen sub-parts | compound names now fire; gibberish still rejected |
| **SECRETS** | *(no change)* | revoked/rotated-context keys correctly stay HIGH — a scanner must not trust narrative "revoked" claims | — |

## Verification
- **Cross-validator regression sweep, all 860 corpus cases (this branch vs main): 0 real findings lost, 0 spurious new fires.** This caught one over-broad keyword mid-development (`batch` was suppressing a real card on a POS receipt — removed, data-driven).
- Golden corpus regenerated — deltas are *only* the intended improvements (SSN decoys 60→55, phone error-code decoy dropped, `no-reply@` 88→85); no real-value snapshot regressed.
- Full `go test ./...` green; `go vet` clean.

## Notes / follow-ups (not in this PR)
- **PERSON_NAME surname dictionary gap**: "Park" and Korean/East-Asian family names generally aren't in the ~2K surname list (even `David Park` misses) — needs a dictionary expansion, separate change.
- **Negative-keyword consolidation**: a shared universal-noise set (test/example/sample/…) is worth extracting to kill drift across validators, but per-validator specifics must stay separate — this PR proved they can be *contradictory* (`batch` suppresses SSN, must not suppress CREDIT_CARD). Captured for a future refactor PR.
- The ML reranker that motivated the corpus is **parked** — the cheap regex/keyword fixes here address the same false positives without the model/deployment cost.