### PR TITLE
fix(redactors): make redacted artifacts and audit logs reproducible

### DIFF
--- a/internal/redactors/audit_order_test.go
+++ b/internal/redactors/audit_order_test.go
@@ -1,0 +1,171 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package redactors
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// auditIterations is high enough that a randomized Go map order over the entries
+// below is overwhelmingly unlikely to produce the expected order every time.
+const auditIterations = 200
+
+// TestListAuditLogs_StableOrder locks the order of the ListAuditLogs listing.
+// It was built by ranging the audit-log map, so the same manager returned its
+// document IDs in a different sequence on every call.
+func TestListAuditLogs_StableOrder(t *testing.T) {
+	// Registered in neither the expected order nor its reverse.
+	register := []string{"doc_c", "doc_a", "doc_e", "doc_b", "doc_d"}
+	want := []string{"doc_a", "doc_b", "doc_c", "doc_d", "doc_e"}
+
+	for i := 0; i < auditIterations; i++ {
+		m := NewRedactionAuditLogManager("test", t.TempDir())
+		for _, id := range register {
+			if _, err := m.CreateAuditLog(id, "/in/"+id+".txt", "/out/"+id+".txt"); err != nil {
+				t.Fatalf("CreateAuditLog(%s): %v", id, err)
+			}
+		}
+
+		got := m.ListAuditLogs()
+		if len(got) != len(want) {
+			t.Fatalf("iteration %d: got %d IDs, want %d: %v", i, len(got), len(want), got)
+		}
+		for j := range want {
+			if got[j] != want[j] {
+				t.Fatalf("iteration %d: ID %d = %q, want %q\nfull order: %v",
+					i, j, got[j], want[j], got)
+			}
+		}
+	}
+}
+
+// TestExportAllAuditLogs_StableValidationError locks which document an export
+// blames when more than one audit log is invalid. The validation loop ranged the
+// map, so the same broken state produced a different error message on each run —
+// an operator fixed whichever document happened to surface and then hit the next.
+func TestExportAllAuditLogs_StableValidationError(t *testing.T) {
+	seen := make(map[string]int)
+	for i := 0; i < auditIterations; i++ {
+		m := NewRedactionAuditLogManager("test", t.TempDir())
+		// Three logs, all invalid: clearing DocumentID fails Validate.
+		for _, id := range []string{"doc_c", "doc_a", "doc_b"} {
+			log, err := m.CreateAuditLog(id, "/in/"+id+".txt", "/out/"+id+".txt")
+			if err != nil {
+				t.Fatalf("CreateAuditLog(%s): %v", id, err)
+			}
+			log.DocumentID = ""
+		}
+
+		_, err := m.ExportAllAuditLogs()
+		if err == nil {
+			t.Fatalf("iteration %d: want a validation error, got nil", i)
+		}
+		seen[err.Error()]++
+	}
+
+	if len(seen) != 1 {
+		t.Fatalf("the same invalid state produced %d distinct error messages, want 1: %v", len(seen), seen)
+	}
+	for msg := range seen {
+		if !strings.Contains(msg, "doc_a") {
+			t.Fatalf("want the lowest-sorting document reported, got %q", msg)
+		}
+	}
+}
+
+// TestValidateAllAuditLogs_StableError is the same guard for the standalone
+// validation entry point.
+func TestValidateAllAuditLogs_StableError(t *testing.T) {
+	seen := make(map[string]int)
+	for i := 0; i < auditIterations; i++ {
+		m := NewRedactionAuditLogManager("test", t.TempDir())
+		for _, id := range []string{"doc_z", "doc_m", "doc_b"} {
+			log, err := m.CreateAuditLog(id, "/in/"+id+".txt", "/out/"+id+".txt")
+			if err != nil {
+				t.Fatalf("CreateAuditLog(%s): %v", id, err)
+			}
+			log.DocumentID = ""
+		}
+
+		err := m.ValidateAllAuditLogs()
+		if err == nil {
+			t.Fatalf("iteration %d: want a validation error, got nil", i)
+		}
+		seen[err.Error()]++
+	}
+
+	if len(seen) != 1 {
+		t.Fatalf("the same invalid state produced %d distinct error messages, want 1: %v", len(seen), seen)
+	}
+	for msg := range seen {
+		if !strings.Contains(msg, "doc_b") {
+			t.Fatalf("want the lowest-sorting document reported, got %q", msg)
+		}
+	}
+}
+
+// TestExportAllAuditLogs_StableJSON confirms the exported document is byte
+// identical across runs. encoding/json already sorts map keys, so this held even
+// before the ordering fix — it is here so a future change to the export shape
+// (an array of logs, say, built by ranging the map) cannot quietly reintroduce
+// per-run variance in a compliance artifact.
+func TestExportAllAuditLogs_StableJSON(t *testing.T) {
+	seen := make(map[string]int)
+	for i := 0; i < auditIterations; i++ {
+		m := NewRedactionAuditLogManager("test", t.TempDir())
+		for _, id := range []string{"doc_c", "doc_a", "doc_e", "doc_b", "doc_d"} {
+			if _, err := m.CreateAuditLog(id, "/in/"+id+".txt", "/out/"+id+".txt"); err != nil {
+				t.Fatalf("CreateAuditLog(%s): %v", id, err)
+			}
+		}
+
+		data, err := m.ExportAllAuditLogs()
+		if err != nil {
+			t.Fatalf("iteration %d: ExportAllAuditLogs: %v", i, err)
+		}
+
+		// The export and each audit log stamp wall-clock timestamps, which are
+		// legitimately variable — strip them before comparing. Everything else,
+		// including the set and order of documents, must be identical.
+		var doc interface{}
+		if err := json.Unmarshal(data, &doc); err != nil {
+			t.Fatalf("iteration %d: unmarshal export: %v", i, err)
+		}
+		canonical, err := json.Marshal(stripTimestamps(doc))
+		if err != nil {
+			t.Fatalf("iteration %d: re-marshal: %v", i, err)
+		}
+		seen[string(canonical)]++
+	}
+
+	if len(seen) != 1 {
+		t.Fatalf("exporting one unchanged manager produced %d distinct documents, want 1", len(seen))
+	}
+}
+
+// stripTimestamps removes every key ending in "timestamp" from a decoded JSON
+// document, recursively. Timestamps are environmental (a clock reading), unlike
+// emit order, which is our own behavior and must not be normalized away.
+func stripTimestamps(v interface{}) interface{} {
+	switch t := v.(type) {
+	case map[string]interface{}:
+		for k, child := range t {
+			if strings.HasSuffix(k, "timestamp") {
+				delete(t, k)
+				continue
+			}
+			t[k] = stripTimestamps(child)
+		}
+		return t
+	case []interface{}:
+		for i, child := range t {
+			t[i] = stripTimestamps(child)
+		}
+		return t
+	default:
+		return v
+	}
+}

