### PR TITLE
fix(validators): tier negative keywords so ID labels don't hard-drop real cards/MRNs

### DIFF
--- a/internal/goldencorpus/corpus.go
+++ b/internal/goldencorpus/corpus.go
@@ -251,6 +251,21 @@ var Cases = []Case{
 			"Priya Raghavan approved the budget request\n" +
 			"Ford Mustang sales rose sharply\n",
 	},
+	{
+		Name: "context_soft_negative_labels",
+		Description: "Real PII labelled with an identifier word that is a SOFT suppressor " +
+			"(account/order for CREDIT_CARD, patient-account for MEDICAL_ID MRN). Locks the " +
+			"two-tier negative fix: a soft label must NOT hard-drop a real value when a strong " +
+			"positive keyword co-occurs (card word / MRN keyword), while a bare label line and " +
+			"a device-identifier decoy (IMEI: Luhn-valid, card-shaped) must stay suppressed. " +
+			"A future regression that reinstates the old -100 hard-drop shows up here.",
+		Checks: []string{"CREDIT_CARD", "MEDICAL_ID"},
+		Input: "Order 5678 paid with card 4532015112830366\n" +
+			"Account Number for visa 5425233430109903\n" +
+			"Patient account number: 1234567 on chart\n" +
+			"imei 490154203237518 on the handset\n" +
+			"order id: 4532015112830366 catalog\n",
+	},
 }
 
 // FileCase is one file-based corpus entry. Unlike Case (which scans an in-memory

--- a/internal/goldencorpus/testdata/golden/context_soft_negative_labels.csv
+++ b/internal/goldencorpus/testdata/golden/context_soft_negative_labels.csv
@@ -1,0 +1,4 @@
+Filename,Type,Confidence Level,Confidence %,Line Number,Text
+<golden:context_soft_negative_labels>,MASTERCARD,HIGH,100.0,2,5425233430109903
+<golden:context_soft_negative_labels>,VISA,HIGH,100.0,1,4532015112830366
+<golden:context_soft_negative_labels>,MRN,MEDIUM,65.0,3,1234567

