### PR TITLE
fix(pptx): order slides numerically and attach speaker notes via slide rels

### DIFF
--- a/internal/preprocessors/text-extractors/text-extract-officetextlib/office-text-extractor.go
+++ b/internal/preprocessors/text-extractors/text-extract-officetextlib/office-text-extractor.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -328,23 +329,31 @@ func extractPptxText(filePath string, content *TextContent) (*TextContent, error
 	}
 	defer reader.Close()
 
-	// Find all presentation content files
+	// Find all presentation content files. byName lets us resolve a slide's notes
+	// through its relationships part, rather than guessing by position.
 	var slides []*zip.File
-	var notes []*zip.File
 	var masters []*zip.File
 	var corePropsFile *zip.File
+	byName := make(map[string]*zip.File, len(reader.File))
 
 	for _, file := range reader.File {
+		byName[file.Name] = file
 		if strings.HasPrefix(file.Name, "ppt/slides/slide") && strings.HasSuffix(file.Name, ".xml") {
 			slides = append(slides, file)
-		} else if strings.HasPrefix(file.Name, "ppt/notesSlides/notesSlide") && strings.HasSuffix(file.Name, ".xml") {
-			notes = append(notes, file)
 		} else if strings.HasPrefix(file.Name, "ppt/slideMasters/") && strings.HasSuffix(file.Name, ".xml") {
 			masters = append(masters, file)
 		} else if file.Name == "docProps/core.xml" {
 			corePropsFile = file
 		}
 	}
+
+	// Order slides and masters by their numeric index. zip.OpenReader returns
+	// entries in the archive's central-directory order, which the producer
+	// controls and is NOT guaranteed to be slideN order — a re-saved or
+	// tool-generated deck can interleave them, which would both mislabel
+	// "--- Slide N ---" and emit content out of reading order.
+	sortByNumericSuffix(slides)
+	sortByNumericSuffix(masters)
 
 	// Process slides, notes, and masters
 	var allText strings.Builder
@@ -363,9 +372,14 @@ func extractPptxText(filePath string, content *TextContent) (*TextContent, error
 			allText.WriteString(slideText)
 		}
 
