### PR TITLE
fix(socialmedia): make clustering output deterministic (plain .html recall bug)

### DIFF
--- a/internal/validators/socialmedia/determinism_test.go
+++ b/internal/validators/socialmedia/determinism_test.go
@@ -1,0 +1,121 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package socialmedia
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+)
+
+// fingerprint renders a match set into a stable, order-independent string so two
+// runs can be compared by content regardless of the order the slice happens to
+// be in. It sorts, so it cannot itself hide an ordering difference — that is the
+// job of the caller, which compares raw slices too.
+func fingerprint(matches []detector.Match) string {
+	rows := make([]string, len(matches))
+	for i, m := range matches {
+		rows[i] = fmt.Sprintf("%s|%d|%.2f|%s", m.Type, m.LineNumber, m.Confidence, m.Text)
+	}
+	sort.Strings(rows)
+	return strings.Join(rows, "\n")
+}
+
+// TestSocialMedia_ClusteringIsDeterministic is the regression test for the plain-
+// .html nondeterminism: the same content produced 14–21 findings across runs of
+// one binary.
+//
+// Root cause was map iteration order leaking into an order-sensitive stage.
+// processLineForAllPatterns discovered matches by ranging over the compiledPatterns
+// map, and processLineMatchesWithClustering flattened the line-keyed map with a
+// bare range; the resulting slice was a random permutation. The clustering that
+// consumes it is greedy first-wins (identifyProfileClusters seeds on slice
+// position), and areMatchesRelated is symmetric but NOT transitive, so a different
+// seed order produced a different partition and collapsed a different number of
+// rows into SOCIAL_MEDIA_CLUSTER findings.
+//
+// The content below is built to exercise exactly that: many handles that pass the
+// proximity gate and are pairwise-but-not-transitively related, so the number of
+// clusters is sensitive to seed order on the unfixed code.
+func TestSocialMedia_ClusteringIsDeterministic(t *testing.T) {
+	v := newConfiguredValidator()
+
+	var b strings.Builder
+	// Interleave several platforms and overlapping usernames across adjacent
+	// lines so the ±16-line proximity window links many of them and the greedy
+	// partition is order-sensitive.
+	for i := 0; i < 30; i++ {
+		fmt.Fprintf(&b, "Contact https://twitter.com/user%d and @user%d today\n", i%7, i%5)
+		fmt.Fprintf(&b, "Also see https://github.com/user%d and https://facebook.com/user%d.page\n", i%5, i%7)
+		fmt.Fprintf(&b, "Profile https://linkedin.com/in/user%d plus https://instagram.com/user%d\n", i%7, i%5)
+	}
+	content := b.String()
+
+	first, err := v.ValidateContent(content, "determinism-fixture.txt")
+	if err != nil {
+		t.Fatalf("ValidateContent: %v", err)
+	}
+	want := fingerprint(first)
+
+	// Many iterations: map order is randomized per-run within a process, so
+	// repeated calls sample different permutations. On the unfixed code the count
+	// and partition drift within a few dozen calls.
+	const iterations = 200
+	for i := 0; i < iterations; i++ {
+		got, err := v.ValidateContent(content, "determinism-fixture.txt")
+		if err != nil {
+			t.Fatalf("ValidateContent (iter %d): %v", i, err)
+		}
+		if len(got) != len(first) {
+			t.Fatalf("iter %d: finding COUNT changed: got %d, first run %d "+
+				"(clustering partition is nondeterministic)", i, len(got), len(first))
+		}
+		if fp := fingerprint(got); fp != want {
+			t.Fatalf("iter %d: finding SET changed across runs of the same binary:\n--- first ---\n%s\n--- iter %d ---\n%s",
+				i, want, i, fp)
+		}
+	}
+}
+
+// TestSocialMedia_PerLineMatchOrderIsStable pins the narrower half of the fix:
+// processLineForAllPatterns must return a line's matches in a fixed order
+// regardless of the compiledPatterns map iteration order, because that order is
+// what seeds the clustering. A single line carrying several distinct platform
+// handles is enough to exercise it.
+func TestSocialMedia_PerLineMatchOrderIsStable(t *testing.T) {
+	v := newConfiguredValidator()
+
+	// One line, many platforms, so the only ordering input is the pattern-map
+	// iteration order.
+	content := "links: https://twitter.com/alice https://github.com/alice " +
+		"https://facebook.com/alice.page https://instagram.com/alice https://linkedin.com/in/alice"
+
+	first, err := v.ValidateContent(content, "single-line.txt")
+	if err != nil {
+		t.Fatalf("ValidateContent: %v", err)
+	}
+
+	// Compare the RAW slice order (not a sorted fingerprint) across runs.
+	rawOrder := func(ms []detector.Match) string {
+		parts := make([]string, len(ms))
+		for i, m := range ms {
+			parts[i] = m.Type + ":" + m.Text
+		}
+		return strings.Join(parts, ",")
+	}
+	want := rawOrder(first)
+
+	for i := 0; i < 200; i++ {
+		got, err := v.ValidateContent(content, "single-line.txt")
+		if err != nil {
+			t.Fatalf("iter %d: %v", i, err)
+		}
+		if o := rawOrder(got); o != want {
+			t.Fatalf("iter %d: per-line match ORDER changed across runs:\n want: %s\n got:  %s", i, want, o)
+		}
+	}
+}

