### PR TITLE
fix(preprocessors): emit audio and video metadata properties in sorted key order

### DIFF
--- a/internal/preprocessors/meta-extractors/meta-extract-audiolib/audio-metadata.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-audiolib/audio-metadata.go
@@ -6,6 +6,7 @@ package audiolib
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 )
@@ -144,9 +145,18 @@ func (am *AudioMetadata) ToProcessedContent() string {
 		content.WriteString(fmt.Sprintf("Engineer: %s\n", am.Engineer))
 	}
 
-	// Additional properties
-	for key, value := range am.Properties {
-		if value != "" {
+	// Additional properties, emitted in sorted key order. Ranging over the map
+	// directly made the extracted text (and therefore every finding's line
+	// number, and the byte-for-byte redaction output) vary run to run — verified
+	// on a real .m4a where EncodingTool jumped lines between runs. The image
+	// metadata path already sorts its keys for exactly this reason.
+	propKeys := make([]string, 0, len(am.Properties))
+	for key := range am.Properties {
+		propKeys = append(propKeys, key)
+	}
+	sort.Strings(propKeys)
+	for _, key := range propKeys {
+		if value := am.Properties[key]; value != "" {
 			content.WriteString(fmt.Sprintf("%s: %s\n", key, value))
 		}
 	}

--- a/internal/preprocessors/meta-extractors/meta-extract-audiolib/determinism_test.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-audiolib/determinism_test.go
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package audiolib
+
+import (
+	"testing"
+)
+
+// TestToProcessedContent_DeterministicPropertyOrder is the regression test for
+// the audio-metadata emit nondeterminism. ToProcessedContent ranged over the
+// Properties map directly, so the extracted text — and therefore every finding's
+// line number and the byte-for-byte redaction output — varied run to run.
+// Verified originally on a real .m4a where EncodingTool jumped lines between runs.
+func TestToProcessedContent_DeterministicPropertyOrder(t *testing.T) {
+	am := &AudioMetadata{
+		Filename: "sample.m4a",
+		Properties: map[string]string{
+			"EncodingTool":    "com.apple.VoiceMemos",
+			"FileExtension":   ".m4a",
+			"FilePath":        "/tmp/sample.m4a",
+			"MajorBrand":      "M4A",
+			"MinorVersion":    "0",
+			"CompatibleBrand": "isom",
+			"CreationTime":    "2026-01-01",
+			"Encoder":         "example-encoder",
+			"HandlerType":     "soun",
+			"MediaLanguage":   "und",
+		},
+	}
+
+	first := am.ToProcessedContent()
+	for i := 0; i < 300; i++ {
+		if got := am.ToProcessedContent(); got != first {
+			t.Fatalf("iter %d: audio ToProcessedContent order is not stable:\n--- first ---\n%s\n--- iter %d ---\n%s", i, first, i, got)
+		}
+	}
+}

--- a/internal/preprocessors/meta-extractors/meta-extract-videolib/determinism_test.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-videolib/determinism_test.go
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package metaextractvideolib
+
+import (
+	"testing"
+)
+
+// TestToProcessedContent_DeterministicPropertyOrder is the regression test for
+// the video-metadata emit nondeterminism. ToProcessedContent ranged over the
+// Properties map directly, so the extracted text — and therefore finding line
+// numbers and the byte-for-byte redaction output — varied run to run. Verified
+// originally on a real .mov and .mp4.
+func TestToProcessedContent_DeterministicPropertyOrder(t *testing.T) {
+	vm := &VideoMetadata{
+		Filename: "sample.mov",
+		Properties: map[string]string{
+			"MajorBrand":      "qt",
+			"MinorVersion":    "0",
+			"CompatibleBrand": "qt",
+			"CreationTime":    "2026-01-01",
+			"HandlerType":     "vide",
+			"Encoder":         "example",
+			"MediaLanguage":   "und",
+			"ColorPrimaries":  "bt709",
+			"FrameRate":       "30",
+			"TrackCount":      "2",
+		},
+	}
+
+	first := vm.ToProcessedContent()
+	for i := 0; i < 300; i++ {
+		if got := vm.ToProcessedContent(); got != first {
+			t.Fatalf("iter %d: video ToProcessedContent order is not stable:\n--- first ---\n%s\n--- iter %d ---\n%s", i, first, i, got)
+		}
+	}
+}

--- a/internal/preprocessors/meta-extractors/meta-extract-videolib/determinism_test.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-videolib/determinism_test.go
@@ -4,6 +4,8 @@
 package metaextractvideolib
 
 import (
+	"math"
+	"strings"
 	"testing"
 )
 
@@ -34,5 +36,81 @@ func TestToProcessedContent_DeterministicPropertyOrder(t *testing.T) {
 		if got := vm.ToProcessedContent(); got != first {
 			t.Fatalf("iter %d: video ToProcessedContent order is not stable:\n--- first ---\n%s\n--- iter %d ---\n%s", i, first, i, got)
 		}
+	}
+}
+
+// TestSearchForGPSInMetadata_DeterministicCoordinate covers the second video-side
+// map-order defect: searchForGPSInMetadata scraped coordinates out of the
+// Properties map, and both parse helpers write the SAME scalar GPSLatitude/
+// GPSLongitude fields. Ranging the map meant whichever candidate property landed
+// last won, so the emitted "GPS_Coordinates" value itself — not just its position
+// in the text — changed between runs of the same binary on the same file.
+//
+// The fixture mirrors a real file: the property names are the udta string boxes
+// this scrape actually sees (Information, Warning, URL — populated by parseUdtaBox
+// before the scrape runs), two of which parse as coordinates. Built into a real
+// .mov with ffmpeg, this shape made the parent emit a SPLICED coordinate — the
+// latitude from "Information" with the longitude 11.111100 from "Warning" — in 23
+// of 25 runs, and the correct -82.698500 in the other 2. A wrong location, not
+// just a reordered one.
+//
+// So the assertion is on the VALUE, not merely on stability: "Warning" sorts
+// after "Information", so sorting the keys without the first-complete-wins guard
+// would be deterministic yet deterministically wrong.
+func TestSearchForGPSInMetadata_DeterministicCoordinate(t *testing.T) {
+	const wantLat, wantLon = 36.3506, -82.6985
+
+	newFixture := func() *VideoMetadata {
+		return &VideoMetadata{
+			Filename: "clip.mov",
+			Properties: map[string]string{
+				"Information": `36 deg 21' 2.16" N, 82 deg 41' 54.60" W, 447.403 m Above Sea Level`,
+				"Warning":     "Coordinates +11.1111-022.2222+033.333/ embedded",
+				"URL":         "https://example.test/clip?t=+1-2+3",
+				"Genre":       "example",
+				"MajorBrand":  "qt  ",
+			},
+		}
+	}
+
+	// DMS-to-decimal conversion is inexact, so compare within a tolerance far
+	// tighter than the gap between the competing candidates (whole degrees apart).
+	const eps = 1e-6
+
+	for i := 0; i < 300; i++ {
+		vm := newFixture()
+		searchForGPSInMetadata(vm)
+		if math.Abs(vm.GPSLatitude-wantLat) > eps || math.Abs(vm.GPSLongitude-wantLon) > eps {
+			t.Fatalf("iter %d: GPS scrape picked a different property: got (%.6f, %.6f), want (%.6f, %.6f)",
+				i, vm.GPSLatitude, vm.GPSLongitude, wantLat, wantLon)
+		}
+	}
+
+	// And the emitted text carries that one stable coordinate.
+	vm := newFixture()
+	searchForGPSInMetadata(vm)
+	out := vm.ToProcessedContent()
+	if !strings.Contains(out, "36.350600, -82.698500") {
+		t.Errorf("expected the stable coordinate in emitted text, got:\n%s", out)
+	}
+}
+
+// TestSearchForGPSInMetadata_DoesNotOverwriteContainerCoordinate asserts the
+// precedence half of the fix: when the container's own atom already produced a
+// complete coordinate, the property scrape must not replace it with a guess.
+func TestSearchForGPSInMetadata_DoesNotOverwriteContainerCoordinate(t *testing.T) {
+	vm := &VideoMetadata{
+		Filename:     "clip.mov",
+		GPSLatitude:  36.3506,
+		GPSLongitude: -82.6985,
+		Properties: map[string]string{
+			"Warning":    "Coordinates +11.1111-022.2222+033.333/ embedded",
+			"GPS_SOURCE": "Apple QuickTime Location",
+		},
+	}
+	searchForGPSInMetadata(vm)
+	if math.Abs(vm.GPSLatitude-36.3506) > 1e-6 || math.Abs(vm.GPSLongitude-(-82.6985)) > 1e-6 {
+		t.Errorf("property scrape overwrote the authoritative container coordinate: got (%.4f, %.4f)",
+			vm.GPSLatitude, vm.GPSLongitude)
 	}
 }

--- a/internal/preprocessors/meta-extractors/meta-extract-videolib/video-extractor.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-videolib/video-extractor.go
@@ -144,10 +144,42 @@ func ExtractVideoMetadataWithContext(ctx context.Context, filePath string) (*Vid
 	return metadata, nil
 }
 
-// searchForGPSInMetadata searches for GPS data in all metadata properties and values
+// searchForGPSInMetadata searches for GPS data in all metadata properties and values.
+//
+// This is a heuristic scrape: it guesses at coordinates from any property whose
+// key or value merely mentions "location"/"gps"/"deg", or whose value carries two
+// or more signs. Both parse helpers write the SCALAR GPSLatitude/GPSLongitude/
+// GPSAltitude fields, which are emitted as the single "GPS_Coordinates" line, so
+// two candidate properties compete for one output value. Iterating the map
+// directly made that competition a coin flip: the emitted coordinate could differ
+// run to run for the same file. Properties are therefore walked in sorted key
+// order, and the first complete pair wins.
+//
+// First-complete-wins also protects precision, which a bare sort would not. By
+// the time this runs, the container parse has already handled the authoritative
+// '©xyz' GPS atom, so a real coordinate may already be present. The properties
+// scanned here are mostly free text — the udta string boxes (Information,
+// Warning, URL, Lyrics, Source, ...) and unrecognized four-character ilst tags —
+// and any of them can mention "deg" or carry two signs and parse into a
+// meaningless coordinate. Sorting alone would still let such a value overwrite
+// the atom's; stopping at the first complete pair keeps the better value instead
+// of merely making the worse one repeatable.
 func searchForGPSInMetadata(metadata *VideoMetadata) {
+	keys := make([]string, 0, len(metadata.Properties))
+	for key := range metadata.Properties {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
 	// Search in existing properties
-	for key, value := range metadata.Properties {
+	for _, key := range keys {
+		if metadata.GPSLatitude != 0 && metadata.GPSLongitude != 0 {
+			// A complete coordinate is already known (from the container atom or
+			// an earlier property); do not let a later guess overwrite it.
+			return
+		}
+		value := metadata.Properties[key]
+
 		if strings.Contains(strings.ToLower(key), "location") ||
 			strings.Contains(strings.ToLower(key), "gps") ||
 			strings.Contains(strings.ToLower(value), "location") ||

--- a/internal/preprocessors/meta-extractors/meta-extract-videolib/video-extractor.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-videolib/video-extractor.go
@@ -12,6 +12,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -1195,9 +1196,17 @@ func (vm *VideoMetadata) ToProcessedContent() string {
 		content.WriteString(fmt.Sprintf("Software: %s\n", vm.Software))
 	}
 
-	// Additional properties
-	for key, value := range vm.Properties {
-		if value != "" {
+	// Additional properties, emitted in sorted key order. Ranging over the map
+	// directly made the extracted text (and therefore finding line numbers and
+	// the byte-for-byte redaction output) vary run to run — verified on a real
+	// .mov. The image metadata path already sorts its keys for this reason.
+	propKeys := make([]string, 0, len(vm.Properties))
+	for key := range vm.Properties {
+		propKeys = append(propKeys, key)
+	}
+	sort.Strings(propKeys)
+	for _, key := range propKeys {
+		if value := vm.Properties[key]; value != "" {
 			content.WriteString(fmt.Sprintf("%s: %s\n", key, value))
 		}
 	}

--- a/internal/preprocessors/shared_utilities_determinism_test.go
+++ b/internal/preprocessors/shared_utilities_determinism_test.go
@@ -1,0 +1,65 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package preprocessors
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFormatPropertiesMap_DeterministicOrder is the regression test for the
+// metadata-emit nondeterminism. FormatPropertiesMap ranged over the properties
+// map directly, so the formatted metadata text — and therefore every finding's
+// line number and the byte-for-byte redaction output — varied run to run.
+//
+// Go randomizes map iteration WITHIN a single process across range statements,
+// so calling the function repeatedly in one test samples different orders; on
+// the unfixed code this fails within a handful of iterations.
+func TestFormatPropertiesMap_DeterministicOrder(t *testing.T) {
+	mf := NewMetadataFormatter()
+
+	props := map[string]string{
+		"EncodingTool": "com.example.Tool 1.0",
+		"Album":        "Example Album",
+		"Artist":       "Example Artist",
+		"Comment":      "some comment",
+		"Genre":        "Example",
+		"Track":        "3",
+		"Year":         "2026",
+		"Composer":     "Example Composer",
+		"Publisher":    "Example Publisher",
+		"Copyright":    "example",
+	}
+
+	first := mf.FormatPropertiesMap(props, nil)
+	for i := 0; i < 300; i++ {
+		if got := mf.FormatPropertiesMap(props, nil); got != first {
+			t.Fatalf("iter %d: FormatPropertiesMap output order is not stable:\n--- first ---\n%s\n--- iter %d ---\n%s", i, first, i, got)
+		}
+	}
+}
+
+// TestFormatPropertiesMap_ExclusionAndEmptyStillHold guards that making the
+// order deterministic did not change WHICH properties are emitted: excluded keys
+// and empty values must still be dropped.
+func TestFormatPropertiesMap_ExclusionAndEmptyStillHold(t *testing.T) {
+	mf := NewMetadataFormatter()
+
+	props := map[string]string{
+		"Keep":        "value",
+		"DropEmpty":   "",
+		"DropExclude": "should not appear",
+	}
+	out := mf.FormatPropertiesMap(props, []string{"DropExclude"})
+
+	if !strings.Contains(out, "Keep") {
+		t.Errorf("kept key missing from output: %q", out)
+	}
+	if strings.Contains(out, "DropEmpty") {
+		t.Errorf("empty-valued key should be dropped: %q", out)
+	}
+	if strings.Contains(out, "DropExclude") {
+		t.Errorf("excluded key should be dropped: %q", out)
+	}
+}


### PR DESCRIPTION
Audio and video metadata serialized a Go **map** straight to the extracted-text output by ranging over it. Map iteration order is randomized per run, so the extracted text — and therefore **every finding's line number and the byte-for-byte redaction output** — changed run to run on the same binary. For a redaction tool that is a correctness bug: unstable line numbers mean unstable redaction output and unstable suppression hashes over unchanged input.

> **Scope changed after a rebase onto `main` (`a8a4a39`).** The Office half of this fix landed independently via #181, which needed `FormatPropertiesMap` sorted to make container extraction reproducible. Both Office files are now **byte-identical to `main`** on this branch; what this PR adds for them is the regression test #181 shipped without. See [the rebase comment](https://github.com/awslabs/ferret-scan/pull/186#issuecomment-5106925996) for the full re-verification.

## Verified on real files

- A real `.m4a` whose `EncodingTool` line jumped position between runs.
- A real `.mov` whose HIGH-confidence GPS finding moves **line 9 <-> 8** across runs of the same binary — `main` splits 2/8 over 10 runs, this PR is 1 distinct.
- A real `.mp4` whose entire output hashed differently across runs.

The line shift is not cosmetic: on `main` the **suppression hash** for that unchanged file changes with it (`3c2f01f5...` vs `db93a781...`), so a captured baseline silently stops matching on the next run.

## Fix

The image metadata path already sorted its keys (`GetSortedKeys`) for exactly this reason; audio and video never got the same treatment. This brings them in line:
- `audiolib` `AudioMetadata.ToProcessedContent`
- `videolib` `VideoMetadata.ToProcessedContent`

Plus the GPS coordinate fix in commit 2 (first-complete-pair-wins, so the container's authoritative `(c)xyz` atom is not overwritten by a free-text scrape), and the `FormatPropertiesMap` regression test.

**Why sort is the right tool here, and its cost:** these emit a map to output *once per file*, so `O(n log n)` on a few dozen keys is microseconds against multi-millisecond extraction. Interleaved best-of-5 fix/base ratios: `.m4a` x0.983, `.mov` x1.017, `.mp4` x1.006. Scaling at n=100/200/400/800 gives per-doubling ratios 1.79 / 1.80 / 1.80 — n log n, not quadratic. (Argmax and per-match hot-path map iteration are a different category with different fixes — tie-break comparators and natural-order preservation respectively — and are not touched here.)

## Tests

Non-vacuous, re-checked after the rebase by copying the new test files onto `main`: both `ToProcessedContent` tests and both GPS tests **fail on `main`**. The `FormatPropertiesMap` test passes there, which is the correct reason to keep it — it guards a fix that currently has no test.

`gofmt` / `go build` / `go vet` / `GOOS=windows` / `GOOS=linux` / `-race` / full suite (53 packages) all clean. Golden corpus 5/5 consecutive passes. **Golden impact: none.** Finding sets identical to `main` across all fixtures — 0 new FPs, 0 lost TPs.

## Out of scope (verified, not this PR)

- Redacted `.docx` **container** bytes still vary, but the unzipped payload is byte-identical (`diff -r` clean) — zip metadata, which is #190.
- `.mov`/`.m4a` redaction erases findings entirely — that is #201, confirmed fixed when stacked with it.
- `gitlab-sast` "Additional Information" bullet order — #189. Stacked #189 + this PR: all 7 formats 1 distinct / 10 runs.

## Scope note

This PR is the concrete, verified subset of a broader "PR-5" grab-bag. The phone country-code comparator I investigated and **proved is not a determinism bug** (distinct same-length codes cannot both prefix-match, and the length-desc sort handles nesting deterministically — confirmed empirically over 100 runs). Help-text items were speculative and dropped for lack of a demonstrable defect.

Merges clean against `main` and all 15 other open PR branches.
