### PR TITLE
fix(validators): treat '_' as a word boundary in keyword matching

### DIFF
--- a/internal/context/analyzer.go
+++ b/internal/context/analyzer.go
@@ -169,12 +169,17 @@ func (sd *StructureDetector) DetectStructure(content, filePath string) (string, 
 		scores[structType] = confidence
 	}
 
-	// Find the highest scoring structure type
+	// Find the highest scoring structure type. Ties are broken by type name so
+	// the result is deterministic: ranging a map with a strict > let Go's
+	// randomized iteration order decide between equal scores, so the same
+	// content was detected as "TSV" on one run and "Code" on the next. That
+	// choice feeds calculateConfidenceAdjustments (tabular_boost is +20), so the
+	// flapping moved every finding in the document across a confidence band.
 	bestType := "Unknown"
 	bestScore := 0.0
 
 	for structType, score := range scores {
-		if score > bestScore {
+		if score > bestScore || (score == bestScore && score > 0 && structType < bestType) {
 			bestScore = score
 			bestType = structType
 		}
@@ -256,12 +261,16 @@ func (dc *DomainClassifier) ClassifyDomain(content string) (string, float64) {
 		return "Unknown", 0.0
 	}
 
-	// Find the highest scoring domain
+	// Find the highest scoring domain. Ties are broken by domain name so the
+	// result is deterministic: ranging a map with a strict > let Go's randomized
+	// iteration order decide between equal scores, so the same input classified
+	// as (for example) Financial on one run and Retail on the next — the domain
+	// lands in reported metadata, which made output non-reproducible.
 	bestDomain := "Unknown"
 	bestScore := 0
 
 	for domain, score := range domainScores {
-		if score > bestScore {
+		if score > bestScore || (score == bestScore && score > 0 && domain < bestDomain) {
 			bestScore = score
 			bestDomain = domain
 		}

--- a/internal/context/analyzer_test.go
+++ b/internal/context/analyzer_test.go
@@ -1,0 +1,120 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package context
+
+import "testing"
+
+// TestClassifyDomainIsDeterministic locks the tie-break in ClassifyDomain. The
+// best-domain search ranged a map with a strict >, so when two domains scored
+// equally Go's randomized map iteration order picked the winner: the same
+// content classified as "Financial" on one run and "Retail" on the next. The
+// domain is reported in finding metadata, so that flapping made scan output
+// non-reproducible and any golden file covering a tied input permanently flaky.
+func TestClassifyDomainIsDeterministic(t *testing.T) {
+	dc := NewDomainClassifier()
+
+	// Each input ties two domains on exactly one keyword apiece:
+	//   "account" -> Financial, "customer" -> Retail
+	//   "taxpayer" -> Government, "bank" -> Financial
+	for _, content := range []string{
+		"customer_ssn: 449-87-4100\naccount_number_test: 4012888888881881\n",
+		"taxpayer id on file, bank record attached",
+		"order product inventory patient medical hospital",
+	} {
+		first, firstConf := dc.ClassifyDomain(content)
+		for i := 0; i < 200; i++ {
+			got, conf := dc.ClassifyDomain(content)
+			if got != first || conf != firstConf {
+				t.Fatalf("ClassifyDomain(%q) is not deterministic: got (%q, %.4f) on iteration %d, want (%q, %.4f)",
+					content, got, conf, i, first, firstConf)
+			}
+		}
+	}
+}
+
+// TestClassifyDomainTieBreaksAlphabetically pins the chosen tie-break rule, so a
+// future refactor cannot silently swap it for another arbitrary order.
+func TestClassifyDomainTieBreaksAlphabetically(t *testing.T) {
+	dc := NewDomainClassifier()
+
+	// One Financial keyword ("account") against one Retail keyword ("customer"):
+	// "Financial" < "Retail", so Financial wins.
+	if got, _ := dc.ClassifyDomain("customer account"); got != "Financial" {
+		t.Errorf("tie between Financial and Retail should resolve to Financial, got %q", got)
+	}
+
+	// A strict majority must still beat the alphabetical order: "Retail" sorts
+	// after "Financial" but carries three keywords to Financial's one.
+	if got, _ := dc.ClassifyDomain("account customer order product"); got != "Retail" {
+		t.Errorf("higher score must win regardless of name order, got %q", got)
+	}
+}
+
+// TestClassifyDomainUnknown covers the two paths that bypass the ranking: no
+// keyword at all, and a winner too weak to clear the density threshold.
+func TestClassifyDomainUnknown(t *testing.T) {
+	dc := NewDomainClassifier()
+
+	if got, conf := dc.ClassifyDomain("the quick brown fox"); got != "Unknown" || conf != 0 {
+		t.Errorf("keyword-free content should be (Unknown, 0), got (%q, %.4f)", got, conf)
+	}
+}
+
+// TestDetectStructureIsDeterministic locks the tie-break in DetectStructure, the
+// second instance of the same defect as ClassifyDomain's: the best-type search
+// ranged a map with a strict >, so tied pattern scores were resolved by Go's
+// randomized map iteration order.
+//
+// This one was the more damaging of the two. DocumentType feeds
+// calculateConfidenceAdjustments, where a tabular type grants tabular_boost of
+// +20 — so a coin flip between "TSV" and "Code" moved EVERY finding in the
+// document across a confidence band. Confidence is part of the suppression hash,
+// so the flapping could also invalidate users' suppression rules between runs.
+func TestDetectStructureIsDeterministic(t *testing.T) {
+	sd := NewStructureDetector()
+
+	for _, content := range []string{
+		// Tab-separated prose that also looks like code to the Code pattern.
+		"name\tvalue\tnotes\nfoo\t1\tok\nbar\t2\tok\n",
+		"key: value\nother: thing\n",
+		"a,b,c\n1,2,3\n",
+		"func main() {\n\tx := 1\n}\n",
+	} {
+		first, firstConf := sd.DetectStructure(content, "input.txt")
+		for i := 0; i < 200; i++ {
+			got, conf := sd.DetectStructure(content, "input.txt")
+			if got != first || conf != firstConf {
+				t.Fatalf("DetectStructure(%q) is not deterministic: got (%q, %.4f) on iteration %d, want (%q, %.4f)",
+					content, got, conf, i, first, firstConf)
+			}
+		}
+	}
+}
+
+// TestAnalyzeContextIsDeterministic is the end-to-end guard: the two tie-breaks
+// above must make the whole insight bundle reproducible, including the
+// ConfidenceAdjustments map that scoring actually consumes.
+func TestAnalyzeContextIsDeterministic(t *testing.T) {
+	ca := NewContextAnalyzer()
+	const content = "customer_ssn\tvalue\n449-87-4100\t1\naccount_number_test\t4012888888881881\n"
+
+	first := ca.AnalyzeContext(content, "export.txt")
+	for i := 0; i < 100; i++ {
+		got := ca.AnalyzeContext(content, "export.txt")
+		if got.Domain != first.Domain || got.DocumentType != first.DocumentType {
+			t.Fatalf("AnalyzeContext not deterministic on iteration %d: (%q,%q) vs (%q,%q)",
+				i, got.Domain, got.DocumentType, first.Domain, first.DocumentType)
+		}
+		if len(got.ConfidenceAdjustments) != len(first.ConfidenceAdjustments) {
+			t.Fatalf("ConfidenceAdjustments size differs on iteration %d: %d vs %d",
+				i, len(got.ConfidenceAdjustments), len(first.ConfidenceAdjustments))
+		}
+		for k, v := range first.ConfidenceAdjustments {
+			if got.ConfidenceAdjustments[k] != v {
+				t.Fatalf("ConfidenceAdjustments[%q] differs on iteration %d: %v vs %v",
+					k, i, got.ConfidenceAdjustments[k], v)
+			}
+		}
+	}
+}

--- a/internal/goldencorpus/corpus.go
+++ b/internal/goldencorpus/corpus.go
@@ -266,6 +266,25 @@ var Cases = []Case{
 			"imei 490154203237518 on the handset\n" +
 			"order id: 4532015112830366 catalog\n",
 	},
+	{
+		Name: "context_keywords_snake_case",
+		Description: "Context keywords carried by snake_case / SCREAMING_SNAKE identifiers rather " +
+			"than spaced prose — the dominant shape in the code and config files this tool scans. " +
+			"Locks the fix for '_' being treated as a word byte, which made keyword matching miss " +
+			"inside an identifier in BOTH directions: positive keywords did not boost " +
+			"(customer_ssn / my_dob_field scored as bare numbers) and negative keywords did not " +
+			"suppress (a Luhn-valid card in TEST_/_test fixture context stayed MEDIUM). Each line " +
+			"here has a spaced counterpart in the cases above, and the two must score the same; a " +
+			"regression that reinstates '_' as a word byte shows up as the underscore lines " +
+			"dropping back to bare-value confidence.",
+		Checks: []string{"SSN", "CREDIT_CARD", "DATE_OF_BIRTH"},
+		Input: "customer_ssn: 449-87-4100\n" +
+			"SSN_VALUE=449-87-4101\n" +
+			"my_dob_field: 1985-03-14\n" +
+			"TEST_CARD_NUMBER = 4532015112830366\n" +
+			"account_number_test: 4012888888881881\n" +
+			"sample_ssn = 449-87-4102\n",
+	},
 }
 
 // FileCase is one file-based corpus entry. Unlike Case (which scans an in-memory

--- a/internal/goldencorpus/testdata/golden/context_keywords_snake_case.csv
+++ b/internal/goldencorpus/testdata/golden/context_keywords_snake_case.csv
@@ -1,0 +1,5 @@
+Filename,Type,Confidence Level,Confidence %,Line Number,Text
+<golden:context_keywords_snake_case>,DATE_OF_BIRTH,HIGH,90.0,3,1985-03-14
+<golden:context_keywords_snake_case>,SSN,HIGH,100.0,1,449-87-4100
+<golden:context_keywords_snake_case>,SSN,HIGH,100.0,2,449-87-4101
+<golden:context_keywords_snake_case>,SSN,MEDIUM,65.0,6,449-87-4102

--- a/internal/goldencorpus/testdata/golden/context_keywords_snake_case.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/context_keywords_snake_case.gitlab-sast.json
@@ -1,0 +1,134 @@
+{
+  "remediations": [],
+  "scan": {
+    "analyzer": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "end_time": "<TIMESTAMP>",
+    "scanner": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "start_time": "<TIMESTAMP>",
+    "status": "success",
+    "type": "sast"
+  },
+  "version": "15.0.4",
+  "vulnerabilities": [
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected sensitive data (date of birth) in this file.\n\n**Location:** <golden:context_keywords_snake_case> (line 3)\n**Confidence:** HIGH (90.0%)\n**Detected by:** dob validator\n\n**Context:**\n```\nmy_dob_field: 1985-03-14\n```\n\n**Additional Information:**\n- context_impact: 75\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "DATE_OF_BIRTH"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "dob"
+        }
+      ],
+      "location": {
+        "end_line": 3,
+        "file": "<golden:context_keywords_snake_case>",
+        "start_line": 3
+      },
+      "message": "Sensitive data (date of birth) detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Date Of Birth Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <golden:context_keywords_snake_case> (line 1)\n**Confidence:** HIGH (100.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\ncustomer_ssn: 449-87-4100\n```\n\n**Additional Information:**\n- context_impact: 25\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "SSN"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "ssn"
+        }
+      ],
+      "location": {
+        "end_line": 1,
+        "file": "<golden:context_keywords_snake_case>",
+        "start_line": 1
+      },
+      "message": "Social Security Number detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Social Security Number Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <golden:context_keywords_snake_case> (line 2)\n**Confidence:** HIGH (100.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\nSSN_VALUE=449-87-4101\n```\n\n**Additional Information:**\n- context_impact: 25\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "SSN"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "ssn"
+        }
+      ],
+      "location": {
+        "end_line": 2,
+        "file": "<golden:context_keywords_snake_case>",
+        "start_line": 2
+      },
+      "message": "Social Security Number detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Social Security Number Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <golden:context_keywords_snake_case> (line 6)\n**Confidence:** MEDIUM (65.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\nsample_ssn = 449-87-4102\n```\n\n**Additional Information:**\n- context_impact: -30\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "SSN"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "ssn"
+        }
+      ],
+      "location": {
+        "end_line": 6,
+        "file": "<golden:context_keywords_snake_case>",
+        "start_line": 6
+      },
+      "message": "Social Security Number detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Social Security Number Detected",
+      "severity": "High"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/context_keywords_snake_case.json.json
+++ b/internal/goldencorpus/testdata/golden/context_keywords_snake_case.json.json
@@ -1,0 +1,144 @@
+{
+  "results": [
+    {
+      "confidence": 100,
+      "confidence_level": "HIGH",
+      "filename": "<golden:context_keywords_snake_case>",
+      "line_number": 1,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0.5,
+        "context_doctype": "Configuration",
+        "context_domain": "Financial",
+        "context_impact": 25,
+        "original_confidence": 100,
+        "original_file": "<golden:context_keywords_snake_case>",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "format": true,
+          "not_common_pattern": true,
+          "not_repeating": true,
+          "not_sequential": true,
+          "not_test_number": true,
+          "valid_area": true
+        },
+        "validation_path": "document"
+      },
+      "text": "449-87-4100",
+      "type": "SSN",
+      "validator": "ssn"
+    },
+    {
+      "confidence": 100,
+      "confidence_level": "HIGH",
+      "filename": "<golden:context_keywords_snake_case>",
+      "line_number": 2,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0.5,
+        "context_doctype": "Configuration",
+        "context_domain": "Financial",
+        "context_impact": 25,
+        "original_confidence": 100,
+        "original_file": "<golden:context_keywords_snake_case>",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "format": true,
+          "not_common_pattern": true,
+          "not_repeating": true,
+          "not_sequential": true,
+          "not_test_number": true,
+          "valid_area": true
+        },
+        "validation_path": "document"
+      },
+      "text": "449-87-4101",
+      "type": "SSN",
+      "validator": "ssn"
+    },
+    {
+      "confidence": 90,
+      "confidence_level": "HIGH",
+      "filename": "<golden:context_keywords_snake_case>",
+      "line_number": 3,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0.5,
+        "context_doctype": "Configuration",
+        "context_domain": "Financial",
+        "context_impact": 75,
+        "original_confidence": 90,
+        "original_file": "<golden:context_keywords_snake_case>",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "not_test": true,
+          "plausible_year": true,
+          "valid_date": true
+        },
+        "validation_path": "document"
+      },
+      "text": "1985-03-14",
+      "type": "DATE_OF_BIRTH",
+      "validator": "dob"
+    },
+    {
+      "confidence": 65,
+      "confidence_level": "MEDIUM",
+      "filename": "<golden:context_keywords_snake_case>",
+      "line_number": 6,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0.5,
+        "context_doctype": "Configuration",
+        "context_domain": "Financial",
+        "context_impact": -30,
+        "original_confidence": 65,
+        "original_file": "<golden:context_keywords_snake_case>",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "format": true,
+          "not_common_pattern": true,
+          "not_repeating": true,
+          "not_sequential": true,
+          "not_test_number": true,
+          "valid_area": true
+        },
+        "validation_path": "document"
+      },
+      "text": "449-87-4102",
+      "type": "SSN",
+      "validator": "ssn"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/context_keywords_snake_case.junit.xml
+++ b/internal/goldencorpus/testdata/golden/context_keywords_snake_case.junit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
+  <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
+    <testcase name="&lt;golden:context_keywords_snake_case&gt;" classname="security-scan" time="0.001">
+      <failure message="4 security findings detected" type="SECURITY_FINDINGS">Line 1: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 2: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 449-87-4101&#xA;Validator: ssn&#xA;Line 3: DATE_OF_BIRTH detected with 90.0% confidence (HIGH)&#xA;Match: 1985-03-14&#xA;Validator: dob&#xA;Line 6: SSN detected with 65.0% confidence (MEDIUM)&#xA;Match: 449-87-4102&#xA;Validator: ssn</failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/internal/goldencorpus/testdata/golden/context_keywords_snake_case.redact_format_preserving.txt
+++ b/internal/goldencorpus/testdata/golden/context_keywords_snake_case.redact_format_preserving.txt
@@ -1,0 +1,12 @@
+=== REDACTED ===
+customer_ssn: ***-**-4100
+SSN_VALUE=***-**-4101
+my_dob_field: **********
+TEST_CARD_NUMBER = 4532015112830366
+account_number_test: 4012888888881881
+sample_ssn = ***-**-4102
+=== FINDINGS (sorted) ===
+type=DATE_OF_BIRTH line=3 conf=high match=1985-03-14
+type=SSN line=1 conf=high match=449-87-4100
+type=SSN line=2 conf=high match=449-87-4101
+type=SSN line=6 conf=medium match=449-87-4102