--- a/internal/validators/socialmedia/validator.go
+++ b/internal/validators/socialmedia/validator.go
@@ -635,12 +635,10 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 		if os.Getenv("FERRET_DEBUG") == "1" {
 			fmt.Fprintf(os.Stderr, "[WARN] Social Media: Clustering failed: %v\n", err)
 		}
-		// Fallback to flattened individual matches
-		var allMatches []detector.Match
-		for _, matches := range lineMatches {
-			allMatches = append(allMatches, matches...)
-		}
-		processedMatches = allMatches
+		// Fallback to flattened individual matches, in the same deterministic
+		// line order as the clustering path so a clustering failure does not
+		// reintroduce the map-order nondeterminism this fixes.
+		processedMatches = flattenLineMatchesSorted(lineMatches)
 	}
 
 	// Performance monitoring and memory cleanup
@@ -734,15 +732,37 @@ func (v *Validator) processLineMatchesWithClusteringAndErrorHandling(lineMatches
 	return processedMatches, nil
 }
 
+// flattenLineMatchesSorted flattens a line-keyed match map into a single slice
+// in ascending line order. Ranging over the map directly is nondeterministic
+// (Go randomizes map iteration), and every consumer of this slice — the greedy
+// first-wins clustering above all — is order sensitive, so the flatten must be
+// ordered. Within a line the slice is already in a stable order (see
+// processLineForAllPatterns), so preserving it here is enough.
+func flattenLineMatchesSorted(lineMatches map[int][]detector.Match) []detector.Match {
+	lineNums := make([]int, 0, len(lineMatches))
+	total := 0
+	for ln, matches := range lineMatches {
+		lineNums = append(lineNums, ln)
+		total += len(matches)
+	}
+	sort.Ints(lineNums)
+
+	all := make([]detector.Match, 0, total)
+	for _, ln := range lineNums {
+		all = append(all, lineMatches[ln]...)
+	}
+	return all
+}
+
 // processLineMatchesWithClustering processes line-based matches and applies social media profile clustering
 // This method groups related social media matches and reconstructs fragmented profile references
 func (v *Validator) processLineMatchesWithClustering(lineMatches map[int][]detector.Match, originalPath string) []detector.Match {
-	var allMatches []detector.Match
-
-	// Flatten line matches into a single slice for clustering analysis
-	for _, matches := range lineMatches {
-		allMatches = append(allMatches, matches...)
-	}
+	// Flatten line matches into a single slice for clustering analysis, in
+	// ascending line order. Ranging over the map directly would hand the greedy
+	// clustering a randomly-permuted slice, and because cluster seeding is
+	// first-wins over slice position, the partition (and thus how many rows
+	// collapse into a single SOCIAL_MEDIA_CLUSTER) would change every run.
+	allMatches := flattenLineMatchesSorted(lineMatches)
 
 	// If clustering is disabled or we have no matches, return flattened matches
 	if !v.clusteringConfig.Enabled || len(allMatches) == 0 {
@@ -2635,7 +2655,19 @@ func (v *Validator) detectPatternsByLineBatch(ctx stdctx.Context, content string
 
 // processLineForAllPatterns efficiently processes a single line against all patterns
 func (v *Validator) processLineForAllPatterns(line string, lineNum int, originalPath string, contextExtractor *detector.ContextExtractor) []detector.Match {
-	var matches []detector.Match
+	// Each match is kept with the byte offset it was found at, so the returned
+	// slice can be put into a stable, content-independent order below. The outer
+	// loop ranges over v.compiledPatterns, which is a map, so the order matches
+	// are discovered in is randomized run to run. That randomness used to leak
+	// all the way to the output: the downstream clustering is greedy first-wins
+	// over this slice, so a different discovery order produced a different
+	// cluster partition and therefore a different number of collapsed rows —
+	// the same file reported 14–21 findings across runs of one binary.
+	type offsetMatch struct {
+		offset int
+		match  detector.Match
+	}
+	var found []offsetMatch
 
 	// Precompute the line-global lowercase form ONCE per line. analyzeContext...
 	// previously recomputed strings.ToLower(line) for every keyword of every
@@ -2663,12 +2695,30 @@ func (v *Validator) processLineForAllPatterns(line string, lineNum int, original
 				// Process match with optimized confidence calculation
 				processedMatch := v.processMatchOptimized(match, platform, patternIndex, line, lineLower, loc[0], lineNum, originalPath, contextExtractor)
 				if processedMatch != nil {
-					matches = append(matches, *processedMatch)
+					found = append(found, offsetMatch{offset: loc[0], match: *processedMatch})
 				}
 			}
 		}
 	}
 
+	// Order matches within the line deterministically: left to right by byte
+	// offset, then by type and text so two patterns matching at the same offset
+	// still resolve to a fixed order regardless of map iteration.
+	sort.SliceStable(found, func(i, j int) bool {
+		a, b := found[i], found[j]
+		if a.offset != b.offset {
+			return a.offset < b.offset
+		}
+		if a.match.Type != b.match.Type {
+			return a.match.Type < b.match.Type
+		}
+		return a.match.Text < b.match.Text
+	})
+
+	matches := make([]detector.Match, len(found))
+	for i, fm := range found {
+		matches[i] = fm.match
+	}
 	return matches
 }
 
@@ -4101,6 +4151,9 @@ func (v *Validator) identifyPlatformGroupings(matches []detector.Match) []string
 	for platform := range platformSet {
 		platforms = append(platforms, platform)
 	}
+	// Sorted so the cluster metadata (and thus JSON/YAML/SARIF output) is stable
+	// across runs; map iteration order is randomized.
+	sort.Strings(platforms)
 
 	return platforms
 }
