### PR TITLE
fix: make validator and CLI emit order independent of map iteration

### DIFF
--- a/cmd/suppress/main.go
+++ b/cmd/suppress/main.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"sort"
 
 	"github.com/awslabs/ferret-scan/v2/internal/suppressions"
 )
@@ -74,8 +75,16 @@ func listSuppressions(manager *suppressions.SuppressionManager) {
 		}
 		if len(rule.Metadata) > 0 {
 			fmt.Println("Metadata:")
-			for k, v := range rule.Metadata {
-				fmt.Printf("  %s: %s\n", k, v)
+			// Sorted: this is printed output, and ranging the map listed the same
+			// rule's metadata in a different order each run, so `--action list`
+			// could not be diffed between invocations.
+			keys := make([]string, 0, len(rule.Metadata))
+			for k := range rule.Metadata {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			for _, k := range keys {
+				fmt.Printf("  %s: %s\n", k, rule.Metadata[k])
 			}
 		}
 		fmt.Println("---")

--- a/cmd/suppress/main_order_test.go
+++ b/cmd/suppress/main_order_test.go
@@ -1,0 +1,135 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/suppressions"
+)
+
+const suppressionFixture = `version: "1.0"
+rules:
+  - id: SUP-00000001
+    hash: abc123def456
+    reason: known test fixture
+    enabled: true
+    created_at: 2026-01-01T00:00:00Z
+    metadata:
+      zone: payments
+      validator: CREDIT_CARD
+      file: fixtures/cards.txt
+      line: "42"
+      ticket: JIRA-1234
+      owner: platform-team
+`
+
+// TestListSuppressionsMetadataIsSorted pins the metadata field order in
+// `--action list`. It was printed by ranging rule.Metadata (a map), so listing
+// the same unchanged suppression file twice produced different output and the
+// two runs could not be diffed — which matters because operators diff this
+// listing to see what changed in review.
+func TestListSuppressionsMetadataIsSorted(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sup.yaml")
+	if err := os.WriteFile(path, []byte(suppressionFixture), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	seen := make(map[string]int)
+	for i := 0; i < 100; i++ {
+		manager := suppressions.NewSuppressionManager(path)
+		out := captureStdout(t, func() { listSuppressions(manager) })
+		seen[metadataBlock(t, out)]++
+	}
+	if len(seen) != 1 {
+		t.Fatalf("metadata order varied across 100 runs: %d distinct orders %v", len(seen), seen)
+	}
+	const want = "file=fixtures/cards.txt,line=42,owner=platform-team,ticket=JIRA-1234,validator=CREDIT_CARD,zone=payments"
+	if _, ok := seen[want]; !ok {
+		t.Fatalf("metadata block = %v, want %q", seen, want)
+	}
+}
+
+// metadataBlock extracts the "  key: value" lines that follow "Metadata:" and
+// renders them as a single comparable string.
+func metadataBlock(t *testing.T, out string) string {
+	t.Helper()
+	idx := strings.Index(out, "Metadata:")
+	if idx < 0 {
+		t.Fatalf("no Metadata: section in listing:\n%s", out)
+	}
+	var parts []string
+	for _, line := range strings.Split(out[idx:], "\n")[1:] {
+		if !strings.HasPrefix(line, "  ") {
+			break
+		}
+		k, v, ok := strings.Cut(strings.TrimSpace(line), ": ")
+		if !ok {
+			break
+		}
+		parts = append(parts, k+"="+v)
+	}
+	if len(parts) == 0 {
+		t.Fatalf("Metadata: section had no entries:\n%s", out)
+	}
+	return strings.Join(parts, ",")
+}
+
+// TestListSuppressionsWithoutMetadata covers the len == 0 branch: a rule with no
+// metadata must not print an empty "Metadata:" header.
+func TestListSuppressionsWithoutMetadata(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sup.yaml")
+	const bare = `version: "1.0"
+rules:
+  - id: SUP-00000002
+    hash: deadbeef
+    reason: no metadata here
+    enabled: true
+    created_at: 2026-01-01T00:00:00Z
+`
+	if err := os.WriteFile(path, []byte(bare), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	manager := suppressions.NewSuppressionManager(path)
+	out := captureStdout(t, func() { listSuppressions(manager) })
+	if !strings.Contains(out, "SUP-00000002") {
+		t.Fatalf("rule not listed:\n%s", out)
+	}
+	if strings.Contains(out, "Metadata:") {
+		t.Fatalf("unexpected Metadata: header for a rule with no metadata:\n%s", out)
+	}
+}
+
+// captureStdout redirects os.Stdout for the duration of fn. listSuppressions
+// writes with fmt.Printf, so there is no injectable writer to use instead.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+	fn()
+	os.Stdout = orig
+	if err := w.Close(); err != nil {
+		t.Fatalf("close write end: %v", err)
+	}
+	out := <-done
+	if err := r.Close(); err != nil {
+		t.Fatalf("close read end: %v", err)
+	}
+	return out
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 
 	"github.com/awslabs/ferret-scan/v2/internal/paths"
 
@@ -103,23 +104,23 @@ type UnixConfig struct {
 
 // Profile represents a scanning profile with specific settings
 type Profile struct {
-	Format               string   `yaml:"format"`
-	ConfidenceLevels     string   `yaml:"confidence_levels"`
-	Checks               string   `yaml:"checks"`
-	Verbose              bool     `yaml:"verbose"`
-	Debug                bool     `yaml:"debug"`
-	NoColor              bool     `yaml:"no_color"`
-	Recursive            bool     `yaml:"recursive"`
-	EnablePreprocessors  bool     `yaml:"enable_preprocessors"`
-	ExcludePatterns      []string `yaml:"exclude_patterns"`
-	RespectGitignore     bool     `yaml:"respect_gitignore"`
-	ShowMatch            bool     `yaml:"show_match"`
-	Quiet                bool     `yaml:"quiet"`
-	ShowSuppressed       bool     `yaml:"show_suppressed"`
-	GenerateSuppressions bool     `yaml:"generate_suppressions"`
-	FailOnIncomplete     bool     `yaml:"fail_on_incomplete"`
-	Description string                            `yaml:"description"`
-	Validators  map[string]map[string]interface{} `yaml:"validators"`
+	Format               string                            `yaml:"format"`
+	ConfidenceLevels     string                            `yaml:"confidence_levels"`
+	Checks               string                            `yaml:"checks"`
+	Verbose              bool                              `yaml:"verbose"`
+	Debug                bool                              `yaml:"debug"`
+	NoColor              bool                              `yaml:"no_color"`
+	Recursive            bool                              `yaml:"recursive"`
+	EnablePreprocessors  bool                              `yaml:"enable_preprocessors"`
+	ExcludePatterns      []string                          `yaml:"exclude_patterns"`
+	RespectGitignore     bool                              `yaml:"respect_gitignore"`
+	ShowMatch            bool                              `yaml:"show_match"`
+	Quiet                bool                              `yaml:"quiet"`
+	ShowSuppressed       bool                              `yaml:"show_suppressed"`
+	GenerateSuppressions bool                              `yaml:"generate_suppressions"`
+	FailOnIncomplete     bool                              `yaml:"fail_on_incomplete"`
+	Description          string                            `yaml:"description"`
+	Validators           map[string]map[string]interface{} `yaml:"validators"`
 	// Redaction settings for this profile
 	Redaction struct {
 		Enabled   bool   `yaml:"enabled"`
@@ -386,12 +387,30 @@ func fileExists(filename string) bool {
 	return !info.IsDir()
 }
 
-// ListProfiles returns a list of available profile names
+// sortedProfileNames returns the profile names in alphabetical order, for loops
+// whose observable behavior depends on which profile is reached first (an error
+// return, a log line) rather than on visiting all of them.
+func sortedProfileNames(profiles map[string]Profile) []string {
+	names := make([]string, 0, len(profiles))
+	for name := range profiles {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// ListProfiles returns the available profile names in alphabetical order.
+//
+// Sorted because this feeds `--list-profiles` directly: ranging the Profiles map
+// printed the same config file's profiles in a different sequence on every
+// invocation, which makes the listing impossible to diff and looks like the
+// config changed when it did not.
 func (c *Config) ListProfiles() []string {
 	profiles := make([]string, 0, len(c.Profiles))
 	for name := range c.Profiles {
 		profiles = append(profiles, name)
 	}
+	sort.Strings(profiles)
 	return profiles
 }
 
@@ -704,8 +723,13 @@ func validateConfigPaths(config *Config) error {
 		}
 	}
 
-	// Validate profile-specific paths
-	for profileName, profile := range config.Profiles {
+	// Validate profile-specific paths. Profiles are visited in name order
+	// because this loop returns on the FIRST invalid path: ranging the map meant
+	// a config with two bad profiles reported whichever one Go happened to visit
+	// first, so an operator fixed it, re-ran, and got a fresh complaint about a
+	// different profile with no indication the first fix had worked.
+	for _, profileName := range sortedProfileNames(config.Profiles) {
+		profile := config.Profiles[profileName]
 		if profile.Redaction.OutputDir != "" {
 			if err := paths.ValidatePath(profile.Redaction.OutputDir); err != nil {
 				return fmt.Errorf("invalid redaction output directory in profile '%s': %w", profileName, err)

--- a/internal/config/order_test.go
+++ b/internal/config/order_test.go
@@ -1,0 +1,119 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func manyProfiles() map[string]Profile {
+	return map[string]Profile{
+		"zebra":      {},
+		"production": {},
+		"ci":         {},
+		"precommit":  {},
+		"audit":      {},
+		"dev":        {},
+		"minimal":    {},
+		"strict":     {},
+	}
+}
+
+// TestListProfilesIsSorted pins the `--list-profiles` output order. Ranging the
+// Profiles map printed the same config file's profiles in a different sequence
+// on every invocation, so the listing could not be diffed and looked like the
+// config had changed when it had not.
+func TestListProfilesIsSorted(t *testing.T) {
+	c := &Config{Profiles: manyProfiles()}
+	want := []string{"audit", "ci", "dev", "minimal", "precommit", "production", "strict", "zebra"}
+	for i := 0; i < 100; i++ {
+		got := c.ListProfiles()
+		if len(got) != len(want) {
+			t.Fatalf("ListProfiles returned %d names, want %d: %v", len(got), len(want), got)
+		}
+		for j := range want {
+			if got[j] != want[j] {
+				t.Fatalf("run %d: ListProfiles = %v, want %v", i, got, want)
+			}
+		}
+	}
+}
+
+// TestSortedProfileNamesIsTotal guards the helper against dropping or inventing
+// a profile. A dropped profile in ValidateConfig's loop would mean an invalid
+// path silently passing validation.
+func TestSortedProfileNamesIsTotal(t *testing.T) {
+	in := manyProfiles()
+	got := sortedProfileNames(in)
+	if len(got) != len(in) {
+		t.Fatalf("sortedProfileNames returned %d names for %d profiles: %v", len(got), len(in), got)
+	}
+	seen := make(map[string]bool, len(got))
+	for _, name := range got {
+		if seen[name] {
+			t.Fatalf("sortedProfileNames returned %q twice: %v", name, got)
+		}
+		seen[name] = true
+		if _, ok := in[name]; !ok {
+			t.Fatalf("sortedProfileNames returned %q, which is not a profile", name)
+		}
+	}
+}
+
+// TestValidateConfigReportsFirstProfileInNameOrder pins which of several bad
+// profiles is reported. ValidateConfig returns on the FIRST invalid path, so
+// with the map ranged directly a config with two bad profiles reported whichever
+// one Go happened to visit first — an operator fixed it, re-ran, and got a fresh
+// complaint about a different profile with no sign the first fix had worked.
+func TestValidateConfigReportsFirstProfileInNameOrder(t *testing.T) {
+	// A NUL byte is the one thing validateUnixPath rejects, and Windows path
+	// validation rejects it via its own rules, so this is invalid on both.
+	bad := "/tmp/out\x00dir"
+	seen := make(map[string]int)
+	for i := 0; i < 100; i++ {
+		cfg := &Config{Profiles: map[string]Profile{}}
+		for _, name := range []string{"zebra", "alpha", "middle", "production"} {
+			p := Profile{}
+			p.Redaction.OutputDir = bad
+			cfg.Profiles[name] = p
+		}
+		err := ValidateConfig(cfg)
+		if err == nil {
+			t.Fatal("ValidateConfig accepted a profile path containing a NUL byte")
+		}
+		switch {
+		case strings.Contains(err.Error(), "'alpha'"):
+			seen["alpha"]++
+		case strings.Contains(err.Error(), "'middle'"):
+			seen["middle"]++
+		case strings.Contains(err.Error(), "'production'"):
+			seen["production"]++
+		case strings.Contains(err.Error(), "'zebra'"):
+			seen["zebra"]++
+		default:
+			t.Fatalf("unexpected error, no profile named: %v", err)
+		}
+	}
+	if len(seen) != 1 {
+		t.Fatalf("reported profile varied across 100 runs: %v", seen)
+	}
+	if seen["alpha"] == 0 {
+		t.Fatalf("expected the alphabetically first bad profile to be reported, got %v", seen)
+	}
+}
+
+// TestValidateConfigAcceptsValidProfiles is the no-false-rejection guard: the
+// sorted loop must still visit every profile and pass clean ones.
+func TestValidateConfigAcceptsValidProfiles(t *testing.T) {
+	a := Profile{}
+	a.Redaction.OutputDir = "/tmp/a"
+	a.Redaction.IndexFile = "/tmp/a/index.json"
+	b := Profile{}
+	b.Redaction.OutputDir = "/tmp/b"
+	cfg := &Config{Profiles: map[string]Profile{"a": a, "b": b, "c": {}}}
+	if err := ValidateConfig(cfg); err != nil {
+		t.Fatalf("ValidateConfig rejected valid profiles: %v", err)
+	}
+}

--- a/internal/help/help.go
+++ b/internal/help/help.go
@@ -6,6 +6,7 @@ package help
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"text/tabwriter"
 
@@ -203,33 +204,26 @@ func (h *System) ShowChecksHelp() {
 	h.colors["header"].Fprintln(w, "  CHECK\tDESCRIPTION")
 	h.colors["header"].Fprintln(w, "  -----\t-----------")
 
-	// Get all check names and sort them alphabetically
-	var checkNames []string
+	// Collect each check's display info once, then sort by name. The previous
+	// version collected only names, sorted them with a hand-rolled O(n^2) bubble
+	// sort, and then re-scanned every provider for each name to find its
+	// description again — O(n^2) a second time. Keeping the info alongside the
+	// name makes one pass enough.
+	type checkRow struct {
+		name string
+		desc string
+	}
+	rows := make([]checkRow, 0, len(h.providers))
 	for _, provider := range h.providers {
 		info := provider.GetCheckInfo()
-		checkNames = append(checkNames, info.Name)
+		rows = append(rows, checkRow{name: info.Name, desc: info.ShortDescription})
 	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].name < rows[j].name })
 
-	// Sort alphabetically
-	for i := 0; i < len(checkNames); i++ {
-		for j := i + 1; j < len(checkNames); j++ {
-			if checkNames[i] > checkNames[j] {
-				checkNames[i], checkNames[j] = checkNames[j], checkNames[i]
-			}
-		}
-	}
-
-	// Display in alphabetical order
-	for _, checkName := range checkNames {
-		for _, provider := range h.providers {
-			info := provider.GetCheckInfo()
-			if info.Name == checkName {
-				fmt.Fprintf(w, "  ")
-				h.colors["emphasis"].Fprintf(w, "%s", info.Name)
-				fmt.Fprintf(w, "\t%s\n", info.ShortDescription)
-				break
-			}
-		}
+	for _, row := range rows {
+		fmt.Fprintf(w, "  ")
+		h.colors["emphasis"].Fprintf(w, "%s", row.name)
+		fmt.Fprintf(w, "\t%s\n", row.desc)
 	}
 	w.Flush()
 
@@ -238,18 +232,12 @@ func (h *System) ShowChecksHelp() {
 	h.colors["example"].Println("  ferret-scan --help <check>")
 	fmt.Println()
 
-	// Get the first available check name for the example
-	var exampleCheck string
-	if len(h.providers) > 0 {
-		// Find the first check name
-		for _, provider := range h.providers {
-			info := provider.GetCheckInfo()
-			exampleCheck = info.Name
-			break
-		}
-	} else {
-		// Fallback if no checks are available
-		exampleCheck = "<check>"
+	// Use the alphabetically first check as the example. This used to break out
+	// of a range over the providers MAP, so `--help checks` suggested a
+	// different check on every invocation — 10 different suggestions in 12 runs.
+	exampleCheck := "<check>"
+	if len(rows) > 0 {
+		exampleCheck = rows[0].name
 	}
 
 	fmt.Println("Example:")

--- a/internal/help/help_order_test.go
+++ b/internal/help/help_order_test.go
@@ -1,0 +1,143 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package help
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/fatih/color"
+)
+
+// fakeProvider is a minimal help Provider so the test does not depend on the
+// real validator packages (which would create an import cycle).
+type fakeProvider struct {
+	info CheckInfo
+}
+
+func (f fakeProvider) GetCheckInfo() CheckInfo { return f.info }
+
+func newTestSystem(names ...string) *System {
+	h := NewSystem(true)
+	for _, name := range names {
+		h.RegisterProvider(fakeProvider{info: CheckInfo{
+			Name:             name,
+			ShortDescription: "desc for " + name,
+		}})
+	}
+	return h
+}
+
+// captureStdout runs fn with output redirected to a pipe and returns what it
+// wrote. ShowChecksHelp prints directly to stdout, so this is the only way to
+// assert on its output. color.Output has to be swapped too: fatih/color
+// captures the real stdout at package init, so the colored lines (including the
+// suggested example) would otherwise bypass an os.Stdout swap entirely.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	orig := os.Stdout
+	origColor := color.Output
+	os.Stdout = w
+	color.Output = w
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+	fn()
+	os.Stdout = orig
+	color.Output = origColor
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe: %v", err)
+	}
+	out := <-done
+	if err := r.Close(); err != nil {
+		t.Fatalf("close read end: %v", err)
+	}
+	return out
+}
+
+// TestShowChecksHelpExampleIsDeterministic pins the suggested example check.
+// It used to be picked by breaking out of a range over the providers MAP, so
+// `--help checks` recommended a different check on every invocation (10
+// distinct suggestions in 12 runs), which reads like the tool changed.
+func TestShowChecksHelpExampleIsDeterministic(t *testing.T) {
+	h := newTestSystem("SSN", "EMAIL", "CREDIT_CARD", "PHONE", "PASSPORT", "VIN", "OTP", "METADATA")
+	seen := make(map[string]int)
+	for i := 0; i < 40; i++ {
+		out := captureStdout(t, h.ShowChecksHelp)
+		// Anchor on "Example:" — the earlier "use: ferret-scan --help <check>"
+		// instruction line also matches the bare prefix.
+		exIdx := strings.LastIndex(out, "Example:")
+		if exIdx < 0 {
+			t.Fatalf("Example: section missing from output:\n%s", out)
+		}
+		idx := strings.Index(out[exIdx:], "ferret-scan --help ")
+		if idx < 0 {
+			t.Fatalf("example line missing from output:\n%s", out)
+		}
+		rest := out[exIdx+idx+len("ferret-scan --help "):]
+		if nl := strings.IndexByte(rest, '\n'); nl >= 0 {
+			rest = rest[:nl]
+		}
+		seen[strings.TrimSpace(rest)]++
+	}
+	if len(seen) != 1 {
+		t.Fatalf("suggested example varied across 40 runs: %v", seen)
+	}
+	// The alphabetically first registered check.
+	if _, ok := seen["CREDIT_CARD"]; !ok {
+		t.Fatalf("expected the alphabetically first check as the example, got %v", seen)
+	}
+}
+
+// TestShowChecksHelpListIsSortedAndComplete asserts the rewritten single-pass
+// collection still lists every registered check, in name order, each with its
+// own description. The previous version re-scanned all providers per name to
+// find the description again; a name/description mismatch would misdescribe a
+// check to the user.
+func TestShowChecksHelpListIsSortedAndComplete(t *testing.T) {
+	names := []string{"SSN", "EMAIL", "CREDIT_CARD", "PHONE", "PASSPORT"}
+	h := newTestSystem(names...)
+	out := captureStdout(t, h.ShowChecksHelp)
+
+	prev := ""
+	found := 0
+	for _, line := range strings.Split(out, "\n") {
+		for _, name := range names {
+			if !strings.Contains(line, name) || !strings.Contains(line, "desc for "+name) {
+				continue
+			}
+			found++
+			if prev != "" && name < prev {
+				t.Fatalf("check %q listed after %q: list is not sorted\n%s", name, prev, out)
+			}
+			prev = name
+		}
+	}
+	if found != len(names) {
+		t.Fatalf("listed %d of %d checks with matching descriptions:\n%s", found, len(names), out)
+	}
+}
+
+// TestShowChecksHelpEmptyRegistry guards the len(rows) > 0 branch: with no
+// providers registered the example must fall back to a placeholder rather than
+// panic on rows[0].
+func TestShowChecksHelpEmptyRegistry(t *testing.T) {
+	h := NewSystem(true)
+	out := captureStdout(t, h.ShowChecksHelp)
+	exIdx := strings.LastIndex(out, "Example:")
+	if exIdx < 0 {
+		t.Fatalf("Example: section missing from output:\n%s", out)
+	}
+	if !strings.Contains(out[exIdx:], "ferret-scan --help <check>") {
+		t.Fatalf("empty registry should print the <check> placeholder:\n%s", out)
+	}
+}

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -203,6 +203,21 @@ func ValidatePath(path string) error {
 
 // validateWindowsPath validates a Windows path
 func validateWindowsPath(path string) error {
+	// A NUL byte is invalid in a path on every platform: Win32 treats it as the
+	// string terminator, and Go's own syscall layer rejects it outright, so a
+	// path containing one can never open the file the caller named. The Unix
+	// validator already rejected it; this one silently accepted it, so a config
+	// with an embedded NUL passed validation on Windows and failed later at the
+	// syscall with a far less obvious error.
+	for _, char := range path {
+		if char == 0 {
+			return &PathValidationError{
+				Path:   path,
+				Reason: "contains null byte",
+			}
+		}
+	}
+
 	// Check for invalid characters
 	invalidChars := []rune{'<', '>', ':', '"', '|', '?', '*'}
 	for i, char := range path {

--- a/internal/paths/validate_test.go
+++ b/internal/paths/validate_test.go
@@ -1,0 +1,58 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package paths
+
+import "testing"
+
+// TestValidatePathRejectsNULOnEveryPlatform pins the one rule both platform
+// validators must agree on. validateWindowsPath only screened the Win32
+// reserved characters (< > : " | ? *) and let a NUL byte through, so the same
+// config that ValidateConfig rejected on Linux and macOS passed validation on
+// Windows and then failed deeper down at the syscall, where the error no longer
+// names the offending setting. It is checked here against both validators
+// directly rather than through ValidatePath, so the case is exercised on every
+// runner instead of only the one matching the host OS.
+func TestValidatePathRejectsNULOnEveryPlatform(t *testing.T) {
+	bad := "/tmp/out\x00dir"
+
+	if err := validateUnixPath(bad); err == nil {
+		t.Error("validateUnixPath accepted a path containing a NUL byte")
+	}
+	if err := validateWindowsPath(bad); err == nil {
+		t.Error("validateWindowsPath accepted a path containing a NUL byte")
+	}
+
+	// ValidatePath dispatches on the host platform; whichever branch it takes
+	// must reject the NUL too.
+	if err := ValidatePath(bad); err == nil {
+		t.Error("ValidatePath accepted a path containing a NUL byte")
+	}
+}
+
+// TestValidateWindowsPathAcceptsOrdinaryPaths is the no-false-rejection guard
+// for the NUL check added above: it must not reject paths that are legitimate
+// on Windows, including a drive-letter colon.
+func TestValidateWindowsPathAcceptsOrdinaryPaths(t *testing.T) {
+	for _, p := range []string{
+		`C:\Users\someone\redacted`,
+		`redacted`,
+		`.\redacted`,
+		`\\server\share\redacted`,
+		``,
+	} {
+		if err := validateWindowsPath(p); err != nil {
+			t.Errorf("validateWindowsPath(%q) = %v, want nil", p, err)
+		}
+	}
+}
+
+// TestValidateWindowsPathRejectsReservedChars keeps the pre-existing behavior
+// covered, so a future edit to the NUL check cannot quietly drop it.
+func TestValidateWindowsPathRejectsReservedChars(t *testing.T) {
+	for _, p := range []string{`bad<name`, `bad>name`, `bad"name`, `bad|name`, `bad?name`, `bad*name`} {
+		if err := validateWindowsPath(p); err == nil {
+			t.Errorf("validateWindowsPath(%q) = nil, want an error", p)
+		}
+	}
+}

--- a/internal/preprocessors/error_handling.go
+++ b/internal/preprocessors/error_handling.go
@@ -6,6 +6,7 @@ package preprocessors
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -287,11 +288,19 @@ func (el *ErrorLogger) LogError(err *MediaProcessingError) {
 
 	message := fmt.Sprintf("[%s] %s", el.getLevelString(level), err.Error())
 
-	// Add context information
+	// Add context information. Keys are sorted because this string is printed:
+	// ranging the map directly put the same error's context fields in a
+	// different order on every run, so two logs of the identical failure could
+	// not be diffed or grep-matched with a fixed pattern.
 	if len(err.Context) > 0 {
-		var contextParts []string
-		for key, value := range err.Context {
-			contextParts = append(contextParts, fmt.Sprintf("%s=%v", key, value))
+		keys := make([]string, 0, len(err.Context))
+		for key := range err.Context {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		contextParts := make([]string, 0, len(keys))
+		for _, key := range keys {
+			contextParts = append(contextParts, fmt.Sprintf("%s=%v", key, err.Context[key]))
 		}
 		message += fmt.Sprintf(" context=[%s]", strings.Join(contextParts, " "))
 	}

--- a/internal/preprocessors/error_log_order_test.go
+++ b/internal/preprocessors/error_log_order_test.go
@@ -1,0 +1,119 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package preprocessors
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestLogErrorContextIsSorted pins the order of the context= fields in a logged
+// error. LogError printed them by ranging err.Context (a map), so two logs of
+// the identical failure came out with the fields in different orders and could
+// not be diffed or matched by a fixed grep pattern.
+func TestLogErrorContextIsSorted(t *testing.T) {
+	logger := NewErrorLogger(LogLevelDebug)
+	mkErr := func() *MediaProcessingError {
+		return &MediaProcessingError{
+			ErrorType: ErrorTypeParsingFailed,
+			FilePath:  "/test/photo.jpg",
+			Message:   "boom",
+			Context: map[string]interface{}{
+				"zone":      "exif",
+				"attempt":   2,
+				"offset":    1024,
+				"format":    "jpeg",
+				"extractor": "exiflib",
+				"bytes":     4096,
+			},
+		}
+	}
+
+	seen := make(map[string]int)
+	for i := 0; i < 100; i++ {
+		out := captureLogOutput(t, func() { logger.LogError(mkErr()) })
+		start := strings.Index(out, "context=[")
+		if start < 0 {
+			t.Fatalf("no context= section in log output: %q", out)
+		}
+		rest := out[start+len("context=["):]
+		end := strings.IndexByte(rest, ']')
+		if end < 0 {
+			t.Fatalf("unterminated context= section: %q", out)
+		}
+		seen[rest[:end]]++
+	}
+	if len(seen) != 1 {
+		t.Fatalf("context field order varied across 100 runs: %d distinct orders %v", len(seen), seen)
+	}
+	const want = "attempt=2 bytes=4096 extractor=exiflib format=jpeg offset=1024 zone=exif"
+	if _, ok := seen[want]; !ok {
+		t.Fatalf("context fields = %v, want %q", seen, want)
+	}
+}
+
+// TestLogErrorContextKeepsEveryField guards against the sort dropping a field:
+// diagnostic context that silently disappears is worse than unordered context.
+func TestLogErrorContextKeepsEveryField(t *testing.T) {
+	logger := NewErrorLogger(LogLevelDebug)
+	ctx := map[string]interface{}{"a": 1, "bb": 2, "ccc": 3, "dddd": 4, "e": 5}
+	out := captureLogOutput(t, func() {
+		logger.LogError(&MediaProcessingError{
+			ErrorType: ErrorTypeParsingFailed,
+			FilePath:  "/test/x.jpg",
+			Message:   "boom",
+			Context:   ctx,
+		})
+	})
+	for key := range ctx {
+		if !strings.Contains(out, key+"=") {
+			t.Fatalf("context key %q missing from log output: %q", key, out)
+		}
+	}
+}
+
+// TestLogErrorNoContextSection covers the len == 0 branch: an error with no
+// context must not grow an empty context=[] suffix.
+func TestLogErrorNoContextSection(t *testing.T) {
+	logger := NewErrorLogger(LogLevelDebug)
+	out := captureLogOutput(t, func() {
+		logger.LogError(&MediaProcessingError{
+			ErrorType: ErrorTypeParsingFailed,
+			FilePath:  "/test/x.jpg",
+			Message:   "boom",
+		})
+	})
+	if strings.Contains(out, "context=") {
+		t.Fatalf("unexpected context= section for an error with no context: %q", out)
+	}
+}
+
+// captureLogOutput redirects os.Stdout for the duration of fn. LogError writes
+// with fmt.Printf, so there is no injectable writer to use instead.
+func captureLogOutput(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+	fn()
+	os.Stdout = orig
+	if err := w.Close(); err != nil {
+		t.Fatalf("close write end: %v", err)
+	}
+	out := <-done
+	if err := r.Close(); err != nil {
+		t.Fatalf("close read end: %v", err)
+	}
+	return out
+}

--- a/internal/validators/intellectualproperty/order_test.go
+++ b/internal/validators/intellectualproperty/order_test.go
@@ -1,0 +1,101 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package intellectualproperty
+
+import (
+	stdctx "context"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// multiLineIPContent has one IP notice per line so every line becomes a distinct
+// key in processLineMatches' lineMatches map. Ranging that map directly rotated
+// the whole file's findings differently on every run.
+const multiLineIPContent = "Copyright (c) 2024 Acme Corp. All rights reserved.\n" +
+	"Patent No. 9,876,543 pending application.\n" +
+	"ACME(TM) is a trademark of Acme Corp.\n" +
+	"CONFIDENTIAL AND PROPRIETARY trade secret information.\n" +
+	"Copyright 2023 Widget Inc.\n"
+
+// lineSignature renders the emitted line numbers in emit order.
+func lineSignature(t *testing.T, content string) string {
+	t.Helper()
+	v := NewValidator()
+	matches, err := v.ValidateContentCtx(stdctx.Background(), content, "/test/notice.txt")
+	if err != nil {
+		t.Fatalf("ValidateContentCtx: %v", err)
+	}
+	parts := make([]string, 0, len(matches))
+	for _, m := range matches {
+		parts = append(parts, strconv.Itoa(m.LineNumber))
+	}
+	return strings.Join(parts, ",")
+}
+
+// TestEmitOrderIsAscendingByLine pins the emit order to document order. Before
+// the fix the emitted sequence was a random rotation of the file's lines.
+func TestEmitOrderIsAscendingByLine(t *testing.T) {
+	v := NewValidator()
+	matches, err := v.ValidateContentCtx(stdctx.Background(), multiLineIPContent, "/test/notice.txt")
+	if err != nil {
+		t.Fatalf("ValidateContentCtx: %v", err)
+	}
+	if len(matches) < 3 {
+		t.Fatalf("expected at least 3 findings across 5 notice lines, got %d", len(matches))
+	}
+	prev := -1
+	for i, m := range matches {
+		if m.LineNumber < prev {
+			t.Fatalf("finding %d is on line %d, after a finding on line %d: emit order is not ascending (%s)",
+				i, m.LineNumber, prev, lineSignature(t, multiLineIPContent))
+		}
+		prev = m.LineNumber
+	}
+}
+
+// TestEmitOrderStableAcrossRuns is the anti-flake guard: Go randomizes map
+// iteration per range statement, so one call can be ordered by luck.
+func TestEmitOrderStableAcrossRuns(t *testing.T) {
+	seen := make(map[string]int)
+	for i := 0; i < 200; i++ {
+		seen[lineSignature(t, multiLineIPContent)]++
+	}
+	if len(seen) != 1 {
+		t.Fatalf("emit order varied across 200 runs: %d distinct orders %v", len(seen), seen)
+	}
+}
+
+// TestEmitOrderKeepsEveryLinesFindings guards against the sort dropping a line.
+// A silently dropped line is an undetected IP notice, which is worse than a
+// randomly ordered one.
+func TestEmitOrderKeepsEveryLinesFindings(t *testing.T) {
+	v := NewValidator()
+	lineMatches := v.detectPatternsByLine(stdctx.Background(), multiLineIPContent, "/test/notice.txt")
+	linesWithMatches := 0
+	for _, ms := range lineMatches {
+		if len(ms) > 0 {
+			linesWithMatches++
+		}
+	}
+	if linesWithMatches == 0 {
+		t.Fatal("fixture produced no per-line matches; the test would not prove anything")
+	}
+	emitted := v.processLineMatches(lineMatches)
+	seenLines := make(map[int]bool, len(emitted))
+	for _, m := range emitted {
+		seenLines[m.LineNumber] = true
+	}
+	// Reconstruction can merge several matches on one line into one finding, so
+	// the count can shrink — but no line that had matches may vanish entirely.
+	for lineNum, ms := range lineMatches {
+		if len(ms) == 0 {
+			continue
+		}
+		if !seenLines[ms[0].LineNumber] {
+			t.Fatalf("line key %d had %d matches but contributed no finding (line %d missing from output)",
+				lineNum, len(ms), ms[0].LineNumber)
+		}
+	}
+}

--- a/internal/validators/intellectualproperty/validator.go
+++ b/internal/validators/intellectualproperty/validator.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -714,8 +715,20 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 func (v *Validator) processLineMatches(lineMatches map[int][]detector.Match) []detector.Match {
 	var finalMatches []detector.Match
 
-	// Process each line's matches
-	for lineNum, matches := range lineMatches {
+	// Process each line's matches in ascending line order. lineMatches is keyed
+	// by line number, and ranging it directly took the lines in Go's randomized
+	// map order — so the whole file's findings came out rotated differently on
+	// every run (measured: 4 distinct orders over 200 runs on a 5-line probe).
+	// Ascending line order is also the only order that makes sense to a reader:
+	// findings follow the document.
+	lineNums := make([]int, 0, len(lineMatches))
+	for lineNum := range lineMatches {
+		lineNums = append(lineNums, lineNum)
+	}
+	sort.Ints(lineNums)
+
+	for _, lineNum := range lineNums {
+		matches := lineMatches[lineNum]
 		if len(matches) == 0 {
 			// No matches on this line, skip
 			continue

--- a/internal/validators/metadata/gps_pairing_test.go
+++ b/internal/validators/metadata/gps_pairing_test.go
@@ -1,0 +1,141 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package metadata
+
+import (
+	"testing"
+)
+
+// gpsMatchText returns the single GPS finding's text, or "" if none was emitted.
+func gpsMatchText(t *testing.T, content string) string {
+	t.Helper()
+	v := NewValidator()
+	matches, err := v.ValidateContent(content, "/test/photo.jpg")
+	if err != nil {
+		t.Fatalf("ValidateContent: %v", err)
+	}
+	text := ""
+	for _, m := range matches {
+		if m.Type != "GPS" {
+			continue
+		}
+		if text != "" {
+			t.Fatalf("expected at most one GPS finding, got another: %q after %q", m.Text, text)
+		}
+		text = m.Text
+	}
+	return text
+}
+
+// bothSourcesContent carries an authoritative EXIF pair (San Francisco) AND a
+// looser plain pair (London). Before the fix, combineGPSCoordinates ranged the
+// field map and assigned to shared latitude/longitude variables, so the winner
+// was whichever field the map happened to yield last — independently for
+// latitude and for longitude. That produced FOUR outcomes across runs of the
+// same binary, two of which mixed the two pairs into a location present nowhere
+// in the file (37.7749/-0.1278 and 51.5074/-122.4194).
+const bothSourcesContent = "--- image_metadata ---\n" +
+	"GPSLatitude: 37.7749\n" +
+	"GPSLongitude: -122.4194\n" +
+	"Latitude: 51.5074\n" +
+	"Longitude: -0.1278\n"
+
+// TestGPSPairIsNeverMixedAcrossSources is the data-integrity assertion: the
+// emitted coordinate must be a pair that actually exists in the input, and
+// specifically the authoritative gps* one.
+func TestGPSPairIsNeverMixedAcrossSources(t *testing.T) {
+	got := gpsMatchText(t, bothSourcesContent)
+	const want = "37.7749, -122.4194"
+	if got != want {
+		t.Fatalf("GPS finding = %q, want %q (the gps*-prefixed pair wins, and latitude/longitude must come from the same source)", got, want)
+	}
+}
+
+// TestGPSPairStableAcrossRuns is the anti-flake guard. A single call could pick
+// the right pair by luck, so pin it over 200 runs; the pre-fix code produced 4
+// distinct values here.
+func TestGPSPairStableAcrossRuns(t *testing.T) {
+	seen := make(map[string]int)
+	for i := 0; i < 200; i++ {
+		seen[gpsMatchText(t, bothSourcesContent)]++
+	}
+	if len(seen) != 1 {
+		t.Fatalf("GPS coordinate varied across 200 runs: %d distinct values %v", len(seen), seen)
+	}
+	if _, ok := seen["37.7749, -122.4194"]; !ok {
+		t.Fatalf("stable but wrong pair: %v", seen)
+	}
+}
+
+// TestGPSFallsBackToPlainPair covers the second precedence tier: no gps* fields
+// at all, so the plain pair is the only pair and must still be emitted.
+func TestGPSFallsBackToPlainPair(t *testing.T) {
+	content := "--- image_metadata ---\n" +
+		"Latitude: 51.5074\n" +
+		"Longitude: -0.1278\n"
+	if got, want := gpsMatchText(t, content), "51.5074, -0.1278"; got != want {
+		t.Fatalf("GPS finding = %q, want %q", got, want)
+	}
+}
+
+// TestGPSCombinesAcrossSourcesOnlyWhenIncomplete covers the third tier and is
+// the behavior-preservation test: a file with GPSLatitude but only a plain
+// Longitude has no complete pair from either source, so cross-source combining
+// is the only way to report the location at all. Detection must not be lost.
+func TestGPSCombinesAcrossSourcesOnlyWhenIncomplete(t *testing.T) {
+	content := "--- image_metadata ---\n" +
+		"GPSLatitude: 37.7749\n" +
+		"Longitude: -122.4194\n"
+	if got, want := gpsMatchText(t, content), "37.7749, -122.4194"; got != want {
+		t.Fatalf("GPS finding = %q, want %q (incomplete sources must still be combined)", got, want)
+	}
+}
+
+// TestSortedGPSFieldsIsLongestFirst pins the helper's contract. Length-first
+// matters because the caller dispatches with strings.Contains over names that
+// are substrings of each other: if "latitude" were visited before
+// "gpslatituderef", the shorter name's case would claim the longer field.
+func TestSortedGPSFieldsIsLongestFirst(t *testing.T) {
+	in := map[string]string{
+		"latitude":        "1",
+		"gpslatitude":     "2",
+		"gpslatituderef":  "3",
+		"gpslongituderef": "4",
+		"longitude":       "5",
+		"gpslongitude":    "6",
+	}
+	got := sortedGPSFields(in)
+	// Strictly by descending length (15, 14, 12, 11, 9, 8), with alphabetical
+	// order only breaking ties between equal-length names.
+	want := []string{"gpslongituderef", "gpslatituderef", "gpslongitude", "gpslatitude", "longitude", "latitude"}
+	if len(got) != len(want) {
+		t.Fatalf("sortedGPSFields returned %d fields, want %d: %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("sortedGPSFields = %v, want %v", got, want)
+		}
+	}
+	// The helper must also be total: every key present, none invented.
+	for _, f := range got {
+		if _, ok := in[f]; !ok {
+			t.Fatalf("sortedGPSFields returned %q, which is not a key of the input", f)
+		}
+	}
+}
+
+// TestSortedGPSFieldsIsDeterministic runs the helper repeatedly on the same map
+// to prove the sort, not the map, decides the order.
+func TestSortedGPSFieldsIsDeterministic(t *testing.T) {
+	in := map[string]string{"aa": "", "bb": "", "cc": "", "dddd": "", "e": "", "ff": "", "gg": ""}
+	first := sortedGPSFields(in)
+	for i := 0; i < 200; i++ {
+		got := sortedGPSFields(in)
+		for j := range first {
+			if got[j] != first[j] {
+				t.Fatalf("run %d differed: %v vs %v", i, got, first)
+			}
+		}
+	}
+}

--- a/internal/validators/metadata/metadata_validator.go
+++ b/internal/validators/metadata/metadata_validator.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -2343,6 +2344,29 @@ func (v *Validator) isGPSCoordinateComponent(fieldName string) bool {
 	return false
 }
 
+// sortedGPSFields returns the GPS field names in a fixed order so
+// combineGPSCoordinates visits them the same way on every run.
+//
+// The order is longest-name-first, then alphabetical. Length first is not
+// cosmetic: the caller dispatches with strings.Contains, and the field names
+// are substrings of each other ("gpslatitude" contains "latitude",
+// "gpslatituderef" contains "gpslatitude"). Visiting the longest name first
+// means the most specific field is seen before any name it contains, which is
+// the order the switch's case sequence already assumes.
+func sortedGPSFields(gpsCoordinates map[string]string) []string {
+	fields := make([]string, 0, len(gpsCoordinates))
+	for field := range gpsCoordinates {
+		fields = append(fields, field)
+	}
+	sort.Slice(fields, func(i, j int) bool {
+		if len(fields[i]) != len(fields[j]) {
+			return len(fields[i]) > len(fields[j])
+		}
+		return fields[i] < fields[j]
+	})
+	return fields
+}
+
 // combineGPSCoordinates combines latitude and longitude into coordinate pairs
 func (v *Validator) combineGPSCoordinates(gpsCoordinates map[string]string, gpsLineNumbers map[string]int, originalPath, currentEmbeddedMedia string) []detector.Match {
 	var matches []detector.Match
@@ -2357,13 +2381,25 @@ func (v *Validator) combineGPSCoordinates(gpsCoordinates map[string]string, gpsL
 	var latitude, longitude, latRef, longRef string
 	var latLine, longLine int
 
+	// Both loops below used to range gpsCoordinates directly. That is a map, so
+	// the visit order was random per run — and this function assigns to shared
+	// latitude/longitude variables with no precedence, meaning last-writer-wins.
+	// A file carrying BOTH a GPSLatitude/GPSLongitude pair and a plain
+	// Latitude/Longitude pair with different values therefore emitted one of
+	// FOUR different coordinates across runs of the same binary, two of them
+	// mixing the latitude of one pair with the longitude of the other — a
+	// location that appears nowhere in the file. See the precedence handling
+	// below for the fix; the fixed field order here is what makes it reachable.
+	fields := sortedGPSFields(gpsCoordinates)
+
 	// Emit any already-consolidated GPS coordinate entries. We do NOT return
 	// early here (M33): a stray "Coordinates:" field — possibly a placeholder
 	// like "N/A" — must not short-circuit the separate GPSLatitude/GPSLongitude
 	// pairing below, and a placeholder value must not be emitted as a GPS match.
 	// We therefore validate the value looks like a real coordinate before
 	// emitting, and fall through to the component-pairing logic regardless.
-	for field, value := range gpsCoordinates {
+	for _, field := range fields {
+		value := gpsCoordinates[field]
 		fieldLower := strings.ToLower(field)
 		if strings.Contains(fieldLower, "gps_coordinates") || strings.Contains(fieldLower, "coordinates") {
 			// A real coordinate value contains digits; skip placeholders such as
@@ -2401,25 +2437,60 @@ func (v *Validator) combineGPSCoordinates(gpsCoordinates map[string]string, gpsL
 		}
 	}
 
-	// Extract coordinate values for individual components (fallback)
-	for field, value := range gpsCoordinates {
+	// Extract coordinate values for individual components (fallback).
+	//
+	// PRECEDENCE, not just order (this is the part a plain sort would get
+	// wrong): a gps*-prefixed field is the authoritative EXIF/QuickTime tag,
+	// while a bare "latitude"/"longitude" is a looser derived or user-supplied
+	// field. When a file carries both, the gps* value must win, and — crucially
+	// — latitude and longitude must be taken from the SAME source, or the pair
+	// describes a place that is in neither. So each source is collected
+	// separately and the winner chosen afterwards, rather than assigning to one
+	// shared variable and letting whichever field is visited last decide.
+	var gpsLat, gpsLong, plainLat, plainLong string
+	var gpsLatLine, gpsLongLine, plainLatLine, plainLongLine int
+	for _, field := range fields {
+		value := gpsCoordinates[field]
 		switch {
 		case strings.Contains(field, "gpslatitude") && !strings.Contains(field, "ref"):
-			latitude = value
-			latLine = gpsLineNumbers[field]
+			gpsLat = value
+			gpsLatLine = gpsLineNumbers[field]
 		case strings.Contains(field, "gpslongitude") && !strings.Contains(field, "ref"):
-			longitude = value
-			longLine = gpsLineNumbers[field]
+			gpsLong = value
+			gpsLongLine = gpsLineNumbers[field]
 		case strings.Contains(field, "gpslatituderef"):
 			latRef = value
 		case strings.Contains(field, "gpslongituderef"):
 			longRef = value
 		case strings.Contains(field, "latitude") && !strings.Contains(field, "gps"):
-			latitude = value
-			latLine = gpsLineNumbers[field]
+			plainLat = value
+			plainLatLine = gpsLineNumbers[field]
 		case strings.Contains(field, "longitude") && !strings.Contains(field, "gps"):
-			longitude = value
-			longLine = gpsLineNumbers[field]
+			plainLong = value
+			plainLongLine = gpsLineNumbers[field]
+		}
+	}
+
+	// Prefer a complete gps* pair; fall back to a complete plain pair. Only if
+	// neither source is complete on its own do we combine across sources, which
+	// preserves the previous behavior for the files that actually relied on it
+	// (e.g. "GPSLatitude" present but only "Longitude" available) while never
+	// mixing two pairs that are each complete.
+	switch {
+	case gpsLat != "" && gpsLong != "":
+		latitude, longitude = gpsLat, gpsLong
+		latLine, longLine = gpsLatLine, gpsLongLine
+	case plainLat != "" && plainLong != "":
+		latitude, longitude = plainLat, plainLong
+		latLine, longLine = plainLatLine, plainLongLine
+	default:
+		latitude, latLine = gpsLat, gpsLatLine
+		if latitude == "" {
+			latitude, latLine = plainLat, plainLatLine
+		}
+		longitude, longLine = gpsLong, gpsLongLine
+		if longitude == "" {
+			longitude, longLine = plainLong, plainLongLine
 		}
 	}
 

--- a/internal/validators/passport/order_test.go
+++ b/internal/validators/passport/order_test.go
@@ -1,0 +1,90 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package passport
+
+import (
+	stdctx "context"
+	"strings"
+	"testing"
+)
+
+// td3MRZ is a real ICAO 9303 TD3 line 1: 44 characters. It matches BOTH the
+// "MRZ" pattern (38-40 trailing filler chars) and "MRZ_TD3" (exactly 39), so
+// the same span is claimed by two entries of the patterns map. That overlap is
+// what made the map's iteration order observable.
+const td3MRZ = "P<GBRSMITH<<JOHN<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
+
+func mrzContent() string {
+	return "passport holder machine readable zone icao\n" + td3MRZ + "\n"
+}
+
+// signature renders the emitted matches as an order-sensitive string. The
+// "country" metadata key is the pattern name, and it reaches the user: the text
+// formatter prints it for every passport finding.
+func signature(t *testing.T, content string) string {
+	t.Helper()
+	v := NewValidator()
+	matches, err := v.ValidateContentCtx(stdctx.Background(), content, "/test/passport.txt")
+	if err != nil {
+		t.Fatalf("ValidateContentCtx: %v", err)
+	}
+	parts := make([]string, 0, len(matches))
+	for _, m := range matches {
+		country, _ := m.Metadata["country"].(string)
+		parts = append(parts, country)
+	}
+	return strings.Join(parts, ",")
+}
+
+// TestPatternOrderIsFixed pins the emitted order for a span two patterns claim.
+// Before the fix the scan ranged v.patterns (a map), so this produced either
+// "MRZ_TD3,MRZ" or "MRZ,MRZ_TD3" at random.
+func TestPatternOrderIsFixed(t *testing.T) {
+	got := signature(t, mrzContent())
+	if got != "MRZ_TD3,MRZ" {
+		t.Fatalf("pattern order = %q, want %q (patternOrder puts the more specific TD3 pattern first)", got, "MRZ_TD3,MRZ")
+	}
+}
+
+// TestPatternOrderStableAcrossRuns is the anti-flake guard: Go randomizes map
+// iteration per range statement, so a single call can pass by luck. 200 calls
+// on the same content must all agree.
+func TestPatternOrderStableAcrossRuns(t *testing.T) {
+	seen := make(map[string]int)
+	content := mrzContent()
+	for i := 0; i < 200; i++ {
+		seen[signature(t, content)]++
+	}
+	if len(seen) != 1 {
+		t.Fatalf("emit order varied across 200 runs: %d distinct orders %v", len(seen), seen)
+	}
+}
+
+// TestPatternOrderCoversEveryPattern guards the panic in NewValidator. If a new
+// pattern is added to the patterns map and not to patternOrder, that pattern
+// would silently stop being applied — for a scanner that means a passport
+// format that is no longer detected at all, which is a missed finding, not a
+// cosmetic regression. NewValidator panics instead; this asserts it does not
+// panic today and that the slice really covers the map.
+func TestPatternOrderCoversEveryPattern(t *testing.T) {
+	v := NewValidator()
+	if len(v.patternOrder) != len(v.compiledPatterns) {
+		t.Fatalf("patternOrder has %d names but there are %d compiled patterns", len(v.patternOrder), len(v.compiledPatterns))
+	}
+	inOrder := make(map[string]bool, len(v.patternOrder))
+	for _, name := range v.patternOrder {
+		if inOrder[name] {
+			t.Fatalf("patternOrder lists %q twice", name)
+		}
+		inOrder[name] = true
+		if v.compiledPatterns[name] == nil {
+			t.Fatalf("patternOrder names %q, which has no compiled pattern", name)
+		}
+	}
+	for name := range v.compiledPatterns {
+		if !inOrder[name] {
+			t.Fatalf("pattern %q is missing from patternOrder, so it would never be applied", name)
+		}
+	}
+}

--- a/internal/validators/passport/validator.go
+++ b/internal/validators/passport/validator.go
@@ -60,6 +60,15 @@ var (
 type Validator struct {
 	patterns         map[string]string
 	compiledPatterns map[string]*regexp.Regexp
+	// patternOrder fixes the order the patterns are applied in. The scan used to
+	// range the patterns map, and Go randomizes map iteration, so when two
+	// patterns matched the SAME span the resulting findings came out in a random
+	// sequence. A real TD3 MRZ line is matched by both "MRZ" and "MRZ_TD3", and
+	// the country name reaches the text report ("Country: MRZ" vs
+	// "Country: MRZ_TD3"), so the same file produced two different reports.
+	// Ordered most-specific-first, so the tightest matching format is the one
+	// reported first.
+	patternOrder []string
 
 	// Keywords that suggest a passport context
 	positiveKeywords []string
@@ -124,13 +133,33 @@ func NewValidator() *Validator {
 		"MRZ_TD3": `\bP<[A-Z]{3}[A-Z0-9<]{39}`,    // MRZ TD3 line 1 (exactly 44 chars)
 	}
 
+	// Application order, most specific format first. MRZ_TD3 (exactly 44 chars)
+	// before MRZ (44-46), and the fixed-shape national formats before the
+	// broadest one (EU's 2 letters + 7 alphanumerics also matches Canada-shaped
+	// and some US-shaped tokens). See Validator.patternOrder for why this is a
+	// slice and not the map's own iteration order.
+	patternOrder := []string{"MRZ_TD3", "MRZ", "US", "UK", "Canada", "EU"}
+
 	compiledPatterns := make(map[string]*regexp.Regexp, len(patterns))
 	for country, pattern := range patterns {
 		compiledPatterns[country] = regexp.MustCompile(pattern)
 	}
 
+	// Guard against patternOrder drifting out of sync with patterns: a pattern
+	// missing from the order would silently stop being applied, which for a
+	// scanner means a passport format that is no longer detected at all.
+	if len(patternOrder) != len(patterns) {
+		panic("passport: patternOrder does not cover every pattern")
+	}
+	for _, name := range patternOrder {
+		if _, ok := patterns[name]; !ok {
+			panic("passport: patternOrder names unknown pattern " + name)
+		}
+	}
+
 	return &Validator{
 		patterns:         patterns,
+		patternOrder:     patternOrder,
 		compiledPatterns: compiledPatterns,
 		positiveKeywords: []string{
 			// High-confidence passport-specific keywords
@@ -359,9 +388,13 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 		lineIsTabular := v.isTabularDataLine(line)
 		lineIsForm := v.isInFormContextLine(lineLower)
 
-		// Check each pattern against the line
-		for country := range v.patterns {
+		// Check each pattern against the line, in the fixed order (see
+		// Validator.patternOrder) rather than the patterns map's random one.
+		for _, country := range v.patternOrder {
 			re := v.compiledPatterns[country]
+			if re == nil {
+				continue
+			}
 			// Use FindAllStringIndex so each match's byte offset is known up
 			// front. This eliminates the per-match strings.Index(line, match)
 			// rescan (O(lineLength) each) AND fixes a latent correctness bug:


### PR DESCRIPTION
Seven sites picked their output by ranging a Go map, so the same input produced different output on different runs of the same binary. **One of them fabricates data**; the rest break reproducibility of printed output.

## The data-fabrication one: metadata GPS pairing

`combineGPSCoordinates` ranged the GPS field map and assigned into shared `latitude`/`longitude` variables, so for a file carrying **both** an EXIF pair and a plain lat/long pair, each coordinate was won independently by whichever field the map happened to yield last.

Measured end-to-end through the CLI on a `.docx` carrying an EXIF San Francisco pair (`37.7749 / -122.4194`) and a plain London pair (`51.5074 / -0.1278`), 30 runs of the same binary:

| reported coordinate | runs | exists in file? |
|---|---|---|
| `51.5074, -0.1278` | 19 | yes (plain pair) |
| `51.5074, -122.4194` | 5 | **no — fabricated** |
| `37.7749, -122.4194` | 3 | yes (EXIF pair) |
| `37.7749, -0.1278` | 3 | **no — fabricated** |

8 of 30 runs reported a location present nowhere in the input. After the fix: 30/30 `37.7749, -122.4194`.

A reported coordinate is now always a pair that exists in the file, with documented precedence — complete `gps*` pair, else complete plain pair, else cross-source combine. That last tier is kept deliberately: an incomplete file (say `GPSLatitude` plus a plain `Longitude`) has no complete pair from either source, so combining is the only way it reports a location at all. Dropping it would have been a detection regression, and there is a test pinning it.

The field walk is also ordered **longest-name first**, because the dispatch is `strings.Contains` over names that are substrings of each other (`gpslongituderef` ⊃ `gpslongitude` ⊃ `longitude`) — under alphabetical order a shorter name's case would claim a longer field.

### Reachability

`combineGPSCoordinates` sits behind `ValidateContent`. The dual-path router normally dispatches metadata through `ValidateMetadataContent`, which has a registered rule for all five metadata preprocessor types and so reaches a different GPS emit site. `ValidateContent` is reached through the documented legacy fallback (`processContentLegacy`, dual_path_bridge.go:278/326) — which is what routing or dual-path failure degrades into on a real scan. The table above was produced through the CLI on that path with fault injection, not at the unit boundary.

## The other six

| site | before | after |
|---|---|---|
| `passport` pattern loop | MRZ vs MRZ_TD3 on the same span flipped, 2 orders / 200 runs | fixed `patternOrder` slice |
| `intellectualproperty` `processLineMatches` | findings grouped in a line→matches map, 4 orders / 200 runs | ascending by line |
| `--help checks` example | picked by breaking out of a range over the providers map — 8 distinct suggestions / 40 runs | alphabetically first check |
| `config` `ListProfiles` / `ValidateConfig` | unordered listing; `ValidateConfig` returns on the FIRST bad path, so which profile got blamed varied 4-way / 100 runs | name order |
| `preprocessors` `LogError` | `context=` fields in a different order per log, 6 orders / 100 runs | sorted keys |
| `cmd/suppress --action list` | rule metadata in map order, 6 orders / 100 runs; 6 distinct output digests / 12 runs of the real binary | sorted keys |

Two of these matter operationally beyond cosmetics. `ValidateConfig` blaming a random profile means an operator fixes one, re-runs, gets a fresh complaint about a different profile, and has no signal the first fix worked. And operators diff `--action list` output during suppression review — unstable field order makes that diff useless.

`ShowChecksHelp` also loses a hand-rolled O(n²) bubble sort and a second O(n²) description re-scan, replaced by one pass into a `{name, desc}` slice + `sort.Slice`.

## Pre-existing bug this does not fix

Passport emits the **same span as two types** (MRZ and MRZ_TD3) when both patterns match a TD3 line. That is a real duplicate-emission bug, and it is pre-existing — this PR only makes *which* one you see deterministic. Filing separately rather than widening this change.

## Testing

Per `docs/testing/TEST_PLAN.md`.

- **Regression tests**: each of the seven fixes ships a test verified **red on the parent commit** and green here. Where a test referenced a new symbol it was truncated on the parent side, so the parent run is a behavioral failure and not a build failure.
- **Behavior preservation**: A/B over a 64-file corpus — 224 findings on both binaries, **0 lost / 0 gained**.
- **Redaction (all comparable strategies)**: `simple` and `format_preserving` artifacts byte-identical between parent and fix, and stable at 1 digest / 5 runs each. (`synthetic` is randomized by design and not byte-comparable.)
- **Suppression**: `cmd/suppress --action list` E2E, 12 runs — 6 distinct digests before, 1 after.
- **All output formats** exercised: text, json, csv, yaml, junit, gitlab-sast, sarif.
- **Golden corpora**: both, ×3 runs, green.
- **Race**: `-race` green on all 7 touched packages.
- **Timing**: no new loop over input; the two O(n²) passes in `ShowChecksHelp` are *removed*. Sorts added are over small fixed-size collections (GPS field names, profile names, log context keys, suppression metadata keys, per-file line numbers), never per-match on scan input.
- **Gates**: `gofmt -l` clean, `go vet ./...` clean, `go test ./... -count=1` → 52 ok / 0 FAIL.

## Residual variance, not introduced here

Full-JSON output still varies run to run in **confidence values only** — that is the analyzer argmax fixed in #178. And the redacted `.docx` byte stream still varies because `repackageOfficeDocument` ranges a map, which is fixed in #190; with #190 merged locally the artifact is **1 digest / 10 runs**. The finding set itself is stable on both sides here.

## Merge safety

`git merge-tree` clean against `origin/main` and all 14 open PR heads (#177, #178, #180–#191).