### PR TITLE
fix(validators): make a file's match order independent of goroutine timing

### DIFF
--- a/internal/parallel/match_order_test.go
+++ b/internal/parallel/match_order_test.go
@@ -1,0 +1,175 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package parallel
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/preprocessors"
+)
+
+// orderProbeValidator returns exactly one match tagged with its own name, after
+// a delay derived from its position. The delays are chosen to invert the
+// registration order: the validator registered first sleeps longest, so a
+// collector that appends in completion order produces the reverse of the wanted
+// sequence rather than a coin flip. That makes the bug deterministic in the test
+// while remaining a faithful model of it — real validators finish in an order
+// set by how long their patterns take on the content, which the caller does not
+// control.
+type orderProbeValidator struct {
+	name  string
+	delay time.Duration
+}
+
+func (v *orderProbeValidator) ValidateProcessedContent(content *preprocessors.ProcessedContent) ([]detector.Match, error) {
+	time.Sleep(v.delay)
+	return []detector.Match{{
+		Text:       v.name + "-value",
+		Type:       strings.ToUpper(v.name),
+		LineNumber: 1,
+		Confidence: 90,
+		Validator:  v.name,
+	}}, nil
+}
+
+func (v *orderProbeValidator) ValidateContent(content string, originalPath string) ([]detector.Match, error) {
+	return nil, nil
+}
+
+func (v *orderProbeValidator) CalculateConfidence(match string) (float64, map[string]bool) {
+	return 90, nil
+}
+
+func (v *orderProbeValidator) AnalyzeContext(match string, ctx detector.ContextInfo) float64 {
+	return 0
+}
+
+// matchTypes renders a match slice as a comparable string.
+func matchTypes(matches []detector.Match) string {
+	parts := make([]string, 0, len(matches))
+	for _, m := range matches {
+		parts = append(parts, m.Type)
+	}
+	return strings.Join(parts, ",")
+}
+
+// TestRunValidators_MatchOrderFollowsValidatorOrder locks the union order to the
+// caller's validator order. RunValidators collects each validator's matches off
+// a buffered channel; draining it appended in goroutine-completion order, so the
+// same content validated twice yielded its matches in a different sequence.
+//
+// That is not a cosmetic problem. The redactors apply matches by searching for
+// each match's text in turn, so given two partially overlapping matches (neither
+// contained in the other, so both survive overlap resolution) whichever is
+// applied second can no longer be found — a different substring is left in
+// cleartext depending on which goroutine won the race.
+func TestRunValidators_MatchOrderFollowsValidatorOrder(t *testing.T) {
+	// Descending delays: first registered finishes last.
+	names := []string{"alpha", "bravo", "charlie", "delta", "echo"}
+	validators := make([]detector.Validator, 0, len(names))
+	for i, n := range names {
+		validators = append(validators, &orderProbeValidator{
+			name:  n,
+			delay: time.Duration(len(names)-i) * 2 * time.Millisecond,
+		})
+	}
+
+	want := "ALPHA,BRAVO,CHARLIE,DELTA,ECHO"
+	content := &preprocessors.ProcessedContent{
+		Text:         "probe content",
+		OriginalPath: "/probe/input.txt",
+		Filename:     "input.txt",
+	}
+
+	for i := 0; i < 10; i++ {
+		matches, err := RunValidators(context.Background(), validators, content, nil)
+		if err != nil {
+			t.Fatalf("iteration %d: RunValidators: %v", i, err)
+		}
+		if got := matchTypes(matches); got != want {
+			t.Fatalf("iteration %d: match order = %s, want %s", i, got, want)
+		}
+	}
+}
+
+// TestRunValidators_MatchOrderStableUnderContention runs validators whose
+// finishing order is genuinely unpredictable (equal, tiny delays) and requires
+// every run to agree. This is the property that matters in production, where
+// completion order is decided by the scheduler and by how long each validator's
+// patterns take on the content.
+func TestRunValidators_MatchOrderStableUnderContention(t *testing.T) {
+	names := []string{"one", "two", "three", "four", "five", "six", "seven", "eight"}
+	validators := make([]detector.Validator, 0, len(names))
+	for _, n := range names {
+		validators = append(validators, &orderProbeValidator{name: n, delay: 50 * time.Microsecond})
+	}
+
+	content := &preprocessors.ProcessedContent{
+		Text:         "probe content",
+		OriginalPath: "/probe/input.txt",
+		Filename:     "input.txt",
+	}
+
+	seen := make(map[string]int)
+	const iterations = 200
+	for i := 0; i < iterations; i++ {
+		matches, err := RunValidators(context.Background(), validators, content, nil)
+		if err != nil {
+			t.Fatalf("iteration %d: RunValidators: %v", i, err)
+		}
+		seen[matchTypes(matches)]++
+	}
+
+	if len(seen) != 1 {
+		var sample []string
+		for k := range seen {
+			sample = append(sample, k)
+			if len(sample) == 3 {
+				break
+			}
+		}
+		t.Fatalf("validating one unchanged input %d times produced %d distinct match orders, want 1\nexamples:\n  %s",
+			iterations, len(seen), strings.Join(sample, "\n  "))
+	}
+}
+
+// TestRunValidators_KeepsEveryValidatorsMatches guards the fix against the
+// trivially wrong version of itself: a slot-indexed collector that mis-sizes or
+// mis-indexes its slots would silently drop a validator's findings, which for a
+// scanner means an undetected secret.
+func TestRunValidators_KeepsEveryValidatorsMatches(t *testing.T) {
+	const n = 12
+	validators := make([]detector.Validator, 0, n)
+	for i := 0; i < n; i++ {
+		validators = append(validators, &orderProbeValidator{
+			name:  fmt.Sprintf("v%02d", i),
+			delay: time.Duration(i%3) * time.Millisecond,
+		})
+	}
+
+	content := &preprocessors.ProcessedContent{
+		Text:         "probe content",
+		OriginalPath: "/probe/input.txt",
+		Filename:     "input.txt",
+	}
+
+	matches, err := RunValidators(context.Background(), validators, content, nil)
+	if err != nil {
+		t.Fatalf("RunValidators: %v", err)
+	}
+	if len(matches) != n {
+		t.Fatalf("got %d matches from %d validators, want %d: %s", len(matches), n, n, matchTypes(matches))
+	}
+	for i, m := range matches {
+		want := strings.ToUpper(fmt.Sprintf("v%02d", i))
+		if m.Type != want {
+			t.Fatalf("match %d = %s, want %s\nfull order: %s", i, m.Type, want, matchTypes(matches))
+		}
+	}
+}