@@ -4126,6 +4179,9 @@ func (v *Validator) extractUserIdentifiers(matches []detector.Match) []string {
 	for identifier := range identifierSet {
 		identifiers = append(identifiers, identifier)
 	}
+	// Sorted so the cluster metadata (and thus JSON/YAML/SARIF output) is stable
+	// across runs; map iteration order is randomized.
+	sort.Strings(identifiers)
 
 	return identifiers
 }
@@ -4514,7 +4570,11 @@ func (v *Validator) buildConsolidatedClusterText(matches []detector.Match) strin
 		}
 	}
 
-	// Build consolidated text
+	// Build consolidated text. platforms is a map, so the segment order is
+	// randomized run to run; sort the finished segments so the cluster's Text
+	// (which becomes the emitted finding's value) is identical across runs.
+	// items within a platform are already in the deterministic match order the
+	// caller passed in, so only the cross-platform ordering needs sorting here.
 	var parts []string
 	for platform, items := range platforms {
 		if len(items) == 1 {
@@ -4523,6 +4583,7 @@ func (v *Validator) buildConsolidatedClusterText(matches []detector.Match) strin
 			parts = append(parts, fmt.Sprintf("%s: %s", platform, strings.Join(items, ", ")))
 		}
 	}
+	sort.Strings(parts)
 
 	return strings.Join(parts, " | ")
 }


