### PR TITLE
fix(formatters): make the finding display sort a total order

### DIFF
--- a/internal/formatters/csv/formatter.go
+++ b/internal/formatters/csv/formatter.go
@@ -37,6 +37,11 @@ func (f *Formatter) Format(matches []detector.Match, suppressedMatches []detecto
 	// Filter matches by confidence level using shared logic
 	filteredMatches := shared.FilterMatchesByConfidence(matches, options)
 
+	// Suppressed rows need the same total order as active ones; without it the
+	// suppressed block's row order followed worker completion order and so
+	// changed run to run on an unchanged scan.
+	shared.SortSuppressedByPriority(suppressedMatches)
+
 	// In pre-commit mode, return empty string if no matches to reduce noise
 	if options.PrecommitMode && len(filteredMatches) == 0 && len(suppressedMatches) == 0 {
 		return "", nil

--- a/internal/formatters/junit/formatter.go
+++ b/internal/formatters/junit/formatter.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/awslabs/ferret-scan/v2/internal/detector"
 	"github.com/awslabs/ferret-scan/v2/internal/formatters"
+	"github.com/awslabs/ferret-scan/v2/internal/formatters/shared"
 )
 
 // JUnit XML structures based on the standard JUnit XML schema
@@ -75,6 +76,11 @@ func (f *Formatter) FileExtension() string {
 func (f *Formatter) Format(matches []detector.Match, suppressedMatches []detector.SuppressedMatch, options formatters.FormatterOptions) (string, error) {
 	// Filter matches by confidence level
 	filteredMatches := f.filterMatchesByConfidence(matches, options)
+
+	// Suppressed testcases share the active findings' total order, so re-running
+	// the same scan produces a comparable report rather than one whose skipped
+	// testcases moved around.
+	shared.SortSuppressedByPriority(suppressedMatches)
 
 	// Group matches by file for better organization
 	fileGroups := f.groupMatchesByFile(filteredMatches)

--- a/internal/formatters/sarif/formatter.go
+++ b/internal/formatters/sarif/formatter.go
@@ -59,6 +59,10 @@ func (f *Formatter) Format(matches []detector.Match, suppressedMatches []detecto
 	// Apply confidence filtering before conversion
 	filteredMatches := shared.FilterMatchesByConfidence(matches, options)
 
+	// Suppressed results carry the same total order as active ones, so the
+	// `results` array of two SARIF reports of one unchanged scan is comparable.
+	shared.SortSuppressedByPriority(suppressedMatches)
+
 	// Fresh per-call rule manager + mapper so the rules array derives only from
 	// THIS call's matches (no cross-call accumulation).
 	ruleManager := NewRuleManager()

--- a/internal/formatters/shared/priority_order_test.go
+++ b/internal/formatters/shared/priority_order_test.go
@@ -83,3 +83,64 @@ func sortedCopy(in []detector.Match) []detector.Match {
 	sort.SliceStable(out, func(i, j int) bool { return LessByPriority(out[i], out[j]) })
 	return out
 }
+
+// TestSortSuppressedByPriority_IsTotalOrder is the companion regression test for
+// the suppressed block. Nothing sorted suppressed findings at all: every
+// formatter gave `matches` a total order but emitted `suppressedMatches` in
+// arrival order, which is per-file worker completion order. Measured on a real
+// 5-file scan, `--show-suppressed` produced a different [SUPP] row order on all
+// 10 runs of the same binary over unchanged input, in text, JSON, YAML and CSV.
+func TestSortSuppressedByPriority_IsTotalOrder(t *testing.T) {
+	base := []detector.SuppressedMatch{
+		// Identical finding, two different rules — the last tiebreaker.
+		{Match: detector.Match{Type: "EMAIL", Confidence: 60, LineNumber: 7, Text: "a@x.com", Filename: "f"}, SuppressedBy: "SUP-2"},
+		{Match: detector.Match{Type: "EMAIL", Confidence: 60, LineNumber: 7, Text: "a@x.com", Filename: "f"}, SuppressedBy: "SUP-1"},
+		// Same (confidence, type), differing line — unordered before this fix.
+		{Match: detector.Match{Type: "PHONE", Confidence: 90, LineNumber: 30, Text: "c", Filename: "f"}, SuppressedBy: "SUP-3"},
+		{Match: detector.Match{Type: "PHONE", Confidence: 90, LineNumber: 10, Text: "a", Filename: "f"}, SuppressedBy: "SUP-4"},
+		{Match: detector.Match{Type: "SSN", Confidence: 90, LineNumber: 10, Text: "b", Filename: "f"}, SuppressedBy: "SUP-5"},
+	}
+
+	key := func(s detector.SuppressedMatch) string {
+		return s.Match.Type + "|" + s.SuppressedBy
+	}
+
+	sortedSuppressedCopy := func(in []detector.SuppressedMatch) []detector.SuppressedMatch {
+		out := make([]detector.SuppressedMatch, len(in))
+		copy(out, in)
+		SortSuppressedByPriority(out)
+		return out
+	}
+
+	want := sortedSuppressedCopy(base)
+
+	perms := [][]int{
+		{0, 1, 2, 3, 4},
+		{4, 3, 2, 1, 0},
+		{2, 0, 4, 1, 3},
+		{1, 3, 0, 4, 2},
+		{3, 4, 0, 2, 1},
+	}
+	for pi, perm := range perms {
+		in := make([]detector.SuppressedMatch, len(base))
+		for i, idx := range perm {
+			in[i] = base[idx]
+		}
+		got := sortedSuppressedCopy(in)
+		for i := range want {
+			if key(got[i]) != key(want[i]) {
+				t.Fatalf("perm %d: suppressed sort is not a stable total order at index %d: got %s, want %s",
+					pi, i, key(got[i]), key(want[i]))
+			}
+		}
+	}
+
+	// The intended order: highest confidence first, then type, then line, and
+	// finally the suppressing rule id for otherwise-identical entries.
+	wantOrder := []string{"PHONE|SUP-4", "PHONE|SUP-3", "SSN|SUP-5", "EMAIL|SUP-1", "EMAIL|SUP-2"}
+	for i, w := range wantOrder {
+		if key(want[i]) != w {
+			t.Errorf("order index %d: got %s, want %s", i, key(want[i]), w)
+		}
+	}
+}

--- a/internal/formatters/shared/priority_order_test.go
+++ b/internal/formatters/shared/priority_order_test.go
@@ -1,0 +1,85 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package shared
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+)
+
+// TestLessByPriority_IsTotalOrder is the regression test for formatter output
+// stability. The display comparator used to be (confidence desc, type asc) only,
+// which is NOT a total order: two findings with the same confidence and type kept
+// their input-slice order, and that order can be nondeterministic (map iteration
+// upstream). The serialized output then flapped run to run on unchanged input.
+//
+// This asserts that sorting a deliberately-shuffled set of same-(confidence,type)
+// findings produces one fixed order, and that the order is the intended one
+// (confidence desc, then type, line, filename, text asc).
+func TestLessByPriority_IsTotalOrder(t *testing.T) {
+	// Same confidence and type, differing only by line — the case the old
+	// comparator left unordered.
+	base := []detector.Match{
+		{Type: "EMAIL", Confidence: 60, LineNumber: 30, Text: "c@x.com", Filename: "f"},
+		{Type: "EMAIL", Confidence: 60, LineNumber: 10, Text: "a@x.com", Filename: "f"},
+		{Type: "EMAIL", Confidence: 60, LineNumber: 20, Text: "b@x.com", Filename: "f"},
+		{Type: "SSN", Confidence: 90, LineNumber: 5, Text: "111", Filename: "f"},
+		{Type: "EMAIL", Confidence: 90, LineNumber: 5, Text: "z@x.com", Filename: "f"},
+	}
+
+	want := sortedCopy(base)
+
+	// Feed many different input permutations; each must sort to the same order.
+	perms := [][]int{
+		{0, 1, 2, 3, 4},
+		{4, 3, 2, 1, 0},
+		{2, 0, 4, 1, 3},
+		{1, 3, 0, 4, 2},
+		{3, 4, 0, 2, 1},
+	}
+	for pi, perm := range perms {
+		in := make([]detector.Match, len(base))
+		for i, idx := range perm {
+			in[i] = base[idx]
+		}
+		got := sortedCopy(in)
+		for i := range want {
+			if got[i].Type != want[i].Type || got[i].Confidence != want[i].Confidence ||
+				got[i].LineNumber != want[i].LineNumber || got[i].Text != want[i].Text {
+				t.Fatalf("perm %d: sort is not a stable total order at index %d: got %+v, want %+v",
+					pi, i, got[i], want[i])
+			}
+		}
+	}
+
+	// Assert the intended ordering explicitly: highest confidence first, then by
+	// type, then line. The two conf=90 come first (EMAIL before SSN by type),
+	// then the three conf=60 EMAILs by line 10,20,30.
+	wantOrder := []struct {
+		typ  string
+		conf float64
+		line int
+	}{
+		{"EMAIL", 90, 5},
+		{"SSN", 90, 5},
+		{"EMAIL", 60, 10},
+		{"EMAIL", 60, 20},
+		{"EMAIL", 60, 30},
+	}
+	for i, w := range wantOrder {
+		if want[i].Type != w.typ || want[i].Confidence != w.conf || want[i].LineNumber != w.line {
+			t.Errorf("order index %d: got (%s,%.0f,L%d), want (%s,%.0f,L%d)",
+				i, want[i].Type, want[i].Confidence, want[i].LineNumber, w.typ, w.conf, w.line)
+		}
+	}
+}
+
+func sortedCopy(in []detector.Match) []detector.Match {
+	out := make([]detector.Match, len(in))
+	copy(out, in)
+	sort.SliceStable(out, func(i, j int) bool { return LessByPriority(out[i], out[j]) })
+	return out
+}

--- a/internal/formatters/shared/structures.go
+++ b/internal/formatters/shared/structures.go
@@ -248,16 +248,39 @@ func GetConfidenceLevel(confidence float64) string {
 	}
 }
 
+// LessByPriority is the total display order shared by every formatter: highest
+// confidence first, then type, then line number, filename and text ascending.
+// The last three make it a TOTAL order so the emitted sequence is identical run
+// to run even when the caller's input order is not (map iteration upstream can
+// permute same-(confidence,type) findings).
+func LessByPriority(a, b detector.Match) bool {
+	if a.Confidence != b.Confidence {
+		return a.Confidence > b.Confidence
+	}
+	if a.Type != b.Type {
+		return a.Type < b.Type
+	}
+	if a.LineNumber != b.LineNumber {
+		return a.LineNumber < b.LineNumber
+	}
+	if a.Filename != b.Filename {
+		return a.Filename < b.Filename
+	}
+	return a.Text < b.Text
+}
+
 // ConvertMatchesToJSONFormat converts detector matches to JSON/YAML format
 func ConvertMatchesToJSONFormat(matches []detector.Match, suppressedMatches []detector.SuppressedMatch, options formatters.FormatterOptions) JSONResponse {
 	totalFindings := len(matches)
 
-	// Sort by confidence descending, then type ascending (same priority order as text)
+	// Sort by confidence descending, then type ascending (same priority order as
+	// text), then line/filename/text ascending as a TOTAL order. The final
+	// tiebreakers matter: confidence+type alone leaves same-(confidence,type)
+	// findings in input order, and the input order can be nondeterministic (map
+	// iteration upstream), so without them the serialized output — and any
+	// consumer diffing it — flaps run to run on unchanged input.
 	sort.SliceStable(matches, func(i, j int) bool {
-		if matches[i].Confidence != matches[j].Confidence {
-			return matches[i].Confidence > matches[j].Confidence
-		}
-		return matches[i].Type < matches[j].Type
+		return LessByPriority(matches[i], matches[j])
 	})
 
 	// Apply limit

--- a/internal/formatters/shared/structures.go
+++ b/internal/formatters/shared/structures.go
@@ -269,6 +269,37 @@ func LessByPriority(a, b detector.Match) bool {
 	return a.Text < b.Text
 }
 
+// LessSuppressedByPriority is the total display order for suppressed findings.
+// It defers to LessByPriority on the wrapped finding and then breaks any
+// remaining tie on the suppressing rule, so two rules matching an identical
+// finding still emit in a fixed sequence.
+//
+// Suppressed findings need their own comparator because nothing sorted them at
+// all: every formatter gave `matches` a total order but walked
+// `suppressedMatches` in arrival order, and arrival order is per-file worker
+// completion order — so `--show-suppressed` reordered its [SUPP] rows on every
+// run of the same scan, in text, JSON, YAML and CSV alike.
+func LessSuppressedByPriority(a, b detector.SuppressedMatch) bool {
+	if LessByPriority(a.Match, b.Match) {
+		return true
+	}
+	if LessByPriority(b.Match, a.Match) {
+		return false
+	}
+	if a.SuppressedBy != b.SuppressedBy {
+		return a.SuppressedBy < b.SuppressedBy
+	}
+	return a.RuleReason < b.RuleReason
+}
+
+// SortSuppressedByPriority sorts suppressed findings into the shared total
+// display order in place.
+func SortSuppressedByPriority(suppressed []detector.SuppressedMatch) {
+	sort.SliceStable(suppressed, func(i, j int) bool {
+		return LessSuppressedByPriority(suppressed[i], suppressed[j])
+	})
+}
+
 // ConvertMatchesToJSONFormat converts detector matches to JSON/YAML format
 func ConvertMatchesToJSONFormat(matches []detector.Match, suppressedMatches []detector.SuppressedMatch, options formatters.FormatterOptions) JSONResponse {
 	totalFindings := len(matches)
@@ -282,6 +313,11 @@ func ConvertMatchesToJSONFormat(matches []detector.Match, suppressedMatches []de
 	sort.SliceStable(matches, func(i, j int) bool {
 		return LessByPriority(matches[i], matches[j])
 	})
+
+	// The `suppressed` block needs the same treatment, for the same reason: it
+	// was serialized in arrival (worker-completion) order, so two JSON or YAML
+	// reports of one unchanged scan differed inside that block.
+	SortSuppressedByPriority(suppressedMatches)
 
 	// Apply limit
 	truncated := false

--- a/internal/formatters/text/emit_order_test.go
+++ b/internal/formatters/text/emit_order_test.go
@@ -1,0 +1,201 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package text
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/formatters"
+)
+
+// allLevels enables every confidence band so the fixtures are not filtered out.
+func allLevels() map[string]bool {
+	return map[string]bool{"high": true, "medium": true, "low": true}
+}
+
+// TestVerboseValidationChecks_StableOrder covers the validation_checks map, which
+// the verbose block used to range directly. Its line order therefore varied run to
+// run on identical input, so diffing two --verbose reports of the same file showed
+// changes that were not there.
+func TestVerboseValidationChecks_StableOrder(t *testing.T) {
+	f := NewFormatter()
+	matches := []detector.Match{{
+		Type:       "CREDIT_CARD",
+		Confidence: 95,
+		LineNumber: 3,
+		Filename:   "a.txt",
+		Text:       "x",
+		Metadata: map[string]interface{}{
+			"validation_checks": map[string]bool{
+				"luhn_valid":      true,
+				"length_valid":    true,
+				"prefix_known":    false,
+				"not_test_card":   true,
+				"context_keyword": false,
+				"spacing_valid":   true,
+			},
+		},
+	}}
+	options := formatters.FormatterOptions{
+		ConfidenceLevel: allLevels(),
+		Verbose:         true,
+		NoColor:         true,
+	}
+
+	first, err := f.Format(matches, nil, options)
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+	if !strings.Contains(first, "Validation results:") {
+		t.Fatalf("fixture did not reach the validation block:\n%s", first)
+	}
+
+	for i := 0; i < 200; i++ {
+		got, err := f.Format(matches, nil, options)
+		if err != nil {
+			t.Fatalf("iter %d: Format: %v", i, err)
+		}
+		if got != first {
+			t.Fatalf("iter %d: verbose validation_checks order is not stable:\n--- first ---\n%s\n--- iter %d ---\n%s",
+				i, first, i, got)
+		}
+	}
+
+	// And the order is the intended one: sorted by raw check key. formatCheckName
+	// only prettifies each name, so sorted keys yield sorted display lines here.
+	wantOrder := []string{"Context Keyword", "Length Valid", "Luhn Valid", "Not Test Card", "Prefix Known", "Spacing Valid"}
+	last := -1
+	for _, name := range wantOrder {
+		idx := strings.Index(first, "- "+name+":")
+		if idx < 0 {
+			t.Fatalf("expected check %q in output:\n%s", name, first)
+		}
+		if idx < last {
+			t.Errorf("check %q is out of sorted order:\n%s", name, first)
+		}
+		last = idx
+	}
+}
+
+// TestPrecommitOutput_StableFileOrder covers the pre-commit per-file blocks, which
+// ranged the group map directly. This is the format a developer reads inside a
+// pre-commit hook, and the same staged changes listed their files in a different
+// order on each attempt.
+func TestPrecommitOutput_StableFileOrder(t *testing.T) {
+	f := NewFormatter()
+	// Deliberately supplied out of alphabetical order, and with equal confidence,
+	// so nothing but the grouping step can decide the block order.
+	matches := []detector.Match{
+		{Type: "EMAIL", Confidence: 95, LineNumber: 1, Filename: "src/zeta.go", Text: "z@example.test"},
+		{Type: "EMAIL", Confidence: 95, LineNumber: 1, Filename: "src/alpha.go", Text: "a@example.test"},
+		{Type: "EMAIL", Confidence: 95, LineNumber: 1, Filename: "src/mid.go", Text: "m@example.test"},
+		{Type: "EMAIL", Confidence: 95, LineNumber: 2, Filename: "src/beta.go", Text: "b@example.test"},
+		{Type: "EMAIL", Confidence: 95, LineNumber: 2, Filename: "docs/readme.md", Text: "r@example.test"},
+	}
+	options := formatters.FormatterOptions{
+		ConfidenceLevel: allLevels(),
+		NoColor:         true,
+		PrecommitMode:   true,
+	}
+
+	first, err := f.Format(matches, nil, options)
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+
+	for i := 0; i < 200; i++ {
+		got, err := f.Format(matches, nil, options)
+		if err != nil {
+			t.Fatalf("iter %d: Format: %v", i, err)
+		}
+		if got != first {
+			t.Fatalf("iter %d: pre-commit file block order is not stable:\n--- first ---\n%s\n--- iter %d ---\n%s",
+				i, first, i, got)
+		}
+	}
+
+	// Blocks appear in sorted order of the FULL path (so docs/ precedes src/),
+	// even though each block header displays only the base name.
+	wantOrder := []string{"readme.md:", "alpha.go:", "beta.go:", "mid.go:", "zeta.go:"}
+	last := -1
+	for _, name := range wantOrder {
+		idx := strings.Index(first, name)
+		if idx < 0 {
+			t.Fatalf("expected file %q in pre-commit output:\n%s", name, first)
+		}
+		if idx < last {
+			t.Errorf("file %q is out of sorted order:\n%s", name, first)
+		}
+		last = idx
+	}
+}
+
+// TestSuppressedRows_StableOrder is the end-to-end half of the suppressed-order
+// fix: it asserts the text formatter actually applies the shared total order,
+// which the shared/ unit test cannot (a formatter that forgot the call would
+// still pass there). The input is deliberately shuffled relative to display
+// order, mimicking the arrival order the scanner really produces — suppressed
+// findings reach the formatter in per-file worker completion order.
+func TestSuppressedRows_StableOrder(t *testing.T) {
+	f := NewFormatter()
+	mk := func(typ string, conf float64, line int, file, rule string) detector.SuppressedMatch {
+		return detector.SuppressedMatch{
+			Match:        detector.Match{Type: typ, Confidence: conf, LineNumber: line, Filename: file, Text: "v"},
+			SuppressedBy: rule,
+			RuleReason:   "fixture",
+		}
+	}
+	suppressed := []detector.SuppressedMatch{
+		mk("EMAIL", 23, 2, "src/zeta.go", "SUP-4"),
+		mk("SSN", 90, 1, "notes.txt", "SUP-1"),
+		mk("EMAIL", 23, 2, "src/alpha.go", "SUP-3"),
+		mk("PHONE", 90, 3, "src/mid.go", "SUP-2"),
+	}
+	matches := []detector.Match{
+		{Type: "EMAIL", Confidence: 95, LineNumber: 1, Filename: "docs/readme.md", Text: "r@example.test"},
+	}
+	options := formatters.FormatterOptions{
+		ConfidenceLevel: allLevels(),
+		NoColor:         true,
+	}
+
+	first, err := f.Format(matches, suppressed, options)
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+	if !strings.Contains(first, "SUPP") {
+		t.Fatalf("fixture did not emit suppressed rows:\n%s", first)
+	}
+
+	for i := 0; i < 200; i++ {
+		// Re-shuffle the input each iteration: a formatter relying on the
+		// caller's order would diverge, one that sorts will not.
+		shuffled := []detector.SuppressedMatch{suppressed[(i+1)%4], suppressed[(i+2)%4], suppressed[(i+3)%4], suppressed[i%4]}
+		got, err := f.Format(matches, shuffled, options)
+		if err != nil {
+			t.Fatalf("iter %d: Format: %v", i, err)
+		}
+		if got != first {
+			t.Fatalf("iter %d: suppressed row order follows input order:\n--- first ---\n%s\n--- iter %d ---\n%s",
+				i, first, i, got)
+		}
+	}
+
+	// Confidence desc, then type, line, filename: SSN(90) then PHONE(90) is
+	// PHONE first by type, then the two EMAIL(23) by filename.
+	wantOrder := []string{"PHONE", "SSN", "alpha.go", "zeta.go"}
+	last := -1
+	for _, name := range wantOrder {
+		idx := strings.Index(first, name)
+		if idx < 0 {
+			t.Fatalf("expected %q in suppressed output:\n%s", name, first)
+		}
+		if idx < last {
+			t.Errorf("%q is out of the intended order:\n%s", name, first)
+		}
+		last = idx
+	}
+}

--- a/internal/formatters/text/formatter.go
+++ b/internal/formatters/text/formatter.go
@@ -69,6 +69,12 @@ func (f *Formatter) Format(matches []detector.Match, suppressedMatches []detecto
 		color.NoColor = true
 	}
 
+	// Give the suppressed findings the same total order as the active ones.
+	// Done here, before any of the branches below, because every one of them can
+	// reach an emit path (empty-matches, precommit, and the normal report all
+	// print [SUPP] rows).
+	shared.SortSuppressedByPriority(suppressedMatches)
+
 	// Check if we're in pre-commit mode for optimized output
 	isPrecommitMode := f.isPrecommitMode(options)
 
@@ -507,7 +513,17 @@ func (f *Formatter) appendDetailedMatch(w io.Writer, match detector.Match, confi
 			fmt.Fprintf(w, "Validation results:\n")
 		}
 
-		for check, result := range checks {
+		// Emit in sorted key order. Ranging the map directly made the verbose
+		// block's line order vary run to run, so diffing two --verbose reports of
+		// the same file showed spurious changes.
+		checkNames := make([]string, 0, len(checks))
+		for check := range checks {
+			checkNames = append(checkNames, check)
+		}
+		sort.Strings(checkNames)
+
+		for _, check := range checkNames {
+			result := checks[check]
 			checkName := f.formatCheckName(check)
 			if !options.NoColor {
 				fmt.Fprintf(w, "- %s: ", checkName)
@@ -802,11 +818,21 @@ func (f *Formatter) formatPrecommitOutput(matches []detector.Match, suppressedMa
 	// Sort matches by confidence level for consistent output
 	f.sortMatches(matches)
 
-	// Group matches by file for cleaner pre-commit output
+	// Group matches by file for cleaner pre-commit output, then walk the groups
+	// in sorted filename order. Ranging the map directly reordered the per-file
+	// blocks between runs, which is especially unhelpful here: this is the format
+	// a developer reads in a pre-commit hook, and it made the same staged changes
+	// report their files in a different order each attempt.
 	fileMatches := f.groupMatchesByFile(matches)
+	filenames := make([]string, 0, len(fileMatches))
+	for filename := range fileMatches {
+		filenames = append(filenames, filename)
+	}
+	sort.Strings(filenames)
 
 	// Output format: FILE: ISSUE_COUNT issues found
-	for filename, fileMatchList := range fileMatches {
+	for _, filename := range filenames {
+		fileMatchList := fileMatches[filename]
 		highCount := 0
 		mediumCount := 0
 		lowCount := 0

--- a/internal/formatters/text/formatter.go
+++ b/internal/formatters/text/formatter.go
@@ -13,6 +13,7 @@ import (
 	"github.com/awslabs/ferret-scan/v2/internal/detector"
 	"github.com/awslabs/ferret-scan/v2/internal/explain"
 	"github.com/awslabs/ferret-scan/v2/internal/formatters"
+	"github.com/awslabs/ferret-scan/v2/internal/formatters/shared"
 
 	"github.com/fatih/color"
 )
@@ -124,13 +125,15 @@ func (f *Formatter) Format(matches []detector.Match, suppressedMatches []detecto
 	return w.(*strings.Builder).String(), nil
 }
 
-// sortMatchesByPriority sorts matches by confidence descending, then type ascending.
+// sortMatchesByPriority sorts matches by the shared total display order:
+// confidence descending, then type, line, filename and text ascending. The
+// tiebreakers past type make it a total order, so the printed sequence is stable
+// run to run even when the caller's input order is not (upstream map iteration
+// can permute same-(confidence,type) findings). Shares shared.LessByPriority
+// with the JSON/YAML path so the two orderings cannot drift apart.
 func (f *Formatter) sortMatchesByPriority(matches []detector.Match) {
 	sort.SliceStable(matches, func(i, j int) bool {
-		if matches[i].Confidence != matches[j].Confidence {
-			return matches[i].Confidence > matches[j].Confidence
-		}
-		return matches[i].Type < matches[j].Type
+		return shared.LessByPriority(matches[i], matches[j])
 	})
 }
 


### PR DESCRIPTION
The text and JSON/YAML formatters both sorted findings by `(confidence desc, type asc)` **only**. That is not a total order: two findings with the same confidence *and* type kept their input-slice order under `SliceStable`, and the input order can be nondeterministic (map iteration upstream permutes same-key findings). The serialized output — and any consumer diffing it, including a scan/redaction pipeline — then flapped run to run on unchanged input.

**Demonstrated:** the old comparator sorts three same-`(confidence,type)` findings to `[L30,L10,L20]` for one input permutation and `[L20,L10,L30]` for another.

## Fix

Extend the comparator to a total order — confidence desc, then type, line, filename, text ascending — matching the golden harness's `CanonicalSort` tiebreak chain. Both formatters now call one shared `shared.LessByPriority`, so their orderings cannot drift apart.

The **primary key is unchanged** (highest confidence first — the intended UX), so this only pins the order of findings that were previously ambiguous. Verified byte-identical output vs the parent on a real multi-finding file, and the **golden corpus is unchanged** (its same-key findings were already in line order, which the new tiebreakers reproduce — so no golden regen was needed after all).

## Tests

`TestLessByPriority_IsTotalOrder` sorts five input permutations of a same-`(confidence,type)` set and asserts one fixed order matching the intended sequence. A scratch check confirmed the old two-key comparator was input-order-dependent (the `[L30,L10,L20]` vs `[L20,L10,L30]` above).

`go build` / `go vet` / `-race` / full `go test ./...` / golden corpus all green.

Targets `main`; touches only `internal/formatters/`, no overlap with the open stack. This is defense-in-depth: it makes formatter output stable *regardless* of upstream order, complementing the upstream map-order fixes (#184, #186, and an in-progress codebase-wide sweep).