--- a/internal/goldencorpus/testdata/golden/context_soft_negative_labels.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/context_soft_negative_labels.gitlab-sast.json
@@ -1,0 +1,108 @@
+{
+  "remediations": [],
+  "scan": {
+    "analyzer": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "end_time": "<TIMESTAMP>",
+    "scanner": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "start_time": "<TIMESTAMP>",
+    "status": "success",
+    "type": "sast"
+  },
+  "version": "15.0.4",
+  "vulnerabilities": [
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected mastercard credit card in this file.\n\n**Location:** <golden:context_soft_negative_labels> (line 2)\n**Confidence:** HIGH (100.0%)\n**Detected by:** creditcard validator\n\n**Context:**\n```\nAccount Number for visa 5425233430109903\n```\n\n**Additional Information:**\n- card_type: MASTERCARD\n- context_impact: 15\n- source: preprocessed_content\n- vendor: MasterCard\n\n**Remediation:**\nRemove or mask credit card numbers. Consider using tokenization for legitimate payment processing needs.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "MASTERCARD"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "creditcard"
+        }
+      ],
+      "location": {
+        "end_line": 2,
+        "file": "<golden:context_soft_negative_labels>",
+        "start_line": 2
+      },
+      "message": "Mastercard credit card detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Mastercard Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected visa credit card in this file.\n\n**Location:** <golden:context_soft_negative_labels> (line 1)\n**Confidence:** HIGH (100.0%)\n**Detected by:** creditcard validator\n\n**Context:**\n```\nOrder 5678 paid with card 4532015112830366\n```\n\n**Additional Information:**\n- card_type: VISA\n- context_impact: 15\n- source: preprocessed_content\n- vendor: Visa\n\n**Remediation:**\nRemove or mask credit card numbers. Consider using tokenization for legitimate payment processing needs.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "VISA"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "creditcard"
+        }
+      ],
+      "location": {
+        "end_line": 1,
+        "file": "<golden:context_soft_negative_labels>",
+        "start_line": 1
+      },
+      "message": "Visa credit card detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Visa Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected sensitive data (mrn) in this file.\n\n**Location:** <golden:context_soft_negative_labels> (line 3)\n**Confidence:** MEDIUM (65.0%)\n**Detected by:** medicalid validator\n\n**Context:**\n```\nPatient account number: 1234567 on chart\n```\n\n**Additional Information:**\n- context_impact: -5\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "MRN"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "medicalid"
+        }
+      ],
+      "location": {
+        "end_line": 3,
+        "file": "<golden:context_soft_negative_labels>",
+        "start_line": 3
+      },
+      "message": "Sensitive data (mrn) detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Mrn Detected",
+      "severity": "High"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/context_soft_negative_labels.json.json
+++ b/internal/goldencorpus/testdata/golden/context_soft_negative_labels.json.json
@@ -1,0 +1,106 @@
+{
+  "results": [
+    {
+      "confidence": 100,
+      "confidence_level": "HIGH",
+      "filename": "<golden:context_soft_negative_labels>",
+      "line_number": 2,
+      "metadata": {
+        "card_type": "MASTERCARD",
+        "confidence_adjustment": 0,
+        "context_confidence": 0.25,
+        "context_doctype": "Unknown",
+        "context_domain": "Unknown",
+        "context_impact": 15,
+        "original_confidence": 100,
+        "original_file": "<golden:context_soft_negative_labels>",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "entropy": true,
+          "length": true,
+          "luhn": true,
+          "not_repeating": true,
+          "not_test": true,
+          "vendor": true
+        },
+        "validation_path": "document",
+        "vendor": "MasterCard"
+      },
+      "text": "5425233430109903",
+      "type": "MASTERCARD",
+      "validator": "creditcard"
+    },
+    {
+      "confidence": 100,
+      "confidence_level": "HIGH",
+      "filename": "<golden:context_soft_negative_labels>",
+      "line_number": 1,
+      "metadata": {
+        "card_type": "VISA",
+        "confidence_adjustment": 0,
+        "context_confidence": 0.25,
+        "context_doctype": "Unknown",
+        "context_domain": "Unknown",
+        "context_impact": 15,
+        "original_confidence": 100,
+        "original_file": "<golden:context_soft_negative_labels>",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "entropy": true,
+          "length": true,
+          "luhn": true,
+          "not_repeating": true,
+          "not_test": true,
+          "vendor": true
+        },
+        "validation_path": "document",
+        "vendor": "Visa"
+      },
+      "text": "4532015112830366",
+      "type": "VISA",
+      "validator": "creditcard"
+    },
+    {
+      "confidence": 65,
+      "confidence_level": "MEDIUM",
+      "filename": "<golden:context_soft_negative_labels>",
+      "line_number": 3,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0.25,
+        "context_doctype": "Unknown",
+        "context_domain": "Unknown",
+        "context_impact": -5,
+        "original_confidence": 65,
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "subtype": "MRN",
+        "validation_path": "document"
+      },
+      "text": "1234567",
+      "type": "MRN",
+      "validator": "medicalid"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/context_soft_negative_labels.junit.xml
+++ b/internal/goldencorpus/testdata/golden/context_soft_negative_labels.junit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
+  <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
+    <testcase name="&lt;golden:context_soft_negative_labels&gt;" classname="security-scan" time="0.001">
+      <failure message="3 security findings detected" type="SECURITY_FINDINGS">Line 2: MASTERCARD detected with 100.0% confidence (HIGH)&#xA;Match: 5425233430109903&#xA;Validator: creditcard&#xA;Line 1: VISA detected with 100.0% confidence (HIGH)&#xA;Match: 4532015112830366&#xA;Validator: creditcard&#xA;Line 3: MRN detected with 65.0% confidence (MEDIUM)&#xA;Match: 1234567&#xA;Validator: medicalid</failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/internal/goldencorpus/testdata/golden/context_soft_negative_labels.redact_format_preserving.txt
+++ b/internal/goldencorpus/testdata/golden/context_soft_negative_labels.redact_format_preserving.txt
@@ -1,0 +1,10 @@
+=== REDACTED ===
+Order 5678 paid with card ************0366
+Account Number for visa ************9903
+Patient account number: ******* on chart
+imei 490154203237518 on the handset
+order id: 4532015112830366 catalog
+=== FINDINGS (sorted) ===
+type=MASTERCARD line=2 conf=high match=5425233430109903
+type=MRN line=3 conf=medium match=1234567
+type=VISA line=1 conf=high match=4532015112830366

--- a/internal/goldencorpus/testdata/golden/context_soft_negative_labels.redact_simple.txt
+++ b/internal/goldencorpus/testdata/golden/context_soft_negative_labels.redact_simple.txt
@@ -1,0 +1,10 @@
+=== REDACTED ===
+Order 5678 paid with card [CREDIT-CARD-REDACTED]
+Account Number for visa [CREDIT-CARD-REDACTED]
+Patient account number: [MRN-REDACTED] on chart
+imei 490154203237518 on the handset
+order id: 4532015112830366 catalog
+=== FINDINGS (sorted) ===
+type=MASTERCARD line=2 conf=high match=5425233430109903
+type=MRN line=3 conf=medium match=1234567
+type=VISA line=1 conf=high match=4532015112830366

