### PR TITLE
fix(redactors): stop dropping audit entries on document-ID collisions

### DIFF
--- a/internal/redactors/docid_test.go
+++ b/internal/redactors/docid_test.go
@@ -1,0 +1,150 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package redactors
+
+import (
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// newDocIDTestManager builds a manager with an audit log manager wired up, which is
+// the only part AddRedactionResult needs.
+func newDocIDTestManager(t *testing.T) *RedactionManager {
+	t.Helper()
+	dir := t.TempDir()
+	return &RedactionManager{
+		redactors:       make(map[string]Redactor),
+		auditLogManager: NewRedactionAuditLogManager("test", dir),
+		config:          &RedactionManagerConfig{},
+		stats:           &RedactionStats{},
+	}
+}
+
+func oneRedaction() *RedactionResult {
+	return &RedactionResult{
+		RedactionMap: []RedactionMapping{{
+			DataType:     "EMAIL",
+			RedactedText: "[EMAIL-REDACTED]",
+			Confidence:   95,
+		}},
+	}
+}
+
+// TestAddRedactionResult_NoDroppedAuditEntries is the regression test for document
+// IDs taken from the clock. time.Now() resolves to a microsecond in practice, so
+// files redacted in the same tick were assigned the same ID; CreateAuditLog rejects
+// the duplicate and AddRedactionResult returned early, silently discarding that
+// file's audit entry while leaving its redacted output on disk. The loss was
+// intermittent — roughly half of a 200-file run — and named a different victim each
+// time, which is exactly the failure mode a compliance artifact must not have.
+//
+// The bodies here do no I/O, so every call lands well inside one clock tick; with a
+// clock-derived ID this fails on the first duplicate.
+func TestAddRedactionResult_NoDroppedAuditEntries(t *testing.T) {
+	const files = 500
+
+	rm := newDocIDTestManager(t)
+	for i := 0; i < files; i++ {
+		in := filepath.Join("/in", fmt.Sprintf("f%d.txt", i))
+		out := filepath.Join("/out", fmt.Sprintf("f%d.txt", i))
+		rm.AddRedactionResult(in, out, oneRedaction())
+	}
+
+	if got := rm.auditLogManager.GetAuditLogCount(); got != files {
+		t.Fatalf("audit log holds %d entries for %d redacted files — %d compliance records were dropped",
+			got, files, files-got)
+	}
+
+	// Every input file must be accounted for by path, not just by count.
+	for i := 0; i < files; i++ {
+		in := filepath.Join("/in", fmt.Sprintf("f%d.txt", i))
+		if _, ok := rm.auditLogManager.GetAuditLogByPath(in); !ok {
+			t.Fatalf("no audit entry for %s, which was redacted", in)
+		}
+	}
+}
+
+// TestAddRedactionResult_ConcurrentNoDroppedEntries covers the real call shape: the
+// worker pool calls AddRedactionResult from several goroutines
+// (internal/parallel/worker_pool.go). Concurrency makes same-tick arrivals more
+// likely, not less, so the ID source has to be safe under it. Run with -race.
+func TestAddRedactionResult_ConcurrentNoDroppedEntries(t *testing.T) {
+	const (
+		workers     = 8
+		perWorker   = 50
+		wantEntries = workers * perWorker
+	)
+
+	rm := newDocIDTestManager(t)
+
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < perWorker; i++ {
+				in := filepath.Join("/in", fmt.Sprintf("w%d_f%d.txt", w, i))
+				out := filepath.Join("/out", fmt.Sprintf("w%d_f%d.txt", w, i))
+				rm.AddRedactionResult(in, out, oneRedaction())
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	if got := rm.auditLogManager.GetAuditLogCount(); got != wantEntries {
+		t.Fatalf("audit log holds %d entries for %d redacted files — %d compliance records were dropped",
+			got, wantEntries, wantEntries-got)
+	}
+}
+
+// TestAddRedactionResult_ReproducibleDocumentIDs locks the second half of the fix.
+// Clock-derived IDs meant two audit logs of byte-identical input shared no document
+// IDs at all, so they could not be diffed or key-matched — and because each
+// redaction's own ID embeds the document ID ("doc_N_redaction_I"), every redaction
+// ID moved too.
+func TestAddRedactionResult_ReproducibleDocumentIDs(t *testing.T) {
+	run := func() []string {
+		rm := newDocIDTestManager(t)
+		for i := 0; i < 20; i++ {
+			in := filepath.Join("/in", fmt.Sprintf("f%d.txt", i))
+			out := filepath.Join("/out", fmt.Sprintf("f%d.txt", i))
+			rm.AddRedactionResult(in, out, oneRedaction())
+		}
+
+		ids := make([]string, 0, 20)
+		for i := 0; i < 20; i++ {
+			in := filepath.Join("/in", fmt.Sprintf("f%d.txt", i))
+			log, ok := rm.auditLogManager.GetAuditLogByPath(in)
+			if !ok {
+				t.Fatalf("no audit entry for %s", in)
+			}
+			ids = append(ids, log.DocumentID)
+		}
+		return ids
+	}
+
+	first, second := run(), run()
+	for i := range first {
+		if first[i] != second[i] {
+			t.Fatalf("document ID for file %d changed between two runs on identical input: %q then %q",
+				i, first[i], second[i])
+		}
+	}
+
+	// A file's redaction IDs derive from its document ID, so they must be stable too.
+	rm := newDocIDTestManager(t)
+	rm.AddRedactionResult("/in/a.txt", "/out/a.txt", oneRedaction())
+	log, ok := rm.auditLogManager.GetAuditLogByPath("/in/a.txt")
+	if !ok {
+		t.Fatal("no audit entry for /in/a.txt")
+	}
+	if len(log.ContentRedactions) != 1 {
+		t.Fatalf("got %d content redactions, want 1", len(log.ContentRedactions))
+	}
+	if want := "doc_1_redaction_0"; log.ContentRedactions[0].ID != want {
+		t.Fatalf("redaction ID = %q, want %q", log.ContentRedactions[0].ID, want)
+	}
+}

--- a/internal/redactors/manager.go
+++ b/internal/redactors/manager.go
@@ -35,6 +35,13 @@ type RedactionManager struct {
 	// mutex protects concurrent access to redactors map
 	mu sync.RWMutex
 
+	// documentCounter assigns audit-log document IDs. It is incremented under
+	// documentMu, never read from the clock: two files finishing within the same
+	// clock tick used to receive the same ID, and the loser's audit entry was
+	// dropped. See nextDocumentID.
+	documentCounter int
+	documentMu      sync.Mutex
+
 	// stats tracks redaction statistics
 	stats *RedactionStats
 }
@@ -844,18 +851,41 @@ func (rm *RedactionManager) GetObserver() observability.Observer {
 	return rm.observer
 }
 
+// nextDocumentID returns a fresh audit-log document ID.
+//
+// IDs come from a counter rather than time.Now().UnixNano(). The clock has
+// microsecond resolution in practice, so two files whose redaction finished in the
+// same tick were handed the same ID; CreateAuditLog rejects a duplicate and the
+// caller treated that as a soft failure, so the second file's audit entry was
+// silently discarded. A counter cannot collide, and it also makes the IDs
+// reproducible for a given traversal order, so two audit logs of the same input can
+// be compared.
+//
+// The worker pool calls in from several goroutines, hence the dedicated mutex — it
+// is separate from rm.mu, which guards the redactors map.
+func (rm *RedactionManager) nextDocumentID() string {
+	rm.documentMu.Lock()
+	defer rm.documentMu.Unlock()
+
+	rm.documentCounter++
+	return fmt.Sprintf("doc_%d", rm.documentCounter)
+}
+
 // AddRedactionResult adds a redaction result to the index manager
 func (rm *RedactionManager) AddRedactionResult(originalPath, redactedPath string, result *RedactionResult) {
 	if rm.auditLogManager != nil && result != nil {
 		// Generate document ID
-		documentID := fmt.Sprintf("doc_%d", time.Now().UnixNano())
+		documentID := rm.nextDocumentID()
 
-		// Create audit log for this document
+		// Create audit log for this document. A failure here loses the compliance
+		// record for a file that was still redacted on disk, so report it as an
+		// error rather than a debug event.
 		_, err := rm.auditLogManager.CreateAuditLog(documentID, originalPath, redactedPath)
 		if err != nil {
 			rm.logEvent("index_creation_failed", false, map[string]interface{}{
-				"error":       err.Error(),
-				"document_id": documentID,
+				"error":         err.Error(),
+				"document_id":   documentID,
+				"original_path": originalPath,
 			})
 			return
 		}


### PR DESCRIPTION
Fixes #196.

## The bug

Audit-log document IDs came from the clock:

```go
documentID := fmt.Sprintf("doc_%d", time.Now().UnixNano())
```

`time.Now()` resolves to a microsecond in practice, so two files whose redaction finished in the
same tick were handed the same ID. `CreateAuditLog` rejects a duplicate, and
`AddRedactionResult` treated that as a soft failure and returned — **silently discarding that
file's audit entry** while leaving its redacted output on disk.

Nothing surfaced to the operator: exit code 0, redacted file correct, only the compliance record
gone.

## Impact

200 single-finding files, six consecutive runs on identical input, before the fix:

```
run 1: entries=199/200  lost=1  [f191.txt]
run 2: entries=200/200  lost=0  []
run 3: entries=199/200  lost=1  [f91.txt]
run 4: entries=200/200  lost=0  []
run 5: entries=199/200  lost=1  [f5.txt]
run 6: entries=200/200  lost=0  []
```

Intermittent, random victim, silent. Measured ID spacing confirms the mechanism — the minimum
gap between consecutive document IDs is exactly **1000 ns**, the clock's resolution floor, so
ties are expected rather than freak events. Loss scales with file count and worker concurrency,
and gets worse on faster hardware:

| files | before | after |
|---|---|---|
| 250 | 249/250 | **250/250** |
| 500 | 497/500 | **500/500** |
| 1000 | 998/1000 | **1000/1000** |
| 2000 | 1996/2000 | **2000/2000** |

An audit log that cannot account for every file it processed does not do its job.

## Second problem, same root cause

Even when nothing was dropped, two audit logs of byte-identical input shared no document IDs:

```
run 1: first 2 IDs ['doc_1785224500243105000', 'doc_1785224500243840000']
run 2: first 2 IDs ['doc_1785224500392426000', 'doc_1785224500393069000']
shared IDs across runs: 0
```

So two logs could not be diffed or key-matched. Each redaction's own ID embeds the document ID
(`doc_1785224500243105000_redaction_0`), so every redaction ID moved too. After the fix, IDs are
`doc_1 … doc_24` and identical across runs (24/24 shared over 3 runs).

## The fix

Assign IDs from a counter guarded by its own mutex. A counter cannot collide, so no entry can be
dropped, and IDs become reproducible for a given traversal order — which the sibling determinism
PRs already make stable.

The counter uses a dedicated mutex rather than `rm.mu` (which guards the redactors map), because
the worker pool calls `AddRedactionResult` from several goroutines
(`internal/parallel/worker_pool.go:381` and `:389`). The duplicate-ID branch now also logs
`original_path`, since losing a compliance record deserves to name the file.

## Tests

Three tests in `internal/redactors/docid_test.go`, each verified to **fail on the old code**:

```
--- FAIL: TestAddRedactionResult_NoDroppedAuditEntries
    audit log holds 478 entries for 500 redacted files — 22 compliance records were dropped
--- FAIL: TestAddRedactionResult_ConcurrentNoDroppedEntries
    audit log holds 391 entries for 400 redacted files — 9 compliance records were dropped
--- FAIL: TestAddRedactionResult_ReproducibleDocumentIDs
    no audit entry for /in/f19.txt
```

and pass on the fix. The concurrent one mirrors the real call shape (8 goroutines) and is clean
under `-race`.

## Verification

A/B against the fully-stacked deterministic base (all open determinism PRs + #194 merged, so the
baseline is genuinely reproducible — an A/B against `5acc670` alone is uninterpretable, both
sides give 6/6 distinct digests). Only the audit log may change; everything else must be a
strict no-op:

| Check | Result |
|---|---|
| All 7 output formats | byte-identical |
| Findings by confidence | 7 / 37 / 57 — identical |
| Per-type breakdown (25 types) | identical |
| Redaction `simple`, `format_preserving` | artifacts byte-identical |
| Redaction `synthetic` | 24/24 artifacts (randomized by design) |
| Planted-secret leak check | 0 leaks both sides |
| Suppression | 101 findings; `--show-suppressed` / `--show-match` digests identical |
| Determinism | 1 distinct digest / 6 runs, both sides |
| Web UI | HTTP 200, 88 468 B, byte-identical page |
| **Audit log** | 24/24 entries, content identical modulo IDs; IDs now `doc_1…doc_24`, 24/24 shared across 3 runs |

Timing — no regression and no O(n²) introduced. Content scaling on the redaction+audit path
(base vs fix): 3312/3205 ms at 1250 lines, 6867/6872 at 2500, 16305/16312 at 5000, 43730/43634
at 10 000. File-count scaling, which is where the new counter and mutex actually live, is linear
with no contention cost: 215/215 ms at 250 files, 375/383 at 500, 553/576 at 1000, 1000/965 at
2000.

Gates: `gofmt` clean, `go vet` clean, `go test ./...` 49/49 packages ok on this branch and 56/56
on the merged stack, golden corpora ×3, `-race` clean on `redactors` + `parallel`.

Branches off `main` — independent of the determinism stack (#190 does not touch
`AddRedactionResult`) and merges into it with no conflicts.
