### PR TITLE
fix(personname): recover Park surnames + suppress technical-word false names (Wave 3)

### DIFF
--- a/internal/goldencorpus/testdata/golden/context_decoys_personname.json.json
+++ b/internal/goldencorpus/testdata/golden/context_decoys_personname.json.json
@@ -200,8 +200,7 @@
         "context_domain": "Retail",
         "context_impact": 0,
         "context_keywords": [
-          "-inc",
-          "-park"
+          "-inc"
         ],
         "cultural_context": [
           "western",

--- a/internal/goldencorpus/testdata/golden/context_decoys_personname.sarif.json
+++ b/internal/goldencorpus/testdata/golden/context_decoys_personname.sarif.json
@@ -188,8 +188,7 @@
               "context_domain": "Retail",
               "context_impact": 0,
               "context_keywords": [
-                "-inc",
-                "-park"
+                "-inc"
               ],
               "cultural_context": [
                 "western",

--- a/internal/goldencorpus/testdata/golden/context_decoys_personname.yaml
+++ b/internal/goldencorpus/testdata/golden/context_decoys_personname.yaml
@@ -177,7 +177,6 @@ results:
         context_impact: 0
         context_keywords:
             - -inc
-            - -park
         cultural_context:
             - western
             - english

--- a/internal/validators/personname/technical_terms.go
+++ b/internal/validators/personname/technical_terms.go
@@ -396,15 +396,19 @@ var productPatternsMap = map[string]bool{
 }
 
 var geoPatternsMap = map[string]bool{
-	"city":      true,
-	"county":    true,
-	"state":     true,
-	"mountain":  true,
-	"lake":      true,
-	"river":     true,
-	"creek":     true,
-	"valley":    true,
-	"park":      true,
+	"city":     true,
+	"county":   true,
+	"state":    true,
+	"mountain": true,
+	"lake":     true,
+	"river":    true,
+	"creek":    true,
+	"valley":   true,
+	// "park" intentionally omitted: it is a very common surname (Korean 박, and
+	// English), so a standalone -35 geo penalty suppressed every real "... Park"
+	// name outright ("Sarah Park approved" scored 0). Genuine addresses are still
+	// caught by the following geo token ("Park Street"/"Park Avenue" via
+	// street/avenue), and "national park" prose lacks a name-shaped bigram.
 	"street":    true,
 	"avenue":    true,
 	"road":      true,

--- a/internal/validators/personname/validator.go
+++ b/internal/validators/personname/validator.go
@@ -79,8 +79,12 @@ func NewValidator() *Validator {
 			"inc", "llc", "ltd", "corp", "enterprises", "industries", "manufacturing",
 			"consulting", "group", "associates", "partners", "holdings",
 			"catalog", "collection", "series", "line", "model", "version",
+			// "park" intentionally omitted here too (it was removed from
+			// geoPatternsMap): it is a common surname, so it must not carry a
+			// geographic/negative penalty. Real addresses are caught by the
+			// accompanying geo word (street/avenue/road/drive).
 			"city", "county", "state", "country", "mountain", "lake", "river",
-			"creek", "valley", "park", "street", "avenue", "road", "drive",
+			"creek", "valley", "street", "avenue", "road", "drive",
 			"algorithm", "method", "protocol", "function", "pattern", "transform",
 		},
 		observer: observability.NewStandardObserver(observability.ObservabilityMetrics, nil),
@@ -780,6 +784,18 @@ func (v *Validator) isTechnicalContext(match string, components NameComponents) 
 		if lastName == tech {
 			return true
 		}
+	}
+
+	// Consult veryCommonNamesMap for either token. These are very common
+	// software/operations words (default, root, update, cancel, warning, debug,
+	// system, ...) that appear beside a known surname in logs and UI text
+	// ("Default Johnson", "Update User") and scored MEDIUM as false names. None
+	// of these tokens is present in the first/last-name databases (verified), so
+	// treating them as technical context cannot demote a real person name — it
+	// only suppresses the technical-word-plus-surname false positive. This is the
+	// intended consumer of veryCommonNamesMap, which was previously dead code.
+	if veryCommonNamesMap[firstName] || veryCommonNamesMap[lastName] {
+		return true
 	}
 
 	return false

--- a/internal/validators/personname/validator_test.go
+++ b/internal/validators/personname/validator_test.go
@@ -1080,10 +1080,59 @@ func TestPersonNameValidator_AllCapsNames(t *testing.T) {
 	}
 }
 
+// TestPersonNameValidator_VeryCommonTechnicalWords locks the re-wiring of
+// veryCommonNamesMap (previously dead code) into isTechnicalContext. Very common
+// software/operations words (default, root, update, cancel, warning, debug, ...)
+// paired with a known surname scored MEDIUM as false person names. None of these
+// tokens is in the first/last-name databases, so treating them as technical
+// context suppresses the FP without demoting any real name.
+func TestPersonNameValidator_VeryCommonTechnicalWords(t *testing.T) {
+	v := NewValidator()
+
+	best := func(line string) float64 {
+		matches, _ := v.ValidateContent(line, "test.txt")
+		var b float64
+		for _, m := range matches {
+			if m.Confidence > b {
+				b = m.Confidence
+			}
+		}
+		return b
+	}
+
+	// Technical word + known surname must NOT reach MEDIUM.
+	for _, line := range []string{
+		"Default Johnson approved",
+		"Root Johnson approved",
+		"Update Johnson approved",
+		"Cancel Johnson approved",
+		"Warning Johnson approved",
+		"Debug Johnson approved",
+	} {
+		if best(line) >= 60 {
+			t.Errorf("technical-word + surname %q must not reach MEDIUM, got %.1f", line, best(line))
+		}
+	}
+
+	// Real names must be unaffected.
+	for _, line := range []string{
+		"Please contact Maria Delgado",
+		"Grace Hopper invented the compiler",
+		"forward the report to James Whitfield",
+	} {
+		if best(line) < 60 {
+			t.Errorf("real name %q should stay >= MEDIUM, got %.1f", line, best(line))
+		}
+	}
+}
+
 // TestPersonNameValidator_ContextKeywordWordBoundary is a regression test for
-// L25: context keywords were matched as substrings, so "park" fired inside
-// "parking" (-35) and "inc" inside "incident" (-20), nudging confidence. They
-// now match on whole words; a real keyword still applies its penalty.
+// L25: context keywords were matched as substrings, so "parking" (-35) and
+// "inc" inside "incident" (-20) nudged confidence. They now match on whole
+// words; a real geographic keyword still applies its penalty. "valley" is used
+// as the geo example rather than "park": "park" was removed from the geographic
+// keyword set because it is a very common surname (see
+// TestPersonNameValidator_ParkSurnameSurfaces).
 func TestPersonNameValidator_ContextKeywordWordBoundary(t *testing.T) {
 	v := NewValidator()
 	// Substrings inside unrelated words must not trip the penalty.
@@ -1094,8 +1143,52 @@ func TestPersonNameValidator_ContextKeywordWordBoundary(t *testing.T) {
 		}
 	}
 	// A real geographic keyword still penalizes.
-	if imp := v.AnalyzeContext("John Smith", detector.ContextInfo{FullLine: "John Smith visited park today"}); imp >= 0 {
-		t.Errorf("L25: a real 'park' keyword should still penalize, got %.1f", imp)
+	if imp := v.AnalyzeContext("John Smith", detector.ContextInfo{FullLine: "John Smith visited valley today"}); imp >= 0 {
+		t.Errorf("L25: a real geographic keyword should still penalize, got %.1f", imp)
+	}
+}
+
+// TestPersonNameValidator_ParkSurnameSurfaces locks the removal of "park" from
+// the geographic keyword set. "Park" is a very common surname (Korean 박, and
+// English); a standalone -35 geo penalty suppressed every real "... Park" name
+// outright. Real Park names must now surface, while genuine addresses stay
+// suppressed via the accompanying geo word (street/avenue), and bare "park"
+// carries no penalty.
+func TestPersonNameValidator_ParkSurnameSurfaces(t *testing.T) {
+	v := NewValidator()
+
+	best := func(line string) float64 {
+		matches, _ := v.ValidateContent(line, "test.txt")
+		var b float64
+		for _, m := range matches {
+			if m.Confidence > b {
+				b = m.Confidence
+			}
+		}
+		return b
+	}
+
+	// Real Park surnames with a distinctive first name must surface (>= MEDIUM-ish;
+	// they were 0 before the fix).
+	for _, line := range []string{
+		"Sarah Park approved the budget",
+		"Contact Maria Park for approval",
+	} {
+		if best(line) < 50 {
+			t.Errorf("real Park surname should surface for %q, got %.1f", line, best(line))
+		}
+	}
+
+	// Genuine addresses must stay suppressed (via street/avenue).
+	for _, line := range []string{"Park Street is closed", "123 Park Avenue reception"} {
+		if best(line) >= 60 {
+			t.Errorf("address %q must not surface as a name, got %.1f", line, best(line))
+		}
+	}
+
+	// Bare "park" no longer carries a geographic penalty.
+	if imp := v.AnalyzeContext("John Smith", detector.ContextInfo{FullLine: "John Smith visited park today"}); imp < 0 {
+		t.Errorf("bare 'park' should no longer penalize (it is a surname), got %.1f", imp)
 	}
 }
 


### PR DESCRIPTION
## Summary

Wave 3 (PERSON_NAME) of the keyword-coverage audit. Two targeted fixes, each verified empirically before implementation.

> Stacked on #171 → #170. Review/merge those first.

## 1. "Park" surname recovery (TP recovery)

`park` sat in `geoPatternsMap`, which applies a flat **-35** penalty to the whole line — so **every** real "… Park" name was zeroed out. `Sarah Park approved the budget` scored **0**, while an equivalent `Sarah Delgado` scored 92. Park is one of the most common surnames in the world (Korean 박, and English).

- Removed `park` from `geoPatternsMap` **and** from the `negativeKeywords` list (double-listed).
- Real Park names now surface: `Sarah Park` 77, `Maria Park` 65, `Jimin Park` 52.
- Genuine addresses stay suppressed via the accompanying geo word: `Park Street`/`Park Avenue` (through `street`/`avenue`); `national park` prose has no name bigram.
- `commonWordNamesMap` left untouched → ambiguous both-common-word bigrams (`Will Park`) stay LOW.

## 2. Wire dead `veryCommonNamesMap` (FP suppression)

`veryCommonNamesMap` (39 entries) was **dead code** — defined, never referenced. Very common software/ops words (`default`, `root`, `update`, `cancel`, `warning`, `debug`, `system`, …) paired with a known surname scored **67 MEDIUM** as false person names (`Default Johnson`, `Update Johnson`). Wired the map into `isTechnicalContext`. **None** of the 39 tokens is present in the first/last-name databases (verified), so this suppresses the FP with **zero** risk of demoting a real name.

## Golden corpus

The only change is a **benign metadata annotation**: `-park` no longer appears in `context_keywords` on the (already-non-finding) AWS decoy line. **No finding, confidence, or level changed** anywhere in the corpus. The TP recovery is proven by new unit tests (the corpus doesn't happen to exercise a Park surname).

## Tests

New: `TestPersonNameValidator_ParkSurnameSurfaces`, `TestPersonNameValidator_VeryCommonTechnicalWords`. Updated `TestPersonNameValidator_ContextKeywordWordBoundary` to use `valley` as its geo example. 21 validator+golden packages pass, 0 failures; vet + gofmt clean.