### PR DESCRIPTION
Scanning a plain `.html` file produced a **varying number of SOCIAL_MEDIA findings across runs of the same binary** — 14 to 21 on one real document — and varying finding *content* even when the count held. In a detection tool that is a recall bug, not a cosmetic one: on an unlucky run, real profile references are silently absent from the report.

## Root cause

Detection itself was never the problem — a fixed 35 raw matches every run. The randomness was **Go map iteration order leaking into order-sensitive stages**, in four places:

1. `processLineForAllPatterns` ranged over the `compiledPatterns` **map** to find matches, so a line's matches came back in random order.
2. `processLineMatchesWithClustering` (and its clustering-failure fallback) flattened the line-keyed map with a bare `range`, so the slice handed to clustering was a random permutation.

   These two matter because `identifyProfileClusters` is **greedy first-wins**: the first unprocessed slice position seeds a cluster and absorbs its related neighbours, and `areMatchesRelated` is symmetric but **not transitive**, so a different seed order yields a different partition — and each collapsed group of size N destroys N−1 output rows. Different partition ⇒ different finding count. (Empirically: group sizes `[9 5 5 3 3 2 2 2 2 2]`→17 rows one run, `[16 6 3 2 2 2 2 2]`→13 rows another, on identical input.)

3. `buildConsolidatedClusterText` ranged over a `platforms` map to build the cluster finding's `Text`, so the emitted value's segment order varied.
4. `identifyPlatformGroupings` / `extractUserIdentifiers` ranged over sets to build cluster metadata, which flows to JSON/YAML/SARIF output.

## Fix

- Order matches within a line by byte offset (then type, then text).
- Flatten the line map in ascending line order, via a shared `flattenLineMatchesSorted` helper used by **both** the clustering path and the failure fallback (so a clustering error can't reintroduce the bug).
- Sort the consolidated-text segments and the two metadata slices.

The clustering **partition** is now seeded in document order (earliest match first) — the natural, stable choice. This does **not** reduce recall: every distinct account still surfaces, either folded into a cluster that references it or on its own. Collapsing fragmented references of one profile into a single finding is clustering's designed behavior, not loss.

## Tests

Two regression tests, both **fail on the parent commit** (non-vacuous):
- `TestSocialMedia_ClusteringIsDeterministic` — runs a related-handle fixture 200× and asserts identical count **and** identical finding set. Parent: 74→32 finding flip.
- `TestSocialMedia_PerLineMatchOrderIsStable` — asserts stable raw per-line match order over 200 runs. Parent: order flips within a few iterations.

## Verification

On the real document: finding count **stable at 17 across 12 runs** (was 14–21), and the full JSON and SARIF output is **byte-identical across 10 runs** once this lands together with the `ClassifyDomain` tie-break already in #178. (The last residual — a `context_domain` Financial↔Government flip — is #178's `internal/context/analyzer.go` fix, a sibling of the same map-argmax class; this PR is **stacked on #178** so the two are tested together and CI sees the complete, deterministic result. I verified the combination directly by building this change on top of #178.)

`go build` / `go vet` / `-race` on the package / full `go test ./...` all green. **Golden impact: none** — the corpus has no `.html` social-media case.

## Sequencing

Stacked on #178 (`fix/keyword-underscore-boundary`) because full determinism of the SOCIAL_MEDIA output requires both this change and #178's `ClassifyDomain` tie-break. No file overlap between the two (this touches only `internal/validators/socialmedia/`).