--- a/internal/goldencorpus/testdata/golden/context_soft_negative_labels.sarif.json
+++ b/internal/goldencorpus/testdata/golden/context_soft_negative_labels.sarif.json
@@ -1,0 +1,257 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/refs/heads/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:context_soft_negative_labels>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "Account Number for visa \nAccount Number for visa 5425233430109903"
+                  },
+                  "startLine": 2
+                },
+                "region": {
+                  "endColumn": 41,
+                  "snippet": {
+                    "text": "Account Number for visa 5425233430109903"
+                  },
+                  "startColumn": 25,
+                  "startLine": 2
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "MASTERCARD Detected in <golden:context_soft_negative_labels> at line 2 (confidence: 100.0% - HIGH). Matched text: '5425233430109903'"
+          },
+          "properties": {
+            "confidence": 100,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "card_type": "MASTERCARD",
+              "confidence_adjustment": 0,
+              "context_confidence": 0.3,
+              "context_doctype": "Unknown",
+              "context_domain": "Unknown",
+              "context_impact": 15,
+              "original_confidence": 100,
+              "original_file": "<golden:context_soft_negative_labels>",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "digits": true,
+                "entropy": true,
+                "length": true,
+                "luhn": true,
+                "not_repeating": true,
+                "not_test": true,
+                "vendor": true
+              },
+              "validation_path": "document",
+              "vendor": "MasterCard"
+            },
+            "validator": "creditcard"
+          },
+          "rank": 75,
+          "ruleId": "MASTERCARD"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:context_soft_negative_labels>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "Order 5678 paid with card \nOrder 5678 paid with card 4532015112830366"
+                  },
+                  "startLine": 1
+                },
+                "region": {
+                  "endColumn": 43,
+                  "snippet": {
+                    "text": "Order 5678 paid with card 4532015112830366"
+                  },
+                  "startColumn": 27,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "VISA Detected in <golden:context_soft_negative_labels> at line 1 (confidence: 100.0% - HIGH). Matched text: '4532015112830366'"
+          },
+          "properties": {
+            "confidence": 100,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "card_type": "VISA",
+              "confidence_adjustment": 0,
+              "context_confidence": 0.3,
+              "context_doctype": "Unknown",
+              "context_domain": "Unknown",
+              "context_impact": 15,
+              "original_confidence": 100,
+              "original_file": "<golden:context_soft_negative_labels>",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "digits": true,
+                "entropy": true,
+                "length": true,
+                "luhn": true,
+                "not_repeating": true,
+                "not_test": true,
+                "vendor": true
+              },
+              "validation_path": "document",
+              "vendor": "Visa"
+            },
+            "validator": "creditcard"
+          },
+          "rank": 75,
+          "ruleId": "VISA"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:context_soft_negative_labels>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "Patient account number: \nPatient account number: 1234567 on chart\n on chart"
+                  },
+                  "startLine": 3
+                },
+                "region": {
+                  "endColumn": 32,
+                  "snippet": {
+                    "text": "Patient account number: 1234567 on chart"
+                  },
+                  "startColumn": 25,
+                  "startLine": 3
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "MRN Detected in <golden:context_soft_negative_labels> at line 3 (confidence: 65.0% - MEDIUM). Matched text: '1234567'"
+          },
+          "properties": {
+            "confidence": 65,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 0.3,
+              "context_doctype": "Unknown",
+              "context_domain": "Unknown",
+              "context_impact": -5,
+              "original_confidence": 65,
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "subtype": "MRN",
+              "validation_path": "document"
+            },
+            "negativeKeywords": [
+              "account"
+            ],
+            "positiveKeywords": [
+              "patient"
+            ],
+            "validator": "medicalid"
+          },
+          "rank": 57.5,
+          "ruleId": "MRN"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/awslabs/ferret-scan",
+          "name": "Ferret Scan",
+          "rules": [
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type MASTERCARD was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/MASTERCARD.md",
+              "id": "MASTERCARD",
+              "shortDescription": {
+                "text": "MASTERCARD Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type MRN was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/MRN.md",
+              "id": "MRN",
+              "shortDescription": {
+                "text": "MRN Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type VISA was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/VISA.md",
+              "id": "VISA",
+              "shortDescription": {
+                "text": "VISA Detected"
+              }
+            }
+          ],
+          "semanticVersion": "0.0.0-development",
+          "version": "0.0.0-development"
+        }
+      },
+      "versionControlProvenance": [
+        {
+          "mappedTo": {
+            "uriBaseId": "%SRCROOT%"
+          },
+          "repositoryUri": "https://github.com/awslabs/ferret-scan",
+          "revisionId": "0.0.0-development"
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/internal/goldencorpus/testdata/golden/context_soft_negative_labels.txt
+++ b/internal/goldencorpus/testdata/golden/context_soft_negative_labels.txt
@@ -1,0 +1,5 @@
+LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH            FILE
+------------------------------------------------------------------------------------------
+[HIGH  ] creditcard   MASTERCARD            100.00% line     2 5425233430109903 <golden:context_soft_negative_labels>
+[HIGH  ] creditcard   VISA                  100.00% line     1 4532015112830366 <golden:context_soft_negative_labels>
+[MEDIUM] medicalid    MRN                    65.00% line     3 1234567          <golden:context_soft_negative_labels>

--- a/internal/goldencorpus/testdata/golden/context_soft_negative_labels.yaml
+++ b/internal/goldencorpus/testdata/golden/context_soft_negative_labels.yaml
@@ -1,0 +1,89 @@
+results:
+    - text: "5425233430109903"
+      line_number: 2
+      type: MASTERCARD
+      confidence: 100
+      confidence_level: HIGH
+      filename: <golden:context_soft_negative_labels>
+      validator: creditcard
+      metadata:
+        card_type: MASTERCARD
+        confidence_adjustment: 0
+        context_confidence: 0.25
+        context_doctype: Unknown
+        context_domain: Unknown
+        context_impact: 15
+        original_confidence: 100
+        original_file: <golden:context_soft_negative_labels>
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            entropy: true
+            length: true
+            luhn: true
+            not_repeating: true
+            not_test: true
+            vendor: true
+        validation_path: document
+        vendor: MasterCard
+    - text: "4532015112830366"
+      line_number: 1
+      type: VISA
+      confidence: 100
+      confidence_level: HIGH
+      filename: <golden:context_soft_negative_labels>
+      validator: creditcard
+      metadata:
+        card_type: VISA
+        confidence_adjustment: 0
+        context_confidence: 0.25
+        context_doctype: Unknown
+        context_domain: Unknown
+        context_impact: 15
+        original_confidence: 100
+        original_file: <golden:context_soft_negative_labels>
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            entropy: true
+            length: true
+            luhn: true
+            not_repeating: true
+            not_test: true
+            vendor: true
+        validation_path: document
+        vendor: Visa
+    - text: "1234567"
+      line_number: 3
+      type: MRN
+      confidence: 65
+      confidence_level: MEDIUM
+      filename: <golden:context_soft_negative_labels>
+      validator: medicalid
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0.25
+        context_doctype: Unknown
+        context_domain: Unknown
+        context_impact: -5
+        original_confidence: 65
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        subtype: MRN
+        validation_path: document

--- a/internal/validators/creditcard/validator.go
+++ b/internal/validators/creditcard/validator.go
@@ -38,14 +38,26 @@ type Validator struct {
 
 	// Keywords for context analysis
 	positiveKeywords []string
-	negativeKeywords []string
+	negativeKeywords []string // hard + soft, combined for help/display
+
+	// Two-tier negative keywords. hardNegativeKeywords denote a fundamentally
+	// different mathematical/synthetic object (hashes, timestamps, version
+	// strings, test fixtures) that is NEVER a payment card, so they suppress the
+	// candidate outright. softNegativeKeywords are identifier/label words
+	// (account, order, serial, imei, ...) that legitimately share a line with a
+	// real card ("Order 5678 paid with card 4111...", "Account Number: 4111...");
+	// they suppress ONLY when no positive card keyword co-occurs, so an explicit
+	// card word overrides the label rather than dropping a real card.
+	hardNegativeKeywords []string
+	softNegativeKeywords []string
 
 	// Pre-compiled word-boundary keyword matchers. Built from the slices above,
 	// these match a keyword only as a whole word (\bkw\b) so short tokens like
 	// "id"/"tel"/"sha" no longer match inside "david"/"hotel"/"sha256" — a
 	// substring match there was forcing Luhn-valid cards to -100 (dropped).
-	positiveKeywordRegex *regexp.Regexp
-	negativeKeywordRegex *regexp.Regexp
+	positiveKeywordRegex     *regexp.Regexp
+	hardNegativeKeywordRegex *regexp.Regexp
+	softNegativeKeywordRegex *regexp.Regexp
 
 	// Observability
 	observer observability.Observer
@@ -79,21 +91,36 @@ func NewValidator() *Validator {
 		binRanges: initBINRanges(),
 
 		positiveKeywords: []string{
-			"credit", "card", "visa", "mastercard", "amex", "american express",
+			"credit", "debit", "card", "visa", "mastercard", "amex", "american express",
 			"discover", "jcb", "diners", "cardholder", "payment", "transaction",
 			"purchase", "expiration", "expiry", "exp", "cvv", "cvc", "ccv",
 			"billing", "checkout", "pay", "paid", "pci", "merchant",
 		},
 
-		negativeKeywords: []string{
-			"account", "id", "identifier", "serial", "tracking", "reference",
-			"order", "invoice", "timestamp", "unix", "epoch", "phone", "tel",
+		// hardNegativeKeywords mark a fundamentally different mathematical or
+		// synthetic object — a hash, a timestamp, a version string, a test
+		// fixture — that a Luhn-valid 13-19 digit run may coincidentally match
+		// but that is NEVER a payment card. These suppress outright (-100)
+		// regardless of any positive keyword on the line.
+		hardNegativeKeywords: []string{
+			"timestamp", "unix", "epoch", "phone", "tel",
 			// "telephone" is kept as an explicit keyword: with whole-word
 			// matching "tel" no longer matches inside "telephone", but a phone
 			// label is still a legitimate negative signal.
 			"telephone",
 			"md5", "sha", "hash", "uuid", "guid", "crc", "checksum",
 			"version", "build", "test", "example", "fake", "mock", "sample",
+		},
+
+		// softNegativeKeywords are identifier/label words that frequently sit
+		// on the SAME line as a real card ("Order 5678 paid with card 4111...",
+		// "Account Number: 4111 1111 1111 1111", "serial ... visa 4532..."). They
+		// suppress ONLY when no positive card keyword co-occurs on the line — an
+		// explicit card word overrides the label — so a genuine card labelled
+		// with an account/order/serial number is no longer hard-dropped.
+		softNegativeKeywords: []string{
+			"account", "id", "identifier", "serial", "tracking", "reference",
+			"order", "invoice",
 			// Synonym clusters the reranker-benchmark corpus proved walk
 			// straight past the list above: "S/N" fired at 95 where "serial"
 			// was suppressed; same for shipping/logistics and inventory
@@ -105,15 +132,24 @@ func NewValidator() *Validator {
 			"s/n", "sn#", "nameplate", "waybill", "parcel",
 			"booking", "barcode", "asset", "asset tag", "sku",
 			"part", "designator", "receipt", "session", "token",
+			// Device/loyalty identifiers whose numbers are Luhn-valid and card-
+			// shaped, surfacing as FPs today: IMEI (15-digit Luhn), ICCID (SIM,
+			// 19-20 digit Luhn), and loyalty/rewards/membership program numbers.
+			"imei", "iccid", "loyalty", "rewards", "membership",
 		},
 	}
+
+	// negativeKeywords is the combined hard+soft list, retained for help/display
+	// (help.go) and the NewValidator sanity test.
+	v.negativeKeywords = append(append([]string{}, v.hardNegativeKeywords...), v.softNegativeKeywords...)
 
 	// Compile regex once
 	v.regex = regexp.MustCompile(v.pattern)
 
 	// Build word-boundary keyword matchers from the slices above.
 	v.positiveKeywordRegex = buildKeywordRegex(v.positiveKeywords)
-	v.negativeKeywordRegex = buildKeywordRegex(v.negativeKeywords)
+	v.hardNegativeKeywordRegex = buildKeywordRegex(v.hardNegativeKeywords)
+	v.softNegativeKeywordRegex = buildKeywordRegex(v.softNegativeKeywords)
 
 	// Pre-compile test patterns for fast rejection
 	v.testPatterns = []*regexp.Regexp{
@@ -568,9 +604,12 @@ func buildKeywordRegex(keywords []string) *regexp.Regexp {
 // implementation used strings.Contains, so a negative keyword like "id"/"tel"/"sha"
 // matched inside ordinary words ("david", "hotel", "sha256") and returned -100,
 // dropping Luhn-valid cards outright even under explicit "credit card" context.
-// Whole-word matching is a strict subset of the old substring matching, so this
-// change can only RECOVER cards that were wrongly dropped — it can never newly
-// drop a card or surface one that carries a genuine negative keyword.
+//
+// Negatives are tiered (see analyzeContextLower): HARD negatives (hash/version/
+// test markers) always suppress; SOFT negatives (account/order/serial-style
+// labels that legitimately co-occur with a real card) suppress only when no
+// positive card keyword is present, so "Order 5678 paid with card 4111..." is
+// no longer dropped while a bare "order id: 4111..." still is.
 func (v *Validator) analyzeContext(match string, context detector.ContextInfo) float64 {
 	return v.analyzeContextLower(strings.ToLower(context.FullLine))
 }
@@ -581,13 +620,25 @@ func (v *Validator) analyzeContext(match string, context detector.ContextInfo) f
 // ONCE and calls this directly, instead of lowercasing the whole line again for
 // every match on the line. Behavior is identical to analyzeContext.
 func (v *Validator) analyzeContextLower(lowerLine string) float64 {
-	// Quick negative keyword check (more important for false positive reduction)
-	if v.negativeKeywordRegex != nil && v.negativeKeywordRegex.MatchString(lowerLine) {
+	// Hard negatives suppress outright: the number is a different mathematical/
+	// synthetic object (hash, timestamp, version, test fixture), never a card,
+	// so an incidental positive word cannot rescue it.
+	if v.hardNegativeKeywordRegex != nil && v.hardNegativeKeywordRegex.MatchString(lowerLine) {
 		return -100 // Very strong negative impact to ensure rejection
 	}
 
+	positive := v.positiveKeywordRegex != nil && v.positiveKeywordRegex.MatchString(lowerLine)
+
+	// Soft negatives are identifier/label words that co-occur with REAL cards.
+	// They suppress only when no positive card keyword is present on the line;
+	// an explicit card word ("card"/"paid"/"visa"/...) overrides the label so a
+	// genuine card labelled with an account/order/serial number is not dropped.
+	if !positive && v.softNegativeKeywordRegex != nil && v.softNegativeKeywordRegex.MatchString(lowerLine) {
+		return -100
+	}
+
 	// Quick positive keyword check
-	if v.positiveKeywordRegex != nil && v.positiveKeywordRegex.MatchString(lowerLine) {
+	if positive {
 		return 15 // Boost for positive context (single boost; avoid over-boosting)
 	}
 

--- a/internal/validators/creditcard/validator_test.go
+++ b/internal/validators/creditcard/validator_test.go
@@ -847,6 +847,89 @@ func TestCreditCardValidator_NegativeKeywordWordBoundary(t *testing.T) {
 	}
 }
 
+// TestCreditCardValidator_SoftNegativeOverride locks the two-tier negative
+// behavior: SOFT negatives (account/order/serial-style identifier labels that
+// legitimately co-occur with a real card) suppress ONLY when no positive card
+// keyword is present. An explicit card word overrides the label so a genuine
+// card labelled with an account/order number is no longer hard-dropped, while a
+// bare label line (no card word) still suppresses.
+func TestCreditCardValidator_SoftNegativeOverride(t *testing.T) {
+	v := NewValidator()
+	const card = "4532015112830366" // Luhn-valid, not a known test pattern
+
+	// Positive card keyword present -> soft negative must NOT drop the card.
+	recovered := []string{
+		"Order 5678 paid with card " + card,    // "order" soft-neg, "paid"/"card" positive
+		"Account Number for visa " + card,      // "account" soft-neg, "visa" positive
+		"serial reference, cardholder " + card, // "serial"/"reference" soft-neg, "cardholder" positive
+		"invoice line: credit card " + card,    // "invoice" soft-neg, "credit"/"card" positive
+	}
+	for _, line := range recovered {
+		impact := v.AnalyzeContext(card, detector.ContextInfo{FullLine: line})
+		if impact <= -100 {
+			t.Errorf("soft negative must not drop card when a positive co-occurs for %q, got impact %.1f", line, impact)
+		}
+		matches, err := v.ValidateContent(line, "test.txt")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		found := false
+		for _, m := range matches {
+			if strings.Contains(m.Text, card) && m.Confidence > 15 {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected labelled real card to surface for %q, got %d matches", line, len(matches))
+		}
+	}
+
+	// Bare soft-negative label (no card word) must STILL suppress.
+	for _, line := range []string{
+		"account number " + card,
+		"order id: " + card,
+		"serial " + card,
+	} {
+		impact := v.AnalyzeContext(card, detector.ContextInfo{FullLine: line})
+		if impact > -100 {
+			t.Errorf("bare soft-negative label should still suppress for %q, got impact %.1f", line, impact)
+		}
+	}
+
+	// HARD negatives suppress regardless of any positive on the line.
+	for _, line := range []string{
+		"card sha256 checksum " + card, // "card" positive but "sha"/"checksum" are hard
+		"payment md5 hash " + card,     // "payment" positive but "md5"/"hash" are hard
+		"visa version 2 build " + card, // "visa" positive but "version"/"build" are hard
+	} {
+		impact := v.AnalyzeContext(card, detector.ContextInfo{FullLine: line})
+		if impact > -100 {
+			t.Errorf("hard negative must suppress even with a positive present for %q, got impact %.1f", line, impact)
+		}
+	}
+}
+
+// TestCreditCardValidator_DeviceIdentifierDecoys locks suppression of Luhn-valid,
+// card-shaped device/loyalty identifiers (IMEI, ICCID, loyalty numbers) that are
+// not payment cards. The IMEI 490154203237518 is 15 digits, Luhn-valid, and
+// starts with 4 — it passes the card regex + Luhn gate and surfaced as an FP
+// before "imei"/"iccid"/"loyalty" were added as soft negatives.
+func TestCreditCardValidator_DeviceIdentifierDecoys(t *testing.T) {
+	v := NewValidator()
+	for _, line := range []string{
+		"imei 490154203237518 on the handset",
+		"device iccid 8991101200003204510 registered",
+		"loyalty number 4532015112830366 redeemed",
+		"rewards membership 4532015112830366 balance",
+	} {
+		impact := v.AnalyzeContext("490154203237518", detector.ContextInfo{FullLine: line})
+		if impact > -100 {
+			t.Errorf("device/loyalty identifier should be suppressed for %q, got impact %.1f", line, impact)
+		}
+	}
+}
+
 // TestCreditCardValidator_EqualsColonDelimiters is a regression test for M4:
 // the delimiter classes omitted '=' and ':', so PANs in config / key=value /
 // key:value logs (the dominant leak format) were missed.

--- a/internal/validators/medicalid/validator.go
+++ b/internal/validators/medicalid/validator.go
@@ -145,8 +145,17 @@ type medicalLineContext struct {
 	medical    bool // hasMedicalContext
 	mrnKeyword bool // hasMRNKeyword
 	insKeyword bool // hasInsuranceKeyword
-	nonMedKW   bool // nonMedicalKeywordPresent (MRN suppressor keywords)
-	nonInsKW   bool // nonInsuranceKeywordPresent (insurance suppressor keywords)
+	// MRN suppressor keywords, split into two tiers (see the eval in
+	// evaluateMRN). nonMedHardKW marks a different NUMBER TYPE (phone/ssn/zip/
+	// postal/fax/extension) that a bare 6-10 digit run is far likelier to be
+	// than an MRN — always suppresses. nonMedSoftKW marks identifier LABELS
+	// (account/order/invoice/tracking/serial) that legitimately sit beside a
+	// real MRN in hospital records ("Patient account number: 1234567"); it
+	// suppresses only when NO strong MRN keyword is present, so a labelled MRN
+	// is not hard-dropped.
+	nonMedHardKW bool
+	nonMedSoftKW bool
+	nonInsKW     bool // nonInsuranceKeywordPresent (insurance suppressor keywords)
 }
 
 // scanLine scans a single line for all medical ID types.
@@ -173,18 +182,19 @@ func (v *Validator) scanLine(ctx stdctx.Context, line string, lineNum int, origi
 	// medicalid O(n^2) the expanded complexity guard caught. Computed once
 	// here and passed down via lc.
 	lc := medicalLineContext{
-		lineImpact: lineImpact,
-		posKW:      linePositiveKeywords,
-		negKW:      lineNegativeKeywords,
-		phone:      v.hasPhoneContext(lowerLine),
-		provider:   v.hasProviderContext(lowerLine),
-		dea:        v.hasDEAContext(lowerLine),
-		medicare:   v.hasMedicareContext(lowerLine),
-		medical:    v.hasMedicalContext(lowerLine),
-		mrnKeyword: v.hasMRNKeyword(lowerLine),
-		insKeyword: v.hasInsuranceKeyword(lowerLine),
-		nonMedKW:   v.nonMedicalKeywordPresent(lowerLine),
-		nonInsKW:   v.nonInsuranceKeywordPresent(lowerLine),
+		lineImpact:   lineImpact,
+		posKW:        linePositiveKeywords,
+		negKW:        lineNegativeKeywords,
+		phone:        v.hasPhoneContext(lowerLine),
+		provider:     v.hasProviderContext(lowerLine),
+		dea:          v.hasDEAContext(lowerLine),
+		medicare:     v.hasMedicareContext(lowerLine),
+		medical:      v.hasMedicalContext(lowerLine),
+		mrnKeyword:   v.hasMRNKeyword(lowerLine),
+		insKeyword:   v.hasInsuranceKeyword(lowerLine),
+		nonMedHardKW: v.nonMedicalHardKeywordPresent(lowerLine),
+		nonMedSoftKW: v.nonMedicalSoftKeywordPresent(lowerLine),
+		nonInsKW:     v.nonInsuranceKeywordPresent(lowerLine),
 	}
 
 	// scanMatches runs one regex over the line, polling ctx between matches so a
@@ -385,7 +395,13 @@ func (v *Validator) evaluateDashedMBI(match, line, lowerLine string, lc medicalL
 func (v *Validator) evaluateMRN(match, line, lowerLine string, lc medicalLineContext, matchStart int, lineNum int, originalPath string) (detector.Match, bool) {
 	// MRN is very generic (just digits), so only detect with strong medical context.
 	// Skip if it looks like a phone, SSN component, zip code, year, etc.
-	if lc.nonMedKW || v.looksLikeNonMedicalNumberShape(match) {
+	//
+	// Hard suppressors (a different number TYPE) always veto. Soft suppressors
+	// (account/order/invoice/tracking/serial labels) veto ONLY without a strong
+	// MRN keyword: a hospital record line "Patient account number: 1234567"
+	// carries both "patient account" (an MRN keyword) and "account" (a soft
+	// suppressor), and the real MRN must not be hard-dropped by the label.
+	if lc.nonMedHardKW || (lc.nonMedSoftKW && !lc.mrnKeyword) || v.looksLikeNonMedicalNumberShape(match) {
 		return detector.Match{}, false
 	}
 
@@ -676,6 +692,10 @@ func (v *Validator) hasMRNKeyword(lowerLine string) bool {
 	mrnKW := []string{
 		"mrn", "medical record", "patient id", "patient number",
 		"record number", "chart number", "admission number",
+		// "patient account (number)" is the standard hospital-billing label for
+		// the MRN/account identifier; without it, the "account" soft suppressor
+		// would hard-drop the real MRN on this line.
+		"patient account",
 	}
 	for _, kw := range mrnKW {
 		if containsKeyword(lowerLine, kw) {
@@ -713,12 +733,28 @@ func (v *Validator) hasInsuranceKeyword(lowerLine string) bool {
 }
 
 // looksLikeNonMedicalNumber checks if a digit sequence is likely not an MRN.
-// nonMedicalKeywordPresent reports whether the line carries a keyword that
-// makes a digit run more likely a phone/SSN/zip/order number than an MRN.
+// nonMedicalHardKeywordPresent reports whether the line names a different NUMBER
+// TYPE (phone/SSN/zip/postal/fax/extension) — a bare 6-10 digit run beside these
+// is overwhelmingly that, not an MRN, so it suppresses unconditionally.
 // Line-global — hoisted into medicalLineContext (was scanned per match).
-func (v *Validator) nonMedicalKeywordPresent(lowerLine string) bool {
+func (v *Validator) nonMedicalHardKeywordPresent(lowerLine string) bool {
 	for _, kw := range []string{
 		"phone", "ssn", "zip", "postal", "fax", "extension",
+	} {
+		if containsKeyword(lowerLine, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// nonMedicalSoftKeywordPresent reports whether the line carries an identifier
+// LABEL (account/order/invoice/tracking/serial) that commonly sits beside a real
+// MRN in hospital records. It suppresses only when no strong MRN keyword is
+// present (see evaluateMRN), so "Patient account number: 1234567" is not dropped.
+// Line-global — hoisted into medicalLineContext (was scanned per match).
+func (v *Validator) nonMedicalSoftKeywordPresent(lowerLine string) bool {
+	for _, kw := range []string{
 		"account", "order", "invoice", "tracking", "serial",
 	} {
 		if containsKeyword(lowerLine, kw) {

--- a/internal/validators/medicalid/validator_test.go
+++ b/internal/validators/medicalid/validator_test.go
@@ -317,6 +317,53 @@ func TestMedicalIDValidator_MRN_Positive(t *testing.T) {
 	}
 }
 
+// TestMedicalIDValidator_PatientAccountMRN locks the soft-suppressor fix: a real
+// MRN labelled with "patient account number" must surface even though "account"
+// is a suppressor keyword, because "patient account" is a strong MRN keyword. A
+// bare "Account: <digits>" line (no MRN keyword) must still be suppressed.
+func TestMedicalIDValidator_PatientAccountMRN(t *testing.T) {
+	validator := NewValidator()
+
+	// Recovered: "patient account (number)" is a hospital MRN label.
+	for _, content := range []string{
+		"Patient account number: 1234567",
+		"patient account: 7654321 on file",
+	} {
+		matches, err := validator.ValidateContent(content, "test.txt")
+		if err != nil {
+			t.Fatalf("ValidateContent() error = %v", err)
+		}
+		found := false
+		for _, m := range matches {
+			if m.Type == "MRN" && m.Confidence >= 60 {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected high-confidence MRN for %q, got %d matches", content, len(matches))
+		}
+	}
+
+	// Still suppressed: soft label without a strong MRN keyword, and hard
+	// suppressors regardless of MRN keyword.
+	for _, content := range []string{
+		"Account: 1104332188",               // soft label, no MRN keyword
+		"Order for patient: 12345678",       // soft label + generic "patient" only
+		"patient account phone: 5551234567", // MRN keyword but a hard phone veto
+	} {
+		matches, err := validator.ValidateContent(content, "test.txt")
+		if err != nil {
+			t.Fatalf("ValidateContent() error = %v", err)
+		}
+		for _, m := range matches {
+			if m.Type == "MRN" && m.Confidence >= 60 {
+				t.Errorf("expected no high-confidence MRN for %q, got %.1f for %s", content, m.Confidence, m.Text)
+			}
+		}
+	}
+}
+
 func TestMedicalIDValidator_MRN_Negative(t *testing.T) {
 	validator := NewValidator()
 


### PR DESCRIPTION
## Summary

Wave 1 (HIGH) of the cross-validator keyword-coverage audit. The `creditcard` and `medicalid` validators treated identifier-label words (`account`, `order`, `invoice`, `serial`, ...) as **absolute** suppressors: a single whole-word match forced context impact to `-100` (creditcard) or vetoed the MRN outright (medicalid) **before any positive signal was considered**. Real, checksum-valid values were dropped to zero and **leaked in cleartext during redaction**:

- `Order 5678 paid with card 4532015112830366` — Luhn-valid VISA, dropped by `order`
- `Account Number for visa 5425233430109903` — Luhn-valid MASTERCARD, dropped by `account`
- `Patient account number: 1234567 on chart` — real MRN, vetoed by `account`

## Fix: two-tier negatives

- **HARD negatives** name a fundamentally different mathematical/number object and still suppress unconditionally (creditcard: hash/timestamp/version/test markers; medicalid: phone/ssn/zip/postal/fax/extension).
- **SOFT negatives** (account/order/invoice/serial/tracking labels that legitimately co-occur with a real value) suppress **only when no strong positive keyword is present**. A card word (creditcard) or MRN keyword (medicalid) overrides the label. `patient account` added as an MRN keyword for the standard hospital-billing label.

Also:
- creditcard: added Luhn-valid, card-shaped **device/loyalty** identifiers (`imei`, `iccid`, `loyalty`, `rewards`, `membership`) as soft negatives — an IMEI (`490154203237518`) passes the regex + Luhn gate and surfaced as an FP. Added `debit` positive.

## Mathematical gates unchanged (earliest hard drop)

Confirmed and preserved: creditcard Luhn (runs before scoring), bankaccount IBAN mod-97 / ABA checksum, medicalid NPI Luhn, VIN North-American check digit. **No compute = dropped, regardless of context.**

## Net effect (TP↑/maintained, FP↓/maintained)

New golden case `context_soft_negative_labels` locks it: **3 real values recovered** (2 cards HIGH, 1 MRN MEDIUM) and now correctly **redacted**; **IMEI decoy and bare `order id:` card stay suppressed**. **Zero diff on all existing golden cases** across the 7 output formats (text/json/csv/yaml/junit/gitlab-sast/sarif).

## Tests

- New: `TestCreditCardValidator_SoftNegativeOverride`, `TestCreditCardValidator_DeviceIdentifierDecoys`, `TestMedicalIDValidator_PatientAccountMRN`
- 23 packages pass, 0 failures; `go vet` clean; gofmt clean.