-		// Add corresponding notes if available
-		if i < len(notes) {
-			notesText, err := extractTextFromXML(notes[i], "//a:t")
+		// Attach the notes that actually belong to THIS slide, resolved through
+		// the slide's .rels. The previous code paired notes[i] with slides[i] by
+		// position, but notesSlideN is not aligned with slideN — decks routinely
+		// have notes on only some slides and in a different order — so a slide
+		// got another slide's speaker notes (or none), mislabeling where that
+		// text, and any PII in it, came from.
+		if notesFile := pptxNotesForSlide(slide, byName); notesFile != nil {
+			notesText, err := extractTextFromXML(notesFile, "//a:t")
 			if err == nil && notesText != "" {
 				allText.WriteString("\n[SPEAKER NOTES]\n")
 				allText.WriteString(notesText)
@@ -821,6 +835,78 @@ func extractWorksheetText(file *zip.File, sharedStrings []string) string {
 	}
 
 	return result.String()
+}
+
+// numericSuffixRe pulls the trailing integer out of an OOXML part name such as
+// "ppt/slides/slide12.xml" (→ 12) so parts can be ordered by index rather than
+// by the archive's central-directory order.
+var numericSuffixRe = regexp.MustCompile(`(\d+)\.xml$`)
+
+// partNumber returns the trailing numeric index of a part name, or a large
+// sentinel for non-standard names so they sort to the end deterministically.
+func partNumber(name string) int {
+	if m := numericSuffixRe.FindStringSubmatch(name); len(m) == 2 {
+		if n, err := strconv.Atoi(m[1]); err == nil {
+			return n
+		}
+	}
+	return 1 << 30
+}
+
+// sortByNumericSuffix orders zip parts by their trailing numeric index (slide2
+// before slide10), then by name as a stable tiebreak.
+func sortByNumericSuffix(files []*zip.File) {
+	sort.SliceStable(files, func(i, j int) bool {
+		ni, nj := partNumber(files[i].Name), partNumber(files[j].Name)
+		if ni != nj {
+			return ni < nj
+		}
+		return files[i].Name < files[j].Name
+	})
+}
+
+// slideRelTargetRe matches a notesSlide relationship target inside a slide's
+// .rels part, e.g. Target="../notesSlides/notesSlide3.xml".
+var slideRelTargetRe = regexp.MustCompile(`Target="([^"]*notesSlides/notesSlide\d+\.xml)"`)
+
+// pptxNotesForSlide resolves the notesSlide part that belongs to the given slide
+// by reading the slide's relationships (ppt/slides/_rels/slideN.xml.rels), which
+// is the authoritative link. Returns nil if the slide has no notes or the rels
+// part is missing/unreadable. This replaces the previous positional pairing of
+// notes[i] with slides[i], which mis-attached notes because notesSlideN is not
+// aligned with slideN.
+func pptxNotesForSlide(slide *zip.File, byName map[string]*zip.File) *zip.File {
+	// ppt/slides/slideN.xml -> ppt/slides/_rels/slideN.xml.rels
+	base := slide.Name[strings.LastIndex(slide.Name, "/")+1:]
+	relsName := "ppt/slides/_rels/" + base + ".rels"
+	relsFile := byName[relsName]
+	if relsFile == nil {
+		return nil
+	}
+
+	rc, err := relsFile.Open()
+	if err != nil {
+		return nil
+	}
+	defer rc.Close()
+
+	data, err := readZipEntryLimited(rc)
+	if err != nil {
+		return nil
+	}
+
+	m := slideRelTargetRe.FindSubmatch(data)
+	if len(m) != 2 {
+		return nil
+	}
+
+	// Resolve the (possibly relative) target against the ppt/ base and look it up.
+	target := string(m[1])
+	target = strings.TrimPrefix(target, "../")
+	if !strings.HasPrefix(target, "ppt/") {
+		target = "ppt/" + target
+	}
+	return byName[target]
 }
 
 // sortWorksheets sorts worksheets by sheet number

--- a/internal/preprocessors/text-extractors/text-extract-officetextlib/pptx_slides_test.go
+++ b/internal/preprocessors/text-extractors/text-extract-officetextlib/pptx_slides_test.go
@@ -1,0 +1,171 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package textextractofficetextlib
+
+import (
+	"archive/zip"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// pptxPart is one entry to write into the test .pptx archive.
+type pptxPart struct {
+	name string
+	body string
+}
+
+// writePptx builds a minimal .pptx from the given parts, in the given archive
+// order (so a test can deliberately write slides out of numeric order), and
+// returns its path.
+func writePptx(t *testing.T, dir string, parts []pptxPart) string {
+	t.Helper()
+	p := filepath.Join(dir, "deck.pptx")
+	f, err := os.Create(p)
+	if err != nil {
+		t.Fatalf("create pptx: %v", err)
+	}
+	defer f.Close()
+
+	zw := zip.NewWriter(f)
+	for _, part := range parts {
+		w, err := zw.Create(part.name)
+		if err != nil {
+			t.Fatalf("zip create %s: %v", part.name, err)
+		}
+		if _, err := w.Write([]byte(part.body)); err != nil {
+			t.Fatalf("zip write %s: %v", part.name, err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zip close: %v", err)
+	}
+	return p
+}
+
+func slideXML(text string) string {
+	return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:cSld><p:spTree><a:t>` +
+		text + `</a:t></p:spTree></p:cSld></p:sld>`
+}
+
+func notesXML(text string) string {
+	return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:notes xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:cSld><p:spTree><a:t>` +
+		text + `</a:t></p:spTree></p:cSld></p:notes>`
+}
+
+func slideRels(notesTarget string) string {
+	rel := ""
+	if notesTarget != "" {
+		rel = `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/notesSlide" Target="` + notesTarget + `"/>`
+	}
+	return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` + rel + `</Relationships>`
+}
+
+// TestExtractPptx_SlideOrderAndNotesByRels covers both pptx defects at once:
+//
+//   - Slides written to the archive OUT of numeric order (slide10 before slide2)
+//     must still be labelled and emitted in slide order.
+//   - Notes must be attached to the slide their .rels points at, NOT by array
+//     position. notesSlide files here are deliberately misaligned with slide
+//     numbers, and only some slides have notes — the shape that made the old
+//     notes[i] pairing attach the wrong slide's speaker notes.
+func TestExtractPptx_SlideOrderAndNotesByRels(t *testing.T) {
+	dir := t.TempDir()
+
+	// slide1 -> notesSlide3, slide2 -> (none), slide3 -> notesSlide1, slide10 -> notesSlide2.
+	// Archive order is deliberately scrambled (slide10 first, notes before slides).
+	parts := []pptxPart{
+		{"ppt/notesSlides/notesSlide2.xml", notesXML("NOTES-FOR-SLIDE-10")},
+		{"ppt/slides/slide10.xml", slideXML("SLIDE-TEN-BODY")},
+		{"ppt/slides/_rels/slide10.xml.rels", slideRels("../notesSlides/notesSlide2.xml")},
+		{"ppt/slides/slide2.xml", slideXML("SLIDE-TWO-BODY")},
+		{"ppt/slides/_rels/slide2.xml.rels", slideRels("")}, // no notes
+		{"ppt/notesSlides/notesSlide1.xml", notesXML("NOTES-FOR-SLIDE-3")},
+		{"ppt/slides/slide1.xml", slideXML("SLIDE-ONE-BODY")},
+		{"ppt/slides/_rels/slide1.xml.rels", slideRels("../notesSlides/notesSlide3.xml")},
+		{"ppt/notesSlides/notesSlide3.xml", notesXML("NOTES-FOR-SLIDE-1")},
+		{"ppt/slides/slide3.xml", slideXML("SLIDE-THREE-BODY")},
+		{"ppt/slides/_rels/slide3.xml.rels", slideRels("../notesSlides/notesSlide1.xml")},
+	}
+	path := writePptx(t, dir, parts)
+
+	content, err := ExtractText(path)
+	if err != nil {
+		t.Fatalf("ExtractText: %v", err)
+	}
+	got := content.Text
+
+	// 1. Slides appear in numeric order: 1, 2, 3, 10.
+	order := []string{"SLIDE-ONE-BODY", "SLIDE-TWO-BODY", "SLIDE-THREE-BODY", "SLIDE-TEN-BODY"}
+	last := -1
+	for _, marker := range order {
+		idx := strings.Index(got, marker)
+		if idx < 0 {
+			t.Fatalf("slide body %q missing from output:\n%s", marker, got)
+		}
+		if idx < last {
+			t.Errorf("slide body %q is out of order:\n%s", marker, got)
+		}
+		last = idx
+	}
+
+	// 2. Slide labels count up 1..4 in that order.
+	for i, marker := range order {
+		label := fmt.Sprintf("--- Slide %d ---", i+1)
+		li := strings.Index(got, label)
+		mi := strings.Index(got, marker)
+		if li < 0 || li > mi {
+			t.Errorf("expected %q immediately before %q:\n%s", label, marker, got)
+		}
+	}
+
+	// 3. Notes are attached to the correct slide via rels.
+	//    slide1 -> NOTES-FOR-SLIDE-1, slide3 -> NOTES-FOR-SLIDE-3, slide10 -> NOTES-FOR-SLIDE-10.
+	assertNotesUnderSlide(t, got, "SLIDE-ONE-BODY", "NOTES-FOR-SLIDE-1")
+	assertNotesUnderSlide(t, got, "SLIDE-THREE-BODY", "NOTES-FOR-SLIDE-3")
+	assertNotesUnderSlide(t, got, "SLIDE-TEN-BODY", "NOTES-FOR-SLIDE-10")
+
+	// 4. Slide 2 has no notes: NOTES-FOR-SLIDE-* must not appear between
+	//    SLIDE-TWO-BODY and the next slide.
+	two := sliceBetween(got, "SLIDE-TWO-BODY", "SLIDE-THREE-BODY")
+	if strings.Contains(two, "SPEAKER NOTES") {
+		t.Errorf("slide 2 has no notes but got a SPEAKER NOTES block:\n%s", two)
+	}
+}
+
+// assertNotesUnderSlide checks that noteText appears after slideMarker and
+// before the next "--- Slide" boundary — i.e. it is attached to that slide.
+func assertNotesUnderSlide(t *testing.T, full, slideMarker, noteText string) {
+	t.Helper()
+	start := strings.Index(full, slideMarker)
+	if start < 0 {
+		t.Fatalf("slide %q missing", slideMarker)
+	}
+	rest := full[start:]
+	next := strings.Index(rest[len(slideMarker):], "--- Slide ")
+	region := rest
+	if next >= 0 {
+		region = rest[:len(slideMarker)+next]
+	}
+	if !strings.Contains(region, noteText) {
+		t.Errorf("expected notes %q attached to slide %q, region was:\n%s", noteText, slideMarker, region)
+	}
+}
+
+func sliceBetween(s, from, to string) string {
+	i := strings.Index(s, from)
+	if i < 0 {
+		return ""
+	}
+	j := strings.Index(s[i:], to)
+	if j < 0 {
+		return s[i:]
+	}
+	return s[i : i+j]
+}


### PR DESCRIPTION
The `.pptx` text extractor had two correctness bugs that mislabeled and misattributed content — including PII in speaker notes.

## 1. Slides processed in zip order, labeled by index

Slides were collected in `zip.OpenReader` order (central-directory order, which the producer controls) and then labeled `--- Slide N ---` by array position. That order is **not guaranteed** to be `slideN` order — the xlsx path already sorts worksheets for exactly this reason; pptx never did. A re-saved or tool-generated deck can emit slides out of reading order under the wrong numbers.

## 2. Speaker notes paired by position — attached to the wrong slide

Notes were paired as `notes[i]` with `slides[i]`. But `notesSlideN` is **not** aligned with `slideN`: decks routinely have notes on only some slides, stored in a different order. Verified on a real 45-slide deck — 24 notes stored as `1,2,…,8,24,23,9,10,…` — so **Slide 9 was given notesSlide24's content (`"37"`) instead of its own** (the substantive "AWS Well-Architected Framework…" notes from notesSlide5). Notes, and any PII in them, were attributed to the wrong slide; slides past the note count got none.

## Fix

- Sort slides and masters by their numeric part index (`slide2` before `slide10`).
- Resolve each slide's notes through `ppt/slides/_rels/slideN.xml.rels` — the authoritative link — instead of by array position. Notes now land on the correct slide; slides with no notes get none.

The `byName` map added here is used **only for point lookups by part name** (never ranged over), so it introduces no iteration-order nondeterminism; all ordering comes from the sorted slide/master slices. Verified: the slide-text portion of a real deck is now byte-identical across 5 runs. (A separate, pre-existing flap in the `EmbeddedMedia_*` **metadata** block comes from a different extractor — `meta-extract-officelib` — and is out of scope here, tracked as a follow-up.)

## Tests

`TestExtractPptx_SlideOrderAndNotesByRels` builds a deck with slides written to the archive out of numeric order and notes deliberately misaligned (`slide1→notesSlide3`, `slide2→none`, `slide3→notesSlide1`, `slide10→notesSlide2`). It **fails on the parent** (slide 2 receives slide 3's notes; slides emitted out of order) and passes here.

`go build` / `go vet` / `-race` / full `go test ./...` / golden corpus all green. **Golden impact: none** (corpus has no `.pptx`).

## Sequencing

Targets `main`. Shares `office-text-extractor.go` with #183 (xlsx), but the two edit disjoint regions (pptx ~L330–390 + new helpers; xlsx ~L690–820) — I verified a sequential merge of both onto `main` is **conflict-free and builds clean**, so they can land in any order.