### PR TITLE
fix(router): make container-file extraction deterministic (#179)

### DIFF
--- a/internal/preprocessors/office_metadata_preprocessor.go
+++ b/internal/preprocessors/office_metadata_preprocessor.go
@@ -5,6 +5,7 @@ package preprocessors
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/awslabs/ferret-scan/v2/internal/observability"
@@ -120,8 +121,16 @@ func (omp *OfficeMetadataPreprocessor) formatOfficeMetadata(meta *meta_extract_o
 	// HIGH-RISK FIELDS: Custom properties (critical organizational metadata)
 	if len(meta.CustomProps) > 0 {
 		result.WriteString("\n--- Custom Properties ---\n")
-		for key, value := range meta.CustomProps {
-			result.WriteString(formatter.FormatMetadataField("Custom_"+key, value))
+		// Sorted, not map order: see FormatPropertiesMap. Purview/SharePoint
+		// labelled documents carry a dozen-plus sibling keys here, so a random
+		// permutation moves every line below this block.
+		customKeys := make([]string, 0, len(meta.CustomProps))
+		for key := range meta.CustomProps {
+			customKeys = append(customKeys, key)
+		}
+		sort.Strings(customKeys)
+		for _, key := range customKeys {
+			result.WriteString(formatter.FormatMetadataField("Custom_"+key, meta.CustomProps[key]))
 		}
 	}
 

--- a/internal/preprocessors/shared_utilities.go
+++ b/internal/preprocessors/shared_utilities.go
@@ -6,6 +6,7 @@ package preprocessors
 import (
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 )
@@ -60,8 +61,18 @@ func (mf *MetadataFormatter) FormatPropertiesMap(properties map[string]string, e
 		exclude[key] = true
 	}
 
-	for key, value := range properties {
-		if !exclude[key] && value != "" {
+	// Emit in sorted key order. Ranging the map directly would follow Go's
+	// randomized iteration order, so the extracted-text payload — and therefore
+	// the line number every finding below it is reported against — would differ
+	// between two scans of the same file.
+	keys := make([]string, 0, len(properties))
+	for key := range properties {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		if value := properties[key]; !exclude[key] && value != "" {
 			result.WriteString(mf.FormatMetadataField(key, value))
 		}
 	}

--- a/internal/router/combine_test.go
+++ b/internal/router/combine_test.go
@@ -73,22 +73,24 @@ func TestCombine_SinglePreprocessor_TextByteIdentical(t *testing.T) {
 
 // TestCombine_MultiPreprocessor_MatchesReferenceConcat locks the combine branch:
 // with 2+ successful preprocessors the output must be byte-identical to the
-// original algorithm's concatenation (first text, then
-// "\n\n--- name ---\n"+text per subsequent processor) FOR THE OBSERVED ARRIVAL
-// ORDER. Because preprocessors run concurrently, arrival order is
-// nondeterministic, so we reconstruct the expected string from the actual
-// ProcessorType (which records the order the results were combined in) rather
-// than assuming a fixed order.
+// reference concatenation (first text, then "\n\n--- name ---\n"+text per
+// subsequent processor) IN SORTED PREPROCESSOR-NAME ORDER.
+//
+// This test previously reconstructed the expectation from the observed
+// ProcessorType, because results were consumed in goroutine completion order and
+// so the arrangement was whatever the race produced. That is exactly the defect
+// behind issue #179, so the order is now pinned instead of accommodated.
 func TestCombine_MultiPreprocessor_MatchesReferenceConcat(t *testing.T) {
 	texts := map[string]string{
 		"alpha": strings.Repeat("A", 500),
 		"beta":  strings.Repeat("B", 700),
 		"gamma": strings.Repeat("C", 300),
 	}
+	// Registered out of order on purpose: the output must not depend on it.
 	fr := routerWithPreprocessors(
+		&fakePreprocessor{name: "gamma", text: texts["gamma"], success: true},
 		&fakePreprocessor{name: "alpha", text: texts["alpha"], success: true},
 		&fakePreprocessor{name: "beta", text: texts["beta"], success: true},
-		&fakePreprocessor{name: "gamma", text: texts["gamma"], success: true},
 	)
 
 	got, err := fr.ProcessFile("x.fake", &ProcessingContext{FilePath: "x.fake"})
@@ -96,16 +98,12 @@ func TestCombine_MultiPreprocessor_MatchesReferenceConcat(t *testing.T) {
 		t.Fatalf("ProcessFile: %v", err)
 	}
 
-	// ProcessorType is "a+b+c" in the exact order results were combined.
-	order := strings.Split(got.ProcessorType, "+")
-	if len(order) != 3 {
-		t.Fatalf("expected 3 combined processors, got %q", got.ProcessorType)
+	if want := "alpha+beta+gamma"; got.ProcessorType != want {
+		t.Errorf("ProcessorType = %q, want %q (sorted by preprocessor name)", got.ProcessorType, want)
 	}
 
-	// Reconstruct the reference concatenation using the SAME rule as the
-	// original loop: first text raw, each subsequent prefixed with a separator.
 	var want strings.Builder
-	for i, name := range order {
+	for i, name := range []string{"alpha", "beta", "gamma"} {
 		if i == 0 {
 			want.WriteString(texts[name])
 		} else {

--- a/internal/router/determinism_test.go
+++ b/internal/router/determinism_test.go
@@ -1,0 +1,296 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package router
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// Regression tests for issue #179: scanning the same container file twice
+// produced different line numbers, and sometimes different finding types and
+// counts, on the same binary.
+//
+// Three constructs contributed, all of them order-of-iteration bugs:
+//
+//  1. processFileInternal consumed preprocessor results in goroutine COMPLETION
+//     order, so for a .docx (where both "Text Extractor" and "office_metadata"
+//     are capable) the metadata block landed above or below the document body at
+//     random — shifting every content finding by the height of that block.
+//  2. formatOfficeMetadata ranged meta.CustomProps directly.
+//  3. MetadataFormatter.FormatPropertiesMap ranged its properties map directly.
+//
+// The golden corpus cannot catch any of these: CanonicalSort imposes a total
+// order on matches before snapshotting, and the corpus has no container-format
+// case at all. So these tests assert reproducibility directly, on the extracted
+// text, which is the artifact line numbers are derived from.
+
+// newProductionRouter wires the router exactly as core.ScanFile does, so the
+// registry creation order these tests depend on is the real one.
+func newProductionRouter() *FileRouter {
+	fr := NewFileRouter(false)
+	RegisterDefaultPreprocessors(fr)
+	fr.InitializePreprocessors(CreateRouterConfig(false))
+	return fr
+}
+
+// buildDOCX synthesizes a minimal but valid .docx: the OPC parts a reader needs
+// (content types, the main document body) plus core/app/custom properties, so
+// both the text extractor and the Office metadata extractor have real work to
+// do. Custom properties are deliberately numerous and NOT in sorted order in the
+// archive, so a map-order regression shows up as reordered output.
+func buildDOCX(t *testing.T, body string, custom map[string]string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	add := func(name, content string) {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatalf("zip create %s: %v", name, err)
+		}
+		if _, err := w.Write([]byte(content)); err != nil {
+			t.Fatalf("zip write %s: %v", name, err)
+		}
+	}
+
+	add("[Content_Types].xml", `<?xml version="1.0" encoding="UTF-8"?>`+
+		`<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">`+
+		`<Default Extension="xml" ContentType="application/xml"/>`+
+		`<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>`+
+		`</Types>`)
+
+	var paras strings.Builder
+	for _, line := range strings.Split(body, "\n") {
+		fmt.Fprintf(&paras, `<w:p><w:r><w:t>%s</w:t></w:r></w:p>`, line)
+	}
+	add("word/document.xml", `<?xml version="1.0" encoding="UTF-8"?>`+
+		`<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">`+
+		`<w:body>`+paras.String()+`</w:body></w:document>`)
+
+	add("docProps/core.xml", `<?xml version="1.0" encoding="UTF-8"?>`+
+		`<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" `+
+		`xmlns:dc="http://purl.org/dc/elements/1.1/">`+
+		`<dc:creator>Dana Reviewer</dc:creator>`+
+		`<cp:lastModifiedBy>Sam Approver</cp:lastModifiedBy>`+
+		`<dc:title>Quarterly Records</dc:title>`+
+		`</cp:coreProperties>`)
+
+	add("docProps/app.xml", `<?xml version="1.0" encoding="UTF-8"?>`+
+		`<Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties">`+
+		`<Application>Microsoft Office Word</Application>`+
+		`<Company>Example Holdings</Company>`+
+		`<Template>Normal.dotm</Template>`+
+		`<Pages>3</Pages><Words>120</Words><Characters>800</Characters>`+
+		`</Properties>`)
+
+	if len(custom) > 0 {
+		var props strings.Builder
+		props.WriteString(`<?xml version="1.0" encoding="UTF-8"?>` +
+			`<Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/custom-properties" ` +
+			`xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes">`)
+		pid := 2
+		for name, value := range custom { // archive order is intentionally arbitrary
+			fmt.Fprintf(&props, `<property fmtid="{D5CDD505-2E9C-101B-9397-08002B2CF9AE}" pid="%d" name="%s"><vt:lpwstr>%s</vt:lpwstr></property>`, pid, name, value)
+			pid++
+		}
+		props.WriteString(`</Properties>`)
+		add("docProps/custom.xml", props.String())
+	}
+
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// docxFixture writes a synthesized .docx carrying PII in both the body and the
+// document properties, with many custom properties (the Purview/SharePoint shape
+// that made this bug so visible in practice).
+func docxFixture(t *testing.T) string {
+	t.Helper()
+
+	body := strings.Join([]string{
+		"Customer record for review.",
+		"Contact: casey.morgan@example.com",
+		"Phone: (555) 012-3456",
+		"Account owner: Riley Chen",
+		"Notes: follow up before renewal.",
+	}, "\n")
+
+	custom := map[string]string{
+		"MSIP_Label_ContentBits":   "0",
+		"MSIP_Label_Enabled":       "true",
+		"MSIP_Label_SetBy":         "dana.reviewer@example.com",
+		"MSIP_Label_SiteId":        "11111111-2222-3333-4444-555555555555",
+		"MSIP_Label_ActionId":      "66666666-7777-8888-9999-000000000000",
+		"ContentTypeId":            "0x010100A1B2C3",
+		"ReviewOwner":              "Sam Approver",
+		"CostCenter":               "CC-4417",
+		"RetentionPolicy":          "7-years",
+		"ClassificationReviewedBy": "morgan.blake@example.com",
+	}
+
+	// NOT t.TempDir(). The Office metadata extractor runs every path through
+	// validateFilePath, which rejects absolute paths under /var/, /tmp/ and
+	// /home/ (office-extractor.go). TMPDIR resolves under /var/folders on macOS
+	// and /tmp on Linux, and on Linux CI the checkout itself sits under
+	// /home/runner — so an absolute fixture path makes office_metadata fail
+	// silently and only the text extractor runs, which is precisely the
+	// multi-preprocessor path these tests exist to cover. A relative path
+	// matches none of those prefixes on any platform.
+	dir, err := os.MkdirTemp(".", "determinism-fixture-")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	path := filepath.Join(dir, "determinism_fixture.docx")
+	if err := os.WriteFile(path, buildDOCX(t, body, custom), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+// TestProcessFile_ContainerOutputIsReproducible is the core #179 regression: the
+// same .docx processed repeatedly must yield byte-identical extracted text and
+// the same ProcessorType every time. Before the fix this failed within a handful
+// of iterations.
+func TestProcessFile_ContainerOutputIsReproducible(t *testing.T) {
+	path := docxFixture(t)
+
+	const reps = 25
+	texts := make(map[string]int)
+	types := make(map[string]int)
+
+	for i := 0; i < reps; i++ {
+		// A fresh router per iteration, so registry creation order is exercised
+		// too — not just the per-call assembly.
+		fr := newProductionRouter()
+		got, err := fr.ProcessFile(path, &ProcessingContext{FilePath: path})
+		if err != nil {
+			t.Fatalf("iteration %d: ProcessFile: %v", i, err)
+		}
+		sum := sha256.Sum256([]byte(got.Text))
+		texts[hex.EncodeToString(sum[:])]++
+		types[got.ProcessorType]++
+	}
+
+	if len(texts) != 1 {
+		t.Errorf("extracted text is not reproducible: %d distinct results over %d runs (distribution %v)", len(texts), reps, texts)
+	}
+	if len(types) != 1 {
+		t.Errorf("ProcessorType is not reproducible: got %v over %d runs", types, reps)
+	}
+}
+
+// TestProcessFile_ContainerBodyPrecedesMetadata pins the arrangement itself, not
+// just its stability. "Text Extractor" sorts before "office_metadata", so the
+// document body is the leading section and the metadata block is introduced by
+// its own "--- name ---" header. That matters because the leading section is the
+// one the content router has to classify without a name.
+func TestProcessFile_ContainerBodyPrecedesMetadata(t *testing.T) {
+	path := docxFixture(t)
+
+	fr := newProductionRouter()
+	got, err := fr.ProcessFile(path, &ProcessingContext{FilePath: path})
+	if err != nil {
+		t.Fatalf("ProcessFile: %v", err)
+	}
+
+	if !strings.Contains(got.ProcessorType, "+") {
+		t.Skipf("only one preprocessor handled the fixture (%q); arrangement not exercised", got.ProcessorType)
+	}
+	if want := "Text Extractor+office_metadata"; got.ProcessorType != want {
+		t.Errorf("ProcessorType = %q, want %q", got.ProcessorType, want)
+	}
+
+	bodyMarker := "casey.morgan@example.com"
+	metaSeparator := "\n\n--- office_metadata ---\n"
+	bodyAt := strings.Index(got.Text, bodyMarker)
+	metaAt := strings.Index(got.Text, metaSeparator)
+	if bodyAt < 0 {
+		t.Fatalf("body text missing from extraction")
+	}
+	if metaAt < 0 {
+		t.Fatalf("office_metadata section header missing from extraction")
+	}
+	if bodyAt > metaAt {
+		t.Errorf("document body (offset %d) must precede the metadata section (offset %d)", bodyAt, metaAt)
+	}
+}
+
+// TestProcessFile_CustomPropertiesAreSorted covers the two map-range sites
+// directly: every block of Custom_* lines must be emitted in sorted key order.
+// This is the assertion that fails if formatOfficeMetadata or
+// FormatPropertiesMap goes back to ranging a map.
+//
+// Blocks, plural: the Office extractor also mirrors every custom property into
+// meta.Properties under the same "Custom_" prefix, so formatOfficeMetadata emits
+// the set once from meta.CustomProps and FormatPropertiesMap emits it again. That
+// duplication is a separate (deterministic) defect — it doubles the metadata
+// findings for every Office document — and it is what makes BOTH sort sites
+// load-bearing: fixing either one alone still leaves the other permuting. The
+// test therefore checks each contiguous run independently rather than assuming a
+// single run, and does not pin how many runs there are.
+func TestProcessFile_CustomPropertiesAreSorted(t *testing.T) {
+	path := docxFixture(t)
+
+	fr := newProductionRouter()
+	got, err := fr.ProcessFile(path, &ProcessingContext{FilePath: path})
+	if err != nil {
+		t.Fatalf("ProcessFile: %v", err)
+	}
+
+	var keys []string
+	for _, line := range strings.Split(got.Text, "\n") {
+		if name, _, ok := strings.Cut(line, ":"); ok && strings.HasPrefix(name, "Custom_") {
+			keys = append(keys, name)
+		}
+	}
+	if len(keys) == 0 {
+		t.Fatalf("fixture yielded no Custom_ lines; the office_metadata path did not run")
+	}
+
+	// The distinct keys in sorted order are what ONE correct emission looks like.
+	// The blocks are adjacent with no intervening line, so rather than trying to
+	// find the seam we assert the whole sequence is an exact repetition of that
+	// unit: N sorted copies back to back. A permutation from either map-range site
+	// breaks this even though the multiset of keys is unchanged.
+	seen := make(map[string]bool, len(keys))
+	var unit []string
+	for _, k := range keys {
+		if !seen[k] {
+			seen[k] = true
+			unit = append(unit, k)
+		}
+	}
+	sort.Strings(unit)
+
+	if len(unit) < 2 {
+		t.Fatalf("fixture yielded %d distinct Custom_ keys; ordering not exercised", len(unit))
+	}
+	if len(keys)%len(unit) != 0 {
+		t.Fatalf("got %d Custom_ lines over %d distinct keys — not a whole number of blocks: %v", len(keys), len(unit), keys)
+	}
+
+	for block := 0; block*len(unit) < len(keys); block++ {
+		chunk := keys[block*len(unit) : (block+1)*len(unit)]
+		for i := range chunk {
+			if chunk[i] != unit[i] {
+				t.Errorf("Custom_ block %d is not in sorted key order\n got: %v\nwant: %v", block, chunk, unit)
+				break
+			}
+		}
+	}
+}

--- a/internal/router/file_router.go
+++ b/internal/router/file_router.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -117,8 +118,18 @@ func (fr *FileRouter) processFileInternal(filePath string, config *ProcessingCon
 		return nil, fmt.Errorf("no preprocessor can handle file: %s", filePath)
 	}
 
+	// Sort by name so the assembly order below is a property of the file type,
+	// not of how the registry happened to be iterated. For Office and PDF files
+	// this puts "Text Extractor" ahead of "office_metadata"/"pdf_metadata", so
+	// the document body is the leading section and each metadata block carries
+	// an explicit "--- name ---" header.
+	sort.Slice(capable, func(i, j int) bool {
+		return capable[i].GetName() < capable[j].GetName()
+	})
+
 	// Run ALL capable preprocessors in parallel
 	type preprocessorResult struct {
+		idx      int
 		name     string
 		result   *preprocessors.ProcessedContent
 		err      error
@@ -128,8 +139,8 @@ func (fr *FileRouter) processFileInternal(filePath string, config *ProcessingCon
 	resultChan := make(chan preprocessorResult, len(capable))
 
 	// Start all preprocessors in parallel
-	for _, p := range capable {
-		go func(processor preprocessors.Preprocessor) {
+	for i, p := range capable {
+		go func(idx int, processor preprocessors.Preprocessor) {
 			processStart := time.Now()
 
 			// Recover from any panics in preprocessors to prevent crashing the whole scan
@@ -147,15 +158,24 @@ func (fr *FileRouter) processFileInternal(filePath string, config *ProcessingCon
 			processingTime := time.Since(processStart)
 
 			resultChan <- preprocessorResult{
+				idx:      idx,
 				name:     processor.GetName(),
 				result:   result,
 				err:      err,
 				duration: processingTime,
 			}
-		}(p)
+		}(i, p)
 	}
 
 	// Collect results.
+	//
+	// Drain into a slice indexed by LAUNCH position, not by arrival position.
+	// Preprocessors run concurrently, so consuming the channel in completion
+	// order made the assembled text — and therefore every line number reported
+	// against it — depend on which goroutine won the race. For a .docx both
+	// "Text Extractor" and "office_metadata" are capable, so the metadata block
+	// landed above or below the body at random, and findings shifted by the
+	// height of that block between two scans of the same file (issue #179).
 	//
 	// The overwhelmingly common case is a single successful preprocessor (one
 	// file type → one extractor). For that case we must NOT copy the extracted
@@ -164,21 +184,24 @@ func (fr *FileRouter) processFileInternal(filePath string, config *ProcessingCon
 	// extracted PDF), even though String() itself is zero-copy. So we keep a
 	// direct reference to the sole result's text (firstText) and only fall back
 	// to the strings.Builder when a SECOND successful preprocessor arrives and
-	// we genuinely have to concatenate with separators. The builder path
-	// reproduces the original output byte-for-byte (first text, then
-	// "\n\n--- name ---\n" + text for each subsequent processor, in arrival
-	// order); the single-processor path yields Text == firstText exactly, since
-	// the original never prepends a separator to the first write. (v2 gap 2.3:
-	// eliminate the combine-step second copy.)
+	// we genuinely have to concatenate with separators. The builder path emits
+	// the first successful text, then "\n\n--- name ---\n" + text for each
+	// subsequent processor, in sorted-name order; the single-processor path
+	// yields Text == firstText exactly, since no separator is prepended to the
+	// first write. (v2 gap 2.3: eliminate the combine-step second copy.)
+	ordered := make([]preprocessorResult, len(capable))
+	for i := 0; i < len(capable); i++ {
+		pResult := <-resultChan
+		ordered[pResult.idx] = pResult
+	}
+
 	var combinedContent strings.Builder
 	var firstText string
 	var combinedMetadata = make(map[string]interface{})
 	var totalWordCount, totalCharCount, totalLineCount int
 	var successfulProcessors []string
 
-	for i := 0; i < len(capable); i++ {
-		pResult := <-resultChan
-
+	for _, pResult := range ordered {
 		if pResult.err == nil && pResult.result != nil && pResult.result.Success && pResult.result.Text != "" {
 			if len(successfulProcessors) == 0 {
 				// First success: reference its text directly (no copy).
@@ -186,7 +209,7 @@ func (fr *FileRouter) processFileInternal(filePath string, config *ProcessingCon
 			} else {
 				// Second+ success: we are truly combining. Flush the stashed
 				// first text into the builder once, then append this one with a
-				// separator — identical bytes to the original loop.
+				// separator.
 				if combinedContent.Len() == 0 {
 					combinedContent.WriteString(firstText)
 				}

--- a/internal/router/registry.go
+++ b/internal/router/registry.go
@@ -4,6 +4,8 @@
 package router
 
 import (
+	"sort"
+
 	"github.com/awslabs/ferret-scan/v2/internal/preprocessors"
 )
 
@@ -35,19 +37,26 @@ func (r *PreprocessorRegistry) Create(name string, config map[string]interface{}
 	return nil
 }
 
-// GetRegisteredNames returns all registered preprocessor names
+// GetRegisteredNames returns all registered preprocessor names, sorted.
+//
+// Sorted rather than map order: callers use this to create and then run
+// preprocessors, and Go randomizes map iteration per range, so an unsorted
+// result made the preprocessor set order differ between processes.
 func (r *PreprocessorRegistry) GetRegisteredNames() []string {
 	names := make([]string, 0, len(r.factories))
 	for name := range r.factories {
 		names = append(names, name)
 	}
+	sort.Strings(names)
 	return names
 }
 
-// CreateAll creates all registered preprocessors with given configuration
+// CreateAll creates all registered preprocessors with given configuration, in a
+// stable (name-sorted) order.
 func (r *PreprocessorRegistry) CreateAll(config map[string]interface{}) []preprocessors.Preprocessor {
-	var processors []preprocessors.Preprocessor
-	for name := range r.factories {
+	names := r.GetRegisteredNames()
+	processors := make([]preprocessors.Preprocessor, 0, len(names))
+	for _, name := range names {
 		if processor := r.Create(name, config); processor != nil {
 			processors = append(processors, processor)
 		}


### PR DESCRIPTION
Fixes #179.

## Problem

Scanning the same `.docx`/`.xlsx`/`.pptx`/`.pdf` twice produced different line numbers, and sometimes different finding **types and counts**, from the same binary. Because the suppression hash embeds `match.LineNumber`, a flapping line number silently orphans a user's suppression rule.

Measured over 80 real container documents from a local corpus, 6 runs each, keyed on sorted `[type, line_number, confidence]`:

| build | flapping files / 80 |
| --- | --- |
| `main` (5acc670) | **37** |
| this branch | **3** |

The 3 residuals are all `.pptx` and differ **only in confidence** — identical types and line numbers on every run. That is the context-analyzer argmax tie-break already fixed in #178, which is not on this branch.

## Root cause — three order-of-iteration defects, all required

**1. `processFileInternal` drained its result channel in goroutine COMPLETION order.**
Every Office file and every PDF has two capable preprocessors (body text *and* metadata), so the metadata block landed above or below the document body at random, shifting every content finding by the height of that block. Worse: the leading section is the one `ContentRouter` must classify *without a name*, so the winner of the race also changed which validators ran over which bytes. One real `.docx` returned 9 findings on some runs and 6 on others.

Capable preprocessors are now sorted by name, and results are drained into a slice indexed by **launch** position. `"Text Extractor"` sorts ahead of `"office_metadata"`/`"pdf_metadata"`, so the body is always the leading section and each metadata block carries its own `--- name ---` header. The single-preprocessor zero-copy fast path (v2 gap 2.3) is preserved.

**2. `formatOfficeMetadata` ranged `meta.CustomProps` directly.**

**3. `MetadataFormatter.FormatPropertiesMap` ranged its properties map directly** — reached from *both* the Office and PDF metadata preprocessors.

Both now emit in sorted key order, and both are load-bearing: the Office extractor mirrors custom properties into `Properties` under the same `Custom_` prefix, so the same key set is permuted twice, independently. Fixing either alone leaves the other flapping. (Purview/SharePoint-labelled documents carry a dozen-plus sibling `MSIP_Label_*` keys here, which is why this was so visible in practice.)

Also: `PreprocessorRegistry.GetRegisteredNames`/`CreateAll` ranged the factory map, making the preprocessor set order differ between processes.

## Testing

**The golden corpus cannot catch any of this.** `CanonicalSort` imposes a total order on matches before snapshotting, and the corpus has no container-format case at all. So `internal/router/determinism_test.go` asserts on the extracted text itself — the artifact line numbers are derived from — using a `.docx` synthesized in-test via `archive/zip` (following the `BuildWAVWithInfo` precedent):

- `TestProcessFile_ContainerOutputIsReproducible` — 25 repetitions, fresh router each time, must yield exactly one distinct sha256 and one `ProcessorType`
- `TestProcessFile_ContainerBodyPrecedesMetadata` — pins the arrangement, not just its stability
- `TestProcessFile_CustomPropertiesAreSorted` — every `Custom_` block in sorted key order

Reverting the four source fixes makes all three fail: **25 distinct hashes over 25 runs**.

`TestCombine_MultiPreprocessor_MatchesReferenceConcat` previously *reconstructed* its expectation from the observed `ProcessorType`, deliberately accommodating this very bug. It now registers preprocessors out of order and pins the sorted result.

One non-obvious detail: the fixture uses a relative temp dir rather than `t.TempDir()`. The Office metadata extractor's `validateFilePath` rejects absolute paths under `/var/`, `/tmp/` and `/home/`, which silently reduces the fixture to a single preprocessor — skipping the exact multi-preprocessor path under test — on both macOS (`/var/folders`) and Linux CI (`/home/runner`).

## Gates

- `go build ./...`, `go vet ./...`, `gofmt` clean (one pre-existing unrelated `internal/config/config.go` alignment diff on `main`)
- Full suite green; `-race` clean on `./internal/router/...` and `./internal/preprocessors/...`
- **Goldens unchanged** — no regeneration needed
- No timing change: interleaved 10-run passes on a 10 MB `.docx` overlap within noise (base 0.109–0.157 s, branch 0.120–0.171 s)

## Follow-ups found while doing this (not in scope here)

- The Office extractor emits every custom property **twice** (once from `CustomProps`, once mirrored into `Properties`), doubling metadata findings for every Office document. Deterministic, so it needs its own TP/FP-measured PR.
- `validateFilePath`'s `/var/`, `/tmp/`, `/home/` prefix rejection makes the Office metadata extractor unusable for any file in a standard temp dir or a Linux home directory.
- The `--- name ---` section marker is a string-typed side channel that document text can forge. Written up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)