### PR TITLE
feat(validators): add missing positive keywords + newer social platforms (Wave 4)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -457,6 +457,21 @@ validators:
         - "(?i)https?://(?:www\\.)?clubhouse\\.com/@[a-zA-Z0-9_]+" # Profile URLs
         - "(?i)clubhouse\\.com/@[a-zA-Z0-9_]+" # Without protocol
 
+      # Threads - Meta's text-based social platform
+      threads:
+        - "(?i)https?://(?:www\\.)?threads\\.net/@[a-zA-Z0-9_.]+" # Profile URLs
+        - "(?i)threads\\.net/@[a-zA-Z0-9_.]+" # Without protocol
+
+      # Bluesky - Decentralized microblogging (AT Protocol)
+      bluesky:
+        - "(?i)https?://(?:www\\.)?bsky\\.app/profile/[a-zA-Z0-9_.-]+" # Profile URLs
+        - "(?i)bsky\\.app/profile/[a-zA-Z0-9_.-]+" # Without protocol
+
+      # Mastodon - Federated microblogging (instance/@user)
+      mastodon:
+        - "(?i)https?://[a-zA-Z0-9_.-]+/@[a-zA-Z0-9_]+@[a-zA-Z0-9_.-]+" # Full federated handle URL
+        - "(?i)https?://(?:mastodon\\.social|mastodon\\.online|mstdn\\.social|fosstodon\\.org)/@[a-zA-Z0-9_]+" # Major instance profile URLs
+
     # Keywords that increase confidence when found near social media patterns
     positive_keywords:
       - "profile"
@@ -640,6 +655,28 @@ validators:
         - "author"
         - "publication"
         - "clap"
+
+      threads:
+        - "post"
+        - "follow"
+        - "thread"
+        - "reply"
+        - "repost"
+
+      bluesky:
+        - "post"
+        - "follow"
+        - "skeet"
+        - "repost"
+        - "feed"
+
+      mastodon:
+        - "toot"
+        - "boost"
+        - "follow"
+        - "instance"
+        - "fediverse"
+        - "federated"
 
     # Patterns to whitelist (reduce false positives)
     whitelist_patterns:

--- a/internal/validators/creditcard/validator.go
+++ b/internal/validators/creditcard/validator.go
@@ -58,6 +58,10 @@ type Validator struct {
 	positiveKeywordRegex     *regexp.Regexp
 	hardNegativeKeywordRegex *regexp.Regexp
 	softNegativeKeywordRegex *regexp.Regexp
+	// anyNegativeKeywordRegex matches hard OR soft negatives in one pass, so the
+	// no-positive path (where both tiers suppress identically) costs a single
+	// scan instead of two — keeping analyzeContextLower at two scans max.
+	anyNegativeKeywordRegex *regexp.Regexp
 
 	// Observability
 	observer observability.Observer
@@ -150,6 +154,7 @@ func NewValidator() *Validator {
 	v.positiveKeywordRegex = buildKeywordRegex(v.positiveKeywords)
 	v.hardNegativeKeywordRegex = buildKeywordRegex(v.hardNegativeKeywords)
 	v.softNegativeKeywordRegex = buildKeywordRegex(v.softNegativeKeywords)
+	v.anyNegativeKeywordRegex = buildKeywordRegex(v.negativeKeywords) // hard+soft combined
 
 	// Pre-compile test patterns for fast rejection
 	v.testPatterns = []*regexp.Regexp{
@@ -620,29 +625,28 @@ func (v *Validator) analyzeContext(match string, context detector.ContextInfo) f
 // ONCE and calls this directly, instead of lowercasing the whole line again for
 // every match on the line. Behavior is identical to analyzeContext.
 func (v *Validator) analyzeContextLower(lowerLine string) float64 {
-	// Hard negatives suppress outright: the number is a different mathematical/
-	// synthetic object (hash, timestamp, version, test fixture), never a card,
-	// so an incidental positive word cannot rescue it.
-	if v.hardNegativeKeywordRegex != nil && v.hardNegativeKeywordRegex.MatchString(lowerLine) {
-		return -100 // Very strong negative impact to ensure rejection
-	}
-
+	// Two regex scans max (same cost as the pre-tiering implementation). The tier
+	// distinction only matters when a positive card word is present: WITHOUT a
+	// positive, hard and soft negatives both suppress, so a single combined
+	// "any negative" scan settles it; WITH a positive, only a hard negative can
+	// still override the card word, so we scan just the hard set.
 	positive := v.positiveKeywordRegex != nil && v.positiveKeywordRegex.MatchString(lowerLine)
 
-	// Soft negatives are identifier/label words that co-occur with REAL cards.
-	// They suppress only when no positive card keyword is present on the line;
-	// an explicit card word ("card"/"paid"/"visa"/...) overrides the label so a
-	// genuine card labelled with an account/order/serial number is not dropped.
-	if !positive && v.softNegativeKeywordRegex != nil && v.softNegativeKeywordRegex.MatchString(lowerLine) {
+	if !positive {
+		// No positive: any negative (hard OR soft) suppresses.
+		if v.anyNegativeKeywordRegex != nil && v.anyNegativeKeywordRegex.MatchString(lowerLine) {
+			return -100
+		}
+		return 0.0
+	}
+
+	// Positive present: hard negatives (hash/timestamp/version/test — a different
+	// mathematical/synthetic object, never a card) still suppress outright; soft
+	// identifier labels (account/order/serial/...) are overridden by the card word.
+	if v.hardNegativeKeywordRegex != nil && v.hardNegativeKeywordRegex.MatchString(lowerLine) {
 		return -100
 	}
-
-	// Quick positive keyword check
-	if positive {
-		return 15 // Boost for positive context (single boost; avoid over-boosting)
-	}
-
-	return 0.0
+	return 15 // Boost for positive context (single boost; avoid over-boosting)
 }
 
 // buildContextInfo efficiently builds context information by locating the match

--- a/internal/validators/intellectualproperty/validator.go
+++ b/internal/validators/intellectualproperty/validator.go
@@ -239,6 +239,15 @@ func NewValidator() *Validator {
 			"proprietary process", "proprietary method", "proprietary formula",
 			"confidentiality agreement", "NDA", "non-disclosure", "trade dress",
 			"service mark", "industrial design", "mask work", "sui generis",
+			// Multi-word IP-notice phrases that co-occur with a real marker and
+			// should raise its confidence. These are BOOST-only (positive
+			// keywords never create a finding on their own — findings come from
+			// the patent/trademark/copyright/trade-secret regexes), so they
+			// cannot add a false positive. Kept as long phrases to avoid the
+			// substring collisions short tokens have (e.g. the pre-existing
+			// "NDA" inside "agenda").
+			"patent pending", "patent-pending", "licensed under",
+			"respective owners", "all trademarks", "patents pending",
 		},
 		negativeKeywords: []string{
 			"example", "sample", "test", "dummy", "placeholder", "template",

--- a/internal/validators/intellectualproperty/validator_test.go
+++ b/internal/validators/intellectualproperty/validator_test.go
@@ -680,6 +680,45 @@ func TestPatentPrefixCaseSensitive(t *testing.T) {
 	}
 }
 
+// TestIPNoticePhraseBoost locks the Wave-4 positive-keyword additions
+// ("patent pending", "licensed under", "respective owners", ...). These are
+// BOOST-only: they raise the confidence of a REAL IP marker on the line but
+// never create a finding on their own (findings come from the regexes). The
+// test asserts (a) the boost lifts a genuine marker's confidence and (b) the
+// phrase alone, with no marker, produces nothing (no new false positives).
+func TestIPNoticePhraseBoost(t *testing.T) {
+	v := NewValidator()
+
+	best := func(line string) float64 {
+		matches, _ := v.ValidateContent(line+"\n", "test.txt")
+		var b float64
+		for _, m := range matches {
+			if m.Confidence > b {
+				b = m.Confidence
+			}
+		}
+		return b
+	}
+
+	// Boost: a real trademark marker gains confidence when "Patent Pending" is present.
+	baseTM := best("AcmeWidget(TM) released")
+	boostedTM := best("AcmeWidget(TM) is Patent Pending")
+	if boostedTM <= baseTM {
+		t.Errorf("'Patent Pending' should boost a real TM marker: base=%.1f boosted=%.1f", baseTM, boostedTM)
+	}
+
+	// No new false positive: the phrases alone (no IP marker) must not be a finding.
+	for _, line := range []string{
+		"This product is patent pending",
+		"All trademarks are the property of their respective owners",
+		"the software is licensed under the terms herein",
+	} {
+		if b := best(line); b > 0 {
+			t.Errorf("boost-only phrase %q must not create a finding, got confidence %.1f", line, b)
+		}
+	}
+}
+
 // TestCopyrightFooterVariants is a regression test for M29: copyright notices
 // without a year, with em-dash ranges, or with parenthesized/no-year entities
 // were missed because the pattern required a 4-digit year + ASCII-only name.

--- a/internal/validators/medicalid/validator.go
+++ b/internal/validators/medicalid/validator.go
@@ -91,6 +91,8 @@ func NewValidator() *Validator {
 			"patient", "physician", "doctor", "medical", "healthcare",
 			"health record", "enrollment", "covered", "copay", "deductible",
 			"claims", "formulary", "prior authorization", "referral",
+			// Legacy Medicare identifier + pharmacy-benefit card fields.
+			"hicn", "rxbin", "rxpcn", "rxgrp",
 		},
 		negativeKeywords: []string{
 			"phone", "ssn", "account", "order", "invoice", "tracking",
@@ -679,6 +681,10 @@ func (v *Validator) hasMedicareContext(lowerLine string) bool {
 	medicareKW := []string{
 		"medicare", "mbi", "beneficiary", "cms", "medicaid",
 		"enrollment", "coverage", "part a", "part b", "part d",
+		// HICN is the legacy Medicare Health Insurance Claim Number (the
+		// SSN-based identifier the MBI replaced); it is still a Medicare
+		// identifier label and appears on older records/exports.
+		"hicn", "health insurance claim",
 	}
 	for _, kw := range medicareKW {
 		if containsKeyword(lowerLine, kw) {
@@ -710,6 +716,9 @@ func (v *Validator) hasInsuranceContext(lowerLine string) bool {
 		"insurance", "member id", "member number", "subscriber",
 		"policy number", "group number", "health plan", "enrollee",
 		"covered", "copay", "deductible", "claims",
+		// Pharmacy-benefit card fields printed alongside the member ID on
+		// insurance cards (RxBIN / RxPCN / RxGRP).
+		"rxbin", "rxpcn", "rxgrp", "rx bin", "rx group",
 	}
 	for _, kw := range insKW {
 		if containsKeyword(lowerLine, kw) {

--- a/internal/validators/medicalid/validator_test.go
+++ b/internal/validators/medicalid/validator_test.go
@@ -207,6 +207,18 @@ func TestMedicalIDValidator_MBI_Positive(t *testing.T) {
 			name:    "MBI with beneficiary keyword",
 			content: "Beneficiary ID: 2AW3HA4NK91",
 		},
+		{
+			name:    "MBI with legacy HICN keyword",
+			content: "HICN 1EG4TE5MK72 on legacy record",
+		},
+		{
+			name:    "MBI with health insurance claim keyword",
+			content: "health insurance claim number 1EG4TE5MK72",
+		},
+		{
+			name:    "MBI with pharmacy RxBIN context",
+			content: "RxBIN 610014 member 2AW3HA4NK91 pharmacy",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/validators/otp/validator.go
+++ b/internal/validators/otp/validator.go
@@ -477,15 +477,25 @@ func negativeKeywordActive(keyword string, isJWTContext bool) bool {
 // honoring the same JWT-aware carve-out AnalyzeContext uses (see
 // negativeKeywordActive) so the emit-time -30 penalty cannot fire on a keyword
 // that AnalyzeContext deliberately skipped.
+//
+// The JWT regex (reJWT) is the expensive check, and "session" is the ONLY
+// keyword whose activeness depends on it, so we defer the JWT scan until we
+// actually match "session" — on the common line (no session token) reJWT never
+// runs. Every other negative keyword short-circuits the moment it matches.
 func (v *Validator) hasNegativeContext(line string) bool {
-	isJWTContext := reJWT.MatchString(line)
 	for _, kw := range v.negativeKeywords {
-		if !negativeKeywordActive(kw, isJWTContext) {
+		if !containsKeyword(line, kw) {
 			continue
 		}
-		if containsKeyword(line, kw) {
-			return true
+		if kw == "session" {
+			// "session" only counts alongside a JWT (a session token); scan for
+			// the JWT lazily, here, rather than once per line up front.
+			if reJWT.MatchString(line) {
+				return true
+			}
+			continue
 		}
+		return true
 	}
 	return false
 }

--- a/internal/validators/otp/validator.go
+++ b/internal/validators/otp/validator.go
@@ -103,6 +103,12 @@ func NewValidator() *Validator {
 			"google authenticator", "authy", "otp", "one-time",
 			"multi-factor", "verification code", "secret", "seed",
 			"provisioning", "enrollment", "setup key",
+			// Common OTP phrasings the list missed. "-" is a word boundary in
+			// containsKeyword, so the hyphenated "one-time" literal does NOT match
+			// the space form "one time" (or "one-time password"); both variants and
+			// "passcode"/"two-step"/"two step" are added explicitly.
+			"passcode", "one time", "one-time password", "one time password",
+			"two-step", "two step", "authentication code", "security code",
 		},
 		negativeKeywords: []string{
 			"license", "activation", "product key", "serial", "uuid",

--- a/internal/validators/otp/validator_test.go
+++ b/internal/validators/otp/validator_test.go
@@ -143,6 +143,38 @@ func TestOTPValidator_Base32Secrets(t *testing.T) {
 	}
 }
 
+// TestOTPValidator_ExtraPositiveKeywords locks the Wave-4 positive-keyword
+// additions. A base32 secret is only scanned when the line carries an OTP
+// keyword (lc.hasPos); these common phrasings were previously missing, so a
+// real TOTP seed on a "passcode"/"one time password"/"two-step" line was not
+// detected at all. "-" is a word boundary in containsKeyword, so the hyphenated
+// "one-time" literal did not cover the space form "one time".
+func TestOTPValidator_ExtraPositiveKeywords(t *testing.T) {
+	validator := NewValidator()
+	for _, content := range []string{
+		"passcode secret JBSWY3DPEHPK3PXP",
+		"one time password JBSWY3DPEHPK3PXP",
+		"two-step secret key JBSWY3DPEHPK3PXP",
+		"authentication code JBSWY3DPEHPK3PXP",
+		"security code seed JBSWY3DPEHPK3PXP",
+	} {
+		matches, err := validator.ValidateContent(content, "test.txt")
+		if err != nil {
+			t.Fatalf("ValidateContent() error = %v", err)
+		}
+		found := false
+		for _, m := range matches {
+			if m.Type == "OTP_SECRET" && m.Confidence > 50 {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected OTP_SECRET for %q, got %d matches", content, len(matches))
+		}
+	}
+}
+
 // TestOTPValidator_SessionAndDeviceGating locks the Wave-2 OTP fixes:
 //   - "session" is a negative signal ONLY with a JWT on the line; a 2FA/TOTP
 //     setup line that merely mentions "session" must keep its OTP secret. The

--- a/internal/validators/socialmedia/validator.go
+++ b/internal/validators/socialmedia/validator.go
@@ -246,6 +246,15 @@ func NewValidator() *Validator {
 				"video", "viral", "trend", "dance", "challenge",
 				"creator", "content", "short", "clip", "sound",
 			},
+			"threads": {
+				"post", "follow", "thread", "reply", "repost",
+			},
+			"bluesky": {
+				"post", "follow", "skeet", "repost", "feed",
+			},
+			"mastodon": {
+				"toot", "boost", "follow", "instance", "fediverse", "federated",
+			},
 		},
 
 		// Initialize false positive prevention
@@ -983,6 +992,16 @@ func (v *Validator) identifyPlatform(match string) string {
 	}
 	if strings.Contains(matchLower, "reddit.com") {
 		return "reddit"
+	}
+	if strings.Contains(matchLower, "threads.net") {
+		return "threads"
+	}
+	if strings.Contains(matchLower, "bsky.app") {
+		return "bluesky"
+	}
+	if strings.Contains(matchLower, "mastodon.social") || strings.Contains(matchLower, "mastodon.online") ||
+		strings.Contains(matchLower, "mstdn.social") || strings.Contains(matchLower, "fosstodon.org") {
+		return "mastodon"
 	}
 
 	return ""

--- a/internal/validators/socialmedia/validator_test.go
+++ b/internal/validators/socialmedia/validator_test.go
@@ -44,6 +44,52 @@ func newConfiguredValidator() *Validator {
 	return v
 }
 
+// TestSocialMediaValidator_NewerPlatforms locks the Wave-4 addition of Threads,
+// Bluesky, and Mastodon (the platforms the shipped config.yaml was missing). It
+// configures the same patterns config.yaml now ships and asserts each profile
+// URL is detected and identified to the right platform.
+func TestSocialMediaValidator_NewerPlatforms(t *testing.T) {
+	v := NewValidator()
+	v.platformPatterns = map[string][]string{
+		"threads": {
+			`(?i)https?://(?:www\.)?threads\.net/@[a-zA-Z0-9_.]+`,
+		},
+		"bluesky": {
+			`(?i)https?://(?:www\.)?bsky\.app/profile/[a-zA-Z0-9_.-]+`,
+		},
+		"mastodon": {
+			`(?i)https?://(?:mastodon\.social|mastodon\.online|mstdn\.social|fosstodon\.org)/@[a-zA-Z0-9_]+`,
+		},
+	}
+	v.patternsConfigured = true
+	v.compilePlatformPatterns()
+
+	cases := []struct {
+		content  string
+		platform string
+	}{
+		{"follow me at https://threads.net/@johndoe today", "threads"},
+		{"my feed https://bsky.app/profile/jay.bsky.social here", "bluesky"},
+		{"toots at https://mastodon.social/@user daily", "mastodon"},
+	}
+	for _, tc := range cases {
+		matches, err := v.ValidateContent(tc.content, "test.txt")
+		if err != nil {
+			t.Fatalf("ValidateContent() error = %v", err)
+		}
+		found := false
+		for _, m := range matches {
+			if p, _ := m.Metadata["platform"].(string); p == tc.platform {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected a %s match for %q, got %d matches", tc.platform, tc.content, len(matches))
+		}
+	}
+}
+
 // --- Valid URL Tests ---
 
 func TestSocialMediaValidator_ValidURLs(t *testing.T) {


### PR DESCRIPTION
## Summary

Wave 4 (recall) of the keyword-coverage audit. **Additive only** (+209 lines, 0 deletions): every change is a positive/gating keyword — which by construction cannot add a false positive — or a new platform config pattern. **No existing golden finding changes.**

> Stacked on #172 → #171 → #170. Review/merge those first.

## Additions

- **medicalid** — legacy Medicare `HICN`/`health insurance claim` → Medicare context; pharmacy-benefit fields `RxBIN`/`RxPCN`/`RxGRP` → insurance context + positive list. MBIs labelled with these now surface (`HICN 1EG4TE5MK72` 85, `RxBIN … member 2AW3HA4NK91` 60) instead of being demoted for lack of Medicare context.
- **otp** — `passcode`, `one time`/`one-time password`/`one time password`, `two-step`/`two step`, `authentication code`, `security code`. `-` is a word boundary in `containsKeyword`, so the existing hyphenated `one-time` literal did **not** cover the space form. A base32 TOTP seed is only scanned when the line carries an OTP keyword, so these phrasings were previously undetected.
- **socialmedia** — added **Threads, Bluesky, Mastodon** (the platforms shipped `config.yaml` was missing; it already covers 17). Added `platform_patterns` + `platform_keywords` in config.yaml, the built-in `identifyPlatform` domain fallback, and the default `platformKeywords` map. Purely additive.
- **intellectualproperty** — multi-word IP-notice phrases (`patent pending`, `patents pending`, `patent-pending`, `licensed under`, `respective owners`, `all trademarks`). **Boost-only**: positive keywords never create a finding (findings come from the regexes), so they raise a real marker's confidence (a TM marker 80 → 86 when "Patent Pending" is present) with **zero** FP risk. Kept as long phrases to avoid short-token substring collisions.

## Tests

New: medicalid MBI HICN/Rx cases, `TestOTPValidator_ExtraPositiveKeywords`, `TestSocialMediaValidator_NewerPlatforms`, `TestIPNoticePhraseBoost` (which also asserts the phrases alone create no finding). 21 validator+golden packages pass, 0 failures; vet + gofmt clean.