--- a/internal/parallel/validator_runner.go
+++ b/internal/parallel/validator_runner.go
@@ -86,8 +86,22 @@ func RunValidators(
 	}
 
 	var wg sync.WaitGroup
-	matchesChan := make(chan []detector.Match, len(validators))
+	// Results carry the launch slot they belong to. Draining the channel appends
+	// in goroutine-completion order, which varies run to run; the slot lets the
+	// collector restore the caller's validator order. See collectMatches.
+	type indexedMatches struct {
+		slot    int
+		matches []detector.Match
+	}
+	matchesChan := make(chan indexedMatches, len(validators))
 	errorChan := make(chan error, len(validators))
+
+	// launched counts the goroutines actually started. It is NOT the loop index:
+	// a validator that matches no dispatch interface, or a non-metadata validator
+	// skipped on pure-metadata content, launches nothing and must not consume a
+	// slot (an unused slot would be a harmless empty gap, but keeping the count
+	// exact means len(slots) == number of results expected).
+	launched := 0
 
 	for _, validator := range validators {
 		// Prefer the context-aware ProcessedContent path when available: it
@@ -98,7 +112,9 @@ func RunValidators(
 			ValidateProcessedContentCtx(ctx context.Context, content *preprocessors.ProcessedContent) ([]detector.Match, error)
 		}); ok {
 			wg.Add(1)
-			go func(pccv interface {
+			slot := launched
+			launched++
+			go func(slot int, pccv interface {
 				ValidateProcessedContentCtx(ctx context.Context, content *preprocessors.ProcessedContent) ([]detector.Match, error)
 			}) {
 				defer wg.Done()
@@ -119,15 +135,15 @@ func RunValidators(
 					// Preserve partial matches on a budget/deadline outcome; drop
 					// them on a hard error (historical behavior).
 					if partialMatchesSurvive(err) {
-						matchesChan <- matches
+						matchesChan <- indexedMatches{slot: slot, matches: matches}
 					} else {
-						matchesChan <- []detector.Match{}
+						matchesChan <- indexedMatches{slot: slot, matches: []detector.Match{}}
 					}
 					errorChan <- err
 					return
 				}
-				matchesChan <- matches
-			}(pccv)
+				matchesChan <- indexedMatches{slot: slot, matches: matches}
+			}(slot, pccv)
 			continue
 		}
 
@@ -135,7 +151,9 @@ func RunValidators(
 			ValidateProcessedContent(content *preprocessors.ProcessedContent) ([]detector.Match, error)
 		}); ok {
 			wg.Add(1)
-			go func(pcv interface {
+			slot := launched
+			launched++
+			go func(slot int, pcv interface {
 				ValidateProcessedContent(content *preprocessors.ProcessedContent) ([]detector.Match, error)
 			}) {
 				defer wg.Done()
@@ -151,15 +169,15 @@ func RunValidators(
 
 				if err := runOne(ctx, op); err != nil {
 					if partialMatchesSurvive(err) {
-						matchesChan <- matches
+						matchesChan <- indexedMatches{slot: slot, matches: matches}
 					} else {
-						matchesChan <- []detector.Match{}
+						matchesChan <- indexedMatches{slot: slot, matches: []detector.Match{}}
 					}
 					errorChan <- err
 					return
 				}
-				matchesChan <- matches
-			}(processedContentValidator)
+				matchesChan <- indexedMatches{slot: slot, matches: matches}
+			}(slot, processedContentValidator)
 			continue
 		}
 
@@ -172,7 +190,9 @@ func RunValidators(
 			}
 
 			wg.Add(1)
-			go func(cv interface {
+			slot := launched
+			launched++
+			go func(slot int, cv interface {
 				ValidateContent(content string, originalPath string) ([]detector.Match, error)
 			}) {
 				defer wg.Done()
@@ -193,15 +213,15 @@ func RunValidators(
 
 				if err := runOne(ctx, op); err != nil {
 					if partialMatchesSurvive(err) {
-						matchesChan <- matches
+						matchesChan <- indexedMatches{slot: slot, matches: matches}
 					} else {
-						matchesChan <- []detector.Match{}
+						matchesChan <- indexedMatches{slot: slot, matches: []detector.Match{}}
 					}
 					errorChan <- err
 					return
 				}
-				matchesChan <- matches
-			}(contentValidator)
+				matchesChan <- indexedMatches{slot: slot, matches: matches}
+			}(slot, contentValidator)
 		}
 	}
 
@@ -223,15 +243,47 @@ func RunValidators(
 	var allMatches []detector.Match
 	var firstErr error
 
+	// slots holds each goroutine's matches in its launch position, so the union
+	// is concatenated in the caller's validator order rather than in the order
+	// the goroutines happened to finish. Arrival order is a race: the same
+	// content validated twice yielded its matches in a different sequence, and
+	// downstream that is not cosmetic — the redactors apply matches by searching
+	// for each match's text in turn, so of two partially overlapping matches
+	// (neither contained in the other, so both survive overlap resolution)
+	// whichever is applied second can no longer be found, leaving a different
+	// substring in cleartext depending on which goroutine won.
+	slots := make([][]detector.Match, launched)
+	collect := func(im indexedMatches) {
+		if im.slot < 0 || im.slot >= len(slots) {
+			// Defensive: never expected, and appending beats panicking or dropping.
+			allMatches = append(allMatches, im.matches...)
+			return
+		}
+		slots[im.slot] = im.matches
+	}
+	// flatten concatenates the slots in launch order. Called on both the
+	// completed and the cancelled path (the latter returns early).
+	flatten := func() {
+		total := len(allMatches)
+		for _, m := range slots {
+			total += len(m)
+		}
+		out := make([]detector.Match, 0, total)
+		for _, m := range slots {
+			out = append(out, m...)
+		}
+		allMatches = append(out, allMatches...)
+	}
+
 	select {
 	case <-done:
-		// All validators completed: safe to close and drain fully (the
-		// pre-existing behavior, byte-for-byte).
+		// All validators completed: safe to close and drain fully.
 		close(matchesChan)
 		close(errorChan)
-		for matches := range matchesChan {
-			allMatches = append(allMatches, matches...)
+		for im := range matchesChan {
+			collect(im)
 		}
+		flatten()
 		for err := range errorChan {
 			if firstErr == nil {
 				firstErr = err
@@ -246,8 +298,8 @@ func RunValidators(
 		// degraded/incomplete coverage rather than a silent clean result.
 		for draining := true; draining; {
 			select {
-			case matches := <-matchesChan:
-				allMatches = append(allMatches, matches...)
+			case im := <-matchesChan:
+				collect(im)
 			case err := <-errorChan:
 				if firstErr == nil {
 					firstErr = err
@@ -256,6 +308,7 @@ func RunValidators(
 				draining = false
 			}
 		}
+		flatten()
 		if firstErr == nil {
 			firstErr = ctx.Err()
 		}

--- a/internal/validators/detector.go
+++ b/internal/validators/detector.go
@@ -5,6 +5,7 @@ package validators
 
 import (
 	stdctx "context"
+	"sort"
 
 	"github.com/awslabs/ferret-scan/v2/internal/detector"
 	"github.com/awslabs/ferret-scan/v2/internal/observability"
@@ -75,11 +76,25 @@ func NewDetector(observer observability.Observer) *Detector {
 // DualPathIntegration.SetMetadataValidator). Non-PreprocessorAware metadata
 // validators are wrapped in a MetadataValidatorAdapter, exactly as before.
 func (d *Detector) SetupValidators(validators map[string]detector.Validator) error {
-	for name, v := range validators {
+	// Register in check-name order. Ranging the map directly made registration
+	// order random per process, and registration order decides which validator
+	// gets to claim a span of text first: NPI 1234567893 is a valid NPI AND a
+	// valid 10-digit phone number, so the same input was redacted as
+	// [NPI-REDACTED] on one run and [PHONE-REDACTED] on the next. Nothing
+	// arbitrates between validators claiming the same bytes today (see the
+	// cross-validator overlap follow-up), so until something does, the order
+	// must at least be fixed rather than a coin flip.
+	names := make([]string, 0, len(validators))
+	for name := range validators {
 		if name == "METADATA" {
 			continue // handled separately below
 		}
-		d.bridge.RegisterDocumentValidator(name, v)
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		d.bridge.RegisterDocumentValidator(name, validators[name])
 	}
 
 	if mv, exists := validators["METADATA"]; exists {

--- a/internal/validators/document_bridge_order_test.go
+++ b/internal/validators/document_bridge_order_test.go
@@ -1,0 +1,151 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package validators
+
+import (
+	stdctx "context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/awslabs/ferret-scan/v2/internal/context"
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+)
+
+// bridgeOrderValidator returns one match tagged with its own name after a
+// per-instance delay. The document fan-out launches one goroutine per registered
+// validator and collects the results through a channel, so the delay decides
+// arrival order.
+type bridgeOrderValidator struct {
+	name  string
+	delay time.Duration
+}
+
+func (v *bridgeOrderValidator) ValidateContent(content string, originalPath string) ([]detector.Match, error) {
+	time.Sleep(v.delay)
+	return []detector.Match{{
+		Text:       v.name + "-value",
+		Type:       strings.ToUpper(v.name),
+		LineNumber: 1,
+		Confidence: 90,
+		Validator:  v.name,
+	}}, nil
+}
+
+func (v *bridgeOrderValidator) CalculateConfidence(match string) (float64, map[string]bool) {
+	return 90, nil
+}
+
+func (v *bridgeOrderValidator) AnalyzeContext(match string, ctx detector.ContextInfo) float64 {
+	return 0
+}
+
+func bridgeMatchTypes(matches []detector.Match) string {
+	parts := make([]string, 0, len(matches))
+	for _, m := range matches {
+		parts = append(parts, m.Type)
+	}
+	return strings.Join(parts, ",")
+}
+
+// TestDocumentBridge_MatchOrderFollowsRegistrationOrder locks the document
+// fan-out's match order to the order validators were registered in. This is the
+// fan-out the CLI actually uses: the scan passes a single Detector facade, which
+// expands here into one goroutine per check. Results were collected off a
+// channel and appended as they arrived, so completion order — decided by the
+// scheduler and by how long each validator's patterns take on the content —
+// determined the order of a file's findings.
+//
+// Delays descend so the validator registered first finishes last, making the
+// pre-fix behavior the exact reverse of the wanted order rather than a coin flip.
+func TestDocumentBridge_MatchOrderFollowsRegistrationOrder(t *testing.T) {
+	names := []string{"alpha", "bravo", "charlie", "delta", "echo"}
+	dvb := NewDocumentValidatorBridge()
+	for i, n := range names {
+		dvb.RegisterValidator(strings.ToUpper(n), &bridgeOrderValidator{
+			name:  n,
+			delay: time.Duration(len(names)-i) * 2 * time.Millisecond,
+		})
+	}
+
+	want := "ALPHA,BRAVO,CHARLIE,DELTA,ECHO"
+	for i := 0; i < 10; i++ {
+		matches, err := dvb.ProcessDocumentContentCtx(
+			stdctx.Background(), "probe content", "/probe/input.txt", context.ContextInsights{})
+		if err != nil {
+			t.Fatalf("iteration %d: ProcessDocumentContentCtx: %v", i, err)
+		}
+		if got := bridgeMatchTypes(matches); got != want {
+			t.Fatalf("iteration %d: match order = %s, want %s", i, got, want)
+		}
+	}
+}
+
+// TestDocumentBridge_MatchOrderStableUnderContention is the property that
+// matters in production: with equal, tiny delays the finishing order is
+// genuinely unpredictable, and every run must still agree.
+func TestDocumentBridge_MatchOrderStableUnderContention(t *testing.T) {
+	names := []string{"one", "two", "three", "four", "five", "six", "seven", "eight"}
+	dvb := NewDocumentValidatorBridge()
+	for _, n := range names {
+		dvb.RegisterValidator(strings.ToUpper(n), &bridgeOrderValidator{name: n, delay: 50 * time.Microsecond})
+	}
+
+	seen := make(map[string]int)
+	const iterations = 200
+	for i := 0; i < iterations; i++ {
+		matches, err := dvb.ProcessDocumentContentCtx(
+			stdctx.Background(), "probe content", "/probe/input.txt", context.ContextInsights{})
+		if err != nil {
+			t.Fatalf("iteration %d: ProcessDocumentContentCtx: %v", i, err)
+		}
+		seen[bridgeMatchTypes(matches)]++
+	}
+
+	if len(seen) != 1 {
+		var sample []string
+		for k := range seen {
+			sample = append(sample, k)
+			if len(sample) == 3 {
+				break
+			}
+		}
+		t.Fatalf("validating one unchanged input %d times produced %d distinct match orders, want 1\nexamples:\n  %s",
+			iterations, len(seen), strings.Join(sample, "\n  "))
+	}
+}
+
+// TestDocumentBridge_KeepsEveryValidatorsMatches guards against the trivially
+// wrong version of the fix: a slot-indexed collector that mis-sizes or
+// mis-indexes its slots would silently drop a validator's findings. For a
+// secret scanner a dropped finding is an undetected secret, so losing one is
+// strictly worse than the ordering bug being fixed.
+func TestDocumentBridge_KeepsEveryValidatorsMatches(t *testing.T) {
+	const n = 12
+	dvb := NewDocumentValidatorBridge()
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("v%02d", i)
+		dvb.RegisterValidator(strings.ToUpper(name), &bridgeOrderValidator{
+			name:  name,
+			delay: time.Duration(i%3) * time.Millisecond,
+		})
+	}
+
+	matches, err := dvb.ProcessDocumentContentCtx(
+		stdctx.Background(), "probe content", "/probe/input.txt", context.ContextInsights{})
+	if err != nil {
+		t.Fatalf("ProcessDocumentContentCtx: %v", err)
+	}
+	if len(matches) != n {
+		t.Fatalf("got %d matches from %d validators, want %d: %s",
+			len(matches), n, n, bridgeMatchTypes(matches))
+	}
+	for i, m := range matches {
+		want := strings.ToUpper(fmt.Sprintf("v%02d", i))
+		if m.Type != want {
+			t.Fatalf("match %d = %s, want %s\nfull order: %s", i, m.Type, want, bridgeMatchTypes(matches))
+		}
+	}
+}

--- a/internal/validators/dual_path_bridge.go
+++ b/internal/validators/dual_path_bridge.go
@@ -651,8 +651,15 @@ func (dvb *DocumentValidatorBridge) SetObserver(observer observability.Observer)
 	dvb.observer = observer
 }
 
-// validatorResult holds the result from a single validator execution
+// validatorResult holds the result from a single validator execution.
+//
+// index is the validator's position in the registration slice. The fan-out
+// collects results through a channel, so they arrive in goroutine-completion
+// order — a race whose winner changes run to run. Carrying the index lets the
+// collector put each result back where it belongs, making the concatenated
+// match order depend on registration order alone.
 type validatorResult struct {
+	index   int
 	matches []detector.Match
 	err     error
 }
@@ -721,10 +728,12 @@ func (dvb *DocumentValidatorBridge) ProcessDocumentContentCtx(ctx stdctx.Context
 	var errorsMu sync.Mutex
 	validationErrors := make([]error, 0)
 
-	// Launch goroutines for each validator
-	for _, validator := range validators {
+	// Launch goroutines for each validator. The loop index travels with the
+	// result so the collector can restore registration order (see
+	// validatorResult.index).
+	for i, validator := range validators {
 		wg.Add(1)
-		go func(nv namedValidator) {
+		go func(idx int, nv namedValidator) {
 			defer wg.Done()
 
 			// Bound process-wide concurrent validator work (v2 gap 2.1): file
@@ -738,7 +747,7 @@ func (dvb *DocumentValidatorBridge) ProcessDocumentContentCtx(ctx stdctx.Context
 				errorsMu.Lock()
 				validationErrors = append(validationErrors, lerr)
 				errorsMu.Unlock()
-				resultsChan <- validatorResult{matches: nil, err: lerr}
+				resultsChan <- validatorResult{index: idx, matches: nil, err: lerr}
 				return
 			}
 
@@ -773,10 +782,10 @@ func (dvb *DocumentValidatorBridge) ProcessDocumentContentCtx(ctx stdctx.Context
 				// validator error (which discards its partial slice). The error is
 				// still recorded above so the scan is flagged incomplete.
 				if errors.Is(err, execguard.ErrMatchBudgetExceeded) {
-					resultsChan <- validatorResult{matches: matches, err: err}
+					resultsChan <- validatorResult{index: idx, matches: matches, err: err}
 					return
 				}
-				resultsChan <- validatorResult{matches: nil, err: err}
+				resultsChan <- validatorResult{index: idx, matches: nil, err: err}
 				return
 			}
 
@@ -826,8 +835,8 @@ func (dvb *DocumentValidatorBridge) ProcessDocumentContentCtx(ctx stdctx.Context
 				}
 			}
 
-			resultsChan <- validatorResult{matches: matches, err: nil}
-		}(validator)
+			resultsChan <- validatorResult{index: idx, matches: matches, err: nil}
+		}(i, validator)
 	}
 
 	// Wait for all goroutines to complete, but do not block indefinitely on a
@@ -852,25 +861,61 @@ func (dvb *DocumentValidatorBridge) ProcessDocumentContentCtx(ctx stdctx.Context
 		return r.matches != nil && (r.err == nil || errors.Is(r.err, execguard.ErrMatchBudgetExceeded))
 	}
 
+	// Collect into a slot per validator rather than appending in arrival order,
+	// then concatenate by registration order. Results arrive off resultsChan in
+	// goroutine-completion order, which is a race: the same file scanned twice
+	// produced its matches in a different sequence, and that sequence is not
+	// cosmetic downstream. The redactors apply matches by sequentially searching
+	// for each match's text, so with two partially overlapping matches (neither
+	// contained in the other, so both survive overlap resolution) whichever is
+	// applied second can no longer be found — leaving a different substring in
+	// cleartext depending on which goroutine happened to win.
+	perValidator := make([][]detector.Match, len(validators))
+	collect := func(r validatorResult) {
+		if !keepMatches(r) {
+			return
+		}
+		// Defensive: a malformed index would otherwise panic here. Out-of-range
+		// results are appended after the ordered ones rather than dropped.
+		if r.index < 0 || r.index >= len(perValidator) {
+			allMatches = append(allMatches, r.matches...)
+			return
+		}
+		perValidator[r.index] = r.matches
+	}
+
+	// flatten concatenates the collected slots in registration order. Called on
+	// both the completed and the cancelled path (the latter returns early).
+	flatten := func() {
+		total := 0
+		for _, m := range perValidator {
+			total += len(m)
+		}
+		out := make([]detector.Match, 0, total+len(allMatches))
+		for _, m := range perValidator {
+			out = append(out, m...)
+		}
+		// allMatches holds only out-of-range salvage at this point; keep it last.
+		allMatches = append(out, allMatches...)
+	}
+
 	select {
 	case <-done:
 		close(resultsChan)
 		for result := range resultsChan {
-			if keepMatches(result) {
-				allMatches = append(allMatches, result.matches...)
-			}
+			collect(result)
 		}
+		flatten()
 	case <-ctx.Done():
 		for draining := true; draining; {
 			select {
 			case result := <-resultsChan:
-				if keepMatches(result) {
-					allMatches = append(allMatches, result.matches...)
-				}
+				collect(result)
 			default:
 				draining = false
 			}
 		}
+		flatten()
 		if finishTiming != nil {
 			finishTiming(false, map[string]interface{}{
 				"match_count":     len(allMatches),

--- a/internal/validators/setup_order_test.go
+++ b/internal/validators/setup_order_test.go
@@ -1,0 +1,101 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package validators
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+)
+
+// TestSetupValidators_RegistrationOrderIsFixed locks the order document
+// validators are registered in.
+//
+// SetupValidators receives a map of check name -> validator and used to range it
+// directly, so registration order was randomized per process. Registration order
+// is not cosmetic: it decides which validator gets to claim a span of text first
+// when two of them match the same bytes, and nothing arbitrates between such
+// claims today. NPI 1234567893 is simultaneously a checksum-valid NPI and a
+// well-formed 10-digit phone number, and it was redacted as [NPI-REDACTED] on
+// one run and [PHONE-REDACTED] on the next for the same input file.
+//
+// Sorting by check name is not claimed to be the *right* precedence — picking
+// one is the cross-validator arbitration problem, which is separate. It only
+// guarantees the choice is the same every run.
+func TestSetupValidators_RegistrationOrderIsFixed(t *testing.T) {
+	// Supplied via a map, so the input has no order of its own. Deliberately
+	// includes METADATA, which is routed to the metadata bridge instead and must
+	// not appear among the document validators.
+	names := []string{"SSN", "NPI", "PHONE", "EMAIL", "CREDIT_CARD", "ADDRESS", "IP_ADDRESS", "METADATA"}
+	want := []string{"ADDRESS", "CREDIT_CARD", "EMAIL", "IP_ADDRESS", "NPI", "PHONE", "SSN"}
+
+	// Repeat so a randomized map order cannot coincide with the wanted order on
+	// every attempt.
+	for i := 0; i < 100; i++ {
+		supplied := make(map[string]detector.Validator, len(names))
+		for _, n := range names {
+			supplied[n] = &bridgeOrderValidator{name: n}
+		}
+
+		d := NewDetector(nil)
+		if err := d.SetupValidators(supplied); err != nil {
+			t.Fatalf("iteration %d: SetupValidators: %v", i, err)
+		}
+
+		got := registeredDocumentNames(d)
+		if len(got) != len(want) {
+			t.Fatalf("iteration %d: registered %d document validators, want %d: %v",
+				i, len(got), len(want), got)
+		}
+		for j := range want {
+			if got[j] != want[j] {
+				t.Fatalf("iteration %d: registration %d = %q, want %q\nfull order: %v",
+					i, j, got[j], want[j], got)
+			}
+		}
+	}
+}
+
+// TestSetupValidators_RegistersEveryValidator guards against the trivially wrong
+// version of the fix. Ordering the registrations must not drop one: a validator
+// that never registers never runs, and for a secret scanner that is an
+// undetected secret rather than a cosmetic problem.
+func TestSetupValidators_RegistersEveryValidator(t *testing.T) {
+	names := []string{"SSN", "NPI", "PHONE", "EMAIL", "CREDIT_CARD"}
+	supplied := make(map[string]detector.Validator, len(names))
+	for _, n := range names {
+		supplied[n] = &bridgeOrderValidator{name: n}
+	}
+
+	d := NewDetector(nil)
+	if err := d.SetupValidators(supplied); err != nil {
+		t.Fatalf("SetupValidators: %v", err)
+	}
+
+	got := registeredDocumentNames(d)
+	if len(got) != len(names) {
+		t.Fatalf("registered %d validators, want %d: %v", len(got), len(names), got)
+	}
+	registered := strings.Join(got, ",")
+	for _, n := range names {
+		if !strings.Contains(registered, n) {
+			t.Errorf("validator %q was not registered (registered: %s)", n, registered)
+		}
+	}
+}
+
+// registeredDocumentNames returns the check names of the document validators in
+// registration order.
+func registeredDocumentNames(d *Detector) []string {
+	dvb := d.bridge.documentBridge
+	dvb.mu.RLock()
+	defer dvb.mu.RUnlock()
+
+	out := make([]string, 0, len(dvb.validators))
+	for _, nv := range dvb.validators {
+		out = append(out, nv.name)
+	}
+	return out
+}


### PR DESCRIPTION
## Problem

Scanning the same unchanged file twice produced its findings in a **different order** each time, because three sites let goroutine completion (or map iteration) decide the order.

On the redaction path that order reaches output. Redacting one unchanged directory 20 times:

| | distinct output sets / 20 runs |
|---|---|
| before | **2** |
| after | **1** |

(measured on both byte-comparable strategies, `simple` and `format_preserving`; `synthetic` is randomized by design.)

## Why order matters, not just its stability

The redactors apply matches by searching for each match's text in the content and replacing it, one match at a time. Given two **partially** overlapping matches — neither contained in the other, so both survive overlap resolution — whichever is applied second can no longer be found, and a *different* substring is left in cleartext depending on which won.

With `AAA-BBB` and `BBB-CCC` both matched in `id AAA-BBB-CCC end`, the result is either `id [REDACTED]-CCC end` or `id AAA-[REDACTED] end`.

## The three sites

**1. The document fan-out** (`internal/validators/dual_path_bridge.go`) — this is the fan-out the CLI actually uses: a scan passes a single `Detector` facade, which expands here into one goroutine per check. Results were collected off a channel and appended as they arrived: **128 distinct match orders over 200 runs** on an 8-validator probe. Each result now carries its registration index and is placed in a slot, so the concatenation follows registration order.

**2. `RunValidators`** (`internal/parallel`) — same pattern one level up, same fix: **76 distinct orders over 200 runs** before. The index is the *launch slot* rather than the loop index, because a validator matching no dispatch interface — or a non-metadata validator skipped on pure-metadata content — launches no goroutine and must not consume a slot.

**3. Registration order itself** (`internal/validators/detector.go`) — `SetupValidators` received a `map[string]detector.Validator` and ranged it, so registration order was randomized per process; fixing (1) made the match order faithfully follow an order that was itself a coin flip.

This third one is the site with a **visible consequence**. `NPI 1234567893` is simultaneously a checksum-valid NPI and a well-formed 10-digit phone number, and the same input file was redacted as `[NPI-REDACTED]` on one run and `[PHONE-REDACTED]` on the next. Now registered in check-name order.

Sorting by check name is **not** a claim about the right precedence between validators competing for the same bytes — choosing one is the separate cross-validator arbitration problem, and nothing arbitrates today. It only guarantees the choice is the same on every run.

## Cost

None measurable. A pre-sized slice plus one concatenation replaces incremental appends, so there is no added comparison and no extra allocation on the hot path — this is cheaper than sorting the result would have been.

Timing A/B, parent vs this branch:

| | parent | fixed |
|---|---|---|
| 400 files | 0.76s | 0.77s |
| single file, 4000 lines | 0.52s | 0.52s |

Scaling stays sublinear in file count (10× files → 1.4× time) and linear in lines. No O(n²).

## Testing

Every new test was confirmed **red on the parent commit** and green here. Each of the three sites gets three:

- one pinning the order with **descending** delays, so the pre-fix result is the exact reverse rather than a coin flip;
- one requiring **200 runs under contention** (equal, tiny delays) to all agree;
- one asserting **no validator's matches are dropped**.

The third is the important guard: a slot-indexed collector that mis-sizes or mis-indexes its slots would silently lose findings, and for a secret scanner a lost finding is an undetected secret — strictly worse than the ordering bug being fixed.

Gates, all clean: `gofmt`, `go vet ./...`, full `go test ./...`, both golden corpora ×5, `go test -race ./internal/parallel/... ./internal/validators/...`.

End-to-end (test plan: regression / redaction / suppression / timing):
- finding count unchanged — 22 before and after, 5 runs each;
- zero occurrences of any of 8 planted secrets across `simple`, `format_preserving` and `synthetic`;
- suppression unchanged — all 14 findings suppressed, stable over 15 runs, identical parent vs fixed;
- no timing regression, no O(n²) (table above).

## Residual variance that is *not* this PR

Two other sources of run-to-run difference survive this change and are called out so they are not mistaken for a regression here:

1. **`context_domain` flips** between `Financial` and `Government` — two argmax-over-map loops in `internal/context/analyzer.go` use strict `>`, so ties break randomly. Fixed in #178, not here.
2. **Two byte-identical files swap places** in the report — the formatter's finding sort has no filename tiebreak, so worker completion order decides between rows that are otherwise equal. Separate follow-up; needs a tiebreak in the comparator, not an ordering change in the engine.