--- a/internal/redactors/config.go
+++ b/internal/redactors/config.go
@@ -6,8 +6,20 @@ package redactors
 import (
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 )
+
+// sortedConfigKeys returns a config map's keys in a fixed order, so that
+// validation visits entries in the same sequence on every run.
+func sortedConfigKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
 
 // RedactionConfig contains all redaction configuration settings
 type RedactionConfig struct {
@@ -269,16 +281,18 @@ func (rc *RedactionConfig) Validate() error {
 		return fmt.Errorf("position_correlation.context_window_size must be non-negative")
 	}
 
-	// Validate document type configurations
-	for docType, config := range rc.DocumentTypes {
-		if err := rc.validateDocumentTypeConfig(docType, config); err != nil {
+	// Validate document type configurations. Sorted keys: with more than one
+	// invalid entry, ranging the map reported a different one on every run, so
+	// the user fixed whichever error happened to surface and hit the next.
+	for _, docType := range sortedConfigKeys(rc.DocumentTypes) {
+		if err := rc.validateDocumentTypeConfig(docType, rc.DocumentTypes[docType]); err != nil {
 			return fmt.Errorf("document_types.%s: %w", docType, err)
 		}
 	}
 
 	// Validate data type configurations
-	for dataType, config := range rc.DataTypes {
-		if err := rc.validateDataTypeConfig(dataType, config); err != nil {
+	for _, dataType := range sortedConfigKeys(rc.DataTypes) {
+		if err := rc.validateDataTypeConfig(dataType, rc.DataTypes[dataType]); err != nil {
 			return fmt.Errorf("data_types.%s: %w", dataType, err)
 		}
 	}

--- a/internal/redactors/config_order_test.go
+++ b/internal/redactors/config_order_test.go
@@ -1,0 +1,65 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package redactors
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidate_StableDocumentTypeError locks which document-type entry a config
+// validation failure names. The loop ranged the map, so a config with several
+// bad entries reported a different one on every run: the user fixed whichever
+// error surfaced, re-ran, and got a fresh complaint about a different key.
+func TestValidate_StableDocumentTypeError(t *testing.T) {
+	seen := make(map[string]int)
+	for i := 0; i < auditIterations; i++ {
+		cfg := NewDefaultRedactionConfig()
+		// Three invalid entries: an unrecognized strategy fails validation.
+		for _, docType := range []string{"zeta", "alpha", "mid"} {
+			cfg.DocumentTypes[docType] = DocumentTypeConfig{Strategy: "not-a-strategy"}
+		}
+
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatalf("iteration %d: want a validation error, got nil", i)
+		}
+		seen[err.Error()]++
+	}
+
+	if len(seen) != 1 {
+		t.Fatalf("the same invalid config produced %d distinct error messages, want 1: %v", len(seen), seen)
+	}
+	for msg := range seen {
+		if !strings.Contains(msg, "document_types.alpha") {
+			t.Fatalf("want the lowest-sorting document type reported, got %q", msg)
+		}
+	}
+}
+
+// TestValidate_StableDataTypeError is the same guard for data-type entries.
+func TestValidate_StableDataTypeError(t *testing.T) {
+	seen := make(map[string]int)
+	for i := 0; i < auditIterations; i++ {
+		cfg := NewDefaultRedactionConfig()
+		for _, dataType := range []string{"ZETA", "BRAVO", "MIKE"} {
+			cfg.DataTypes[dataType] = DataTypeConfig{Strategy: "not-a-strategy"}
+		}
+
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatalf("iteration %d: want a validation error, got nil", i)
+		}
+		seen[err.Error()]++
+	}
+
+	if len(seen) != 1 {
+		t.Fatalf("the same invalid config produced %d distinct error messages, want 1: %v", len(seen), seen)
+	}
+	for msg := range seen {
+		if !strings.Contains(msg, "data_types.BRAVO") {
+			t.Fatalf("want the lowest-sorting data type reported, got %q", msg)
+		}
+	}
+}

--- a/internal/redactors/image/emit_order_test.go
+++ b/internal/redactors/image/emit_order_test.go
@@ -1,0 +1,82 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package image
+
+import (
+	"strings"
+	"testing"
+)
+
+// iterations is high enough that a randomized Go map order over the eight
+// supported formats is overwhelmingly unlikely to match the expected order every
+// time by chance.
+const iterations = 200
+
+// TestGetSupportedTypes_StableOrder locks the reported type list. It was built by
+// ranging the supported-format map, so the same redactor described itself
+// differently on every call — the list reaches registration logs and
+// operator-facing output.
+func TestGetSupportedTypes_StableOrder(t *testing.T) {
+	// Sorted extensions, each immediately followed by its undotted spelling.
+	want := []string{
+		".bmp", "bmp",
+		".gif", "gif",
+		".jpeg", "jpeg",
+		".jpg", "jpg",
+		".png", "png",
+		".tif", "tif",
+		".tiff", "tiff",
+		".webp", "webp",
+	}
+
+	for i := 0; i < iterations; i++ {
+		got := NewImageMetadataRedactor(nil, nil).GetSupportedTypes()
+		if len(got) != len(want) {
+			t.Fatalf("iteration %d: got %d types, want %d: %v", i, len(got), len(want), got)
+		}
+		for j := range want {
+			if got[j] != want[j] {
+				t.Fatalf("iteration %d: type %d = %q, want %q\nfull order: %v",
+					i, j, got[j], want[j], got)
+			}
+		}
+	}
+}
+
+// TestGetSupportedImageFormats_StableOrder locks the format listing, which had
+// the same defect.
+func TestGetSupportedImageFormats_StableOrder(t *testing.T) {
+	want := []string{".bmp", ".gif", ".jpeg", ".jpg", ".png", ".tif", ".tiff", ".webp"}
+
+	for i := 0; i < iterations; i++ {
+		got := NewImageMetadataRedactor(nil, nil).GetSupportedImageFormats()
+		if strings.Join(got, ",") != strings.Join(want, ",") {
+			t.Fatalf("iteration %d: got %v, want %v", i, got, want)
+		}
+	}
+}
+
+// TestSortedEXIFFieldNames_StableOrder locks the EXIF field iteration order used
+// when building redaction mappings. Those mappings become audit-log entries whose
+// IDs are assigned from slice position (doc_N_redaction_I), so ranging the EXIF
+// map gave the same field a different ID on every run and made two audit logs of
+// one image impossible to compare.
+func TestSortedEXIFFieldNames_StableOrder(t *testing.T) {
+	exifData := map[string]string{
+		"GPSLongitude": "-122.4194",
+		"Make":         "ExampleCorp",
+		"DateTime":     "2026:07:27 10:00:00",
+		"GPSLatitude":  "37.7749",
+		"Model":        "ExampleCam",
+		"Artist":       "A. Example",
+	}
+	want := []string{"Artist", "DateTime", "GPSLatitude", "GPSLongitude", "Make", "Model"}
+
+	for i := 0; i < iterations; i++ {
+		got := sortedEXIFFieldNames(exifData)
+		if strings.Join(got, ",") != strings.Join(want, ",") {
+			t.Fatalf("iteration %d: got %v, want %v", i, got, want)
+		}
+	}
+}

--- a/internal/redactors/image/redactor.go
+++ b/internal/redactors/image/redactor.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -136,8 +137,16 @@ func (imr *ImageMetadataRedactor) GetName() string {
 
 // GetSupportedTypes returns the file types this redactor can handle
 func (imr *ImageMetadataRedactor) GetSupportedTypes() []string {
-	types := make([]string, 0, len(imr.supportedFormats)*2)
+	// Sorted extensions so the reported type list is identical between runs —
+	// it reaches --help-style output and registration logs.
+	exts := make([]string, 0, len(imr.supportedFormats))
 	for ext := range imr.supportedFormats {
+		exts = append(exts, ext)
+	}
+	sort.Strings(exts)
+
+	types := make([]string, 0, len(exts)*2)
+	for _, ext := range exts {
 		types = append(types, ext)
 		types = append(types, strings.TrimPrefix(ext, ".")) // Add without dot
 	}
@@ -456,9 +465,14 @@ func (imr *ImageMetadataRedactor) redactJPEGMetadata(originalFile *os.File, outp
 		return fmt.Errorf("failed to encode JPEG: %w", err)
 	}
 
-	// Create redaction mapping for metadata removal
+	// Create redaction mapping for metadata removal. Field names sorted: these
+	// mappings become audit-log entries whose IDs are assigned from slice
+	// position (doc_N_redaction_I), so a map range gave the same EXIF field a
+	// different ID on every run and made two audit logs of one image
+	// incomparable.
 	if metadata.HasEXIF && len(metadata.EXIFData) > 0 {
-		for fieldName, fieldValue := range metadata.EXIFData {
+		for _, fieldName := range sortedEXIFFieldNames(metadata.EXIFData) {
+			fieldValue := metadata.EXIFData[fieldName]
 			mapping := redactors.RedactionMapping{
 				RedactedText: "[METADATA-REMOVED]",
 				Position: redactors.TextPosition{
@@ -481,6 +495,16 @@ func (imr *ImageMetadataRedactor) redactJPEGMetadata(originalFile *os.File, outp
 	}
 
 	return nil
+}
+
+// sortedEXIFFieldNames returns the EXIF field names in a fixed order.
+func sortedEXIFFieldNames(exifData map[string]string) []string {
+	names := make([]string, 0, len(exifData))
+	for name := range exifData {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 // redactPNGMetadata removes metadata from PNG files
@@ -588,6 +612,7 @@ func (imr *ImageMetadataRedactor) GetSupportedImageFormats() []string {
 	for ext := range imr.supportedFormats {
 		formats = append(formats, ext)
 	}
+	sort.Strings(formats)
 	return formats
 }
 

--- a/internal/redactors/index_manager.go
+++ b/internal/redactors/index_manager.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync"
 	"time"
 )
@@ -97,6 +98,24 @@ func (rim *RedactionAuditLogManager) ListAuditLogs() []string {
 	for documentID := range rim.auditLogs {
 		documentIDs = append(documentIDs, documentID)
 	}
+	// Sorted: the caller gets a listing, and a listing that permutes itself
+	// between calls on unchanged state is not usable for display or comparison.
+	sort.Strings(documentIDs)
+	return documentIDs
+}
+
+// sortedDocumentIDs returns the managed document IDs in a fixed order. Callers
+// that walk every audit log use it so their behavior — in particular which
+// document a validation error names when several are invalid — does not depend
+// on Go's randomized map iteration order.
+//
+// Callers must already hold rim.mutex.
+func (rim *RedactionAuditLogManager) sortedDocumentIDs() []string {
+	documentIDs := make([]string, 0, len(rim.auditLogs))
+	for documentID := range rim.auditLogs {
+		documentIDs = append(documentIDs, documentID)
+	}
+	sort.Strings(documentIDs)
 	return documentIDs
 }
 
@@ -200,8 +219,12 @@ func (rim *RedactionAuditLogManager) ExportAllAuditLogs() ([]byte, error) {
 		AuditLogs:       make(map[string]*RedactionAuditLog),
 	}
 
-	// Validate and copy all audit logs
-	for documentID, auditLog := range rim.auditLogs {
+	// Validate and copy all audit logs. Walk in sorted order so that when more
+	// than one log is invalid the reported document is always the same one —
+	// ranging the map made the error message vary run to run on identical input.
+	// The emitted JSON itself is unaffected: encoding/json sorts map keys.
+	for _, documentID := range rim.sortedDocumentIDs() {
+		auditLog := rim.auditLogs[documentID]
 		if err := auditLog.Validate(); err != nil {
 			return nil, fmt.Errorf("audit log validation failed for document %s: %w", documentID, err)
 		}
@@ -318,8 +341,10 @@ func (rim *RedactionAuditLogManager) ValidateAllAuditLogs() error {
 	rim.mutex.RLock()
 	defer rim.mutex.RUnlock()
 
-	for documentID, auditLog := range rim.auditLogs {
-		if err := auditLog.Validate(); err != nil {
+	// Sorted for the same reason as ExportAllAuditLogs: with several invalid logs
+	// a map range named a different document on each call.
+	for _, documentID := range rim.sortedDocumentIDs() {
+		if err := rim.auditLogs[documentID].Validate(); err != nil {
 			return fmt.Errorf("validation failed for document %s: %w", documentID, err)
 		}
 	}

--- a/internal/redactors/manager.go
+++ b/internal/redactors/manager.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -335,7 +336,8 @@ func (rm *RedactionManager) UnregisterRedactor(redactorName string) error {
 	rm.mu.Lock()
 	defer rm.mu.Unlock()
 
-	// Find and remove all registrations for this redactor
+	// Find and remove all registrations for this redactor. removedTypes is
+	// logged, so it is built in sorted order rather than map order.
 	removedTypes := []string{}
 	for fileType, redactor := range rm.redactors {
 		if redactor.GetName() == redactorName {
@@ -343,6 +345,7 @@ func (rm *RedactionManager) UnregisterRedactor(redactorName string) error {
 			removedTypes = append(removedTypes, fileType)
 		}
 	}
+	sort.Strings(removedTypes)
 
 	if len(removedTypes) == 0 {
 		return fmt.Errorf("redactor %s not found", redactorName)
@@ -385,9 +388,17 @@ func (rm *RedactionManager) GetRegisteredRedactors() map[string][]string {
 	rm.mu.RLock()
 	defer rm.mu.RUnlock()
 
+	// Sorted file types: the per-redactor slices are caller-visible listings, and
+	// ranging the map put them in a different order on every call.
+	fileTypes := make([]string, 0, len(rm.redactors))
+	for fileType := range rm.redactors {
+		fileTypes = append(fileTypes, fileType)
+	}
+	sort.Strings(fileTypes)
+
 	redactorTypes := make(map[string][]string)
-	for fileType, redactor := range rm.redactors {
-		redactorName := redactor.GetName()
+	for _, fileType := range fileTypes {
+		redactorName := rm.redactors[fileType].GetName()
 		redactorTypes[redactorName] = append(redactorTypes[redactorName], fileType)
 	}
 
@@ -916,12 +927,25 @@ func (rm *RedactionManager) ProcessMatches(matches []detector.Match, filePaths [
 		matchesByFile[filePath] = append(matchesByFile[filePath], match)
 	}
 
+	// Walk the files in sorted order. Ranging matchesByFile directly made two
+	// things vary run to run on identical input: the order of ProcessedFiles in
+	// the returned results, and — worse — the audit log's document IDs, which are
+	// assigned from the loop position (doc_0, doc_1, …), so the same file was
+	// labelled differently on each run and the audit log could not be compared
+	// against a previous one.
+	orderedPaths := make([]string, 0, len(matchesByFile))
+	for filePath := range matchesByFile {
+		orderedPaths = append(orderedPaths, filePath)
+	}
+	sort.Strings(orderedPaths)
+
 	// Process each file with its matches
 	var processedFiles []ProcessedFile
 	var allErrors []RedactionError
 	totalRedactions := 0
 
-	for filePath, fileMatches := range matchesByFile {
+	for _, filePath := range orderedPaths {
+		fileMatches := matchesByFile[filePath]
 		// Create output path
 		outputPath, err := rm.outputManager.CreateMirroredPath(filePath)
 		if err != nil {

--- a/internal/redactors/manager_order_test.go
+++ b/internal/redactors/manager_order_test.go
@@ -1,0 +1,168 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package redactors
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+)
+
+// stubRedactor is a Redactor that copies its input to the output path and
+// reports one redaction, which is enough to exercise ProcessMatches end to end.
+type stubRedactor struct {
+	name  string
+	types []string
+}
+
+func (s *stubRedactor) GetName() string             { return s.name }
+func (s *stubRedactor) GetSupportedTypes() []string { return s.types }
+
+func (s *stubRedactor) GetSupportedStrategies() []RedactionStrategy {
+	return []RedactionStrategy{RedactionSimple, RedactionFormatPreserving, RedactionSynthetic}
+}
+
+func (s *stubRedactor) RedactDocument(originalPath, outputPath string, matches []detector.Match, strategy RedactionStrategy) (*RedactionResult, error) {
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(outputPath, []byte("redacted"), 0o600); err != nil {
+		return nil, err
+	}
+	mappings := make([]RedactionMapping, 0, len(matches))
+	for _, m := range matches {
+		mappings = append(mappings, RedactionMapping{
+			RedactedText: "[REDACTED]",
+			DataType:     m.Type,
+			Strategy:     strategy,
+			Confidence:   m.Confidence,
+		})
+	}
+	return &RedactionResult{
+		Success:          true,
+		RedactedFilePath: outputPath,
+		RedactionMap:     mappings,
+	}, nil
+}
+
+func (s *stubRedactor) GetComponentName() string { return s.name }
+
+// newTestManager builds a manager writing under dir, failing the test if the
+// output manager cannot be constructed.
+func newTestManager(t *testing.T, dir string) *RedactionManager {
+	t.Helper()
+	om, err := NewOutputStructureManager(dir, nil)
+	if err != nil {
+		t.Fatalf("NewOutputStructureManager(%s): %v", dir, err)
+	}
+	return NewRedactionManager(om, nil)
+}
+
+// TestGetRegisteredRedactors_StableOrder locks the per-redactor file type lists.
+// They were appended while ranging the registration map, so the same manager
+// reported its supported types in a different order on every call.
+func TestGetRegisteredRedactors_StableOrder(t *testing.T) {
+	// Registration lowercases each type and prefixes a dot, so the dotted and
+	// undotted spellings below collapse to four keys. Supplied in neither the
+	// expected order nor its reverse.
+	want := []string{".docx", ".pptx", ".txt", ".xlsx"}
+
+	for i := 0; i < auditIterations; i++ {
+		rm := newTestManager(t, t.TempDir())
+		if err := rm.RegisterRedactor(&stubRedactor{
+			name:  "stub",
+			types: []string{".xlsx", "txt", ".docx", "pptx", ".txt", "docx", ".pptx", "xlsx"},
+		}); err != nil {
+			t.Fatalf("RegisterRedactor: %v", err)
+		}
+
+		got := rm.GetRegisteredRedactors()["stub"]
+		if len(got) != len(want) {
+			t.Fatalf("iteration %d: got %d types, want %d: %v", i, len(got), len(want), got)
+		}
+		for j := range want {
+			if got[j] != want[j] {
+				t.Fatalf("iteration %d: type %d = %q, want %q\nfull order: %v",
+					i, j, got[j], want[j], got)
+			}
+		}
+	}
+}
+
+// TestProcessMatches_StableDocumentIDs is the important one in this file. Audit
+// log document IDs are assigned from the file loop's position (doc_0, doc_1, …).
+// The loop ranged a map keyed on file path, so the SAME file was recorded under a
+// different document ID on every run, and so was the order of ProcessedFiles.
+// An audit log is a compliance artifact — one that cannot be compared against a
+// previous run of the same scan is close to useless.
+func TestProcessMatches_StableDocumentIDs(t *testing.T) {
+	// Five files supplied in neither the expected order nor its reverse.
+	inputs := []string{"src/zeta.txt", "src/alpha.txt", "docs/readme.txt", "notes.txt", "src/mid.txt"}
+	want := []string{"docs/readme.txt", "notes.txt", "src/alpha.txt", "src/mid.txt", "src/zeta.txt"}
+
+	seenPairings := make(map[string]int)
+	for i := 0; i < 40; i++ {
+		root := t.TempDir()
+		var matches []detector.Match
+		for _, rel := range inputs {
+			full := filepath.Join(root, rel)
+			if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			if err := os.WriteFile(full, []byte("SSN: 449-87-4100\n"), 0o600); err != nil {
+				t.Fatalf("write input: %v", err)
+			}
+			matches = append(matches, detector.Match{
+				Text: "449-87-4100", LineNumber: 1, Type: "SSN",
+				Confidence: 100, Filename: full, Validator: "ssn",
+			})
+		}
+
+		rm := newTestManager(t, filepath.Join(root, "out"))
+		if err := rm.RegisterRedactor(&stubRedactor{name: "stub", types: []string{".txt"}}); err != nil {
+			t.Fatalf("RegisterRedactor: %v", err)
+		}
+
+		results, err := rm.ProcessMatches(matches, nil)
+		if err != nil {
+			t.Fatalf("iteration %d: ProcessMatches: %v", i, err)
+		}
+		if len(results.ProcessedFiles) != len(want) {
+			t.Fatalf("iteration %d: got %d processed files, want %d",
+				i, len(results.ProcessedFiles), len(want))
+		}
+
+		// ProcessedFiles order.
+		for j := range want {
+			got := results.ProcessedFiles[j].OriginalPath
+			if !strings.HasSuffix(filepath.ToSlash(got), want[j]) {
+				t.Fatalf("iteration %d: processed file %d = %q, want a path ending in %q",
+					i, j, got, want[j])
+			}
+		}
+
+		// Document ID assignment: doc_0 must always name the same file.
+		var pairing []string
+		for _, id := range rm.auditLogManager.ListAuditLogs() {
+			log, ok := rm.auditLogManager.GetAuditLog(id)
+			if !ok {
+				t.Fatalf("iteration %d: audit log %s vanished", i, id)
+			}
+			rel, err := filepath.Rel(root, log.OriginalPath)
+			if err != nil {
+				t.Fatalf("iteration %d: relativize %s: %v", i, log.OriginalPath, err)
+			}
+			pairing = append(pairing, id+"="+filepath.ToSlash(rel))
+		}
+		seenPairings[strings.Join(pairing, ",")]++
+	}
+
+	if len(seenPairings) != 1 {
+		t.Fatalf("audit log document IDs were assigned to files %d different ways across runs, want 1:\n%v",
+			len(seenPairings), seenPairings)
+	}
+}

--- a/internal/redactors/office/emit_order_test.go
+++ b/internal/redactors/office/emit_order_test.go
@@ -1,0 +1,229 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package office
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/redactors"
+)
+
+// iterations is high enough that a randomized Go map order over the seven-part
+// package below is overwhelmingly unlikely to reproduce the source order every
+// time by chance.
+const iterations = 40
+
+// partOrder is the entry order the fixture package is written in. It is
+// deliberately not alphabetical, so a fix that sorted the names instead of
+// replaying the original order would fail this test.
+var partOrder = []string{
+	"[Content_Types].xml",
+	"_rels/.rels",
+	"word/document.xml",
+	"word/_rels/document.xml.rels",
+	"word/styles.xml",
+	"word/settings.xml",
+	"docProps/core.xml",
+}
+
+// writeFixtureDocx writes a minimal but structurally real .docx containing one
+// SSN and one credit card number in the document body.
+//
+// The path is relative to the test's working directory rather than under
+// t.TempDir(): the Office preprocessors reject absolute paths below /tmp, /var
+// and /home, and a fixture that lands there silently exercises a different code
+// path.
+func writeFixtureDocx(t *testing.T) string {
+	t.Helper()
+
+	dir := filepath.Join("testdata", "tmp-emit-order")
+	// The output subdirectory is created up front: these tests construct the
+	// redactor without an OutputStructureManager, and repackaging only creates
+	// directories when one is wired in.
+	if err := os.MkdirAll(filepath.Join(dir, "out"), 0o755); err != nil {
+		t.Fatalf("create fixture dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(filepath.Join("testdata", "tmp-emit-order")) })
+
+	parts := map[string]string{
+		"[Content_Types].xml": `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+			`<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+			`<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+			`<Default Extension="xml" ContentType="application/xml"/>` +
+			`<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>` +
+			`</Types>`,
+		"_rels/.rels": `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+			`<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+			`<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>` +
+			`</Relationships>`,
+		"word/document.xml": `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+			`<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>` +
+			`<w:p><w:r><w:t>Employee SSN: 449-87-4100</w:t></w:r></w:p>` +
+			`<w:p><w:r><w:t>Card on file: 4532-0151-1283-0366</w:t></w:r></w:p>` +
+			`</w:body></w:document>`,
+		"word/_rels/document.xml.rels": `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+			`<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"/>`,
+		"word/styles.xml": `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+			`<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"/>`,
+		"word/settings.xml": `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+			`<w:settings xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"/>`,
+		"docProps/core.xml": `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+			`<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties"/>`,
+	}
+
+	path := filepath.Join(dir, "probe.docx")
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for _, name := range partOrder {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatalf("create zip entry %s: %v", name, err)
+		}
+		if _, err := w.Write([]byte(parts[name])); err != nil {
+			t.Fatalf("write zip entry %s: %v", name, err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+func fixtureMatches(filename string) []detector.Match {
+	return []detector.Match{
+		{Text: "449-87-4100", LineNumber: 1, Type: "SSN", Confidence: 100, Filename: filename, Validator: "ssn"},
+		{Text: "4532-0151-1283-0366", LineNumber: 2, Type: "CREDIT_CARD", Confidence: 100, Filename: filename, Validator: "creditcard"},
+	}
+}
+
+// zipEntryNames returns the entry names of a ZIP file in central-directory order.
+func zipEntryNames(t *testing.T, path string) []string {
+	t.Helper()
+	r, err := zip.OpenReader(path)
+	if err != nil {
+		t.Fatalf("open redacted package %s: %v", path, err)
+	}
+	defer r.Close()
+
+	names := make([]string, 0, len(r.File))
+	for _, f := range r.File {
+		names = append(names, f.Name)
+	}
+	return names
+}
+
+// TestRepackage_PreservesSourceEntryOrder is the regression guard for the
+// repackaging bug: repackageOfficeDocument wrote the redacted package by ranging
+// the contents map, so the parts came out in a random order on every run. Two
+// consequences, both real: the redacted .docx was not byte reproducible for the
+// same input, and [Content_Types].xml — which OPC requires to be the first entry
+// — frequently ended up somewhere in the middle.
+func TestRepackage_PreservesSourceEntryOrder(t *testing.T) {
+	src := writeFixtureDocx(t)
+	outDir := filepath.Join("testdata", "tmp-emit-order", "out")
+
+	r := NewOfficeRedactor(nil, nil)
+	for i := 0; i < iterations; i++ {
+		out := filepath.Join(outDir, "redacted.docx")
+		if _, err := r.RedactDocument(src, out, fixtureMatches(src), redactors.RedactionSimple); err != nil {
+			t.Fatalf("iteration %d: RedactDocument: %v", i, err)
+		}
+
+		got := zipEntryNames(t, out)
+		if len(got) != len(partOrder) {
+			t.Fatalf("iteration %d: got %d entries, want %d: %v", i, len(got), len(partOrder), got)
+		}
+		for j := range partOrder {
+			if got[j] != partOrder[j] {
+				t.Fatalf("iteration %d: entry %d = %q, want %q\nfull order: %v",
+					i, j, got[j], partOrder[j], got)
+			}
+		}
+		if got[0] != "[Content_Types].xml" {
+			t.Fatalf("iteration %d: [Content_Types].xml must be the first package entry, got %q", i, got[0])
+		}
+		os.Remove(out)
+	}
+}
+
+// TestRepackage_ByteReproducible checks the stronger property the order fix
+// buys: redacting one unchanged input twice produces identical bytes. Simple
+// strategy only — synthetic replacements are randomized by design.
+func TestRepackage_ByteReproducible(t *testing.T) {
+	src := writeFixtureDocx(t)
+	outDir := filepath.Join("testdata", "tmp-emit-order", "out")
+
+	r := NewOfficeRedactor(nil, nil)
+	hashes := make(map[string]int)
+	for i := 0; i < iterations; i++ {
+		out := filepath.Join(outDir, "reproducible.docx")
+		if _, err := r.RedactDocument(src, out, fixtureMatches(src), redactors.RedactionSimple); err != nil {
+			t.Fatalf("iteration %d: RedactDocument: %v", i, err)
+		}
+		data, err := os.ReadFile(out)
+		if err != nil {
+			t.Fatalf("iteration %d: read output: %v", i, err)
+		}
+		sum := sha256.Sum256(data)
+		hashes[hex.EncodeToString(sum[:])]++
+		os.Remove(out)
+	}
+
+	if len(hashes) != 1 {
+		t.Fatalf("redacting one unchanged input %d times produced %d distinct outputs, want 1: %v",
+			iterations, len(hashes), hashes)
+	}
+}
+
+// TestRepackage_RedactsSensitiveValues guards the fix against the trivially
+// wrong version of itself: an entry order that is stable but drops or fails to
+// redact content. The raw SSN and card number must not survive anywhere in the
+// package.
+func TestRepackage_RedactsSensitiveValues(t *testing.T) {
+	src := writeFixtureDocx(t)
+	out := filepath.Join("testdata", "tmp-emit-order", "out", "checked.docx")
+
+	r := NewOfficeRedactor(nil, nil)
+	if _, err := r.RedactDocument(src, out, fixtureMatches(src), redactors.RedactionSimple); err != nil {
+		t.Fatalf("RedactDocument: %v", err)
+	}
+
+	raw, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	// The parts are stored deflated, so scan the decompressed entries rather
+	// than the container bytes.
+	zr, err := zip.NewReader(bytes.NewReader(raw), int64(len(raw)))
+	if err != nil {
+		t.Fatalf("open output as zip: %v", err)
+	}
+	for _, f := range zr.File {
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("open entry %s: %v", f.Name, err)
+		}
+		content, err := io.ReadAll(rc)
+		rc.Close()
+		if err != nil {
+			t.Fatalf("read entry %s: %v", f.Name, err)
+		}
+		for _, secret := range []string{"449-87-4100", "4532-0151-1283-0366"} {
+			if bytes.Contains(content, []byte(secret)) {
+				t.Errorf("entry %s still contains the raw value", f.Name)
+			}
+		}
+	}
+}

--- a/internal/redactors/office/redactor.go
+++ b/internal/redactors/office/redactor.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -247,6 +248,51 @@ func (or *OfficeRedactor) detectDocumentType(filePath string) (OfficeDocumentTyp
 // OfficeZipContents represents the contents of an Office document ZIP file
 type OfficeZipContents struct {
 	Files map[string][]byte // filename -> content
+
+	// Order is the entry order of the ORIGINAL package, captured while reading
+	// it. Repackaging replays this order instead of ranging Files, which is a
+	// Go map and therefore randomized: without it the redacted .docx/.xlsx/.pptx
+	// was written with its parts in a different sequence on every run, so the
+	// same input produced a different output file each time — no byte
+	// reproducibility for anything that hashes or diffs the artifact. It also
+	// meant [Content_Types].xml frequently landed after the content parts, and
+	// OPC requires it to be the first entry in the package.
+	Order []string
+}
+
+// addFile records a package entry, preserving first-seen order.
+func (c *OfficeZipContents) addFile(name string, content []byte) {
+	if _, exists := c.Files[name]; !exists {
+		c.Order = append(c.Order, name)
+	}
+	c.Files[name] = content
+}
+
+// orderedNames returns the entry names in the original package order, with any
+// entry that is present in Files but absent from Order appended in sorted order.
+// The fallback keeps output deterministic even if a future code path adds a part
+// without going through addFile.
+func (c *OfficeZipContents) orderedNames() []string {
+	names := make([]string, 0, len(c.Files))
+	seen := make(map[string]bool, len(c.Files))
+	for _, name := range c.Order {
+		if _, exists := c.Files[name]; exists && !seen[name] {
+			names = append(names, name)
+			seen[name] = true
+		}
+	}
+	if len(names) == len(c.Files) {
+		return names
+	}
+
+	extra := make([]string, 0, len(c.Files)-len(names))
+	for name := range c.Files {
+		if !seen[name] {
+			extra = append(extra, name)
+		}
+	}
+	sort.Strings(extra)
+	return append(names, extra...)
 }
 
 // OfficeTextPosition represents text position information in an Office document
@@ -274,7 +320,8 @@ func (or *OfficeRedactor) extractOfficeContent(filePath string, docType OfficeDo
 	defer reader.Close()
 
 	zipContents := &OfficeZipContents{
-		Files: make(map[string][]byte),
+		Files: make(map[string][]byte, len(reader.File)),
+		Order: make([]string, 0, len(reader.File)),
 	}
 
 	var extractedText strings.Builder
@@ -323,7 +370,9 @@ func (or *OfficeRedactor) extractOfficeContent(filePath string, docType OfficeDo
 				maxOfficeTotalBytes)
 		}
 
-		zipContents.Files[file.Name] = content
+		// Record the entry with its position in the source package, so the
+		// repackaged document is written in the same order.
+		zipContents.addFile(file.Name, content)
 
 		// Extract text from relevant XML files
 		if or.isTextContainingFile(file.Name, docType) {
@@ -468,12 +517,14 @@ func (or *OfficeRedactor) extractAttributes(element xml.StartElement) map[string
 func (or *OfficeRedactor) redactOfficeContent(zipContents *OfficeZipContents, extractedText string, textPositions []OfficeTextPosition, matches []detector.Match, strategy redactors.RedactionStrategy, docType OfficeDocumentType) ([]redactors.RedactionMapping, *OfficeZipContents, error) {
 	var redactionMap []redactors.RedactionMapping
 	modifiedContents := &OfficeZipContents{
-		Files: make(map[string][]byte),
+		Files: make(map[string][]byte, len(zipContents.Files)),
+		Order: make([]string, 0, len(zipContents.Files)),
 	}
 
-	// Copy all files initially
-	for fileName, content := range zipContents.Files {
-		modifiedContents.Files[fileName] = content
+	// Copy all files initially, walking the recorded order rather than the map
+	// so the copy carries the source package's entry order forward.
+	for _, fileName := range zipContents.orderedNames() {
+		modifiedContents.addFile(fileName, zipContents.Files[fileName])
 	}
 
 	// Restore bounded (display-truncated) consolidated match texts to their
@@ -584,8 +635,10 @@ func (or *OfficeRedactor) applyXMLRedaction(zipContents *OfficeZipContents, posi
 	// This is a simplified approach - in production, you'd want more sophisticated XML manipulation
 	modifiedContent := bytes.ReplaceAll(xmlContent, []byte(originalText), []byte(replacement))
 
-	// Update the ZIP contents
-	zipContents.Files[position.FileName] = modifiedContent
+	// Update the ZIP contents. addFile rather than a bare map write so the entry
+	// order stays consistent with Files even though this path only ever replaces
+	// a part that is already present.
+	zipContents.addFile(position.FileName, modifiedContent)
 
 	or.logEvent("xml_content_modified", true, map[string]interface{}{
 		"file_name":     position.FileName,
@@ -617,8 +670,12 @@ func (or *OfficeRedactor) repackageOfficeDocument(contents *OfficeZipContents, o
 	zipWriter := zip.NewWriter(outFile)
 	defer zipWriter.Close()
 
-	// Write all files to ZIP
-	for fileName, content := range contents.Files {
+	// Write all files to ZIP in the order they appeared in the source package.
+	// Ranging contents.Files directly here made the redacted document's entry
+	// order random per run, which broke byte reproducibility and regularly moved
+	// [Content_Types].xml out of the first slot that OPC requires it to occupy.
+	for _, fileName := range contents.orderedNames() {
+		content := contents.Files[fileName]
 		fileWriter, err := zipWriter.Create(fileName)
 		if err != nil {
 			return fmt.Errorf("failed to create ZIP entry for %s: %w", fileName, err)


### PR DESCRIPTION
## Problem

Five sites in the redaction path derived **emitted output** from Go map iteration order, so redacting the same input twice produced a different artifact each time. Redacted documents and audit logs are compliance artifacts; one that cannot be hashed or diffed against a previous run of the same scan loses most of its value.

## The Office repackaging bug (the worst of the five)

`repackageOfficeDocument` wrote the redacted `.docx`/`.xlsx`/`.pptx` by ranging the contents map, so package parts came out in a random sequence on every run.

Measured on one unchanged `.docx`, 20 runs each:

| | distinct SHA-256 outputs | `[Content_Types].xml` first |
|---|---|---|
| before | 6–7 | 2 of 6 |
| after | **1** | **6 of 6** |

The second column matters independently of reproducibility: OPC requires `[Content_Types].xml` to be the **first** entry in the package. A reordered ZIP still opens (validity comes from the central directory), but a strict OPC consumer can reject it.

Fixed by recording the source package's entry order while reading it and replaying that order on write. **Replaying rather than sorting is deliberate** — real packages are not alphabetical, and a sort would still move `[Content_Types].xml` out of first place.

Content is unchanged: parent and fixed outputs have the same part set and byte-identical content in every part. This is pure ordering.

## The other four

- **Audit-log document IDs** — `ProcessMatches` assigned IDs from its loop position (`doc_0`, `doc_1`, …) while ranging a map keyed on file path, so the same file was labelled differently on each run. The image redactor had the same defect one level down, assigning `doc_N_redaction_I` from the position of an EXIF field walked out of a map.
- **Which item an error names** — `ExportAllAuditLogs`, `ValidateAllAuditLogs` and `RedactionConfig.Validate` reported whichever invalid entry the map yielded first, so an operator fixed one, re-ran, and got a fresh complaint about a different one. The exported JSON was already stable here (`encoding/json` sorts map keys); only the error message varied.
- **Self-describing listings** — `ListAuditLogs`, `GetRegisteredRedactors`, `UnregisterRedactor`'s log line, `GetSupportedTypes`, `GetSupportedImageFormats`.

## Deliberately left alone

`RedactorStats` and `MethodCounts` accumulation, `GetAllMappings`, and the `problematicChars` replacement table — all commutative or map-valued, so iteration order cannot reach output. Changing them would be churn.

## Testing

Every new test was confirmed **red on the parent commit** and green here.

The Office tests are built to reject a wrong fix as well as the bug:
- the fixture's 7 parts are in a deliberately **non-alphabetical** order, so a sort-based fix fails the test;
- byte reproducibility is asserted over 40 runs (`simple` strategy only — `synthetic` is randomized by design);
- the raw SSN and card number must survive in **no** decompressed entry, so an entry order that is stable but drops or fails to redact content cannot pass.

The fixture writes to a relative path rather than `t.TempDir()`: the Office preprocessors reject absolute paths under `/tmp`, `/var` and `/home`, and a fixture landing there silently exercises a different code path.

Gates, all clean: `gofmt`, `go vet ./...`, full `go test ./...`, both golden corpora ×3, `go test -race ./internal/redactors/...`. End-to-end A/B on a directory scan across `simple`, `format_preserving` and `synthetic` found zero occurrences of any planted secret in any output file or decompressed part.

## Follow-up found while testing (now #191, not in this PR)

Tracing residual audit-log variance surfaced a **separate and more serious** defect outside this diff: the validator fan-outs collect per-validator results off a buffered channel, so a file's match slice is ordered by **goroutine completion** — 128 distinct orders in 200 runs on the fan-out the CLI actually uses.

**Correction to an earlier version of this section:** I first attributed the consequence to `ResolveOverlaps`' `sort.SliceStable` tie-break deciding which of two equal-width overlapping matches survives. A permutation probe disproved that — the surviving *set* is permutation-stable (1 set across all 24 permutations of 4 matches), because `ResolveOverlaps` drops only *strictly contained* matches. The real mechanism is downstream: the redactors apply matches by searching for each match's text and replacing it, one at a time, so of two **partially** overlapping matches (both survive resolution) whichever is applied second can no longer be found — leaving a different substring in cleartext.

Filed as #191, which also fixes a third site: `SetupValidators` ranged a map, so registration order was itself random.
