### PR TITLE
fix(validators): narrow four over-suppressing negative keywords (Wave 2)

### DIFF
--- a/internal/validators/bankaccount/validator.go
+++ b/internal/validators/bankaccount/validator.go
@@ -41,6 +41,10 @@ var (
 	rePhoneLike   = regexp.MustCompile(`\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}`)
 	reDateLike    = regexp.MustCompile(`\d{1,2}[/-]\d{1,2}[/-]\d{2,4}|\d{4}-\d{2}-\d{2}`)
 	reVersionLike = regexp.MustCompile(`\b[vV]?\d+\.\d+\.\d+`)
+	// reVersionPrefix matches a "v"/"v." version prefix bound to a digit at a
+	// word boundary (v.1, v2, V.10), so a version-labelled number is suppressed
+	// without a bare "v." substring firing inside unrelated words.
+	reVersionPrefix = regexp.MustCompile(`\b[vV]\.?\d`)
 
 	// ISO 3166-1 alpha-2 country codes (subset used for IBAN validation).
 	validIBANCountries = map[string]int{
@@ -975,13 +979,22 @@ func (v *Validator) looksLikeDate(line string, start, end int) bool {
 }
 
 // looksLikeVersion checks if the digit sequence is preceded by a version indicator.
+//
+// The "version" word is matched on a WHOLE-WORD boundary (containsKeyword), not a
+// raw substring: a bare strings.Contains matched "version" inside "conversion",
+// "subversion" and "aversion", wrongly suppressing a real account number that
+// happened to follow one of those words. The "v." prefix check is likewise
+// anchored to a version token (reVersionPrefix: "v." or "v" immediately before a
+// digit at a word boundary, e.g. "v.1"/"v2"), not any word merely ending in "v".
 func (v *Validator) looksLikeVersion(line string, start int) bool {
 	windowStart := start - 10
 	if windowStart < 0 {
 		windowStart = 0
 	}
 	window := line[windowStart:start]
-	return reVersionLike.MatchString(window) || strings.Contains(strings.ToLower(window), "version") || strings.Contains(strings.ToLower(window), "v.")
+	return reVersionLike.MatchString(window) ||
+		containsKeyword(window, "version") ||
+		reVersionPrefix.MatchString(window)
 }
 
 // --- Utility helpers ---

--- a/internal/validators/bankaccount/validator_test.go
+++ b/internal/validators/bankaccount/validator_test.go
@@ -470,6 +470,43 @@ func TestBankAccountValidator_USAccount_Negative(t *testing.T) {
 	}
 }
 
+// TestBankAccountValidator_VersionSubstring locks the looksLikeVersion whole-word
+// fix: "version" as a bare substring inside "conversion"/"subversion"/"aversion"
+// wrongly suppressed a real account number that happened to follow one of those
+// words. Whole-word matching detects the account again, while a genuine "version"
+// label and a "v.N" prefix still suppress.
+func TestBankAccountValidator_VersionSubstring(t *testing.T) {
+	validator := NewValidator()
+
+	// Recovered: "conversion"/"subversion" must NOT suppress a banking-context account.
+	for _, content := range []string{
+		"checking conversion 12345678901",
+		"savings subversion 98765432100",
+	} {
+		matches, err := validator.ValidateContent(content, "test.txt")
+		if err != nil {
+			t.Fatalf("ValidateContent() error = %v", err)
+		}
+		if len(filterByType(matches, "US_BANK_ACCOUNT")) == 0 {
+			t.Errorf("expected US_BANK_ACCOUNT for %q (version-substring must not suppress), got none", content)
+		}
+	}
+
+	// Still suppressed: a genuine version label / v.N prefix.
+	for _, content := range []string{
+		"checking version 12345678901",
+		"savings v.2 12345678901",
+	} {
+		matches, err := validator.ValidateContent(content, "test.txt")
+		if err != nil {
+			t.Fatalf("ValidateContent() error = %v", err)
+		}
+		if len(filterByType(matches, "US_BANK_ACCOUNT")) > 0 {
+			t.Errorf("expected version context to suppress account for %q, got a match", content)
+		}
+	}
+}
+
 func TestBankAccountValidator_ContextAnalysis(t *testing.T) {
 	validator := NewValidator()
 

--- a/internal/validators/driverslicense/validator.go
+++ b/internal/validators/driverslicense/validator.go
@@ -131,7 +131,12 @@ func NewValidator() *Validator {
 			"ssn", "social security", "phone", "account", "serial",
 			"order", "invoice", "reference", "tracking", "confirmation",
 			"test", "example", "sample", "placeholder", "fake", "mock", "demo",
-			"ip", "address", "port", "version", "build", "hash",
+			// "address" is intentionally NOT a negative: a driver's-license record
+			// almost always lists the holder's physical address on the same line,
+			// so it hard-suppressed real DLs. "IP address" is still caught by the
+			// "ip" keyword; a bare address line never reaches scoring because the
+			// positive-keyword gate (lineHasPositiveKeyword) requires DL context.
+			"ip", "port", "version", "build", "hash",
 			"uuid", "guid", "isbn", "sku", "model",
 			// Non-DL license/permit contexts (common false positive sources)
 			"software", "fishing", "hunting", "gun", "concealed",
@@ -387,11 +392,15 @@ func (v *Validator) lineHasPositiveKeyword(line string) bool {
 			return true
 		}
 	}
-	// Also accept state name + a generic ID indicator
+	// Also accept state name + a generic ID indicator. "id" is matched as a
+	// WHOLE WORD (containsKeyword), not a raw substring: strings.Contains(lower,
+	// "id") fired inside "resident"/"valid"/"midtown", so a state name plus any
+	// such word wrongly opened the DL gate. "number"/"no."/"no:" stay as-is
+	// (they do not collide with common words the way bare "id" does).
 	if reStateName.MatchString(line) {
-		// State name alone is not enough; require at least "id" or "number" nearby
 		lower := strings.ToLower(line)
-		if strings.Contains(lower, "id") || strings.Contains(lower, "number") || strings.Contains(lower, "no.") || strings.Contains(lower, "no:") {
+		if containsKeyword(line, "id") || strings.Contains(lower, "number") ||
+			strings.Contains(lower, "no.") || strings.Contains(lower, "no:") {
 			return true
 		}
 	}

--- a/internal/validators/driverslicense/validator_test.go
+++ b/internal/validators/driverslicense/validator_test.go
@@ -140,6 +140,51 @@ func TestDriversLicenseValidator_PositiveCases(t *testing.T) {
 	}
 }
 
+// TestDriversLicenseValidator_AddressDoesNotSuppress locks the removal of the
+// "address" negative keyword: a driver's-license record almost always lists the
+// holder's physical address on the same line, so "address" hard-suppressed real
+// DLs. The DL must still surface with address context, while "IP address" (via
+// the "ip" keyword) still suppresses.
+func TestDriversLicenseValidator_AddressDoesNotSuppress(t *testing.T) {
+	validator := NewValidator()
+
+	// Recovered: a real DL line that also mentions the holder's address.
+	for _, content := range []string{
+		"Driver's License: D1234567, address 123 Main St",
+		"California DL D1234567 mailing address on file",
+	} {
+		matches, err := validator.ValidateContent(content, "test.txt")
+		if err != nil {
+			t.Fatalf("ValidateContent() error = %v", err)
+		}
+		found := false
+		for _, m := range matches {
+			if m.Type == "DRIVERS_LICENSE" && m.Confidence >= 60 {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("real DL with address context should surface for %q, got %d matches", content, len(matches))
+		}
+	}
+
+	// Still suppressed: an IP address / port context (via "ip"/"port").
+	for _, content := range []string{
+		"IP address port for device D1234567",
+	} {
+		matches, err := validator.ValidateContent(content, "test.txt")
+		if err != nil {
+			t.Fatalf("ValidateContent() error = %v", err)
+		}
+		for _, m := range matches {
+			if m.Type == "DRIVERS_LICENSE" && m.Confidence >= 60 {
+				t.Errorf("IP/port context should suppress DL for %q, got %.1f", content, m.Confidence)
+			}
+		}
+	}
+}
+
 func TestDriversLicenseValidator_NegativeCases(t *testing.T) {
 	validator := NewValidator()
 

--- a/internal/validators/otp/validator.go
+++ b/internal/validators/otp/validator.go
@@ -388,9 +388,7 @@ func (v *Validator) AnalyzeContext(match string, context detector.ContextInfo) f
 	}
 
 	for _, keyword := range v.negativeKeywords {
-		// Skip "token" suppression if not in JWT context — "token" in
-		// isolation is not negative for OTP (it can mean "OTP token").
-		if keyword == "session" && !isJWTContext {
+		if !negativeKeywordActive(keyword, isJWTContext) {
 			continue
 		}
 		if containsKeyword(fullContext, keyword) {
@@ -455,9 +453,30 @@ func (v *Validator) hasPositiveContext(line string) bool {
 	return false
 }
 
-// hasNegativeContext checks if the line contains any negative keywords.
+// negativeKeywordActive reports whether a negative keyword should count against
+// an OTP candidate given the line's JWT context. "session" is a negative signal
+// ONLY alongside a JWT (session tokens): on its own, a 2FA/TOTP setup line that
+// merely mentions "session" is not evidence against an OTP secret. Both the
+// per-keyword score (AnalyzeContext) and the presence gate (hasNegativeContext,
+// which drives the -30 in emit) must apply this identically — otherwise the
+// carve-out in one path is silently overridden by the -30 in the other.
+func negativeKeywordActive(keyword string, isJWTContext bool) bool {
+	if keyword == "session" && !isJWTContext {
+		return false
+	}
+	return true
+}
+
+// hasNegativeContext checks if the line contains any active negative keyword,
+// honoring the same JWT-aware carve-out AnalyzeContext uses (see
+// negativeKeywordActive) so the emit-time -30 penalty cannot fire on a keyword
+// that AnalyzeContext deliberately skipped.
 func (v *Validator) hasNegativeContext(line string) bool {
+	isJWTContext := reJWT.MatchString(line)
 	for _, kw := range v.negativeKeywords {
+		if !negativeKeywordActive(kw, isJWTContext) {
+			continue
+		}
 		if containsKeyword(line, kw) {
 			return true
 		}
@@ -488,7 +507,11 @@ func (v *Validator) hasRecoveryContext(line string) bool {
 		"product key", "product keys", "license", "activation", "serial",
 		"version", "firmware", "patch", "release",
 		"exit", "room", "door", "floor",
-		"staff", "employee", "device id", "device",
+		// "device id" (a hardware identifier label) suppresses, but bare "device"
+		// does NOT: real recovery codes are routinely described per device
+		// ("recovery codes for this device"), and a lone "device" wrongly vetoed
+		// them.
+		"staff", "employee", "device id",
 		"tracking", "order", "invoice",
 		"disk", "contains key", "replacement",
 	}

--- a/internal/validators/otp/validator_test.go
+++ b/internal/validators/otp/validator_test.go
@@ -143,6 +143,61 @@ func TestOTPValidator_Base32Secrets(t *testing.T) {
 	}
 }
 
+// TestOTPValidator_SessionAndDeviceGating locks the Wave-2 OTP fixes:
+//   - "session" is a negative signal ONLY with a JWT on the line; a 2FA/TOTP
+//     setup line that merely mentions "session" must keep its OTP secret. The
+//     AnalyzeContext carve-out and the emit-time -30 (hasNegativeContext) must
+//     agree, so the secret is not silently dropped by the -30.
+//   - bare "device" no longer vetoes recovery codes ("recovery codes for this
+//     device"), while "device id" still suppresses.
+func TestOTPValidator_SessionAndDeviceGating(t *testing.T) {
+	validator := NewValidator()
+
+	// "session" without a JWT must NOT suppress a real TOTP secret.
+	got, err := validator.ValidateContent(
+		"2FA authenticator secret key JBSWY3DPEHPK3PXP for this session", "test.txt")
+	if err != nil {
+		t.Fatalf("ValidateContent() error = %v", err)
+	}
+	foundSecret := false
+	for _, m := range got {
+		if m.Type == "OTP_SECRET" && m.Confidence > 50 {
+			foundSecret = true
+		}
+	}
+	if !foundSecret {
+		t.Errorf("'session' without a JWT should not suppress the OTP secret; got %d matches", len(got))
+	}
+
+	// bare "device" must NOT veto recovery codes.
+	rc, err := validator.ValidateContent(
+		"Your recovery codes for this device: ABCD-EFGH-IJKL MNOP-QRST-UVWX", "test.txt")
+	if err != nil {
+		t.Fatalf("ValidateContent() error = %v", err)
+	}
+	foundRC := false
+	for _, m := range rc {
+		if m.Type == "RECOVERY_CODES" {
+			foundRC = true
+		}
+	}
+	if !foundRC {
+		t.Errorf("bare 'device' should not veto recovery codes; got %d matches", len(rc))
+	}
+
+	// "device id" (hardware identifier) must still suppress recovery-code shapes.
+	di, err := validator.ValidateContent(
+		"backup device id list: ABCD-EFGH-IJKL MNOP-QRST-UVWX", "test.txt")
+	if err != nil {
+		t.Fatalf("ValidateContent() error = %v", err)
+	}
+	for _, m := range di {
+		if m.Type == "RECOVERY_CODES" {
+			t.Errorf("'device id' should still suppress recovery codes; got a match %q", m.Text)
+		}
+	}
+}
+
 func TestOTPValidator_RecoveryCodes(t *testing.T) {
 	validator := NewValidator()
 

--- a/internal/validators/ssn/validator.go
+++ b/internal/validators/ssn/validator.go
@@ -134,13 +134,15 @@ func NewValidator() *Validator {
 			"work order", "invoice", "rma", "asset tag", "asset",
 			"case", "ticket", "sku", "purchase order", "docket",
 			"tracking", "shipment", "order number",
-			"po", "permit", "reservation", "grant", "bin",
+			"po", "permit", "reservation", "bin",
 			"accession", "specimen", "contract", "txn", "transaction",
-			// "policy" is intentionally NOT listed: insurance-policy documents
-			// legitimately carry SSNs on the same line ("policy holder SSN:"),
-			// and the strong positive keywords win there anyway — verified in
-			// the regression test.
-			"policy number", "policy no",
+			// "policy" and "grant" are intentionally NOT listed as bare words:
+			// insurance-policy and grant/benefit documents legitimately carry
+			// SSNs on the same line ("policy holder SSN:", "grant recipient SSN"),
+			// and "Grant" is a common surname — a bare "grant" penalty demoted
+			// real SSNs near a person named Grant. Only the ID-number forms, which
+			// share the SSN shape in ERP/grants-management exports, suppress.
+			"policy number", "policy no", "grant number", "grant no",
 		},
 		invalidPatterns: []string{
 			"000", "666", "900", "901", "902", "903", "904", "905", "906", "907", "908", "909",

--- a/internal/validators/ssn/validator_test.go
+++ b/internal/validators/ssn/validator_test.go
@@ -896,6 +896,30 @@ func TestSSNValidator_DocWordDoesNotSuppress(t *testing.T) {
 	}
 }
 
+// TestSSNValidator_GrantWordDoesNotSuppress locks the narrowing of the "grant"
+// negative keyword to its ID-number forms. Bare "grant" penalized real SSNs on
+// grant/benefit documents and near a person named Grant; only "grant number"/
+// "grant no" (the SSN-shaped grant-management identifier) should now suppress.
+func TestSSNValidator_GrantWordDoesNotSuppress(t *testing.T) {
+	v := NewValidator()
+	const mediumThreshold = 60.0
+
+	// Real SSN near "grant" (funding doc / surname) must not be demoted below MEDIUM.
+	for _, line := range []string{
+		"grant recipient SSN 219-09-9999 on file",
+		"Grant Wilson SSN 219-09-9999 approved",
+	} {
+		if c := ssnMatchConfidence(t, v, line); c < mediumThreshold {
+			t.Errorf("real SSN should not be suppressed by bare 'grant' in %q, got %.1f", line, c)
+		}
+	}
+
+	// The SSN-shaped grant-management ID number still suppresses.
+	if c := ssnMatchConfidence(t, v, "grant number 321-07-4567 in the ledger"); c >= 90 {
+		t.Errorf("'grant number' ID should not reach HIGH, got %.1f", c)
+	}
+}
+
 // TestSSNValidator_BareNineDigitWeakerThanDashed is a regression test for M2:
 // a separator-less 9-digit token (order/serial/ZIP9 ID) over-matched and could
 // reach HIGH in vaguely positive context. The bare form now scores lower than


### PR DESCRIPTION
## Summary

Wave 2 (MED) of the cross-validator keyword-coverage audit. Four validators carried negative keywords that suppressed **real PII** more broadly than their true decoy target. Each fix narrows the suppressor; none loosens a mathematical/checksum gate; the golden corpus is **unchanged**.

> Stacked on #170 (base branch `fix/validator-keyword-coverage-high`). Review/merge #170 first.

## Fixes

- **bankaccount** — `looksLikeVersion` matched `version` as a bare substring inside `conversion`/`subversion`/`aversion`, dropping a real account number that followed one of those words. Now whole-word matched; the `v.` prefix check is anchored to a version token (`reVersionPrefix`) instead of any word ending in `v`.
- **ssn** — bare `grant` penalized real SSNs on grant/benefit docs and near a person named **Grant** (common surname). Narrowed to `grant number`/`grant no`, mirroring the existing `policy` → `policy number`/`policy no` treatment.
- **driverslicense** — `address` hard-suppressed real DLs even though a license record almost always lists the holder's address (`IP address` still caught via `ip`; a bare address line never reaches scoring). Also tightened the state-name gate's raw `strings.Contains(lower, "id")` to a whole-word match so it no longer fires inside `resident`/`valid`.
- **otp** — (1) fixed a stale comment referencing `token` while the code gates `session`; (2) made the JWT-aware `session` carve-out **consistent** across `AnalyzeContext` and `hasNegativeContext` (shared `negativeKeywordActive`) so the emit-time `-30` no longer overrides the `-15` skip and silently drops a TOTP secret on a `session`-mentioning 2FA line; (3) removed bare `device` from recovery-code suppression while keeping precise `device id`.

## Tests

New: `TestBankAccountValidator_VersionSubstring`, `TestSSNValidator_GrantWordDoesNotSuppress`, `TestDriversLicenseValidator_AddressDoesNotSuppress`, `TestOTPValidator_SessionAndDeviceGating`. 21 validator+golden packages pass, 0 failures; `go vet` + gofmt clean.