### PR TITLE
fix(cli): stop discarding text output when the formatter did not stream

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1737,10 +1737,8 @@ func main() {
 	// Enable streaming for text format writing to stdout (no output file).
 	// The text formatter writes directly to os.Stdout, avoiding a multi-GB
 	// string buffer for large result sets.
-	streamingActive := false
 	if finalConfig.format == "text" && *outputFile == "" {
 		formatterOptions.StreamWriter = os.Stdout
-		streamingActive = true
 	}
 
 	// Format and display results
@@ -1798,9 +1796,16 @@ func main() {
 				"Check file permissions and available disk space")
 			os.Exit(1)
 		}
-	} else if !streamingActive {
-		// When streaming was active, the text formatter already wrote to
-		// os.Stdout — skip the redundant (and potentially empty) Println.
+	} else if result != "" {
+		// A streaming formatter signals "already written to StreamWriter" by
+		// returning "", so an empty result means there is nothing left to print.
+		// Keying on the result rather than on whether streaming was *requested*
+		// matters because Format has several early returns that produce a string
+		// and never touch StreamWriter: "No matches found.", "No matches found
+		// at the specified confidence levels.", the suppressed-only report, and
+		// pre-commit output. Suppressing those unconditionally meant a text scan
+		// to stdout printed zero bytes — including a pre-commit run that found
+		// blocking secrets and exited 1 with no explanation.
 		fmt.Println(result)
 	}
 