--- a/internal/goldencorpus/testdata/golden/context_keywords_snake_case.redact_simple.txt
+++ b/internal/goldencorpus/testdata/golden/context_keywords_snake_case.redact_simple.txt
@@ -1,0 +1,12 @@
+=== REDACTED ===
+customer_ssn: [SSN-REDACTED]
+SSN_VALUE=[SSN-REDACTED]
+my_dob_field: [DATE_OF_BIRTH-REDACTED]
+TEST_CARD_NUMBER = 4532015112830366
+account_number_test: 4012888888881881
+sample_ssn = [SSN-REDACTED]
+=== FINDINGS (sorted) ===
+type=DATE_OF_BIRTH line=3 conf=high match=1985-03-14
+type=SSN line=1 conf=high match=449-87-4100
+type=SSN line=2 conf=high match=449-87-4101
+type=SSN line=6 conf=medium match=449-87-4102

--- a/internal/goldencorpus/testdata/golden/context_keywords_snake_case.sarif.json
+++ b/internal/goldencorpus/testdata/golden/context_keywords_snake_case.sarif.json
@@ -1,0 +1,318 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/refs/heads/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:context_keywords_snake_case>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "my_dob_field: \nmy_dob_field: 1985-03-14"
+                  },
+                  "startLine": 3
+                },
+                "region": {
+                  "endColumn": 25,
+                  "snippet": {
+                    "text": "my_dob_field: 1985-03-14"
+                  },
+                  "startColumn": 15,
+                  "startLine": 3
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "DATE_OF_BIRTH Detected in <golden:context_keywords_snake_case> at line 3 (confidence: 90.0% - HIGH). Matched text: '1985-03-14'"
+          },
+          "properties": {
+            "confidence": 90,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 0.5,
+              "context_doctype": "Configuration",
+              "context_domain": "Financial",
+              "context_impact": 75,
+              "original_confidence": 90,
+              "original_file": "<golden:context_keywords_snake_case>",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "not_test": true,
+                "plausible_year": true,
+                "valid_date": true
+              },
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "dob"
+            ],
+            "validator": "dob"
+          },
+          "rank": 70,
+          "ruleId": "DATE_OF_BIRTH"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:context_keywords_snake_case>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "customer_ssn: \ncustomer_ssn: 449-87-4100"
+                  },
+                  "startLine": 1
+                },
+                "region": {
+                  "endColumn": 26,
+                  "snippet": {
+                    "text": "customer_ssn: 449-87-4100"
+                  },
+                  "startColumn": 15,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Social Security Number Detected in <golden:context_keywords_snake_case> at line 1 (confidence: 100.0% - HIGH). Matched text: '449-87-4100'"
+          },
+          "properties": {
+            "confidence": 100,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 0.5,
+              "context_doctype": "Configuration",
+              "context_domain": "Financial",
+              "context_impact": 25,
+              "original_confidence": 100,
+              "original_file": "<golden:context_keywords_snake_case>",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "digits": true,
+                "format": true,
+                "not_common_pattern": true,
+                "not_repeating": true,
+                "not_sequential": true,
+                "not_test_number": true,
+                "valid_area": true
+              },
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "ssn"
+            ],
+            "validator": "ssn"
+          },
+          "rank": 100,
+          "ruleId": "SSN"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:context_keywords_snake_case>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "SSN_VALUE=\nSSN_VALUE=449-87-4101"
+                  },
+                  "startLine": 2
+                },
+                "region": {
+                  "endColumn": 22,
+                  "snippet": {
+                    "text": "SSN_VALUE=449-87-4101"
+                  },
+                  "startColumn": 11,
+                  "startLine": 2
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Social Security Number Detected in <golden:context_keywords_snake_case> at line 2 (confidence: 100.0% - HIGH). Matched text: '449-87-4101'"
+          },
+          "properties": {
+            "confidence": 100,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 0.5,
+              "context_doctype": "Configuration",
+              "context_domain": "Financial",
+              "context_impact": 25,
+              "original_confidence": 100,
+              "original_file": "<golden:context_keywords_snake_case>",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "digits": true,
+                "format": true,
+                "not_common_pattern": true,
+                "not_repeating": true,
+                "not_sequential": true,
+                "not_test_number": true,
+                "valid_area": true
+              },
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "ssn"
+            ],
+            "validator": "ssn"
+          },
+          "rank": 100,
+          "ruleId": "SSN"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:context_keywords_snake_case>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "sample_ssn = \nsample_ssn = 449-87-4102"
+                  },
+                  "startLine": 6
+                },
+                "region": {
+                  "endColumn": 25,
+                  "snippet": {
+                    "text": "sample_ssn = 449-87-4102"
+                  },
+                  "startColumn": 14,
+                  "startLine": 6
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Social Security Number Detected in <golden:context_keywords_snake_case> at line 6 (confidence: 65.0% - MEDIUM). Matched text: '449-87-4102'"
+          },
+          "properties": {
+            "confidence": 65,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 0.5,
+              "context_doctype": "Configuration",
+              "context_domain": "Financial",
+              "context_impact": -30,
+              "original_confidence": 65,
+              "original_file": "<golden:context_keywords_snake_case>",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "digits": true,
+                "format": true,
+                "not_common_pattern": true,
+                "not_repeating": true,
+                "not_sequential": true,
+                "not_test_number": true,
+                "valid_area": true
+              },
+              "validation_path": "document"
+            },
+            "negativeKeywords": [
+              "sample"
+            ],
+            "positiveKeywords": [
+              "ssn"
+            ],
+            "validator": "ssn"
+          },
+          "rank": 82.5,
+          "ruleId": "SSN"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/awslabs/ferret-scan",
+          "name": "Ferret Scan",
+          "rules": [
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type DATE_OF_BIRTH was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/DATE_OF_BIRTH.md",
+              "id": "DATE_OF_BIRTH",
+              "shortDescription": {
+                "text": "DATE_OF_BIRTH Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "A Social Security Number (SSN) pattern was detected in the scanned content. SSNs are highly sensitive personally identifiable information (PII) that must be protected under various regulations."
+              },
+              "help": {
+                "text": "Social Security Numbers are protected under numerous regulations including GDPR, HIPAA, and various state privacy laws. SSNs should never be stored in source code, configuration files, or logs. Remove this SSN immediately and ensure it is stored in a secure, encrypted system with appropriate access controls. Consider implementing tokenization or other data protection mechanisms."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/SSN.md",
+              "id": "SSN",
+              "shortDescription": {
+                "text": "Social Security Number Detected"
+              }
+            }
+          ],
+          "semanticVersion": "0.0.0-development",
+          "version": "0.0.0-development"
+        }
+      },
+      "versionControlProvenance": [
+        {
+          "mappedTo": {
+            "uriBaseId": "%SRCROOT%"
+          },
+          "repositoryUri": "https://github.com/awslabs/ferret-scan",
+          "revisionId": "0.0.0-development"
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/internal/goldencorpus/testdata/golden/context_keywords_snake_case.txt
+++ b/internal/goldencorpus/testdata/golden/context_keywords_snake_case.txt
@@ -1,0 +1,6 @@
+LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH       FILE
+-------------------------------------------------------------------------------------
+[HIGH  ] ssn          SSN                   100.00% line     1 449-87-4100 <golden:context_keywords_snake_case>
+[HIGH  ] ssn          SSN                   100.00% line     2 449-87-4101 <golden:context_keywords_snake_case>
+[HIGH  ] dob          DATE_OF_BIRTH          90.00% line     3 1985-03-14  <golden:context_keywords_snake_case>
+[MEDIUM] ssn          SSN                    65.00% line     6 449-87-4102 <golden:context_keywords_snake_case>

--- a/internal/goldencorpus/testdata/golden/context_keywords_snake_case.yaml
+++ b/internal/goldencorpus/testdata/golden/context_keywords_snake_case.yaml
@@ -1,0 +1,121 @@
+results:
+    - text: 449-87-4100
+      line_number: 1
+      type: SSN
+      confidence: 100
+      confidence_level: HIGH
+      filename: <golden:context_keywords_snake_case>
+      validator: ssn
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0.5
+        context_doctype: Configuration
+        context_domain: Financial
+        context_impact: 25
+        original_confidence: 100
+        original_file: <golden:context_keywords_snake_case>
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            format: true
+            not_common_pattern: true
+            not_repeating: true
+            not_sequential: true
+            not_test_number: true
+            valid_area: true
+        validation_path: document
+    - text: 449-87-4101
+      line_number: 2
+      type: SSN
+      confidence: 100
+      confidence_level: HIGH
+      filename: <golden:context_keywords_snake_case>
+      validator: ssn
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0.5
+        context_doctype: Configuration
+        context_domain: Financial
+        context_impact: 25
+        original_confidence: 100
+        original_file: <golden:context_keywords_snake_case>
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            format: true
+            not_common_pattern: true
+            not_repeating: true
+            not_sequential: true
+            not_test_number: true
+            valid_area: true
+        validation_path: document
+    - text: "1985-03-14"
+      line_number: 3
+      type: DATE_OF_BIRTH
+      confidence: 90
+      confidence_level: HIGH
+      filename: <golden:context_keywords_snake_case>
+      validator: dob
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0.5
+        context_doctype: Configuration
+        context_domain: Financial
+        context_impact: 75
+        original_confidence: 90
+        original_file: <golden:context_keywords_snake_case>
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            not_test: true
+            plausible_year: true
+            valid_date: true
+        validation_path: document
+    - text: 449-87-4102
+      line_number: 6
+      type: SSN
+      confidence: 65
+      confidence_level: MEDIUM
+      filename: <golden:context_keywords_snake_case>
+      validator: ssn
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0.5
+        context_doctype: Configuration
+        context_domain: Financial
+        context_impact: -30
+        original_confidence: 65
+        original_file: <golden:context_keywords_snake_case>
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            format: true
+            not_common_pattern: true
+            not_repeating: true
+            not_sequential: true
+            not_test_number: true
+            valid_area: true
+        validation_path: document

--- a/internal/validators/address/validator.go
+++ b/internal/validators/address/validator.go
@@ -163,10 +163,12 @@ var (
 // containsKeyword reports whether text contains keyword as a whole word/phrase,
 // case-insensitively, using word-boundary detection.
 //
-// ModeAlnumUnderscore preserves this validator's historical boundary
-// semantics: '_' counts as a word byte here.
+// ModeAlnum treats '_' as a word boundary, so a keyword is found inside a
+// snake_case identifier ("customer_ssn", "TEST_VALUE") exactly as it is
+// between spaces. Code and config — where those identifiers dominate — are
+// primary scan targets for this tool.
 func containsKeyword(text, keyword string) bool {
-	return kwmatch.Contains(text, keyword, kwmatch.ModeAlnumUnderscore)
+	return kwmatch.Contains(text, keyword)
 }
 
 // Validator implements the detector.Validator interface for detecting

--- a/internal/validators/bankaccount/validator.go
+++ b/internal/validators/bankaccount/validator.go
@@ -84,10 +84,12 @@ var (
 // containsKeyword reports whether text contains keyword as a whole word/phrase,
 // case-insensitively.
 //
-// ModeAlnumUnderscore preserves this validator's historical boundary
-// semantics: '_' counts as a word byte here.
+// ModeAlnum treats '_' as a word boundary, so a keyword is found inside a
+// snake_case identifier ("customer_ssn", "TEST_VALUE") exactly as it is
+// between spaces. Code and config — where those identifiers dominate — are
+// primary scan targets for this tool.
 func containsKeyword(text, keyword string) bool {
-	return kwmatch.Contains(text, keyword, kwmatch.ModeAlnumUnderscore)
+	return kwmatch.Contains(text, keyword)
 }
 
 // Validator implements the detector.Validator interface for detecting

--- a/internal/validators/cloudresources/cloudresources.go
+++ b/internal/validators/cloudresources/cloudresources.go
@@ -493,7 +493,7 @@ func (v *Validator) scoreMatch(match, resourceType string, lineHasNegKeyword, is
 // predicate also counted 'A'-'Z', which was unreachable — every caller passes
 // text it has already lowercased.
 func hasKeywordToken(lowerLine string, keywords []string) bool {
-	return kwmatch.ContainsAny(lowerLine, keywords, kwmatch.ModeAlnum)
+	return kwmatch.ContainsAny(lowerLine, keywords)
 }
 
 // CalculateConfidence implements the detector.Validator interface. It mirrors

--- a/internal/validators/creditcard/validator.go
+++ b/internal/validators/creditcard/validator.go
@@ -587,11 +587,19 @@ func (v *Validator) calculateEntropy(number string) float64 {
 }
 
 // buildKeywordRegex compiles a slice of keywords into a single case-insensitive
-// whole-word matcher: \b(kw1|kw2|...)\b. Keywords are lowercased and regex-quoted
-// (so multi-word entries like "american express" still match, with \b sitting at
-// the outer edges and the space matched literally). Matching on word boundaries
-// — rather than strings.Contains — prevents short keywords ("id", "tel", "sha")
-// from matching inside unrelated words ("david", "hotel", "sha256").
+// whole-token matcher. Keywords are lowercased and regex-quoted (so multi-word
+// entries like "american express" still match, with the space matched
+// literally). Matching on token boundaries — rather than strings.Contains —
+// prevents short keywords ("id", "tel", "sha") from matching inside unrelated
+// words ("david", "hotel", "sha256").
+//
+// The boundary is deliberately NOT \b: Go's \b uses \w, which includes '_', so
+// `\btest\b` does not match "account_number_test" and a negative keyword failed
+// to suppress inside a snake_case identifier. Since RE2 has no lookaround, the
+// alphanumeric-only boundary is expressed as an optional non-alphanumeric byte
+// on each side, anchored to the string edges with ^/$ alternatives. This keeps
+// '_' a boundary, matching the kwmatch semantics the other validators
+// use.
 func buildKeywordRegex(keywords []string) *regexp.Regexp {
 	if len(keywords) == 0 {
 		return nil
@@ -600,7 +608,8 @@ func buildKeywordRegex(keywords []string) *regexp.Regexp {
 	for i, k := range keywords {
 		escaped[i] = regexp.QuoteMeta(strings.ToLower(k))
 	}
-	return regexp.MustCompile(`\b(?:` + strings.Join(escaped, "|") + `)\b`)
+	alts := strings.Join(escaped, "|")
+	return regexp.MustCompile(`(?:^|[^0-9a-z])(?:` + alts + `)(?:$|[^0-9a-z])`)
 }
 
 // analyzeContext provides faster context analysis with better false positive detection.

--- a/internal/validators/creditcard/validator_test.go
+++ b/internal/validators/creditcard/validator_test.go
@@ -847,6 +847,62 @@ func TestCreditCardValidator_NegativeKeywordWordBoundary(t *testing.T) {
 	}
 }
 
+// TestCreditCardValidator_SnakeCaseKeyword locks the keyword boundary against
+// snake_case identifiers. buildKeywordRegex used \b, and Go's \b is defined on
+// \w — which includes '_' — so `\btest\b` did not match "TEST_CARD_NUMBER" and
+// `\border\b` did not match "order_id". Negative labels therefore failed to
+// suppress, and positive card words failed to boost, exactly in the code and
+// config files where snake_case identifiers dominate. The boundary is now
+// alphanumeric-only, so each identifier below must score as its spaced twin.
+func TestCreditCardValidator_SnakeCaseKeyword(t *testing.T) {
+	validator := NewValidator()
+	const card = "4532015112830366" // Luhn-valid, not a known test pattern
+
+	for _, tc := range []struct {
+		snake, spaced string
+	}{
+		{"card_number: " + card, "card number: " + card},
+		{"TEST_CARD_NUMBER = " + card, "test card number = " + card},
+		{"account_number_test: " + card, "account number test: " + card},
+		{"order_id: " + card, "order id: " + card},
+	} {
+		snakeImpact := validator.AnalyzeContext(card, detector.ContextInfo{FullLine: tc.snake})
+		spacedImpact := validator.AnalyzeContext(card, detector.ContextInfo{FullLine: tc.spaced})
+		if snakeImpact != spacedImpact {
+			t.Errorf("'_' must score as a separator: %q gave %.1f but %q gave %.1f",
+				tc.snake, snakeImpact, tc.spaced, spacedImpact)
+		}
+	}
+
+	// The equality above must not pass by every line scoring the same: the
+	// snake_case negatives have to actually reach the -100 rejection, and the
+	// snake_case positive has to actually boost.
+	for _, line := range []string{
+		"TEST_CARD_NUMBER = " + card,
+		"account_number_test: " + card,
+		"order_id: " + card,
+	} {
+		if impact := validator.AnalyzeContext(card, detector.ContextInfo{FullLine: line}); impact > -100 {
+			t.Errorf("snake_case negative keyword should suppress %q, got impact %.1f", line, impact)
+		}
+	}
+	if impact := validator.AnalyzeContext(card, detector.ContextInfo{FullLine: "card_number: " + card}); impact <= 0 {
+		t.Errorf("snake_case positive keyword should boost, got impact %.1f", impact)
+	}
+
+	// End-to-end: a Luhn-valid card labeled as a test fixture in SCREAMING_SNAKE
+	// must not be reported at all.
+	matches, err := validator.ValidateContent("TEST_CARD_NUMBER = "+card, "config.py")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, m := range matches {
+		if strings.Contains(m.Text, card) {
+			t.Errorf("TEST_CARD_NUMBER fixture should be suppressed, got %s at %.1f", m.Type, m.Confidence)
+		}
+	}
+}
+
 // TestCreditCardValidator_SoftNegativeOverride locks the two-tier negative
 // behavior: SOFT negatives (account/order/serial-style identifier labels that
 // legitimately co-occur with a real card) suppress ONLY when no positive card

--- a/internal/validators/dob/validator.go
+++ b/internal/validators/dob/validator.go
@@ -64,10 +64,12 @@ var monthMap = map[string]int{
 // containsKeyword reports whether text contains keyword as a whole word/phrase,
 // case-insensitively.
 //
-// ModeAlnumUnderscore preserves this validator's historical boundary
-// semantics: '_' counts as a word byte here.
+// ModeAlnum treats '_' as a word boundary, so a keyword is found inside a
+// snake_case identifier ("customer_ssn", "TEST_VALUE") exactly as it is
+// between spaces. Code and config — where those identifiers dominate — are
+// primary scan targets for this tool.
 func containsKeyword(text, keyword string) bool {
-	return kwmatch.Contains(text, keyword, kwmatch.ModeAlnumUnderscore)
+	return kwmatch.Contains(text, keyword)
 }
 
 // Validator implements the detector.Validator interface for detecting

--- a/internal/validators/dob/validator_test.go
+++ b/internal/validators/dob/validator_test.go
@@ -601,6 +601,60 @@ func TestDOBValidator_NewValidator(t *testing.T) {
 	}
 }
 
+// TestDOBValidator_SnakeCaseKeyword locks the word-byte predicate: '_' is a
+// separator, not a word byte, so a "dob"/"birth" keyword carried by a
+// snake_case field name scores as it would between spaces. Before the fix
+// "my_dob_field" contained no "dob" token, so a date in a struct field or JSON
+// key — the most common way a DOB actually appears in code — stayed at the
+// bare, below-surfacing score.
+//
+// Scope: single-token keywords only. Multi-word keyword entries ("birth date",
+// "born on") contain a literal space and so still do not match their
+// underscore-joined spellings ("BIRTH_DATE", "born_on") — that needs separator
+// normalization in the keyword lists, which is deliberately not part of this
+// boundary fix.
+func TestDOBValidator_SnakeCaseKeyword(t *testing.T) {
+	validator := NewValidator()
+	const date = "1985-03-14"
+
+	conf := func(line string) float64 {
+		t.Helper()
+		matches, err := validator.ValidateContent(line, "test.txt")
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", line, err)
+		}
+		if len(matches) == 0 {
+			return -1
+		}
+		return matches[0].Confidence
+	}
+
+	for _, tc := range []struct {
+		snake, spaced string
+	}{
+		{"my_dob_field: " + date, "my dob field: " + date},
+		{"date_of_birth=" + date, "date of birth=" + date},
+		{"PATIENT_DOB = " + date, "PATIENT DOB = " + date},
+		{"birthday_value=" + date, "birthday value=" + date},
+	} {
+		if s, p := conf(tc.snake), conf(tc.spaced); s != p {
+			t.Errorf("'_' must score as a separator: %q gave %.1f but %q gave %.1f",
+				tc.snake, s, tc.spaced, p)
+		}
+	}
+
+	// The equality above must not pass by both collapsing to the no-keyword
+	// score: the snake_case field name has to actually promote the date.
+	bare := conf(date)
+	boosted := conf("my_dob_field: " + date)
+	if boosted <= bare {
+		t.Errorf("snake_case DOB field name should boost above the bare score %.1f, got %.1f", bare, boosted)
+	}
+	if boosted < 90 {
+		t.Errorf("snake_case DOB field name should reach HIGH, got %.1f", boosted)
+	}
+}
+
 func TestDOBValidator_FalsePositiveRegression(t *testing.T) {
 	validator := NewValidator()
 

--- a/internal/validators/driverslicense/validator.go
+++ b/internal/validators/driverslicense/validator.go
@@ -77,10 +77,12 @@ var (
 // case-insensitively. Word-boundary-aware matching prevents false positives from
 // substring matches (e.g. "dl" inside "handle").
 //
-// ModeAlnumUnderscore preserves this validator's historical boundary
-// semantics: '_' counts as a word byte here.
+// ModeAlnum treats '_' as a word boundary, so a keyword is found inside a
+// snake_case identifier ("customer_ssn", "TEST_VALUE") exactly as it is
+// between spaces. Code and config — where those identifiers dominate — are
+// primary scan targets for this tool.
 func containsKeyword(text, keyword string) bool {
-	return kwmatch.Contains(text, keyword, kwmatch.ModeAlnumUnderscore)
+	return kwmatch.Contains(text, keyword)
 }
 
 // Validator implements the detector.Validator interface for detecting

--- a/internal/validators/email/validator.go
+++ b/internal/validators/email/validator.go
@@ -23,7 +23,7 @@ import (
 // ModeAlnum preserves this validator's historical boundary semantics: a word
 // byte is [a-z0-9], so '_' acts as a word boundary here.
 func containsKeyword(text, keyword string) bool {
-	return kwmatch.Contains(text, keyword, kwmatch.ModeAlnum)
+	return kwmatch.Contains(text, keyword)
 }
 
 // containsKeywordLower is containsKeyword for callers that have already
@@ -32,7 +32,7 @@ func containsKeyword(text, keyword string) bool {
 // out of the hot path matters because the previous code re-lowercased the
 // (potentially huge) line text once per keyword per match.
 func containsKeywordLower(lt, lk string) bool {
-	return kwmatch.ContainsLower(lt, lk, kwmatch.ModeAlnum)
+	return kwmatch.ContainsLower(lt, lk)
 }
 
 // maxKeywordLen bounds how far past a context-window/full-line junction a
@@ -451,7 +451,7 @@ func buildJunctionWindows(beforeText, lowerLine, afterText string) junctionWindo
 // ModeAlnum matches the boundary semantics of the other keyword scans in this
 // package; accept is only consulted for whole-word occurrences.
 func containsKeywordCrossing(s, lk string, accept func(start, end int) bool) bool {
-	return kwmatch.ContainsFunc(s, lk, kwmatch.ModeAlnum, accept)
+	return kwmatch.ContainsFunc(s, lk, accept)
 }
 
 // keywordInContext reports whether keyword (lowercased as lowerKw) appears

--- a/internal/validators/ipaddress/validator.go
+++ b/internal/validators/ipaddress/validator.go
@@ -30,7 +30,7 @@ var (
 // ModeAlnum preserves this validator's historical boundary semantics: a word
 // byte is [a-z0-9], so '_' acts as a word boundary here.
 func ipContainsKeyword(text, keyword string) bool {
-	return kwmatch.Contains(text, keyword, kwmatch.ModeAlnum)
+	return kwmatch.Contains(text, keyword)
 }
 
 // Validator implements the detector.Validator interface for detecting

--- a/internal/validators/kwmatch/kwmatch.go
+++ b/internal/validators/kwmatch/kwmatch.go
@@ -14,13 +14,20 @@
 // times per match (AnalyzeContext, findKeywords, per-line context caches), and
 // a regexp.MatchString per keyword measured ~13x slower on keyword-dense input.
 //
-// # Word bytes and the Mode parameter
+// # Word bytes
 //
-// A "word" byte is what a keyword may not be adjacent to; a boundary is the
-// string edge or any non-word byte. Validators historically disagreed about
-// whether '_' is a word byte, so Mode makes that choice explicit at the call
-// site instead of hiding it in a per-package copy. See Mode's documentation for
-// which to pick.
+// A "word" byte is [a-z0-9]: what a keyword may not be adjacent to. A boundary
+// is the string edge or any other byte. Notably '_' is a boundary, NOT a word
+// byte, so a keyword is found inside a snake_case identifier exactly as it is
+// between spaces: "ssn" matches in "customer_ssn", "test" in
+// "account_number_test". Identifiers in code and config are overwhelmingly
+// snake_case, and those are primary scan targets — treating '_' as a word byte
+// silently cost both recall (positive keywords never fired) and precision
+// (test/sample markers never suppressed).
+//
+// This is also why the scan does not use Go's \b: RE2 defines \b on \w, which
+// includes '_', so `\btest\b` cannot express this boundary and RE2 has no
+// lookaround to work around it.
 //
 // Because boundaries are defined by the *text* bytes surrounding a match, a
 // keyword whose own edges are non-word characters (for example "w-2") is still
@@ -29,34 +36,11 @@ package kwmatch
 
 import "strings"
 
-// Mode selects which bytes count as word characters for boundary detection.
-//
-// The distinction matters for snake_case text: under [ModeAlnum] the keyword
-// "ssn" matches in "customer_ssn" (the '_' is a boundary), while under
-// [ModeAlnumUnderscore] it does not (the '_' continues the word).
-type Mode uint8
-
-const (
-	// ModeAlnum treats [a-z0-9] as word bytes, so '_' acts as a word
-	// boundary. Prefer this for context keywords: identifiers in code and
-	// config are overwhelmingly snake_case, and a keyword should be found in
-	// "customer_ssn" or "test_fixture" just as it is in "customer ssn".
-	ModeAlnum Mode = iota
-
-	// ModeAlnumUnderscore treats [a-z0-9_] as word bytes, so a keyword
-	// adjacent to '_' does not match. Use only where a keyword must bind to a
-	// complete underscore-delimited identifier rather than one of its parts.
-	ModeAlnumUnderscore
-)
-
-// isWordByte reports whether b is a word byte under m. Callers pass
-// already-lowercased text, so the uppercase range is intentionally absent:
-// under ASCII lowercasing no byte in 'A'-'Z' can reach here.
-func (m Mode) isWordByte(b byte) bool {
-	if b >= 'a' && b <= 'z' || b >= '0' && b <= '9' {
-		return true
-	}
-	return b == '_' && m == ModeAlnumUnderscore
+// isWordByte reports whether b is a word byte. Callers pass already-lowercased
+// text, so the uppercase range is intentionally absent: under ASCII lowercasing
+// no byte in 'A'-'Z' can reach here.
+func isWordByte(b byte) bool {
+	return b >= 'a' && b <= 'z' || b >= '0' && b <= '9'
 }
 
 // Contains reports whether text contains keyword as a whole word or phrase,
@@ -65,8 +49,8 @@ func (m Mode) isWordByte(b byte) bool {
 //
 // An empty keyword never matches, so a stray "" in a keyword list cannot score
 // every line.
-func Contains(text, keyword string, m Mode) bool {
-	return ContainsLower(strings.ToLower(text), strings.ToLower(keyword), m)
+func Contains(text, keyword string) bool {
+	return ContainsLower(strings.ToLower(text), strings.ToLower(keyword))
 }
 
 // ContainsLower is [Contains] for callers that have already lowercased both
@@ -76,8 +60,8 @@ func Contains(text, keyword string, m Mode) bool {
 //
 // Passing text or keyword that is not lowercased will simply fail to match
 // uppercase bytes; it is not otherwise unsafe.
-func ContainsLower(text, keyword string, m Mode) bool {
-	return ContainsFunc(text, keyword, m, nil)
+func ContainsLower(text, keyword string) bool {
+	return ContainsFunc(text, keyword, nil)
 }
 
 // ContainsFunc is [ContainsLower] with an optional filter on where a match may
@@ -91,7 +75,7 @@ func ContainsLower(text, keyword string, m Mode) bool {
 // fabricate matches that the full text would not have produced.
 //
 // A nil accept accepts any occurrence.
-func ContainsFunc(text, keyword string, m Mode, accept func(start, end int) bool) bool {
+func ContainsFunc(text, keyword string, accept func(start, end int) bool) bool {
 	if keyword == "" {
 		return false
 	}
@@ -102,8 +86,8 @@ func ContainsFunc(text, keyword string, m Mode, accept func(start, end int) bool
 		}
 		i += from
 		end := i + len(keyword)
-		leftOK := i == 0 || !m.isWordByte(text[i-1])
-		rightOK := end >= len(text) || !m.isWordByte(text[end])
+		leftOK := i == 0 || !isWordByte(text[i-1])
+		rightOK := end >= len(text) || !isWordByte(text[end])
 		if leftOK && rightOK && (accept == nil || accept(i, end)) {
 			return true
 		}
@@ -114,9 +98,9 @@ func ContainsFunc(text, keyword string, m Mode, accept func(start, end int) bool
 
 // ContainsAny reports whether text contains any of keywords as a whole word.
 // Both text and keywords must already be lowercased.
-func ContainsAny(text string, keywords []string, m Mode) bool {
+func ContainsAny(text string, keywords []string) bool {
 	for _, kw := range keywords {
-		if ContainsLower(text, kw, m) {
+		if ContainsLower(text, kw) {
 			return true
 		}
 	}

--- a/internal/validators/kwmatch/kwmatch_test.go
+++ b/internal/validators/kwmatch/kwmatch_test.go
@@ -36,20 +36,23 @@ func TestContainsWholeWord(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			for _, m := range []Mode{ModeAlnum, ModeAlnumUnderscore} {
-				if got := Contains(tc.text, tc.kw, m); got != tc.want {
-					t.Errorf("Contains(%q, %q, mode=%d) = %v, want %v", tc.text, tc.kw, m, got, tc.want)
-				}
+			if got := Contains(tc.text, tc.kw); got != tc.want {
+				t.Errorf("Contains(%q, %q) = %v, want %v", tc.text, tc.kw, got, tc.want)
 			}
 		})
 	}
 }
 
-// TestUnderscoreModeDivergence pins the ONLY behavioral difference between the
-// two modes. These are the cases that made the per-package copies disagree:
-// under ModeAlnum a keyword is found inside a snake_case identifier, under
-// ModeAlnumUnderscore it is not.
-func TestUnderscoreModeDivergence(t *testing.T) {
+// TestUnderscoreIsABoundary pins the single most consequential property of the
+// matcher: '_' is a boundary, not a word byte, so a keyword is found inside a
+// snake_case or SCREAMING_SNAKE identifier exactly as it is between spaces.
+//
+// The per-validator copies this package replaced disagreed on precisely this
+// byte, and the ones treating '_' as a word byte were wrong in both directions:
+// positive keywords in "customer_ssn" never boosted real findings, and fixture
+// markers in "TEST_CARD_NUMBER" / "account_number_test" never suppressed false
+// ones — in code and config, where those identifiers are how labels are spelled.
+func TestUnderscoreIsABoundary(t *testing.T) {
 	cases := []struct{ text, kw string }{
 		{"test_ssn = 123-45-6789", "test"},
 		{"ssn_value: 123-45-6789", "ssn"},
@@ -63,13 +66,22 @@ func TestUnderscoreModeDivergence(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.text+"/"+tc.kw, func(t *testing.T) {
-			if !Contains(tc.text, tc.kw, ModeAlnum) {
-				t.Errorf("ModeAlnum: Contains(%q, %q) = false, want true ('_' must be a boundary)", tc.text, tc.kw)
-			}
-			if Contains(tc.text, tc.kw, ModeAlnumUnderscore) {
-				t.Errorf("ModeAlnumUnderscore: Contains(%q, %q) = true, want false ('_' must be a word byte)", tc.text, tc.kw)
+			if !Contains(tc.text, tc.kw) {
+				t.Errorf("Contains(%q, %q) = false, want true ('_' must be a boundary)", tc.text, tc.kw)
 			}
 		})
+	}
+
+	// The boundary rule must not degrade into plain substring matching: an
+	// alphanumeric neighbor still blocks the match even next to underscores.
+	for _, tc := range []struct{ text, kw string }{
+		{"latest_value", "test"},
+		{"my_attestation_field", "test"},
+		{"_assn_", "ssn"},
+	} {
+		if Contains(tc.text, tc.kw) {
+			t.Errorf("Contains(%q, %q) = true, want false (alphanumeric neighbor must block)", tc.text, tc.kw)
+		}
 	}
 }
 
@@ -79,11 +91,11 @@ func TestUnderscoreModeDivergence(t *testing.T) {
 func TestUppercaseInputIsNotSilentlyMatched(t *testing.T) {
 	// ContainsLower with un-lowercased text simply does not match; it must not
 	// panic or match partially.
-	if ContainsLower("Customer SSN", "ssn", ModeAlnum) {
+	if ContainsLower("Customer SSN", "ssn") {
 		t.Error("ContainsLower must not match uppercase text (caller contract is lowercased input)")
 	}
 	// Contains lowercases internally, so the same input matches.
-	if !Contains("Customer SSN", "ssn", ModeAlnum) {
+	if !Contains("Customer SSN", "ssn") {
 		t.Error("Contains must lowercase its arguments")
 	}
 }
@@ -93,10 +105,10 @@ func TestUppercaseInputIsNotSilentlyMatched(t *testing.T) {
 // a caller passes mixed case the neighbor must still be treated as a word byte
 // after lowercasing by Contains.
 func TestBoundaryAdjacentToUppercaseNeighbor(t *testing.T) {
-	if Contains("XSSN", "ssn", ModeAlnum) {
+	if Contains("XSSN", "ssn") {
 		t.Error(`Contains("XSSN", "ssn") must be false: 'x' is a word byte after lowercasing`)
 	}
-	if Contains("SSNX", "ssn", ModeAlnum) {
+	if Contains("SSNX", "ssn") {
 		t.Error(`Contains("SSNX", "ssn") must be false: 'x' is a word byte after lowercasing`)
 	}
 }
@@ -104,23 +116,23 @@ func TestBoundaryAdjacentToUppercaseNeighbor(t *testing.T) {
 func TestContainsFuncAcceptFilter(t *testing.T) {
 	const text = "ssn alpha ssn"
 
-	if !ContainsFunc(text, "ssn", ModeAlnum, nil) {
+	if !ContainsFunc(text, "ssn", nil) {
 		t.Error("nil accept must accept any occurrence")
 	}
 
 	// Accept only the occurrence at or past offset 5 — i.e. skip the first.
-	if !ContainsFunc(text, "ssn", ModeAlnum, func(start, end int) bool { return start >= 5 }) {
+	if !ContainsFunc(text, "ssn", func(start, end int) bool { return start >= 5 }) {
 		t.Error("accept must keep scanning past a rejected occurrence")
 	}
 
 	// Reject everything: scanning must terminate and report false.
-	if ContainsFunc(text, "ssn", ModeAlnum, func(start, end int) bool { return false }) {
+	if ContainsFunc(text, "ssn", func(start, end int) bool { return false }) {
 		t.Error("accept returning false for every occurrence must yield false")
 	}
 
 	// The reported range must delimit the keyword exactly.
 	var gotStart, gotEnd int
-	ContainsFunc("xx ssn yy", "ssn", ModeAlnum, func(start, end int) bool {
+	ContainsFunc("xx ssn yy", "ssn", func(start, end int) bool {
 		gotStart, gotEnd = start, end
 		return true
 	})
@@ -135,7 +147,7 @@ func TestContainsFuncAcceptFilter(t *testing.T) {
 func TestContainsFuncSkipsNonWholeWordBeforeAccept(t *testing.T) {
 	var calls int
 	// "assn" contains "ssn" as a substring but not as a whole word.
-	ContainsFunc("assn", "ssn", ModeAlnum, func(start, end int) bool {
+	ContainsFunc("assn", "ssn", func(start, end int) bool {
 		calls++
 		return true
 	})
@@ -147,24 +159,21 @@ func TestContainsFuncSkipsNonWholeWordBeforeAccept(t *testing.T) {
 func TestContainsAny(t *testing.T) {
 	kws := []string{"test", "example", "sample"}
 
-	if !ContainsAny("see the example below", kws, ModeAlnum) {
+	if !ContainsAny("see the example below", kws) {
 		t.Error("ContainsAny must match a keyword present as a whole word")
 	}
-	if ContainsAny("company-templates bucket", kws, ModeAlnum) {
+	if ContainsAny("company-templates bucket", kws) {
 		t.Error(`ContainsAny must not match "template" inside "templates" for keyword "test"/"sample"`)
 	}
-	if ContainsAny("attestation of latest", kws, ModeAlnum) {
+	if ContainsAny("attestation of latest", kws) {
 		t.Error(`ContainsAny must not match "test" inside "attestation"/"latest"`)
 	}
-	if ContainsAny("nothing here", nil, ModeAlnum) {
+	if ContainsAny("nothing here", nil) {
 		t.Error("ContainsAny over an empty list must be false")
 	}
-	// Underscore mode: the snake_case identifier must NOT match.
-	if ContainsAny("run_test_case", kws, ModeAlnumUnderscore) {
-		t.Error("ContainsAny must respect ModeAlnumUnderscore")
-	}
-	if !ContainsAny("run_test_case", kws, ModeAlnum) {
-		t.Error("ContainsAny must respect ModeAlnum")
+	// '_' is a boundary, so a keyword inside a snake_case identifier matches.
+	if !ContainsAny("run_test_case", kws) {
+		t.Error(`ContainsAny must match "test" inside "run_test_case" ('_' is a boundary)`)
 	}
 }
 
@@ -172,10 +181,10 @@ func TestContainsAny(t *testing.T) {
 // occurrences overlap must still be found when a later one is whole-word.
 func TestNoOverlappingMatchMissed(t *testing.T) {
 	// "aaa" inside "aaaa" is never whole-word; inside "aaaa aaa" the second is.
-	if !Contains("aaaa aaa", "aaa", ModeAlnum) {
+	if !Contains("aaaa aaa", "aaa") {
 		t.Error("overlapping-prefix scan must still find the later whole-word occurrence")
 	}
-	if Contains("aaaa", "aaa", ModeAlnum) {
+	if Contains("aaaa", "aaa") {
 		t.Error(`"aaa" must not match inside "aaaa"`)
 	}
 }
@@ -184,10 +193,10 @@ func TestNoOverlappingMatchMissed(t *testing.T) {
 // length and always terminates (the loop advance must make progress).
 func TestLongTextTerminates(t *testing.T) {
 	text := strings.Repeat("ssnx ", 20000)
-	if Contains(text, "ssn", ModeAlnum) {
+	if Contains(text, "ssn") {
 		t.Error(`"ssn" must not match inside repeated "ssnx"`)
 	}
-	if !Contains(text+" ssn", "ssn", ModeAlnum) {
+	if !Contains(text+" ssn", "ssn") {
 		t.Error("whole-word occurrence at the end of a long text must be found")
 	}
 }
@@ -195,13 +204,13 @@ func TestLongTextTerminates(t *testing.T) {
 func BenchmarkContainsLowerMiss(b *testing.B) {
 	text := strings.Repeat("some ordinary log line with no keyword at all ", 20)
 	for i := 0; i < b.N; i++ {
-		ContainsLower(text, "ssn", ModeAlnum)
+		ContainsLower(text, "ssn")
 	}
 }
 
 func BenchmarkContainsLowerHit(b *testing.B) {
 	text := strings.Repeat("some ordinary log line with no keyword at all ", 20) + "ssn"
 	for i := 0; i < b.N; i++ {
-		ContainsLower(text, "ssn", ModeAlnum)
+		ContainsLower(text, "ssn")
 	}
 }

--- a/internal/validators/medicalid/validator.go
+++ b/internal/validators/medicalid/validator.go
@@ -44,10 +44,12 @@ var (
 // containsKeyword reports whether text contains keyword as a whole word/phrase,
 // case-insensitively.
 //
-// ModeAlnumUnderscore preserves this validator's historical boundary
-// semantics: '_' counts as a word byte here.
+// ModeAlnum treats '_' as a word boundary, so a keyword is found inside a
+// snake_case identifier ("customer_ssn", "TEST_VALUE") exactly as it is
+// between spaces. Code and config — where those identifiers dominate — are
+// primary scan targets for this tool.
 func containsKeyword(text, keyword string) bool {
-	return kwmatch.Contains(text, keyword, kwmatch.ModeAlnumUnderscore)
+	return kwmatch.Contains(text, keyword)
 }
 
 // Validator implements the detector.Validator interface for detecting

--- a/internal/validators/otp/validator.go
+++ b/internal/validators/otp/validator.go
@@ -56,10 +56,12 @@ var (
 // containsKeyword reports whether text contains keyword as a whole word/phrase,
 // case-insensitively.
 //
-// ModeAlnumUnderscore preserves this validator's historical boundary
-// semantics: '_' counts as a word byte here.
+// ModeAlnum treats '_' as a word boundary, so a keyword is found inside a
+// snake_case identifier ("customer_ssn", "TEST_VALUE") exactly as it is
+// between spaces. Code and config — where those identifiers dominate — are
+// primary scan targets for this tool.
 func containsKeyword(text, keyword string) bool {
-	return kwmatch.Contains(text, keyword, kwmatch.ModeAlnumUnderscore)
+	return kwmatch.Contains(text, keyword)
 }
 
 // Validator implements the detector.Validator interface for detecting

--- a/internal/validators/otp/validator_test.go
+++ b/internal/validators/otp/validator_test.go
@@ -281,6 +281,80 @@ func TestOTPValidator_RecoveryCodes(t *testing.T) {
 	}
 }
 
+// TestOTPValidator_SnakeCaseKeyword covers both directions of treating '_' as a
+// word boundary, measured against real vulnerability-report exports.
+//
+// The win: a suppression keyword inside a SCREAMING_SNAKE placeholder now fires.
+// "<MFA_SERIAL_NUMBER>" hides "serial" from a matcher that counts '_' as a word
+// byte, so seven project and resource names on that line ("engagement-artifacts",
+// "shopping-assistant", "bucket-versioning") used to be reported as recovery
+// codes at 85-95% confidence.
+//
+// The cost: a positive keyword inside a placeholder fires too. In the AWS CLI
+// lines below "mfa" is only present inside "<no_mfa_console_signin_metric>", and
+// exposing it admits every hyphenated flag name on the line as a candidate. The
+// candidates themselves are extracted by reRecoveryCodeBlock either way — this
+// change only decides whether the line has recovery context — so the fix belongs
+// in the block regex (it matches mid-token, e.g. "metric-filter" out of
+// "put-metric-filter"), not in the boundary rule. Tracked separately; pinned
+// here so the tradeoff is visible rather than silent.
+func TestOTPValidator_SnakeCaseKeyword(t *testing.T) {
+	validator := NewValidator()
+
+	t.Run("suppression keyword inside placeholder suppresses", func(t *testing.T) {
+		const line = "aws s3api put-bucket-versioning --bucket=<BUCKET_NAME> --mfa=<MFA_SERIAL_NUMBER>"
+		matches, err := validator.ValidateContent(line, "report.csv")
+		if err != nil {
+			t.Fatalf("ValidateContent() error = %v", err)
+		}
+		for _, m := range matches {
+			if m.Type == "RECOVERY_CODES" {
+				t.Errorf("'serial' inside <MFA_SERIAL_NUMBER> must suppress recovery codes, got %s at %.0f%%",
+					m.Type, m.Confidence)
+			}
+		}
+	})
+
+	t.Run("positive keyword inside placeholder grants context", func(t *testing.T) {
+		// Documents the known cost above: "mfa" appears only inside the
+		// placeholder, and that is enough to give the line recovery context.
+		const line = "aws logs put-metric-filter --log-group-name <lg> --filter-name <no_mfa_console_signin_metric>"
+		matches, err := validator.ValidateContent(line, "runbook.md")
+		if err != nil {
+			t.Fatalf("ValidateContent() error = %v", err)
+		}
+		var got int
+		for _, m := range matches {
+			if m.Type == "RECOVERY_CODES" {
+				got++
+			}
+		}
+		if got == 0 {
+			t.Skip("no recovery-code candidates on this line; the block regex changed")
+		}
+		t.Logf("known false positives on AWS CLI flag names: %d (see doc comment)", got)
+	})
+
+	t.Run("real recovery codes still detected", func(t *testing.T) {
+		// The gains and losses above must not come at the cost of the true
+		// positive this validator exists for.
+		const line = "MFA recovery codes: XYZW-ABCD-1234 EFGH-IJKL-5678 MNOP-QRST-9012"
+		matches, err := validator.ValidateContent(line, "secrets.txt")
+		if err != nil {
+			t.Fatalf("ValidateContent() error = %v", err)
+		}
+		var best float64
+		for _, m := range matches {
+			if m.Type == "RECOVERY_CODES" && m.Confidence > best {
+				best = m.Confidence
+			}
+		}
+		if best < 60 {
+			t.Errorf("real recovery codes must stay at MEDIUM or above, got %.0f%%", best)
+		}
+	})
+}
+
 func TestOTPValidator_FalsePositives(t *testing.T) {
 	validator := NewValidator()
 

--- a/internal/validators/personname/validator.go
+++ b/internal/validators/personname/validator.go
@@ -850,7 +850,7 @@ func (v *Validator) isTechnicalTerm(match string) bool {
 // byte is [a-z0-9], so '_' acts as a word boundary here. ContainsLower (rather
 // than Contains) keeps the existing contract that callers pass lowercased text.
 func containsWordKeyword(text, keyword string) bool {
-	return kwmatch.ContainsLower(text, keyword, kwmatch.ModeAlnum)
+	return kwmatch.ContainsLower(text, keyword)
 }
 
 // lineContextCache holds the per-line work shared by every name match found on a

--- a/internal/validators/secrets/aws_secret_key_test.go
+++ b/internal/validators/secrets/aws_secret_key_test.go
@@ -83,6 +83,27 @@ func TestAWSSecretAccessKey(t *testing.T) {
 		}
 	})
 
+	t.Run("test keyword in snake_case identifier suppresses", func(t *testing.T) {
+		// '_' is a separator, not a word byte, so a fixture marker carried by a
+		// snake_case identifier suppresses exactly as the spaced spelling does.
+		// Before the fix "unit_test_fixture" contained no "test" token, so a
+		// hardcoded fixture secret in a Go/Python test file was reported at 90.
+		for _, line := range []string{
+			"unit_test_fixture secret_access_key = " + secret + "\n",
+			"MOCK_CREDS: aws_secret_access_key=" + secret + "\n",
+			"my_example_config secret_access_key " + secret + "\n",
+		} {
+			if c := find(t, line); len(c) != 0 {
+				t.Errorf("snake_case fixture marker must suppress %q, got %d detections at %v", line, len(c), c)
+			}
+		}
+		// Control: the same shape with no fixture marker is still reported, so
+		// the suppression above is not blanket.
+		if c := find(t, "prod_config secret_access_key = "+secret+"\n"); len(c) != 1 {
+			t.Fatalf("unmarked secret must still be detected, got %d detections", len(c))
+		}
+	})
+
 	t.Run("EXAMPLE embedded demotes below HIGH", func(t *testing.T) {
 		c := find(t, "AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n")
 		if len(c) != 1 {

--- a/internal/validators/secrets/validator.go
+++ b/internal/validators/secrets/validator.go
@@ -940,10 +940,12 @@ var (
 // word (text must already be lowercased). Prevents "test" from matching inside
 // "latest" or "attestation".
 //
-// ModeAlnumUnderscore preserves this validator's historical boundary
-// semantics: a word byte is [a-z0-9_], so '_' counts as a word byte here.
+// ModeAlnum treats '_' as a word boundary, so a keyword is found inside a
+// snake_case identifier ("customer_ssn", "TEST_VALUE") exactly as it is
+// between spaces. Code and config — where those identifiers dominate — are
+// primary scan targets for this tool.
 func containsWordBoundary(text, keyword string) bool {
-	return kwmatch.ContainsLower(text, keyword, kwmatch.ModeAlnumUnderscore)
+	return kwmatch.ContainsLower(text, keyword)
 }
 
 // isKeywordAlnum reports whether b is an ASCII letter or digit.

--- a/internal/validators/ssn/validator.go
+++ b/internal/validators/ssn/validator.go
@@ -40,10 +40,12 @@ var (
 // "next", "code" in "barcode" — which both fabricated context boosts on non-SSN
 // lines and spuriously penalized real SSNs.
 //
-// ModeAlnumUnderscore preserves this validator's historical boundary
-// semantics: '_' counts as a word byte here.
+// ModeAlnum treats '_' as a word boundary, so a keyword is found inside a
+// snake_case identifier ("customer_ssn", "TEST_VALUE") exactly as it is
+// between spaces. Code and config — where those identifiers dominate — are
+// primary scan targets for this tool.
 func containsKeyword(text, keyword string) bool {
-	return kwmatch.Contains(text, keyword, kwmatch.ModeAlnumUnderscore)
+	return kwmatch.Contains(text, keyword)
 }
 
 // Validator implements the detector.Validator interface for detecting

--- a/internal/validators/ssn/validator_test.go
+++ b/internal/validators/ssn/validator_test.go
@@ -844,6 +844,56 @@ func TestSSNValidator_KeywordWordBoundary(t *testing.T) {
 	}
 }
 
+// TestSSNValidator_SnakeCaseKeyword locks the word-byte predicate: '_' is a
+// separator, not a word byte, so a context keyword carried by a snake_case or
+// SCREAMING_SNAKE identifier scores exactly as it would between spaces.
+//
+// Before the fix the boundary check treated '_' as part of the word, so
+// "customer_ssn" contained no "ssn" token: real SSNs in code and config lost
+// their positive boost (recall) and test/sample labels lost their suppression
+// (precision). Both directions are asserted, each against its spaced twin.
+func TestSSNValidator_SnakeCaseKeyword(t *testing.T) {
+	v := NewValidator()
+	const ssn = "449-87-4100" // valid area/group/serial, not denylisted
+
+	for _, tc := range []struct {
+		snake, spaced string
+	}{
+		// Positive keyword: must boost identically.
+		{"customer_ssn: " + ssn, "customer ssn: " + ssn},
+		{"SSN_VALUE=" + ssn, "SSN VALUE=" + ssn},
+		// Negative keyword: must suppress identically.
+		{"sample_ssn = " + ssn, "sample ssn = " + ssn},
+		{"TEST_SSN=" + ssn, "TEST SSN=" + ssn},
+	} {
+		snakeConf := ssnMatchConfidence(t, v, tc.snake)
+		spacedConf := ssnMatchConfidence(t, v, tc.spaced)
+		if snakeConf != spacedConf {
+			t.Errorf("'_' must score as a separator: %q gave %.1f but %q gave %.1f",
+				tc.snake, snakeConf, tc.spaced, spacedConf)
+		}
+	}
+
+	// The equality above must not pass by both sides collapsing to the same
+	// no-keyword score: the snake_case positive has to actually promote, and the
+	// snake_case negative has to actually hold the same identifier back.
+	boosted := ssnMatchConfidence(t, v, "customer_ssn: "+ssn)
+	suppressed := ssnMatchConfidence(t, v, "sample_ssn = "+ssn)
+	if boosted < 90 {
+		t.Errorf("snake_case positive keyword should reach HIGH, got %.1f", boosted)
+	}
+	// "sample_ssn" carries both an "ssn" boost and a "sample" penalty; the
+	// penalty must keep it out of HIGH even though the boost applies.
+	if suppressed >= 90 {
+		t.Errorf("snake_case negative keyword should keep %q below HIGH, got %.1f",
+			"sample_ssn", suppressed)
+	}
+	if suppressed >= boosted {
+		t.Errorf("snake_case negative keyword must cost confidence: sample_ssn=%.1f vs customer_ssn=%.1f",
+			suppressed, boosted)
+	}
+}
+
 // TestSSNValidator_KnownTestSSNStaysLow is a regression test for H3: the
 // denylisted test SSN 123-45-4321 scored 100 (HIGH) whenever a positive keyword
 // like "SSN"/"employee" was nearby, because the flat -25 test penalty left it at

--- a/internal/validators/vin/validator.go
+++ b/internal/validators/vin/validator.go
@@ -36,7 +36,7 @@ var positionWeights = [17]int{8, 7, 6, 5, 4, 3, 2, 10, 0, 9, 8, 7, 6, 5, 4, 3, 2
 // ModeAlnum preserves this validator's historical boundary semantics: a word
 // byte is [a-z0-9], so '_' acts as a word boundary here.
 func containsKeyword(text, keyword string) bool {
-	return kwmatch.Contains(text, keyword, kwmatch.ModeAlnum)
+	return kwmatch.Contains(text, keyword)
 }
 
 // knownWMIs maps common World Manufacturer Identifier prefixes to manufacturer names.


### PR DESCRIPTION
Stacked on #177 (base: `refactor/kwmatch-shared-matcher`). #177 proved the dedup inert — goldens byte-identical. This PR is the behavior change it enables.

## The bug

Eight validators counted `_` as a word byte, so a keyword inside a snake_case identifier was invisible. That is backwards for a scanner whose primary targets include code and config, where snake_case is how labels are spelled. It failed in both directions:

| | Example | Effect |
|---|---|---|
| Positive keyword never fired | `customer_ssn`, `ACCT_ID`, `PATIENT_DOB` | real findings under-scored |
| Suppression keyword never fired | `TEST_CARD_NUMBER`, `<MFA_SERIAL_NUMBER>`, `db_template_version` | fixture data reported as real |

All validators now share one predicate: `[a-z0-9]` is a word byte, everything else is a boundary. `Mode` and its constants are removed from `kwmatch`, so the package no longer offers a way to be inconsistent. `creditcard` builds its own regex and now uses an explicit character class instead of `\b`, which in Go's RE2 is defined on `\w` and therefore includes `_`.

## Two commits

1. **`fix(context)`** — a prerequisite, found while validating this change. `ClassifyDomain` and `DetectStructure` each picked their winner by ranging a map with a strict `>`, so ties were resolved by Go's randomized iteration order and the same input classified differently run to run. `DetectStructure` is the damaging one: `DocumentType` grants `tabular_boost` of +20, so a TSV↔Code coin flip moved every finding in a document across a confidence band — and confidence is part of the suppression hash, so it could invalidate a user's suppression rules between runs over unchanged input. Tie-break costs one string comparison, only on an exact tie. `internal/context` had no tests; adds five.

2. **`fix(validators)`** — the boundary change itself.

Split because the first is an independent bug with its own blast radius. Without it, no measurement of the second is trustworthy.

## Measurement

1,156 real documents from `~/Downloads`, baseline carrying commit 1 so both sides are reproducible. Restricted to the 16 changed files proven stable over 15 repeat runs of each binary — container formats (`.docx`, `.pptx`) have pre-existing extraction-order churn and are excluded (issue to follow).

| | n | Detail |
|---|---|---|
| Removed | 472 | 465 LOW `DATE_OF_BIRTH`, almost all `Detected At` scan timestamps in vulnerability-report exports; 7 `RECOVERY_CODES` on project names (`shopping-assistant`) now suppressed by `serial` in `<MFA_SERIAL_NUMBER>` |
| Gained | 15 | `US_BANK_ACCOUNT` on `ACCT_ID = '731229612337'` at MEDIUM; 14 `RECOVERY_CODES` that are false positives — see below |
| Rescored | 2 | `NPI` 60→45 on an S3 name containing `cross_account_access`; `US_STREET_ADDRESS` 50→25 on a path containing `sample_react_project` |

**The 14 new false positives are the honest cost.** On AWS CLI runbook lines, `mfa` appears only inside `<no_mfa_console_signin_metric>`; exposing it gives the line recovery-code context, admitting every hyphenated flag name on it. Those candidates are extracted by `reRecoveryCodeBlock` either way — it matches mid-token, pulling `metric-filter` out of `put-metric-filter` — so the defect is in that regex, not in the boundary rule, and predates this change. `TestOTPValidator_SnakeCaseKeyword` pins both directions so the tradeoff is visible rather than silent.

## Timing

174.2s vs 175.1s total over the corpus (**-0.6%**), paired per-file median -0.001s. The predicate is one byte-range comparison shorter and `kwmatch` remains zero-allocation (~160-200ns/op). All 18 validators still pass the subquadratic complexity guard.

## Gates

`go build` / `go vet` / `gofmt` clean, full suite 51 packages exit 0, goldens 12 consecutive runs. Adds a golden corpus case and snake_case regression tests for ssn, creditcard, dob, secrets, otp. **No existing golden file changed** — the 472 removals are all on real documents, not corpus cases.

## Known gap, not in scope

Multi-word keyword entries (`birth date`, `born on`, `account number`) still cannot match their underscore-joined spellings; that needs separator normalization in the keyword lists.