### PR TITLE
refactor(validators): extract the shared keyword matcher into internal/validators/kwmatch

### DIFF
--- a/internal/validators/address/validator.go
+++ b/internal/validators/address/validator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/awslabs/ferret-scan/v2/internal/detector"
 	"github.com/awslabs/ferret-scan/v2/internal/execguard"
 	"github.com/awslabs/ferret-scan/v2/internal/observability"
+	"github.com/awslabs/ferret-scan/v2/internal/validators/kwmatch"
 )
 
 // Pre-compiled regex patterns used across validator methods.
@@ -161,32 +162,11 @@ var (
 
 // containsKeyword reports whether text contains keyword as a whole word/phrase,
 // case-insensitively, using word-boundary detection.
+//
+// ModeAlnumUnderscore preserves this validator's historical boundary
+// semantics: '_' counts as a word byte here.
 func containsKeyword(text, keyword string) bool {
-	if keyword == "" {
-		return false
-	}
-	lt := strings.ToLower(text)
-	lk := strings.ToLower(keyword)
-	for from := 0; from+len(lk) <= len(lt); {
-		i := strings.Index(lt[from:], lk)
-		if i < 0 {
-			return false
-		}
-		i += from
-		leftOK := i == 0 || !isWordByte(lt[i-1])
-		right := i + len(lk)
-		rightOK := right >= len(lt) || !isWordByte(lt[right])
-		if leftOK && rightOK {
-			return true
-		}
-		from = i + 1
-	}
-	return false
-}
-
-// isWordByte reports whether b is a word character for boundary detection.
-func isWordByte(b byte) bool {
-	return b == '_' || (b >= 'a' && b <= 'z') || (b >= '0' && b <= '9')
+	return kwmatch.Contains(text, keyword, kwmatch.ModeAlnumUnderscore)
 }
 
 // Validator implements the detector.Validator interface for detecting

--- a/internal/validators/bankaccount/validator.go
+++ b/internal/validators/bankaccount/validator.go
@@ -13,6 +13,7 @@ import (
 	"github.com/awslabs/ferret-scan/v2/internal/detector"
 	"github.com/awslabs/ferret-scan/v2/internal/execguard"
 	"github.com/awslabs/ferret-scan/v2/internal/observability"
+	"github.com/awslabs/ferret-scan/v2/internal/validators/kwmatch"
 )
 
 // Pre-compiled regex patterns for bank account detection.
@@ -81,33 +82,12 @@ var (
 )
 
 // containsKeyword reports whether text contains keyword as a whole word/phrase,
-// case-insensitively. Uses manual boundary checks for performance.
+// case-insensitively.
+//
+// ModeAlnumUnderscore preserves this validator's historical boundary
+// semantics: '_' counts as a word byte here.
 func containsKeyword(text, keyword string) bool {
-	if keyword == "" {
-		return false
-	}
-	lt := strings.ToLower(text)
-	lk := strings.ToLower(keyword)
-	for from := 0; from+len(lk) <= len(lt); {
-		i := strings.Index(lt[from:], lk)
-		if i < 0 {
-			return false
-		}
-		i += from
-		leftOK := i == 0 || !isWordByte(lt[i-1])
-		right := i + len(lk)
-		rightOK := right >= len(lt) || !isWordByte(lt[right])
-		if leftOK && rightOK {
-			return true
-		}
-		from = i + 1
-	}
-	return false
-}
-
-// isWordByte reports whether b is a word character for boundary detection.
-func isWordByte(b byte) bool {
-	return b == '_' || (b >= 'a' && b <= 'z') || (b >= '0' && b <= '9')
+	return kwmatch.Contains(text, keyword, kwmatch.ModeAlnumUnderscore)
 }
 
 // Validator implements the detector.Validator interface for detecting

--- a/internal/validators/cloudresources/cloudresources.go
+++ b/internal/validators/cloudresources/cloudresources.go
@@ -24,6 +24,7 @@ import (
 	"github.com/awslabs/ferret-scan/v2/internal/detector"
 	"github.com/awslabs/ferret-scan/v2/internal/execguard"
 	"github.com/awslabs/ferret-scan/v2/internal/observability"
+	"github.com/awslabs/ferret-scan/v2/internal/validators/kwmatch"
 )
 
 // maxContentBytes bounds the input this validator will scan. Beyond this size
@@ -486,33 +487,13 @@ func (v *Validator) scoreMatch(match, resourceType string, lineHasNegKeyword, is
 // hasKeywordToken reports whether lowerLine contains any keyword as a whole
 // token (delimited by non-alphanumeric boundaries), so "company-templates" does
 // NOT match "template" but "see example below" does match "example".
+//
+// ModeAlnum preserves this validator's historical boundary semantics: a word
+// byte is alphanumeric, so '_' acts as a word boundary here. The previous local
+// predicate also counted 'A'-'Z', which was unreachable — every caller passes
+// text it has already lowercased.
 func hasKeywordToken(lowerLine string, keywords []string) bool {
-	for _, kw := range keywords {
-		idx := 0
-		for {
-			i := strings.Index(lowerLine[idx:], kw)
-			if i < 0 {
-				break
-			}
-			at := idx + i
-			before := at - 1
-			after := at + len(kw)
-			okBefore := before < 0 || !isWordByte(lowerLine[before])
-			okAfter := after >= len(lowerLine) || !isWordByte(lowerLine[after])
-			if okBefore && okAfter {
-				return true
-			}
-			idx = at + 1
-			if idx >= len(lowerLine) {
-				break
-			}
-		}
-	}
-	return false
-}
-
-func isWordByte(b byte) bool {
-	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
+	return kwmatch.ContainsAny(lowerLine, keywords, kwmatch.ModeAlnum)
 }
 
 // CalculateConfidence implements the detector.Validator interface. It mirrors

--- a/internal/validators/dob/validator.go
+++ b/internal/validators/dob/validator.go
@@ -13,6 +13,7 @@ import (
 	"github.com/awslabs/ferret-scan/v2/internal/detector"
 	"github.com/awslabs/ferret-scan/v2/internal/execguard"
 	"github.com/awslabs/ferret-scan/v2/internal/observability"
+	"github.com/awslabs/ferret-scan/v2/internal/validators/kwmatch"
 )
 
 // Pre-compiled regex patterns for date detection.
@@ -62,33 +63,11 @@ var monthMap = map[string]int{
 
 // containsKeyword reports whether text contains keyword as a whole word/phrase,
 // case-insensitively.
+//
+// ModeAlnumUnderscore preserves this validator's historical boundary
+// semantics: '_' counts as a word byte here.
 func containsKeyword(text, keyword string) bool {
-	if keyword == "" {
-		return false
-	}
-	lt := strings.ToLower(text)
-	lk := strings.ToLower(keyword)
-	for from := 0; from+len(lk) <= len(lt); {
-		i := strings.Index(lt[from:], lk)
-		if i < 0 {
-			return false
-		}
-		i += from
-		leftOK := i == 0 || !isWordByte(lt[i-1])
-		right := i + len(lk)
-		rightOK := right >= len(lt) || !isWordByte(lt[right])
-		if leftOK && rightOK {
-			return true
-		}
-		from = i + 1
-	}
-	return false
-}
-
-// isWordByte reports whether b is a word character ([a-z0-9_]) for keyword
-// boundary detection. text is already lowercased by the caller.
-func isWordByte(b byte) bool {
-	return b == '_' || (b >= 'a' && b <= 'z') || (b >= '0' && b <= '9')
+	return kwmatch.Contains(text, keyword, kwmatch.ModeAlnumUnderscore)
 }
 
 // Validator implements the detector.Validator interface for detecting

--- a/internal/validators/driverslicense/validator.go
+++ b/internal/validators/driverslicense/validator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/awslabs/ferret-scan/v2/internal/detector"
 	"github.com/awslabs/ferret-scan/v2/internal/execguard"
 	"github.com/awslabs/ferret-scan/v2/internal/observability"
+	"github.com/awslabs/ferret-scan/v2/internal/validators/kwmatch"
 )
 
 // Pre-compiled regex patterns for US driver's license formats by state.
@@ -73,34 +74,13 @@ var (
 )
 
 // containsKeyword reports whether text contains keyword as a whole word/phrase,
-// case-insensitively. Implements word-boundary-aware matching to prevent false
-// positives from substring matches (e.g. "dl" inside "handle").
+// case-insensitively. Word-boundary-aware matching prevents false positives from
+// substring matches (e.g. "dl" inside "handle").
+//
+// ModeAlnumUnderscore preserves this validator's historical boundary
+// semantics: '_' counts as a word byte here.
 func containsKeyword(text, keyword string) bool {
-	if keyword == "" {
-		return false
-	}
-	lt := strings.ToLower(text)
-	lk := strings.ToLower(keyword)
-	for from := 0; from+len(lk) <= len(lt); {
-		i := strings.Index(lt[from:], lk)
-		if i < 0 {
-			return false
-		}
-		i += from
-		leftOK := i == 0 || !isWordByte(lt[i-1])
-		right := i + len(lk)
-		rightOK := right >= len(lt) || !isWordByte(lt[right])
-		if leftOK && rightOK {
-			return true
-		}
-		from = i + 1
-	}
-	return false
-}
-
-// isWordByte reports whether b is a word character for boundary detection.
-func isWordByte(b byte) bool {
-	return b == '_' || (b >= 'a' && b <= 'z') || (b >= '0' && b <= '9')
+	return kwmatch.Contains(text, keyword, kwmatch.ModeAlnumUnderscore)
 }
 
 // Validator implements the detector.Validator interface for detecting

--- a/internal/validators/email/validator.go
+++ b/internal/validators/email/validator.go
@@ -11,17 +11,19 @@ import (
 	"github.com/awslabs/ferret-scan/v2/internal/detector"
 	"github.com/awslabs/ferret-scan/v2/internal/execguard"
 	"github.com/awslabs/ferret-scan/v2/internal/observability"
+	"github.com/awslabs/ferret-scan/v2/internal/validators/kwmatch"
 )
 
 // containsKeyword reports whether text contains keyword as a whole word/phrase,
 // case-insensitively. The previous code used strings.Contains, so short negative
 // keywords matched inside ordinary words — "bar" in "barack", "baz" in "bazaar",
 // "temp" in "temptation" — suppressing real emails (and short positives like
-// "to"/"info" spuriously boosting). Implemented as a plain string scan (a word
-// byte is [a-z0-9]) rather than a per-keyword regex to keep context analysis
-// cheap in the hot path.
+// "to"/"info" spuriously boosting).
+//
+// ModeAlnum preserves this validator's historical boundary semantics: a word
+// byte is [a-z0-9], so '_' acts as a word boundary here.
 func containsKeyword(text, keyword string) bool {
-	return containsKeywordLower(strings.ToLower(text), strings.ToLower(keyword))
+	return kwmatch.Contains(text, keyword, kwmatch.ModeAlnum)
 }
 
 // containsKeywordLower is containsKeyword for callers that have already
@@ -30,30 +32,7 @@ func containsKeyword(text, keyword string) bool {
 // out of the hot path matters because the previous code re-lowercased the
 // (potentially huge) line text once per keyword per match.
 func containsKeywordLower(lt, lk string) bool {
-	if lk == "" {
-		return false
-	}
-	for from := 0; from+len(lk) <= len(lt); {
-		i := strings.Index(lt[from:], lk)
-		if i < 0 {
-			return false
-		}
-		i += from
-		leftOK := i == 0 || !isEmailWordByte(lt[i-1])
-		right := i + len(lk)
-		rightOK := right >= len(lt) || !isEmailWordByte(lt[right])
-		if leftOK && rightOK {
-			return true
-		}
-		from = i + 1
-	}
-	return false
-}
-
-// isEmailWordByte reports whether b is a word character ([a-z0-9]) for keyword
-// boundary detection. text is already lowercased by the caller.
-func isEmailWordByte(b byte) bool {
-	return (b >= 'a' && b <= 'z') || (b >= '0' && b <= '9')
+	return kwmatch.ContainsLower(lt, lk, kwmatch.ModeAlnum)
 }
 
 // maxKeywordLen bounds how far past a context-window/full-line junction a
@@ -468,25 +447,11 @@ func buildJunctionWindows(beforeText, lowerLine, afterText string) junctionWindo
 // Matches that fall entirely on the line side past the junction are interior
 // line matches and are intentionally skipped (covered by the *InLine flag), so
 // the bounded-line slice cut cannot fabricate them.
+//
+// ModeAlnum matches the boundary semantics of the other keyword scans in this
+// package; accept is only consulted for whole-word occurrences.
 func containsKeywordCrossing(s, lk string, accept func(start, end int) bool) bool {
-	if lk == "" {
-		return false
-	}
-	for from := 0; from+len(lk) <= len(s); {
-		i := strings.Index(s[from:], lk)
-		if i < 0 {
-			return false
-		}
-		i += from
-		leftOK := i == 0 || !isEmailWordByte(s[i-1])
-		right := i + len(lk)
-		rightOK := right >= len(s) || !isEmailWordByte(s[right])
-		if leftOK && rightOK && accept(i, right) {
-			return true
-		}
-		from = i + 1
-	}
-	return false
+	return kwmatch.ContainsFunc(s, lk, kwmatch.ModeAlnum, accept)
 }
 
 // keywordInContext reports whether keyword (lowercased as lowerKw) appears

--- a/internal/validators/ipaddress/validator.go
+++ b/internal/validators/ipaddress/validator.go
@@ -12,6 +12,7 @@ import (
 	"github.com/awslabs/ferret-scan/v2/internal/detector"
 	"github.com/awslabs/ferret-scan/v2/internal/execguard"
 	"github.com/awslabs/ferret-scan/v2/internal/observability"
+	"github.com/awslabs/ferret-scan/v2/internal/validators/kwmatch"
 )
 
 // Structural signals that a dotted-decimal token is being used as a network
@@ -24,35 +25,12 @@ var (
 
 // ipContainsKeyword reports whether text contains keyword as a whole word,
 // case-insensitively. Whole-word matching avoids "ip"/"nat" firing inside
-// unrelated words. Implemented as a plain string scan (not a regex) to keep the
-// per-match context check cheap; a word byte is [a-z0-9].
+// unrelated words.
+//
+// ModeAlnum preserves this validator's historical boundary semantics: a word
+// byte is [a-z0-9], so '_' acts as a word boundary here.
 func ipContainsKeyword(text, keyword string) bool {
-	if keyword == "" {
-		return false
-	}
-	lt := strings.ToLower(text)
-	lk := strings.ToLower(keyword)
-	for from := 0; from+len(lk) <= len(lt); {
-		i := strings.Index(lt[from:], lk)
-		if i < 0 {
-			return false
-		}
-		i += from
-		leftOK := i == 0 || !isIPWordByte(lt[i-1])
-		right := i + len(lk)
-		rightOK := right >= len(lt) || !isIPWordByte(lt[right])
-		if leftOK && rightOK {
-			return true
-		}
-		from = i + 1
-	}
-	return false
-}
-
-// isIPWordByte reports whether b is a word character ([a-z0-9]) for keyword
-// boundary detection. text is already lowercased by the caller.
-func isIPWordByte(b byte) bool {
-	return (b >= 'a' && b <= 'z') || (b >= '0' && b <= '9')
+	return kwmatch.Contains(text, keyword, kwmatch.ModeAlnum)
 }
 
 // Validator implements the detector.Validator interface for detecting

--- a/internal/validators/kwmatch/kwmatch.go
+++ b/internal/validators/kwmatch/kwmatch.go
@@ -1,0 +1,124 @@
+// Package kwmatch provides the whole-word keyword matching shared by the
+// validator packages' context scoring.
+//
+// Every validator scores a match by looking for context keywords near it
+// ("ssn", "test", "invoice"). Plain substring matching is wrong for this: short
+// keywords fire inside unrelated words — "hr" in "Christopher", "ein" in
+// "Einstein", "park" in "parking", "arn" in "learn" — which both fabricates
+// context boosts and spuriously penalizes real findings. Each validator had
+// grown its own byte-identical copy of the same boundary-scanning helper; this
+// package is the single implementation they all call.
+//
+// The scan is a plain strings.Index loop with manual boundary checks rather
+// than a compiled regex on purpose. Callers invoke it on the order of a hundred
+// times per match (AnalyzeContext, findKeywords, per-line context caches), and
+// a regexp.MatchString per keyword measured ~13x slower on keyword-dense input.
+//
+// # Word bytes and the Mode parameter
+//
+// A "word" byte is what a keyword may not be adjacent to; a boundary is the
+// string edge or any non-word byte. Validators historically disagreed about
+// whether '_' is a word byte, so Mode makes that choice explicit at the call
+// site instead of hiding it in a per-package copy. See Mode's documentation for
+// which to pick.
+//
+// Because boundaries are defined by the *text* bytes surrounding a match, a
+// keyword whose own edges are non-word characters (for example "w-2") is still
+// anchored correctly.
+package kwmatch
+
+import "strings"
+
+// Mode selects which bytes count as word characters for boundary detection.
+//
+// The distinction matters for snake_case text: under [ModeAlnum] the keyword
+// "ssn" matches in "customer_ssn" (the '_' is a boundary), while under
+// [ModeAlnumUnderscore] it does not (the '_' continues the word).
+type Mode uint8
+
+const (
+	// ModeAlnum treats [a-z0-9] as word bytes, so '_' acts as a word
+	// boundary. Prefer this for context keywords: identifiers in code and
+	// config are overwhelmingly snake_case, and a keyword should be found in
+	// "customer_ssn" or "test_fixture" just as it is in "customer ssn".
+	ModeAlnum Mode = iota
+
+	// ModeAlnumUnderscore treats [a-z0-9_] as word bytes, so a keyword
+	// adjacent to '_' does not match. Use only where a keyword must bind to a
+	// complete underscore-delimited identifier rather than one of its parts.
+	ModeAlnumUnderscore
+)
+
+// isWordByte reports whether b is a word byte under m. Callers pass
+// already-lowercased text, so the uppercase range is intentionally absent:
+// under ASCII lowercasing no byte in 'A'-'Z' can reach here.
+func (m Mode) isWordByte(b byte) bool {
+	if b >= 'a' && b <= 'z' || b >= '0' && b <= '9' {
+		return true
+	}
+	return b == '_' && m == ModeAlnumUnderscore
+}
+
+// Contains reports whether text contains keyword as a whole word or phrase,
+// case-insensitively. It lowercases both arguments; callers that already hold
+// lowercased values should use [ContainsLower] to skip the allocations.
+//
+// An empty keyword never matches, so a stray "" in a keyword list cannot score
+// every line.
+func Contains(text, keyword string, m Mode) bool {
+	return ContainsLower(strings.ToLower(text), strings.ToLower(keyword), m)
+}
+
+// ContainsLower is [Contains] for callers that have already lowercased both
+// arguments — the common case in the per-line hot paths, where hoisting the
+// lowercasing out of the loop avoids re-lowercasing a potentially huge line
+// once per keyword per match.
+//
+// Passing text or keyword that is not lowercased will simply fail to match
+// uppercase bytes; it is not otherwise unsafe.
+func ContainsLower(text, keyword string, m Mode) bool {
+	return ContainsFunc(text, keyword, m, nil)
+}
+
+// ContainsFunc is [ContainsLower] with an optional filter on where a match may
+// land. Both arguments must already be lowercased.
+//
+// When accept is non-nil it is called with the [start, end) byte range of each
+// whole-word occurrence, and the scan continues until accept returns true.
+// This lets callers that stitch a bounded window together from several pieces
+// (for example a context window joined to a line by a single space) consider
+// only the occurrences that touch the junction, so slicing the text cannot
+// fabricate matches that the full text would not have produced.
+//
+// A nil accept accepts any occurrence.
+func ContainsFunc(text, keyword string, m Mode, accept func(start, end int) bool) bool {
+	if keyword == "" {
+		return false
+	}
+	for from := 0; from+len(keyword) <= len(text); {
+		i := strings.Index(text[from:], keyword)
+		if i < 0 {
+			return false
+		}
+		i += from
+		end := i + len(keyword)
+		leftOK := i == 0 || !m.isWordByte(text[i-1])
+		rightOK := end >= len(text) || !m.isWordByte(text[end])
+		if leftOK && rightOK && (accept == nil || accept(i, end)) {
+			return true
+		}
+		from = i + 1
+	}
+	return false
+}
+
+// ContainsAny reports whether text contains any of keywords as a whole word.
+// Both text and keywords must already be lowercased.
+func ContainsAny(text string, keywords []string, m Mode) bool {
+	for _, kw := range keywords {
+		if ContainsLower(text, kw, m) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/validators/kwmatch/kwmatch_test.go
+++ b/internal/validators/kwmatch/kwmatch_test.go
@@ -1,0 +1,207 @@
+package kwmatch
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestContainsWholeWord(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+		kw   string
+		want bool
+	}{
+		{"exact", "ssn", "ssn", true},
+		{"space delimited", "the ssn field", "ssn", true},
+		{"punctuation delimited", "ssn: 123-45-6789", "ssn", true},
+		{"dot delimited", "example.ssn", "ssn", true},
+		{"leading substring rejected", "assn", "ssn", false},
+		{"trailing substring rejected", "ssnx", "ssn", false},
+		{"interior substring rejected", "Christopher", "hr", false},
+		{"interior substring rejected 2", "Einstein", "ein", false},
+		{"interior substring rejected 3", "parking", "park", false},
+		{"interior substring rejected 4", "learn", "arn", false},
+		{"interior substring rejected 5", "barcode", "code", false},
+		{"phrase match", "date of birth: 1985", "date of birth", true},
+		{"phrase substring rejected", "update of birthday", "date of birth", false},
+		{"keyword with non-word edges", "form w-2 attached", "w-2", true},
+		{"case insensitive text", "Customer SSN Here", "ssn", true},
+		{"case insensitive keyword", "customer ssn here", "SSN", true},
+		{"empty keyword never matches", "anything at all", "", false},
+		{"empty text", "", "ssn", false},
+		{"keyword longer than text", "ss", "ssn", false},
+		{"second occurrence matches", "assn and ssn", "ssn", true},
+		{"hyphen is a boundary", "test-ssn", "ssn", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, m := range []Mode{ModeAlnum, ModeAlnumUnderscore} {
+				if got := Contains(tc.text, tc.kw, m); got != tc.want {
+					t.Errorf("Contains(%q, %q, mode=%d) = %v, want %v", tc.text, tc.kw, m, got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+// TestUnderscoreModeDivergence pins the ONLY behavioral difference between the
+// two modes. These are the cases that made the per-package copies disagree:
+// under ModeAlnum a keyword is found inside a snake_case identifier, under
+// ModeAlnumUnderscore it is not.
+func TestUnderscoreModeDivergence(t *testing.T) {
+	cases := []struct{ text, kw string }{
+		{"test_ssn = 123-45-6789", "test"},
+		{"ssn_value: 123-45-6789", "ssn"},
+		{"SAMPLE_SSN=123-45-6789", "sample"},
+		{"my_dob_field", "dob"},
+		{"customer_ssn", "ssn"},
+		{"FAKE_CARD_NUMBER", "fake"},
+		{"account_number_test", "test"},
+		{"_ssn", "ssn"},
+		{"ssn_", "ssn"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.text+"/"+tc.kw, func(t *testing.T) {
+			if !Contains(tc.text, tc.kw, ModeAlnum) {
+				t.Errorf("ModeAlnum: Contains(%q, %q) = false, want true ('_' must be a boundary)", tc.text, tc.kw)
+			}
+			if Contains(tc.text, tc.kw, ModeAlnumUnderscore) {
+				t.Errorf("ModeAlnumUnderscore: Contains(%q, %q) = true, want false ('_' must be a word byte)", tc.text, tc.kw)
+			}
+		})
+	}
+}
+
+// TestUppercaseInputIsNotSilentlyMatched documents that the dropped 'A'-'Z'
+// word-byte arm is unreachable for lowercased input: ContainsLower callers must
+// lowercase, and Contains does it for them.
+func TestUppercaseInputIsNotSilentlyMatched(t *testing.T) {
+	// ContainsLower with un-lowercased text simply does not match; it must not
+	// panic or match partially.
+	if ContainsLower("Customer SSN", "ssn", ModeAlnum) {
+		t.Error("ContainsLower must not match uppercase text (caller contract is lowercased input)")
+	}
+	// Contains lowercases internally, so the same input matches.
+	if !Contains("Customer SSN", "ssn", ModeAlnum) {
+		t.Error("Contains must lowercase its arguments")
+	}
+}
+
+// TestBoundaryAdjacentToUppercaseNeighbor guards the removed uppercase arm: a
+// keyword next to an uppercase letter in *lowercased* text cannot occur, but if
+// a caller passes mixed case the neighbor must still be treated as a word byte
+// after lowercasing by Contains.
+func TestBoundaryAdjacentToUppercaseNeighbor(t *testing.T) {
+	if Contains("XSSN", "ssn", ModeAlnum) {
+		t.Error(`Contains("XSSN", "ssn") must be false: 'x' is a word byte after lowercasing`)
+	}
+	if Contains("SSNX", "ssn", ModeAlnum) {
+		t.Error(`Contains("SSNX", "ssn") must be false: 'x' is a word byte after lowercasing`)
+	}
+}
+
+func TestContainsFuncAcceptFilter(t *testing.T) {
+	const text = "ssn alpha ssn"
+
+	if !ContainsFunc(text, "ssn", ModeAlnum, nil) {
+		t.Error("nil accept must accept any occurrence")
+	}
+
+	// Accept only the occurrence at or past offset 5 — i.e. skip the first.
+	if !ContainsFunc(text, "ssn", ModeAlnum, func(start, end int) bool { return start >= 5 }) {
+		t.Error("accept must keep scanning past a rejected occurrence")
+	}
+
+	// Reject everything: scanning must terminate and report false.
+	if ContainsFunc(text, "ssn", ModeAlnum, func(start, end int) bool { return false }) {
+		t.Error("accept returning false for every occurrence must yield false")
+	}
+
+	// The reported range must delimit the keyword exactly.
+	var gotStart, gotEnd int
+	ContainsFunc("xx ssn yy", "ssn", ModeAlnum, func(start, end int) bool {
+		gotStart, gotEnd = start, end
+		return true
+	})
+	if gotStart != 3 || gotEnd != 6 {
+		t.Errorf("accept got range [%d,%d), want [3,6)", gotStart, gotEnd)
+	}
+}
+
+// TestContainsFuncSkipsNonWholeWordBeforeAccept verifies accept is only
+// consulted for whole-word occurrences, so a caller's range filter never has to
+// re-check boundaries.
+func TestContainsFuncSkipsNonWholeWordBeforeAccept(t *testing.T) {
+	var calls int
+	// "assn" contains "ssn" as a substring but not as a whole word.
+	ContainsFunc("assn", "ssn", ModeAlnum, func(start, end int) bool {
+		calls++
+		return true
+	})
+	if calls != 0 {
+		t.Errorf("accept called %d times for a non-whole-word occurrence, want 0", calls)
+	}
+}
+
+func TestContainsAny(t *testing.T) {
+	kws := []string{"test", "example", "sample"}
+
+	if !ContainsAny("see the example below", kws, ModeAlnum) {
+		t.Error("ContainsAny must match a keyword present as a whole word")
+	}
+	if ContainsAny("company-templates bucket", kws, ModeAlnum) {
+		t.Error(`ContainsAny must not match "template" inside "templates" for keyword "test"/"sample"`)
+	}
+	if ContainsAny("attestation of latest", kws, ModeAlnum) {
+		t.Error(`ContainsAny must not match "test" inside "attestation"/"latest"`)
+	}
+	if ContainsAny("nothing here", nil, ModeAlnum) {
+		t.Error("ContainsAny over an empty list must be false")
+	}
+	// Underscore mode: the snake_case identifier must NOT match.
+	if ContainsAny("run_test_case", kws, ModeAlnumUnderscore) {
+		t.Error("ContainsAny must respect ModeAlnumUnderscore")
+	}
+	if !ContainsAny("run_test_case", kws, ModeAlnum) {
+		t.Error("ContainsAny must respect ModeAlnum")
+	}
+}
+
+// TestNoOverlappingMatchMissed guards the from = i + 1 advance: a keyword whose
+// occurrences overlap must still be found when a later one is whole-word.
+func TestNoOverlappingMatchMissed(t *testing.T) {
+	// "aaa" inside "aaaa" is never whole-word; inside "aaaa aaa" the second is.
+	if !Contains("aaaa aaa", "aaa", ModeAlnum) {
+		t.Error("overlapping-prefix scan must still find the later whole-word occurrence")
+	}
+	if Contains("aaaa", "aaa", ModeAlnum) {
+		t.Error(`"aaa" must not match inside "aaaa"`)
+	}
+}
+
+// TestLongTextTerminates is a cheap guard that the scan is linear in text
+// length and always terminates (the loop advance must make progress).
+func TestLongTextTerminates(t *testing.T) {
+	text := strings.Repeat("ssnx ", 20000)
+	if Contains(text, "ssn", ModeAlnum) {
+		t.Error(`"ssn" must not match inside repeated "ssnx"`)
+	}
+	if !Contains(text+" ssn", "ssn", ModeAlnum) {
+		t.Error("whole-word occurrence at the end of a long text must be found")
+	}
+}
+
+func BenchmarkContainsLowerMiss(b *testing.B) {
+	text := strings.Repeat("some ordinary log line with no keyword at all ", 20)
+	for i := 0; i < b.N; i++ {
+		ContainsLower(text, "ssn", ModeAlnum)
+	}
+}
+
+func BenchmarkContainsLowerHit(b *testing.B) {
+	text := strings.Repeat("some ordinary log line with no keyword at all ", 20) + "ssn"
+	for i := 0; i < b.N; i++ {
+		ContainsLower(text, "ssn", ModeAlnum)
+	}
+}

--- a/internal/validators/medicalid/validator.go
+++ b/internal/validators/medicalid/validator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/awslabs/ferret-scan/v2/internal/detector"
 	"github.com/awslabs/ferret-scan/v2/internal/execguard"
 	"github.com/awslabs/ferret-scan/v2/internal/observability"
+	"github.com/awslabs/ferret-scan/v2/internal/validators/kwmatch"
 )
 
 // Pre-compiled regex patterns for medical identifier detection.
@@ -42,32 +43,11 @@ var (
 
 // containsKeyword reports whether text contains keyword as a whole word/phrase,
 // case-insensitively.
+//
+// ModeAlnumUnderscore preserves this validator's historical boundary
+// semantics: '_' counts as a word byte here.
 func containsKeyword(text, keyword string) bool {
-	if keyword == "" {
-		return false
-	}
-	lt := strings.ToLower(text)
-	lk := strings.ToLower(keyword)
-	for from := 0; from+len(lk) <= len(lt); {
-		i := strings.Index(lt[from:], lk)
-		if i < 0 {
-			return false
-		}
-		i += from
-		leftOK := i == 0 || !isWordByte(lt[i-1])
-		right := i + len(lk)
-		rightOK := right >= len(lt) || !isWordByte(lt[right])
-		if leftOK && rightOK {
-			return true
-		}
-		from = i + 1
-	}
-	return false
-}
-
-// isWordByte reports whether b is a word character ([a-z0-9_]).
-func isWordByte(b byte) bool {
-	return b == '_' || (b >= 'a' && b <= 'z') || (b >= '0' && b <= '9')
+	return kwmatch.Contains(text, keyword, kwmatch.ModeAlnumUnderscore)
 }
 
 // Validator implements the detector.Validator interface for detecting

--- a/internal/validators/otp/validator.go
+++ b/internal/validators/otp/validator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/awslabs/ferret-scan/v2/internal/detector"
 	"github.com/awslabs/ferret-scan/v2/internal/execguard"
 	"github.com/awslabs/ferret-scan/v2/internal/observability"
+	"github.com/awslabs/ferret-scan/v2/internal/validators/kwmatch"
 )
 
 // Pre-compiled regex patterns used across validator methods.
@@ -53,34 +54,12 @@ var (
 )
 
 // containsKeyword reports whether text contains keyword as a whole word/phrase,
-// case-insensitively. Implements word-boundary-aware matching rather than plain
-// strings.Contains.
+// case-insensitively.
+//
+// ModeAlnumUnderscore preserves this validator's historical boundary
+// semantics: '_' counts as a word byte here.
 func containsKeyword(text, keyword string) bool {
-	if keyword == "" {
-		return false
-	}
-	lt := strings.ToLower(text)
-	lk := strings.ToLower(keyword)
-	for from := 0; from+len(lk) <= len(lt); {
-		i := strings.Index(lt[from:], lk)
-		if i < 0 {
-			return false
-		}
-		i += from
-		leftOK := i == 0 || !isWordByte(lt[i-1])
-		right := i + len(lk)
-		rightOK := right >= len(lt) || !isWordByte(lt[right])
-		if leftOK && rightOK {
-			return true
-		}
-		from = i + 1
-	}
-	return false
-}
-
-// isWordByte reports whether b is a word character ([a-z0-9_]) for boundary detection.
-func isWordByte(b byte) bool {
-	return b == '_' || (b >= 'a' && b <= 'z') || (b >= '0' && b <= '9')
+	return kwmatch.Contains(text, keyword, kwmatch.ModeAlnumUnderscore)
 }
 
 // Validator implements the detector.Validator interface for detecting

--- a/internal/validators/personname/validator.go
+++ b/internal/validators/personname/validator.go
@@ -16,6 +16,7 @@ import (
 	"github.com/awslabs/ferret-scan/v2/internal/detector"
 	"github.com/awslabs/ferret-scan/v2/internal/execguard"
 	"github.com/awslabs/ferret-scan/v2/internal/observability"
+	"github.com/awslabs/ferret-scan/v2/internal/validators/kwmatch"
 )
 
 // Package-level variables for business suffixes and technical phrases to avoid repeated allocations
@@ -843,33 +844,13 @@ func (v *Validator) isTechnicalTerm(match string) bool {
 // phrase (case-insensitive, text already lowercased by callers). The previous
 // substring matching let short context keywords fire inside unrelated words
 // ("park" in "parking" -> -35, "inc" in "incident" -> -20, "name" in
-// "username" -> +12), nudging confidence in both directions (L25). A word byte
-// is [a-z0-9]; multi-word phrases are matched with \b on the outer edges.
+// "username" -> +12), nudging confidence in both directions (L25).
+//
+// ModeAlnum preserves this validator's historical boundary semantics: a word
+// byte is [a-z0-9], so '_' acts as a word boundary here. ContainsLower (rather
+// than Contains) keeps the existing contract that callers pass lowercased text.
 func containsWordKeyword(text, keyword string) bool {
-	if keyword == "" {
-		return false
-	}
-	for from := 0; from+len(keyword) <= len(text); {
-		i := strings.Index(text[from:], keyword)
-		if i < 0 {
-			return false
-		}
-		i += from
-		leftOK := i == 0 || !isNameWordByte(text[i-1])
-		right := i + len(keyword)
-		rightOK := right >= len(text) || !isNameWordByte(text[right])
-		if leftOK && rightOK {
-			return true
-		}
-		from = i + 1
-	}
-	return false
-}
-
-// isNameWordByte reports whether b is a word character ([a-z0-9]) for keyword
-// boundary detection. Callers pass already-lowercased text.
-func isNameWordByte(b byte) bool {
-	return (b >= 'a' && b <= 'z') || (b >= '0' && b <= '9')
+	return kwmatch.ContainsLower(text, keyword, kwmatch.ModeAlnum)
 }
 
 // lineContextCache holds the per-line work shared by every name match found on a

--- a/internal/validators/secrets/validator.go
+++ b/internal/validators/secrets/validator.go
@@ -15,6 +15,7 @@ import (
 	"github.com/awslabs/ferret-scan/v2/internal/execguard"
 	"github.com/awslabs/ferret-scan/v2/internal/help"
 	"github.com/awslabs/ferret-scan/v2/internal/observability"
+	"github.com/awslabs/ferret-scan/v2/internal/validators/kwmatch"
 )
 
 // Multi-line PEM-style secret patterns. Compiled once at package init —
@@ -936,32 +937,13 @@ var (
 )
 
 // containsWordBoundary reports whether keyword appears in text as a whole
-// word (text must already be lowercased). Same boundary semantics as the
-// containsKeyword helper in the other validator packages: a word byte is
-// [a-z0-9_]; boundaries are string edges or non-word bytes. Prevents "test"
-// from matching inside "latest" or "attestation".
+// word (text must already be lowercased). Prevents "test" from matching inside
+// "latest" or "attestation".
+//
+// ModeAlnumUnderscore preserves this validator's historical boundary
+// semantics: a word byte is [a-z0-9_], so '_' counts as a word byte here.
 func containsWordBoundary(text, keyword string) bool {
-	for from := 0; from+len(keyword) <= len(text); {
-		i := strings.Index(text[from:], keyword)
-		if i < 0 {
-			return false
-		}
-		i += from
-		leftOK := i == 0 || !isSecretWordByte(text[i-1])
-		right := i + len(keyword)
-		rightOK := right >= len(text) || !isSecretWordByte(text[right])
-		if leftOK && rightOK {
-			return true
-		}
-		from = i + 1
-	}
-	return false
-}
-
-// isSecretWordByte reports whether b is a word character for boundary
-// detection (input is lowercased by the caller).
-func isSecretWordByte(b byte) bool {
-	return b == '_' || (b >= 'a' && b <= 'z') || (b >= '0' && b <= '9')
+	return kwmatch.ContainsLower(text, keyword, kwmatch.ModeAlnumUnderscore)
 }
 
 // isKeywordAlnum reports whether b is an ASCII letter or digit.

--- a/internal/validators/ssn/validator.go
+++ b/internal/validators/ssn/validator.go
@@ -12,6 +12,7 @@ import (
 	"github.com/awslabs/ferret-scan/v2/internal/detector"
 	"github.com/awslabs/ferret-scan/v2/internal/execguard"
 	"github.com/awslabs/ferret-scan/v2/internal/observability"
+	"github.com/awslabs/ferret-scan/v2/internal/validators/kwmatch"
 )
 
 // Pre-compiled regex patterns used across validator methods.
@@ -34,44 +35,15 @@ var (
 )
 
 // containsKeyword reports whether text contains keyword as a whole word/phrase,
-// case-insensitively. The previous code used strings.Contains, so short keywords
-// matched inside unrelated words — "hr" in "Christopher" (+45 inflation), "ein"
-// in "Einstein", "ext" in "next", "code" in "barcode" — both fabricating context
-// boosts on non-SSN lines and spuriously penalizing real SSNs.
+// case-insensitively. Whole-word matching stops short keywords from firing
+// inside unrelated words — "hr" in "Christopher", "ein" in "Einstein", "ext" in
+// "next", "code" in "barcode" — which both fabricated context boosts on non-SSN
+// lines and spuriously penalized real SSNs.
 //
-// It is implemented as a plain string scan with manual boundary checks rather
-// than a regex: AnalyzeContext/validateSSNByDomain/findKeywords invoke it on the
-// order of a hundred times per matched SSN, and a compiled-regex MatchString per
-// keyword made SSN-dense input ~13x slower. A "word" character here is
-// [a-z0-9_]; a boundary is the string edge or any non-word byte, which also
-// correctly anchors keywords whose own edges are non-word (e.g. "w-2").
+// ModeAlnumUnderscore preserves this validator's historical boundary
+// semantics: '_' counts as a word byte here.
 func containsKeyword(text, keyword string) bool {
-	if keyword == "" {
-		return false
-	}
-	lt := strings.ToLower(text)
-	lk := strings.ToLower(keyword)
-	for from := 0; from+len(lk) <= len(lt); {
-		i := strings.Index(lt[from:], lk)
-		if i < 0 {
-			return false
-		}
-		i += from
-		leftOK := i == 0 || !isWordByte(lt[i-1])
-		right := i + len(lk)
-		rightOK := right >= len(lt) || !isWordByte(lt[right])
-		if leftOK && rightOK {
-			return true
-		}
-		from = i + 1
-	}
-	return false
-}
-
-// isWordByte reports whether b is a word character ([a-z0-9_]) for the purpose
-// of keyword boundary detection. text is already lowercased by the caller.
-func isWordByte(b byte) bool {
-	return b == '_' || (b >= 'a' && b <= 'z') || (b >= '0' && b <= '9')
+	return kwmatch.Contains(text, keyword, kwmatch.ModeAlnumUnderscore)
 }
 
 // Validator implements the detector.Validator interface for detecting

--- a/internal/validators/vin/validator.go
+++ b/internal/validators/vin/validator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/awslabs/ferret-scan/v2/internal/detector"
 	"github.com/awslabs/ferret-scan/v2/internal/execguard"
 	"github.com/awslabs/ferret-scan/v2/internal/observability"
+	"github.com/awslabs/ferret-scan/v2/internal/validators/kwmatch"
 )
 
 // transliterationMap maps VIN characters to their numeric values for check digit calculation.
@@ -30,34 +31,12 @@ var positionWeights = [17]int{8, 7, 6, 5, 4, 3, 2, 10, 0, 9, 8, 7, 6, 5, 4, 3, 2
 // keywords matched inside unrelated words — positive "car"/"vin" inside
 // "carbon"/"moving" fabricated a +50 boost on a random check-digit-passing
 // token, and negative "sha"/"key"/"api" inside "shall"/"monkey"/"rapid" dropped
-// real VINs. A plain string scan (word byte = [a-z0-9]) keeps this cheap.
+// real VINs.
+//
+// ModeAlnum preserves this validator's historical boundary semantics: a word
+// byte is [a-z0-9], so '_' acts as a word boundary here.
 func containsKeyword(text, keyword string) bool {
-	if keyword == "" {
-		return false
-	}
-	lt := strings.ToLower(text)
-	lk := strings.ToLower(keyword)
-	for from := 0; from+len(lk) <= len(lt); {
-		i := strings.Index(lt[from:], lk)
-		if i < 0 {
-			return false
-		}
-		i += from
-		leftOK := i == 0 || !isVINWordByte(lt[i-1])
-		right := i + len(lk)
-		rightOK := right >= len(lt) || !isVINWordByte(lt[right])
-		if leftOK && rightOK {
-			return true
-		}
-		from = i + 1
-	}
-	return false
-}
-
-// isVINWordByte reports whether b is a word character ([a-z0-9]) for keyword
-// boundary detection. text is already lowercased by the caller.
-func isVINWordByte(b byte) bool {
-	return (b >= 'a' && b <= 'z') || (b >= '0' && b <= '9')
+	return kwmatch.Contains(text, keyword, kwmatch.ModeAlnum)
 }
 
 // knownWMIs maps common World Manufacturer Identifier prefixes to manufacturer names.


### PR DESCRIPTION
## What

Thirteen validator packages had each grown their own copy of the same whole-word keyword scan used by context scoring. Nine copies of `containsKeyword` were byte-identical; the rest differed only in the name of the word-byte predicate. This replaces all of them with one implementation in `internal/validators/kwmatch` and leaves each validator a one-line wrapper, so **call sites are untouched**.

Net **−284 LOC** in the validator packages.

## Why the API takes a Mode parameter

The copies were *not* all semantically identical — three variants existed:

| Predicate | Packages |
|---|---|
| `ModeAlnumUnderscore` (`[a-z0-9_]`) | address, bankaccount, dob, driverslicense, medicalid, otp, ssn, secrets |
| `ModeAlnum` (`[a-z0-9]`) | email, ipaddress, personname, vin |
| alnum + `A-Z` | cloudresources |

Every validator **keeps the predicate it had**, so this PR is a pure extraction. cloudresources' `A-Z` arm is dropped rather than modelled: every caller passes already-lowercased text, so that arm was unreachable.

The two modes disagree only on `_`, and that disagreement is a **real detection bug** in the eight `ModeAlnumUnderscore` validators — a keyword next to `_` never matches, so snake_case identifiers neither earn positive context nor trigger negative suppression. It is preserved here on purpose and fixed in a follow-up, so this diff can be reviewed as inert and the behavior change measured on its own.

`kwmatch` keeps the plain `strings.Index` scan rather than a regex (callers invoke it ~100× per match; the packages that measured it recorded a compiled regex as ~13× slower on dense input). `Mode` is a `uint8` compared inside the boundary check, not a function value, so no indirect call is added to the hot path.

## Verification — no behavior change

- **All 204 golden files byte-identical, with zero regeneration.**
- `go build` / `go vet` / `gofmt` clean; full unit suite (46 pkgs) + integration suite pass.
- `TestValidatorComplexityIsSubQuadratic` passes for all 18 text validators.
- **25,933 findings across 29 real documents** compared on type, line, confidence, level, validator and the scoring metadata (`confidence_adjustment` + `confidence_factors`): **identical**. The only two files that differed are pre-existing nondeterminism, reproduced by running the *unmodified* binary against itself (filed separately).
- Wall clock on a 7.1MB real report unchanged: min 5.833s → 5.843s, median 6.006s → 5.983s.

New `kwmatch` tests cover boundary/phrase/empty-keyword behavior, pin the `_` divergence between both modes in both directions, and cover the accept-filter and overlapping-occurrence paths.