--- a/tests/integration/text_stdout_output_test.go
+++ b/tests/integration/text_stdout_output_test.go
@@ -1,0 +1,215 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runStdinEnv is runStdin with extra environment variables. The pre-commit exit
+// policy is only reachable through FERRET_PRECOMMIT_EXIT_ON, so the blocking case
+// below needs to set it for the child process.
+func runStdinEnv(t *testing.T, bin, input string, extraEnv []string, args ...string) (string, string, int) {
+	t.Helper()
+	cmd := exec.Command(bin, args...) //nolint:gosec // bin is built by the test
+	cmd.Stdin = strings.NewReader(input)
+	cmd.Env = append(os.Environ(), extraEnv...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	exitCode := 0
+	if err != nil {
+		ee, ok := err.(*exec.ExitError)
+		if !ok {
+			t.Fatalf("unexpected exec error: %v\nstderr=%s", err, stderr.String())
+		}
+		exitCode = ee.ExitCode()
+	}
+	return stdout.String(), stderr.String(), exitCode
+}
+
+// The text formatter signals "I already wrote to StreamWriter" by returning an
+// empty string, and main.go used to suppress its own Println whenever streaming
+// was *requested* — regardless of whether the formatter had actually streamed
+// anything. Format has several early returns that build a string and never touch
+// StreamWriter, so every one of them was silently discarded: a clean scan, a scan
+// whose findings were all filtered out by --confidence, and (worst) a pre-commit
+// run that found blocking secrets, exited 1, and printed nothing at all.
+//
+// These tests drive the real binary, because the defect only exists at the
+// main.go/formatter seam — the formatter's return values were always correct.
+
+// scanFixtures writes the two fixtures the cases below share and returns the dir.
+func scanFixtures(t *testing.T) (dir, clean, withPII string) {
+	t.Helper()
+	dir = t.TempDir()
+	clean = filepath.Join(dir, "clean.txt")
+	withPII = filepath.Join(dir, "pii.txt")
+	if err := os.WriteFile(clean, []byte("nothing sensitive here at all\njust plain words\n"), 0o600); err != nil {
+		t.Fatalf("write clean fixture: %v", err)
+	}
+	// A structurally valid SSN with a "SSN:" label, so it lands at medium
+	// confidence — high enough to be a finding, low enough that --confidence
+	// high filters it out (which exercises a second early return).
+	if err := os.WriteFile(withPII, []byte("Employee SSN: 456-78-9012\n"), 0o600); err != nil {
+		t.Fatalf("write pii fixture: %v", err)
+	}
+	return dir, clean, withPII
+}
+
+// TestTextStdoutPrintsNoMatchesFound is the plainest form of the bug: a clean
+// file produced zero bytes on stdout, so a user could not tell a successful scan
+// from a crashed one.
+func TestTextStdoutPrintsNoMatchesFound(t *testing.T) {
+	bin := stdinBinary(t)
+	_, clean, _ := scanFixtures(t)
+
+	stdout, stderr, code := runStdin(t, bin, "", "--file", clean, "--checks", "ssn", "--format", "text")
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0 (stderr=%s)", code, stderr)
+	}
+	if strings.TrimSpace(stdout) == "" {
+		t.Fatalf("a clean scan printed nothing to stdout (stderr=%s)", stderr)
+	}
+	if !strings.Contains(stdout, "No matches found") {
+		t.Fatalf("stdout = %q, want it to report that no matches were found", stdout)
+	}
+}
+
+// TestTextStdoutPrintsConfidenceFilteredNotice covers the second early return:
+// findings existed but were all filtered out by --confidence. Reporting nothing
+// here is actively misleading — it looks identical to a clean file, when in fact
+// the file has PII that was merely below the requested threshold.
+func TestTextStdoutPrintsConfidenceFilteredNotice(t *testing.T) {
+	bin := stdinBinary(t)
+	_, _, withPII := scanFixtures(t)
+
+	stdout, stderr, code := runStdin(t, bin,
+		"", "--file", withPII, "--checks", "ssn", "--format", "text", "--confidence", "high")
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0 (stderr=%s)", code, stderr)
+	}
+	if strings.TrimSpace(stdout) == "" {
+		t.Fatalf("a scan whose findings were all confidence-filtered printed nothing (stderr=%s)", stderr)
+	}
+	if !strings.Contains(stdout, "confidence") {
+		t.Fatalf("stdout = %q, want it to mention the confidence filter", stdout)
+	}
+}
+
+// TestPrecommitTextStdoutPrintsBlockingFindings is the severe case. With
+// FERRET_PRECOMMIT_EXIT_ON=medium the run exits 1 and blocks the commit; before
+// the fix it did so having printed zero bytes to both stdout and stderr, so the
+// developer got a failed commit with no indication of what was found or where.
+func TestPrecommitTextStdoutPrintsBlockingFindings(t *testing.T) {
+	bin := stdinBinary(t)
+	_, _, withPII := scanFixtures(t)
+
+	stdout, stderr, code := runStdinEnv(t, bin, "",
+		[]string{"FERRET_PRECOMMIT_EXIT_ON=medium"},
+		"--file", withPII, "--checks", "ssn", "--format", "text", "--pre-commit-mode")
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1 (a medium finding must block) stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	if strings.TrimSpace(stdout) == "" {
+		t.Fatalf("pre-commit blocked the commit but printed nothing to stdout (stderr=%s)", stderr)
+	}
+	if !strings.Contains(stdout, "pii.txt") {
+		t.Fatalf("stdout = %q, want the offending file named", stdout)
+	}
+	if !strings.Contains(stdout, "line 1") {
+		t.Fatalf("stdout = %q, want the offending line reported", stdout)
+	}
+}
+
+// TestPrecommitTextStdoutSilentOnCleanScan pins the intended silence. Pre-commit
+// mode deliberately prints nothing when there is nothing to report, and the fix
+// must not turn that into noise on every commit.
+func TestPrecommitTextStdoutSilentOnCleanScan(t *testing.T) {
+	bin := stdinBinary(t)
+	_, clean, _ := scanFixtures(t)
+
+	stdout, stderr, code := runStdin(t, bin, "",
+		"--file", clean, "--checks", "ssn", "--format", "text", "--pre-commit-mode")
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0 (stderr=%s)", code, stderr)
+	}
+	if strings.TrimSpace(stdout) != "" {
+		t.Fatalf("pre-commit mode should be silent on a clean scan, got stdout=%q", stdout)
+	}
+}
+
+// TestTextStdoutStreamsFindingsExactlyOnce is the anti-double-print guard. The
+// streaming path is the one case where the formatter really does write to stdout
+// itself, so printing the (empty) return value on top of it must not duplicate
+// the report — and the header must appear exactly once.
+func TestTextStdoutStreamsFindingsExactlyOnce(t *testing.T) {
+	bin := stdinBinary(t)
+	_, _, withPII := scanFixtures(t)
+
+	stdout, stderr, code := runStdin(t, bin, "", "--file", withPII, "--checks", "ssn", "--format", "text")
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0 (stderr=%s)", code, stderr)
+	}
+	if n := strings.Count(stdout, "VALIDATOR"); n != 1 {
+		t.Fatalf("table header appears %d times, want exactly 1:\n%s", n, stdout)
+	}
+	if n := strings.Count(stdout, "Scan Summary"); n != 1 {
+		t.Fatalf("scan summary appears %d times, want exactly 1:\n%s", n, stdout)
+	}
+	if !strings.Contains(stdout, "SSN") {
+		t.Fatalf("stdout = %q, want the SSN finding reported", stdout)
+	}
+}
+
+// TestTextFileOutputUnaffected pins the --output path, which never streamed and
+// must be byte-for-byte what it always was.
+func TestTextFileOutputUnaffected(t *testing.T) {
+	bin := stdinBinary(t)
+	dir, clean, _ := scanFixtures(t)
+	out := filepath.Join(dir, "report.txt")
+
+	stdout, stderr, code := runStdin(t, bin, "",
+		"--file", clean, "--checks", "ssn", "--format", "text", "--output", out)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0 (stderr=%s)", code, stderr)
+	}
+	if strings.TrimSpace(stdout) != "" {
+		t.Fatalf("writing to --output should leave stdout empty, got %q", stdout)
+	}
+	body, err := os.ReadFile(out) //nolint:gosec // path is from t.TempDir()
+	if err != nil {
+		t.Fatalf("read output file: %v", err)
+	}
+	if !strings.Contains(string(body), "No matches found") {
+		t.Fatalf("output file = %q, want the no-matches report", body)
+	}
+}
+
+// TestNonTextFormatsUnaffected walks every other formatter to prove none of them
+// gained or lost output. They never set StreamWriter, so they always went through
+// the Println branch — but the branch condition changed, so pin them.
+func TestNonTextFormatsUnaffected(t *testing.T) {
+	bin := stdinBinary(t)
+	_, _, withPII := scanFixtures(t)
+
+	for _, format := range []string{"json", "csv", "yaml", "junit", "gitlab-sast", "sarif"} {
+		t.Run(format, func(t *testing.T) {
+			stdout, stderr, code := runStdin(t, bin, "",
+				"--file", withPII, "--checks", "ssn", "--format", format)
+			if code != 0 {
+				t.Fatalf("exit code = %d, want 0 (stderr=%s)", code, stderr)
+			}
+			if strings.TrimSpace(stdout) == "" {
+				t.Fatalf("format %s printed nothing to stdout (stderr=%s)", format, stderr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
A text scan to stdout could print **zero bytes**. The worst shape: a pre-commit run finds a blocking secret, **exits 1, and prints nothing at all** — not to stdout, not to stderr. The developer gets a failed commit with no indication of what was found or where.

```
$ FERRET_PRECOMMIT_EXIT_ON=medium ferret-scan --file pii.txt --checks ssn \
    --format text --pre-commit-mode > out 2> err
$ echo $?; wc -c < out; wc -c < err
1
0
0
```

## Root cause

The text formatter signals *"I already wrote to `StreamWriter`"* by returning an empty string, and `main.go` suppressed its own `Println` whenever streaming had been **requested**:

```go
streamingActive := false
if finalConfig.format == "text" && *outputFile == "" {
    formatterOptions.StreamWriter = os.Stdout
    streamingActive = true
}
...
} else if !streamingActive {
    fmt.Println(result)
}
```

But `Format` has four early returns that build a string and **never touch `StreamWriter`** — they run before the writer is even selected:

- `"No matches found."`
- `"No matches found at the specified confidence levels."`
- the suppressed-only report (`formatTextWithSuppressed`)
- **all** pre-commit output (`formatPrecommitOutput`)

Every one was discarded. Keying the `Println` on the returned *result* rather than the streaming *mode* fixes all four at once, because `""` is precisely the signal that the formatter already emitted its own bytes.

## Measured, parent vs fix (bytes on stdout)

| case | parent | fixed | |
|---|---:|---:|---|
| clean scan | 0 | 17 | **fixed** |
| findings all confidence-filtered | 0 | 52 | **fixed** |
| pre-commit with findings | 0 | 416 | **fixed** |
| pre-commit blocking, rc=1 | 0 | 416 | **fixed** |
| scan with findings (streaming) | 854 | 854 | unchanged |
| pre-commit, clean scan | 0 | 0 | unchanged — intended |
| json / csv / yaml / junit / sarif / gitlab-sast | same | same | unchanged |
| text to `--output` | same | same | unchanged |

The confidence-filtered case is worth calling out separately: a file *with* PII below the requested threshold printed the same zero bytes as a clean file, so the two were indistinguishable.

Pre-commit silence on a clean scan is deliberate and preserved — it comes from `Format` returning `""` with no matches, which is the same signal streaming uses. There is a test pinning it, so this does not become noise on every commit.

## Age

Shipped in `ba4f31d` (v2.1.0). Every release since has carried it.

## Testing

Per `docs/testing/TEST_PLAN.md`.

- **Regression**: 7 integration tests driving the real binary. The 3 that detect the bug **fail on `origin/main`**; the 4 behavior-preservation ones pass on both sides. One counts the table header and scan summary occurrences to prove the streaming path is not now printed **twice** — the obvious way to get this fix wrong.
- **All output formats**: every one of the 7 exercised. Only the 4 text-to-stdout cases above change.
- **Redaction (all types)**: `simple` and `format_preserving` artifacts byte-identical to parent over a 4-file corpus, and stable at 1 digest / 5 runs each. `synthetic` is randomized by design, so checked only for clean completion and artifact count.
- **Suppression**: identical finding counts (4/4) and identical `--show-suppressed` stdout (850 bytes) on both sides.
- **Timing / O(n²)**: 5k / 10k / 20k / 40k-line inputs — parent `0.08 / 0.10 / 0.17 / 0.30s` vs fix `0.08 / 0.11 / 0.17 / 0.29s`. Linear, no measurable delta. The change adds one string comparison on a path that runs once per scan.
- **Gates**: `go test ./... -count=1` → 49 ok / 0 FAIL. Golden corpora ×3 green. `-race` green on `tests/integration` and all formatter packages.
- **Web**: unaffected and verified — the web path never sets `StreamWriter`; `internal/web` tests green.
- **Dead code**: `streamingActive` is removed entirely, no remaining references.

## Merge safety

`git merge-tree` clean against `origin/main` and all 15 open PR heads (#177, #178, #180–#192).

Note: `gofmt -l` flags `internal/config/config.go` on `origin/main` — pre-existing struct-tag misalignment, untouched here, fixed in #192.