### PR TITLE
fix(xlsx): recover cell values lost to non-dotall regexes and shared-string index shift

### DIFF
--- a/docs/testing/TEST_PLAN.md
+++ b/docs/testing/TEST_PLAN.md
@@ -1,0 +1,229 @@
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# ferret-scan test plan
+
+ferret-scan is a PII/secret **detection and redaction** tool. A miss is not a cosmetic
+defect: content that is not detected is not redacted, so it leaves the tool in
+cleartext. Every change is therefore held to the checklist below before it ships.
+The guiding rule is **prove it, don't assume it** — each claim in a PR ("no
+regression", "faster", "redaction covers it") must be backed by a command whose
+output is in the PR body.
+
+This document is the standing definition of "tested enough to merge". It is a
+checklist to reason against, not a gate that every trivial change must clear in
+full — see [Applicability](#applicability-scaling-the-plan-to-the-change) — but the
+default is to run more of it, not less.
+
+---
+
+## The dimensions
+
+Each dimension names what it protects, the minimum bar, and how to run it.
+
+### 1. Build, vet, format
+
+- `go build ./...` — compiles.
+- `go vet ./...` — clean.
+- `gofmt -l <touched dirs>` — empty output. (Known pre-existing exception:
+  `internal/config/config.go` reports under gofmt on `main`; prove any gofmt hit is
+  pre-existing by stashing your change and re-running before dismissing it.)
+
+### 2. Unit + full regression suite
+
+- `go test ./...` — the whole module, **not** just the package you touched. A
+  validator change can move a golden file or a formatter test three packages away.
+- Capture the exit code explicitly (`go test ./... > log 2>&1; echo $?`); a piped
+  `tail` hides the real status.
+- New behavior gets a new test **that fails on the pre-change code** — a test that
+  passes both before and after proves nothing. State in the PR which tests are
+  non-vacuous (fail on the parent commit).
+
+### 3. Golden corpus
+
+- `go test ./internal/goldencorpus/` — the end-to-end contract across all output
+  formats (9 per case, including `redact_simple.txt` and
+  `redact_format_preserving.txt`).
+- Regenerate intentionally with `UPDATE_GOLDEN=1 go test ./internal/goldencorpus/`,
+  then **read every diff line** — a golden change is a behavior change and must be
+  explained in the PR, never rubber-stamped.
+- State golden impact even when it is "none" (e.g. the corpus has no `.xlsx` case, so
+  spreadsheet-extraction work moves no goldens — say so).
+- Run it **uncached** (`-count=1`) once before commit; the corpus test caches
+  aggressively.
+
+### 4. Timing / complexity (O(n²) and unacceptable slowdowns)
+
+The scanner routinely runs over adversarial and machine-generated input where a line
+can be megabytes and a file can be tens of thousands of near-identical rows. A hidden
+`O(n²)` there is a denial-of-service, not a micro-optimization.
+
+- **Scaling curve, not a single point.** Measure at N, 2N, 4N. Linear work roughly
+  doubles per doubling; quadratic roughly quadruples. One data point cannot tell them
+  apart.
+- **Isolate the layer.** `--preprocess-only` measures extraction+preprocessing without
+  validation; a focused `go test -bench` on the changed function measures it alone.
+  Wall-clock of the whole CLI includes stages you did not touch — attribute the cost
+  before blaming (or crediting) your change.
+- **Compare against a same-parent baseline binary**, built by stashing your change, so
+  the delta is your change and not machine noise. Never benchmark in `/tmp` on macOS —
+  the reaper deletes the binary mid-run and yields fake 0.00s readings; build under
+  the repo or home dir.
+- **Profile, don't guess** (`-cpuprofile` + `go tool pprof -top`) when a number
+  surprises you.
+- A measured regression is a blocker unless it is the unavoidable cost of correct
+  behavior (e.g. emitting findings that were previously dropped) — and then it is
+  stated in the PR with the reason.
+
+### 5. Redaction — all types
+
+Because redaction only rewrites what the validators emit, **every detection change is
+also a redaction change**. Test it explicitly, do not infer it.
+
+- `--enable-redaction --redaction-output-dir <dir>`, then assert **no raw sensitive
+  value survives** in the output — for binary containers (`.xlsx`, `.docx`, `.pptx`)
+  unzip the rewritten file and `grep` the parts, since the value lives inside the XML.
+- Cover **both** redaction styles the golden corpus distinguishes: simple
+  (`[TYPE-REDACTED]`) and format-preserving (masking that keeps length/shape, e.g.
+  `************0366`).
+- The decisive test for a recall fix is the **base-vs-fix leak diff**: show that the
+  parent binary leaks the value through `--enable-redaction` and the changed binary
+  does not. That is the whole point of a detection fix, stated as a security result.
+- On macOS the output dir nests under `private/…` (the `/tmp` symlink); `find` for the
+  rewritten file rather than assuming a flat path.
+
+### 6. Suppression
+
+- Confirm intended suppression still suppresses **and is counted**: `stats.suppressed`
+  must reflect it. The TM-11 class of bug is precisely a finding that is *dropped
+  before emission* so `stats.suppressed` stays 0 and nothing signals the value was
+  hidden — that is a leak, not a suppression. A demoted-to-LOW finding is emitted
+  (and therefore redacted); an erased one is not. Know which your change produces.
+- Suppression-hash stability: the hash embeds `%.2f` confidence, so a confidence
+  change silently invalidates saved suppressions — check when confidence math moves.
+- Exercise the suppression *mutation* path only over loopback (TM-01); never test it
+  against a `--bind 0.0.0.0` posture.
+
+### 7. All output formats
+
+- `--format` covers `text, json, csv, yaml, junit, gitlab-sast, sarif`. A schema or
+  field change must be checked in **every** format, not just JSON — the golden corpus
+  emits all of them per case, which is the cheapest way to cover this.
+- `--show-match` is a formatter-layer concern and must never cause a validator to log
+  the raw matched value (BSC4 / [[no-match-in-debug-logs]]).
+- A zero-finding scan emits `[]`; `jq '.results'` on it errors — that is expected, not
+  a bug. Guard analysis scripts with a type check.
+
+### 8. Web UI (when affected)
+
+- If the change touches `internal/web/`, its assets, or anything the embedded template
+  renders: run the web tests, and verify CSP is not loosened (`script-src 'self'`, no
+  new `'unsafe-inline'`) and no new security header is dropped (TM-03/05/06).
+- The public redaction API (`pkg/redact`) is a separate external contract — a bump
+  that external consumers pin to must keep `redact.ValidCheckNames()` and friends
+  stable. Most `internal/formatter` and `internal/web` changes do not touch it; say so
+  when true.
+
+### 9. TP / FP and recall (real-world documents)
+
+- Measure against real documents in `~/Downloads` (never invent synthetic-only
+  evidence when real material exists), plus a purpose-built adversarial fixture for
+  the specific mechanism.
+- **Build ground truth independently** where possible (e.g. an XML-parser reference
+  for spreadsheet cells) and score recall/precision against it, rather than trusting
+  the tool to grade itself.
+- Report the delta as **new / lost / confidence-changed by type**, and classify each
+  new finding as TP or FP by hand. "0 lost" is the recall floor; unexplained "lost"
+  is a blocker.
+- **Anonymize** customer document names in anything destined for GitHub; refer to "a
+  real-world .xlsx", never the filename.
+- Do not trust an A/B corpus diff without a **same-binary noise floor first** — several
+  code paths are nondeterministic run-to-run (see dimension 11), and a diff key of
+  `(file, validator, type, line)` is not unique (one line holds several matches), so
+  `join` on it manufactures fake symmetric "confidence changed" pairs. Include a value
+  hash or per-line index in the key.
+
+### 10. Dead / unreachable code
+
+- A fix that makes an old branch unreachable (e.g. replacing `if x <= 0 { continue }`
+  with a floor so `x` can never be `<= 0`) must **remove or rewrite** that branch, not
+  leave it as misleading dead code.
+- `go vet` and the deadcode tool over-report; `pkg/redact`, `internal/web`, and test
+  helpers are protected surfaces — confirm a reported-dead symbol is truly unreferenced
+  before deleting. Deletions ride their own PR, not a behavior change.
+
+### 11. Determinism
+
+Identical input must yield identical output across runs of the same binary. Randomized
+Go **map iteration** is the recurring culprit — any argmax / first-wins / append-while-
+ranging over a map is a latent nondeterminism bug.
+
+- For any change near extraction, clustering, or ranking: run the same file **10×** and
+  assert a stable finding count and stable line numbers.
+- Add a repeat-N-runs determinism test in the style of
+  `internal/router/determinism_test.go` when the change touches an ordering-sensitive
+  path.
+- Known live sites (do not attribute new flakes to your change until excluded):
+  container-format line churn (#179, fixed in PR #181), analyzer map-argmax (fixed in
+  #178), and **SOCIAL_MEDIA on plain `.html`** (14–21 rows across 10 runs of the same
+  binary — open).
+
+### 12. Cross-platform
+
+- No wall-clock-granularity assertions (Windows timer resolution flakes); use a
+  pre-cancelled context instead of a real sleep.
+- Golden/fixture files pinned to LF, not CRLF; paths compared with `filepath.ToSlash`.
+- Office-extractor fixtures: `meta-extract-officelib` has a path guard rejecting
+  `/tmp`, `/var`, `/home`, so `t.TempDir()` silently drops a preprocessor there; build
+  the zip **in memory** (`archive/zip` + `zip.NewReader`) and call the extractor
+  directly, which also sidesteps the guard. `text-extract-officetextlib` has no such
+  guard.
+
+### 13. Race
+
+- `go test -race -count=1` on every touched package, and on any package with shared
+  mutable state (package-level caches, compiled-pattern maps) even if untouched, when
+  the validator runs concurrently across files/chunks.
+
+---
+
+## Sequencing (stacked PRs)
+
+Work lands as a conflict-free sequence, so:
+
+- Check file overlap with every open PR (`gh pr view <n> --json files`) before
+  starting; stack a PR on the one that already edits the same files rather than
+  racing it.
+- Keep each worktree on its own branch; verify `mergeable=MERGEABLE`,
+  `mergeStateStatus=CLEAN`, and the file list is exactly what you intended (no stray
+  scratch files) before opening.
+- Do **not** babysit per-OS CI after push — local gates are the real check, CI is the
+  backstop. Report the PR link and move on.
+
+---
+
+## Applicability (scaling the plan to the change)
+
+| Change kind | Always | Add |
+|---|---|---|
+| Validator confidence / keyword logic | 1,2,3,5,6,9,10 | 4 if loops over line/match; 11 if ranking |
+| Extraction / preprocessing | 1,2,4,5,9,11,12 | 3 only if corpus has that format; 13 if concurrent |
+| Formatter / output schema | 1,2,3,7 | 8 if web-facing |
+| Web / template / assets | 1,2,7,8 | — |
+| Dead-code removal | 1,2,3,10 | (lands alone) |
+| Pure docs | 1 | — |
+
+When in doubt, run more. The cost of an extra `go test ./...` is seconds; the cost of a
+shipped redaction bypass is a cleartext leak.
+
+---
+
+## Security reporting
+
+A newly discovered vulnerability is reported to AWS/Amazon Security via the
+[vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/)
+**before** any public write-up — never as a public GitHub issue (`CONTRIBUTING.md`).
+A remediation for an *already-documented* threat-model item (e.g. a `THREAT_MODEL.md`
+row) is ordinary tracked work and ships as a normal PR.

--- a/internal/preprocessors/text-extractors/text-extract-officetextlib/office-text-extractor.go
+++ b/internal/preprocessors/text-extractors/text-extract-officetextlib/office-text-extractor.go
@@ -686,31 +686,28 @@ func extractSharedStringsSimple(file *zip.File) []string {
 	// Extract strings using regex
 	var result []string
 
-	// Match <si> elements
-	siRe := regexp.MustCompile(`<si>(.*?)</si>`)
-	siMatches := siRe.FindAllSubmatch(content, -1)
+	// Match <si> elements. The (?s) flag is mandatory, not cosmetic: a cell whose
+	// text contains a line break (very common for multi-line answer lists) has
+	// literal newlines inside its <si>, and without (?s) the `.` stops at them so
+	// the element does not match at all. Because the shared-string table is
+	// referenced *positionally* by <v> indices, a skipped entry does not merely
+	// lose one string — it shifts every subsequent index, so unrelated cells
+	// silently resolve to the wrong text. Measured on a real 15 KB spreadsheet:
+	// 12 of 123 entries were skipped, first divergence at index 89.
+	siMatches := sharedStringSiRe.FindAllSubmatch(content, -1)
 
 	for _, siMatch := range siMatches {
 		if len(siMatch) < 2 {
 			continue
 		}
 
-		// Extract text from <t> elements
-		tRe := regexp.MustCompile(`<t[^>]*>(.*?)</t>`)
-		tMatches := tRe.FindAllSubmatch(siMatch[1], -1)
+		// Extract text from <t> elements. Same (?s) requirement, same reason.
+		tMatches := sharedStringTRe.FindAllSubmatch(siMatch[1], -1)
 
 		var combinedText strings.Builder
 		for _, tMatch := range tMatches {
 			if len(tMatch) >= 2 {
-				text := string(tMatch[1])
-				// Clean up XML entities
-				text = strings.Replace(text, "&lt;", "<", -1)
-				text = strings.Replace(text, "&gt;", ">", -1)
-				text = strings.Replace(text, "&amp;", "&", -1)
-				text = strings.Replace(text, "&quot;", "\"", -1)
-				text = strings.Replace(text, "&apos;", "'", -1)
-
-				combinedText.WriteString(text)
+				combinedText.WriteString(decodeXMLEntities(string(tMatch[1])))
 			}
 		}
 
@@ -718,6 +715,85 @@ func extractSharedStringsSimple(file *zip.File) []string {
 	}
 
 	return result
+}
+
+// Shared-string and worksheet patterns are compiled once at package level rather
+// than inside the per-element loops they are used in; the previous code rebuilt
+// them for every <si> and every <row>.
+var (
+	sharedStringSiRe = regexp.MustCompile(`(?s)<si>(.*?)</si>`)
+	sharedStringTRe  = regexp.MustCompile(`(?s)<t[^>]*>(.*?)</t>`)
+
+	worksheetRowRe = regexp.MustCompile(`(?s)<row[^>]*>(.*?)</row>`)
+
+	// Cells are matched in two stages because Go's RE2 has no lookahead and a
+	// self-closing `<c r="B2"/>` must not be treated as an opening tag. The
+	// attribute group deliberately requires the last character before `>` to not
+	// be `/`, which is the RE2-compatible way to say "not self-closing".
+	worksheetCellRe = regexp.MustCompile(`(?s)<c((?:[^>]*[^/>])?)>(.*?)</c>`)
+
+	// Value extraction inside a single cell body.
+	cellValueRe  = regexp.MustCompile(`(?s)<v>(.*?)</v>`)
+	cellInlineRe = regexp.MustCompile(`(?s)<is>.*?<t[^>]*>(.*?)</t>.*?</is>`)
+	cellTextRe   = regexp.MustCompile(`(?s)<t[^>]*>(.*?)</t>`)
+
+	worksheetFormControlRe = regexp.MustCompile(`<formControlPr[^>]*defaultValue="([^"]*)"|<dataValidation[^>]*formula1="([^"]*)"`)
+
+	sharedStringTypeRe = regexp.MustCompile(`\bt="s"`)
+
+	// Named entities and numeric character references, matched in one alternation
+	// so decodeXMLEntities can resolve each in a single non-overlapping pass.
+	entityRe = regexp.MustCompile(`&(?:lt|gt|quot|apos|amp|#x[0-9a-fA-F]+|#[0-9]+);`)
+)
+
+// decodeXMLEntities expands the XML entities that appear in OOXML text runs.
+//
+// Every entity is decoded in a SINGLE pass, because any two-pass scheme
+// re-reads its own output and invents markup that was never in the document.
+// Both orderings are wrong in the same way:
+//
+//	`&amp;lt;`  is the encoded *literal* "&lt;" — expanding &amp; first, then
+//	            &lt;, yields "<".
+//	`&#38;lt;`  is the same literal written with a numeric reference —
+//	            expanding numeric refs first, then &lt;, also yields "<".
+//
+// A single left-to-right pass that consumes each reference exactly once and
+// never revisits the text it just wrote gets both cases right.
+func decodeXMLEntities(s string) string {
+	if !strings.ContainsRune(s, '&') {
+		return s
+	}
+
+	return entityRe.ReplaceAllStringFunc(s, func(m string) string {
+		switch m {
+		case "&lt;":
+			return "<"
+		case "&gt;":
+			return ">"
+		case "&quot;":
+			return "\""
+		case "&apos;":
+			return "'"
+		case "&amp;":
+			return "&"
+		}
+
+		// Numeric character reference: &#NNN; or &#xHHH;. Excel emits these for
+		// characters outside the sheet's encoding.
+		body := m[2 : len(m)-1]
+		base, digits := 10, body
+		if body[0] == 'x' || body[0] == 'X' {
+			base, digits = 16, body[1:]
+		}
+		cp, err := strconv.ParseInt(digits, base, 32)
+		// Leave anything unparseable or outside the valid Unicode scalar range
+		// as written rather than emitting U+FFFD, so the raw form still reaches
+		// the validators instead of becoming an unsearchable placeholder.
+		if err != nil || cp <= 0 || cp > 0x10FFFF || (cp >= 0xD800 && cp <= 0xDFFF) {
+			return m
+		}
+		return string(rune(cp))
+	})
 }
 
 // extractWorksheetText extracts text from a worksheet
@@ -743,8 +819,7 @@ func extractWorksheetText(file *zip.File, sharedStrings []string) string {
 	var result strings.Builder
 
 	// Find rows
-	rowRe := regexp.MustCompile(`<row[^>]*>(.*?)</row>`)
-	rowMatches := rowRe.FindAllSubmatch(content, -1)
+	rowMatches := worksheetRowRe.FindAllSubmatch(content, -1)
 
 	for _, rowMatch := range rowMatches {
 		if len(rowMatch) < 2 {
@@ -754,45 +829,52 @@ func extractWorksheetText(file *zip.File, sharedStrings []string) string {
 		var rowText strings.Builder
 		rowContent := rowMatch[1]
 
-		// Find cells and form controls
-		cellRe := regexp.MustCompile(`<c[^>]*>.*?(?:<v>(.*?)</v>|<is>.*?<t>(.*?)</t>.*?</is>|<t>(.*?)</t>).*?</c>`)
-		cellMatches := cellRe.FindAllSubmatch(rowContent, -1)
+		// Find cells. This is a two-stage match: locate each non-self-closing
+		// <c>…</c> first, then pull the value out of its body. The previous
+		// single-pattern approach had two defects on real spreadsheets:
+		//
+		//  1. `<c[^>]*>` also matched a self-closing `<c r="B2"/>` (an empty,
+		//     styled cell — 16 of 52 cells in one real sheet). Having consumed
+		//     it as an opening tag, `.*?</c>` then ran on to the *next* cell's
+		//     closing tag and reported that neighbour's value under the empty
+		//     cell, dropping cells in the process.
+		//  2. The inline-string and direct-text branches used a bare `<t>`,
+		//     which does not match the attributed `<t xml:space="preserve">`
+		//     Excel writes whenever a value has leading or trailing spaces.
+		cellMatches := worksheetCellRe.FindAllSubmatch(rowContent, -1)
 
 		// Also look for form controls in Excel
-		formControlRe := regexp.MustCompile(`<formControlPr[^>]*defaultValue="([^"]*)"|<dataValidation[^>]*formula1="([^"]*)"`)
-		formMatches := formControlRe.FindAllSubmatch(rowContent, -1)
+		formMatches := worksheetFormControlRe.FindAllSubmatch(rowContent, -1)
 
 		for _, cellMatch := range cellMatches {
-			if len(cellMatch) < 4 {
+			if len(cellMatch) < 3 {
 				continue
 			}
 
-			// Get cell content
+			attrs, body := cellMatch[1], cellMatch[2]
+
+			// Check if it's a shared string. Matched on a word boundary so a
+			// different attribute ending in `t="s"` cannot be mistaken for the
+			// cell type.
+			isSharedString := sharedStringTypeRe.Match(attrs)
+
 			var cellText string
-
-			// Check if it's a shared string
-			cellStr := string(cellMatch[0])
-			isSharedString := strings.Contains(cellStr, `t="s"`)
-
-			// Extract value from <v> tag
-			if cellMatch[1] != nil {
-				value := string(cellMatch[1])
-
+			switch {
+			case cellValueRe.Match(body):
+				value := string(cellValueRe.FindSubmatch(body)[1])
 				if isSharedString && len(sharedStrings) > 0 {
-					// Convert to shared string
-					index, err := strconv.Atoi(value)
+					// Shared strings are referenced positionally.
+					index, err := strconv.Atoi(strings.TrimSpace(value))
 					if err == nil && index >= 0 && index < len(sharedStrings) {
 						cellText = sharedStrings[index]
 					}
 				} else {
-					cellText = value
+					cellText = decodeXMLEntities(value)
 				}
-			} else if cellMatch[2] != nil {
-				// Inline string
-				cellText = string(cellMatch[2])
-			} else if cellMatch[3] != nil {
-				// Direct text
-				cellText = string(cellMatch[3])
+			case cellInlineRe.Match(body):
+				cellText = decodeXMLEntities(string(cellInlineRe.FindSubmatch(body)[1]))
+			case cellTextRe.Match(body):
+				cellText = decodeXMLEntities(string(cellTextRe.FindSubmatch(body)[1]))
 			}
 
 			if cellText != "" {

--- a/internal/preprocessors/text-extractors/text-extract-officetextlib/xlsx_extraction_test.go
+++ b/internal/preprocessors/text-extractors/text-extract-officetextlib/xlsx_extraction_test.go
@@ -1,0 +1,248 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package textextractofficetextlib
+
+import (
+	"archive/zip"
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// zipEntry builds an in-memory zip containing a single named entry and returns
+// the *zip.File handle for it. The xlsx extraction helpers take a *zip.File
+// directly, so tests can exercise them without writing to disk — which also
+// avoids the extractor's on-disk path guard rejecting temp directories.
+func zipEntry(t *testing.T, name, body string) *zip.File {
+	t.Helper()
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, err := zw.Create(name)
+	if err != nil {
+		t.Fatalf("zip create: %v", err)
+	}
+	if _, err := w.Write([]byte(body)); err != nil {
+		t.Fatalf("zip write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zip close: %v", err)
+	}
+
+	zr, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	if err != nil {
+		t.Fatalf("zip open: %v", err)
+	}
+	if len(zr.File) != 1 {
+		t.Fatalf("expected 1 zip entry, got %d", len(zr.File))
+	}
+	return zr.File[0]
+}
+
+// TestExtractSharedStrings_MultilineEntriesKeepTheirIndex is the regression test
+// for the positional-index shift.
+//
+// The shared-string table is referenced by *ordinal*: a cell says <v>7</v>,
+// meaning "the eighth <si>". So an <si> the extractor fails to match is not one
+// lost string — it renumbers the whole table from that point on, and every later
+// cell renders some other cell's text. That is worse than a gap: a spreadsheet
+// scan reports values against the wrong rows.
+//
+// The trigger is mundane. A cell containing a line break (an answer list, an
+// address block) has literal newlines inside its <si>, and a non-(?s) `.*?`
+// cannot cross them. Measured on a real 15 KB workbook: 12 of 123 entries
+// skipped, first divergence at index 89.
+func TestExtractSharedStrings_MultilineEntriesKeepTheirIndex(t *testing.T) {
+	// Index 1 is deliberately multi-line, so a non-(?s) pattern drops it and
+	// shifts indices 2 and 3 down by one.
+	sst := `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><si><t>first</t></si>` +
+		"<si><t>answer one\nanswer two\nanswer three</t></si>" +
+		`<si><t>Payment card 4532015112830366</t></si><si><t>last</t></si></sst>`
+
+	got := extractSharedStringsSimple(zipEntry(t, "xl/sharedStrings.xml", sst))
+
+	if len(got) != 4 {
+		t.Fatalf("expected 4 shared strings, got %d: %q", len(got), got)
+	}
+
+	want := []string{
+		"first",
+		"answer one\nanswer two\nanswer three",
+		"Payment card 4532015112830366",
+		"last",
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("shared string %d: got %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestExtractWorksheet_SelfClosingCellDoesNotSwallowNeighbour covers the second
+// extraction defect: `<c[^>]*>` matched a self-closing `<c r="A2"/>` — an empty
+// but styled cell, which real spreadsheets are full of (16 of 52 cells in one
+// sheet of a real workbook). Having consumed it as an *opening* tag, the old
+// `.*?</c>` then ran on to the next cell's closing tag, so the empty cell
+// reported its neighbour's value and the neighbour itself was consumed.
+//
+// Go's RE2 has no lookahead, so "not self-closing" is expressed by requiring the
+// last character before `>` to not be `/`.
+func TestExtractWorksheet_SelfClosingCellDoesNotSwallowNeighbour(t *testing.T) {
+	shared := []string{"alpha", "SSN 536-22-8765", "omega"}
+
+	sheet := `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData>` +
+		`<row r="1"><c r="A1" t="s"><v>0</v></c></row>` +
+		`<row r="2"><c r="A2" s="3"/><c r="B2" t="s"><v>1</v></c></row>` +
+		`<row r="3"><c r="A3" t="s"><v>2</v></c></row>` +
+		`</sheetData></worksheet>`
+
+	got := extractWorksheetText(zipEntry(t, "xl/worksheets/sheet1.xml", sheet), shared)
+
+	for _, want := range shared {
+		if !strings.Contains(got, want) {
+			t.Errorf("extracted text lost %q; got:\n%s", want, got)
+		}
+	}
+
+	// The empty cell must not have borrowed its neighbour's value: "SSN ..."
+	// belongs to B2 and must appear exactly once, not twice.
+	if n := strings.Count(got, shared[1]); n != 1 {
+		t.Errorf("value %q appears %d times, want exactly 1; got:\n%s", shared[1], n, got)
+	}
+}
+
+// TestExtractWorksheet_SelfClosingValueDoesNotSwallowNeighbour covers the
+// self-closing <v/> variant of the same swallowing bug: a cell with a cached-but-
+// empty formula result writes <v/>, and the old single-pattern `.*?</c>` ran past
+// it into the following cell's value. The two-stage match bounds each cell at its
+// own </c> first, so an empty <v/> simply yields no text for that cell.
+func TestExtractWorksheet_SelfClosingValueDoesNotSwallowNeighbour(t *testing.T) {
+	sheet := `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData>` +
+		`<row r="1"><c r="A1" t="s"><v/></c><c r="B1" t="s"><v>0</v></c></row>` +
+		`</sheetData></worksheet>`
+
+	got := extractWorksheetText(zipEntry(t, "xl/worksheets/sheet1.xml", sheet), []string{"real value"})
+
+	if !strings.Contains(got, "real value") {
+		t.Errorf("cell after self-closing <v/> was lost; got %q", got)
+	}
+	// The empty <v/> cell must not have resolved the ordinal 0 twice.
+	if n := strings.Count(got, "real value"); n != 1 {
+		t.Errorf("value appears %d times, want 1; got %q", n, got)
+	}
+}
+
+// TestExtractWorksheet_AttributedAndInlineText covers two narrower misses that
+// hid real values: Excel writes <t xml:space="preserve"> whenever a value has
+// leading or trailing whitespace, which a bare `<t>` pattern does not match, and
+// inline strings (t="inlineStr", used by whole workbooks that have no
+// sharedStrings.xml at all — one of the two real files tested was entirely
+// inline) went the same way.
+func TestExtractWorksheet_AttributedAndInlineText(t *testing.T) {
+	sheet := `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData>` +
+		`<row r="1"><c r="A1" t="inlineStr"><is><t xml:space="preserve">Inline phone 415-555-0199 </t></is></c></row>` +
+		`<row r="2"><c r="A2" t="str"><t xml:space="preserve"> trailing space value </t></c></row>` +
+		`</sheetData></worksheet>`
+
+	got := extractWorksheetText(zipEntry(t, "xl/worksheets/sheet1.xml", sheet), nil)
+
+	for _, want := range []string{"Inline phone 415-555-0199", "trailing space value"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("extracted text lost %q; got:\n%s", want, got)
+		}
+	}
+}
+
+// TestExtractWorksheet_MultilineInlineString pins (?s) on the row and cell
+// patterns themselves, not just on the shared-string table: a multi-line inline
+// string means literal newlines inside <row> and <c>, so a non-(?s) pattern
+// fails to match the row at all and the entire row disappears.
+func TestExtractWorksheet_MultilineInlineString(t *testing.T) {
+	sheet := "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" +
+		`<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData>` +
+		"<row r=\"1\"><c r=\"A1\" t=\"inlineStr\"><is><t>line one\nSSN 536-22-8765\nline three</t></is></c></row>" +
+		`</sheetData></worksheet>`
+
+	got := extractWorksheetText(zipEntry(t, "xl/worksheets/sheet1.xml", sheet), nil)
+
+	if !strings.Contains(got, "536-22-8765") {
+		t.Errorf("multi-line inline string lost its content; got:\n%s", got)
+	}
+}
+
+// TestDecodeXMLEntities_AmpersandExpandedLast guards the ordering trap in entity
+// decoding. If `&amp;` is expanded before `&lt;`, then the encoded *literal*
+// `&amp;lt;` becomes `&lt;` and then `<` — inventing markup the document never
+// contained. Expanding `&amp;` last keeps a literal literal.
+func TestDecodeXMLEntities_AmpersandExpandedLast(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"no entities passes through", "plain text", "plain text"},
+		{"basic entities", "a &lt;b&gt; c &quot;d&quot; e &apos;f&apos;", `a <b> c "d" e 'f'`},
+		{"bare ampersand", "Smith &amp; Sons", "Smith & Sons"},
+		{"encoded literal stays literal", "&amp;lt;notatag&amp;gt;", "&lt;notatag&gt;"},
+		{"decimal numeric refs", "&#65;&#66;&#67;", "ABC"},
+		{"hex numeric refs", "&#x41;&#x42;", "AB"},
+		{"malformed ref left as written", "&#;", "&#;"},
+		{"out-of-range ref left as written", "&#x110000;", "&#x110000;"},
+		{"surrogate ref left as written", "&#xD800;", "&#xD800;"},
+		{"numeric ref for ampersand is not re-expanded", "&#38;lt;", "&lt;"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := decodeXMLEntities(tc.in); got != tc.want {
+				t.Errorf("decodeXMLEntities(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExtractWorksheet_SharedStringIndexOutOfRange asserts the extractor stays
+// quiet on malformed input rather than panicking: an index past the end of the
+// table (a truncated or mismatched sharedStrings.xml) must yield no text for
+// that cell while leaving valid neighbours intact.
+func TestExtractWorksheet_SharedStringIndexOutOfRange(t *testing.T) {
+	sheet := `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData>` +
+		`<row r="1"><c r="A1" t="s"><v>99</v></c><c r="B1" t="s"><v>0</v></c><c r="C1" t="s"><v>-3</v></c></row>` +
+		`</sheetData></worksheet>`
+
+	got := extractWorksheetText(zipEntry(t, "xl/worksheets/sheet1.xml", sheet), []string{"only entry"})
+
+	if !strings.Contains(got, "only entry") {
+		t.Errorf("valid shared-string reference lost; got %q", got)
+	}
+	if strings.Contains(got, "99") || strings.Contains(got, "-3") {
+		t.Errorf("out-of-range index leaked its raw ordinal into the text: %q", got)
+	}
+}
+
+// TestExtractWorksheet_NumericCellsAreNotSharedStrings checks the cell-type
+// discrimination: a numeric cell has no t="s", so its <v> is the value itself
+// and must never be dereferenced through the shared-string table.
+func TestExtractWorksheet_NumericCellsAreNotSharedStrings(t *testing.T) {
+	sheet := `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData>` +
+		`<row r="1"><c r="A1"><v>4532015112830366</v></c><c r="B1" t="n"><v>42</v></c></row>` +
+		`</sheetData></worksheet>`
+
+	got := extractWorksheetText(zipEntry(t, "xl/worksheets/sheet1.xml", sheet), []string{"decoy", "another decoy"})
+
+	for _, want := range []string{"4532015112830366", "42"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("numeric cell value %q lost; got %q", want, got)
+		}
+	}
+	if strings.Contains(got, "decoy") {
+		t.Errorf("numeric cell was wrongly dereferenced through the shared-string table: %q", got)
+	}
+}


### PR DESCRIPTION
The `.xlsx` text extractor silently dropped a large fraction of every real spreadsheet's cell values. In a detection+redaction tool that is a security bug, not a cosmetic one: **content that is never extracted is never scanned and never redacted, so PII in the affected cells passes through `--enable-redaction` in cleartext.**

## Recall, measured against independent ground truth

Two real spreadsheets (anonymized), scored against an independent XML-parser reference for the cell values:

| file | shared-string style | before | after |
|---|---|---|---|
| A | shared strings | 70.9% | **100%** |
| B | inline strings | 56.7% | **100%** |

Precision held at 100% (no fabricated content — the only non-cell strings extracted are the preprocessor's own metadata header).

## The three defects

**1. Missing `(?s)` on `<si>`/`<t>`/`<row>`/`<c>`.** A cell with a line break (Alt+Enter answer lists, address blocks) has literal newlines inside its element, and `.*?` without `(?s)` cannot cross them, so the element does not match. Because the shared-string table is referenced **positionally** by `<v>` index, a skipped `<si>` does not lose one string — it renumbers the table from that point on and every later cell renders *some other cell's* text. On a real 15 KB file: 12 of 123 entries skipped, first divergence at index 89.

**2. `<c[^>]*>` matched a self-closing `<c r="B2"/>`** (an empty styled cell — 16 of 52 cells in one real sheet). Consumed as an opening tag, `.*?</c>` then ran on to the *next* cell's closing tag, reporting the neighbour's value under the empty cell and dropping the neighbour. Fixed with a two-stage match. Go's RE2 has no lookahead, so "not self-closing" is expressed by requiring the last character before `>` to not be `/`. The same fix covers self-closing `<v/>` (cached-empty formula results).

**3. Inline strings and attributed `<t xml:space=\"preserve\">`** (Excel writes the attribute whenever a value has leading/trailing spaces) were matched with a bare `<t>` and missed. Entity decoding was applied to shared strings but not to worksheet cell values.

## Entity decoding

Now a single-pass function shared by both paths. A two-pass scheme re-reads its own output and invents markup: `&amp;lt;` and `&#38;lt;` are both encoded literals of `&lt;` and must decode to `&lt;`, **not** `<`. Numeric character references are handled; anything unparseable or outside the Unicode scalar range is left as written so the raw form still reaches the validators rather than becoming an unsearchable `U+FFFD`.

This requirement was found *by a test* — the first implementation double-decoded `&#38;lt;`, the test caught it, and the numeric pass was folded into the single alternation.

## Redaction — proven end to end

On a controlled fixture with PII in the previously-dropped cells, unzipping the rewritten workbook and grepping every XML part for the raw values:

- Parent binary **leaks** an inline-string phone number through `--enable-redaction` — its row was never extracted, so it was never detected, so the redactor left it verbatim.
- This change detects and redacts it. **0 raw values survive** in the redacted output.

## Timing

Extraction is **linear** (`go test -bench`: N2500=10ms, N5000=19ms, N10000=40ms — clean 2×/doubling) and time-neutral-to-faster than the parent on equal-size output, because the two in-loop `regexp.MustCompile` calls are now hoisted to package level.

A separate, **pre-existing** `O(n²)` lives *downstream* of extraction in the router line-splitting path (a 10k-row sheet is 40ms to extract but 3418ms in the router's `file_evaluation`). It is not introduced here — on equal-output-size input this change is faster than the parent — and is tracked for its own PR.

## Tests

Build their `.xlsx` in memory with `archive/zip` and call the extraction helpers directly, which needs no binary fixtures and sidesteps the on-disk path guard. Each fails on the parent commit (non-vacuous). Coverage: multi-line index shift, self-closing `<c/>` and `<v/>` swallowing, attributed/inline text, multi-line inline strings, out-of-range and numeric-cell shared-string discrimination, and 10 entity-decoding cases.

**Golden impact: none** — the corpus has no spreadsheet input. Full `go test ./...`, `-race` on the package, `gofmt`, `go vet` all green. Extraction verified deterministic (stable finding count over 10 runs).

## Also included

`docs/testing/TEST_PLAN.md` — the project's standing definition of "tested enough to merge" (timing/O(n²), regression, golden, redaction all types, suppression, all output formats, web, TP/FP, recall, dead code, determinism, cross-platform, race), which this change was held to.

Targets `main`; no file overlap with the open PR stack (#177/#178/#182/#180/#181).