### PR TITLE
fix(medicalid): recall long-form card/EDI field labels

### DIFF
--- a/internal/goldencorpus/corpus.go
+++ b/internal/goldencorpus/corpus.go
@@ -205,6 +205,27 @@ var Cases = []Case{
 			"3 items in way of progress\n",
 	},
 	{
+		Name: "medical_long_form_labels",
+		Description: "Long-form field labels as printed on physical insurance/Medicare cards and " +
+			"used in EDI 837 exports (\"member identification number\") alongside the abbreviated " +
+			"forms already covered (\"member id\"). Keyword matching is whole-token, so the " +
+			"abbreviations did not cover the long forms: the card's own wording scored the MBI " +
+			"and MRN LOW, and an all-uppercase insurance ID was dropped entirely (the strong " +
+			"keyword gates the uppercase-shape check), which meant it passed through redaction " +
+			"in cleartext. Decoy lines lock the deliberate exclusions: a bare \"certificate " +
+			"number\" names an X.509 certificate and \"policy identification\" names an IAM or " +
+			"Terraform policy far more often than an insurance one, so neither is a keyword.",
+		Checks: []string{"MEDICAL_ID"},
+		Input: "member identification number: W1234567801\n" +
+			"subscriber identification number: X9876543210\n" +
+			"medicare member identification number: 1EG4TE5MK73\n" +
+			"patient identification number: 4472901\n" +
+			"policyholder id: P5551234567\n" +
+			"member id: W1122009988\n" +
+			"X.509 certificate serial number: 0A1B2C3D4E5F6789\n" +
+			"policy identification for terraform module: MODULEVERSION123\n",
+	},
+	{
 		Name: "context_decoys_original",
 		Description: "Real-context vs decoy-context pairs for the ORIGINAL validators (SSN, " +
 			"PHONE, CREDIT_CARD, EMAIL): the same shaped value framed as PII on one line and " +

--- a/internal/goldencorpus/testdata/golden/medical_long_form_labels.csv
+++ b/internal/goldencorpus/testdata/golden/medical_long_form_labels.csv
@@ -1,0 +1,8 @@
+Filename,Type,Confidence Level,Confidence %,Line Number,Text
+<golden:medical_long_form_labels>,INSURANCE_MEMBER_ID,MEDIUM,70.0,1,W1234567801
+<golden:medical_long_form_labels>,INSURANCE_MEMBER_ID,MEDIUM,80.0,2,X9876543210
+<golden:medical_long_form_labels>,INSURANCE_MEMBER_ID,MEDIUM,80.0,3,1EG4TE5MK73
+<golden:medical_long_form_labels>,INSURANCE_MEMBER_ID,MEDIUM,70.0,5,P5551234567
+<golden:medical_long_form_labels>,INSURANCE_MEMBER_ID,MEDIUM,80.0,6,W1122009988
+<golden:medical_long_form_labels>,MEDICARE_MBI,MEDIUM,85.0,3,1EG4TE5MK73
+<golden:medical_long_form_labels>,MRN,MEDIUM,80.0,4,4472901

--- a/internal/goldencorpus/testdata/golden/medical_long_form_labels.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/medical_long_form_labels.gitlab-sast.json
@@ -1,0 +1,212 @@
+{
+  "remediations": [],
+  "scan": {
+    "analyzer": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "end_time": "<TIMESTAMP>",
+    "scanner": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "start_time": "<TIMESTAMP>",
+    "status": "success",
+    "type": "sast"
+  },
+  "version": "15.0.4",
+  "vulnerabilities": [
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected sensitive data (insurance member id) in this file.\n\n**Location:** <golden:medical_long_form_labels> (line 1)\n**Confidence:** MEDIUM (70.0%)\n**Detected by:** medicalid validator\n\n**Context:**\n```\nmember identification number: W1234567801\n```\n\n**Additional Information:**\n- context_impact: 0\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "INSURANCE_MEMBER_ID"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "medicalid"
+        }
+      ],
+      "location": {
+        "end_line": 1,
+        "file": "<golden:medical_long_form_labels>",
+        "start_line": 1
+      },
+      "message": "Sensitive data (insurance member id) detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Insurance Member Id Detected",
+      "severity": "High"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected sensitive data (insurance member id) in this file.\n\n**Location:** <golden:medical_long_form_labels> (line 2)\n**Confidence:** MEDIUM (80.0%)\n**Detected by:** medicalid validator\n\n**Context:**\n```\nsubscriber identification number: X9876543210\n```\n\n**Additional Information:**\n- context_impact: 10\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "INSURANCE_MEMBER_ID"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "medicalid"
+        }
+      ],
+      "location": {
+        "end_line": 2,
+        "file": "<golden:medical_long_form_labels>",
+        "start_line": 2
+      },
+      "message": "Sensitive data (insurance member id) detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Insurance Member Id Detected",
+      "severity": "High"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected sensitive data (insurance member id) in this file.\n\n**Location:** <golden:medical_long_form_labels> (line 3)\n**Confidence:** MEDIUM (80.0%)\n**Detected by:** medicalid validator\n\n**Context:**\n```\nmedicare member identification number: 1EG4TE5MK73\n```\n\n**Additional Information:**\n- context_impact: 10\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "INSURANCE_MEMBER_ID"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "medicalid"
+        }
+      ],
+      "location": {
+        "end_line": 3,
+        "file": "<golden:medical_long_form_labels>",
+        "start_line": 3
+      },
+      "message": "Sensitive data (insurance member id) detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Insurance Member Id Detected",
+      "severity": "High"
+    },
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected sensitive data (insurance member id) in this file.\n\n**Location:** <golden:medical_long_form_labels> (line 5)\n**Confidence:** MEDIUM (70.0%)\n**Detected by:** medicalid validator\n\n**Context:**\n```\npolicyholder id: P5551234567\n```\n\n**Additional Information:**\n- context_impact: 0\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "INSURANCE_MEMBER_ID"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "medicalid"
+        }
+      ],
+      "location": {
+        "end_line": 5,
+        "file": "<golden:medical_long_form_labels>",
+        "start_line": 5
+      },
+      "message": "Sensitive data (insurance member id) detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Insurance Member Id Detected",
+      "severity": "High"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected sensitive data (insurance member id) in this file.\n\n**Location:** <golden:medical_long_form_labels> (line 6)\n**Confidence:** MEDIUM (80.0%)\n**Detected by:** medicalid validator\n\n**Context:**\n```\nmember id: W1122009988\n```\n\n**Additional Information:**\n- context_impact: 10\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "INSURANCE_MEMBER_ID"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "medicalid"
+        }
+      ],
+      "location": {
+        "end_line": 6,
+        "file": "<golden:medical_long_form_labels>",
+        "start_line": 6
+      },
+      "message": "Sensitive data (insurance member id) detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Insurance Member Id Detected",
+      "severity": "High"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected sensitive data (medicare mbi) in this file.\n\n**Location:** <golden:medical_long_form_labels> (line 3)\n**Confidence:** MEDIUM (85.0%)\n**Detected by:** medicalid validator\n\n**Context:**\n```\nmedicare member identification number: 1EG4TE5MK73\n```\n\n**Additional Information:**\n- context_impact: 10\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "MEDICARE_MBI"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "medicalid"
+        }
+      ],
+      "location": {
+        "end_line": 3,
+        "file": "<golden:medical_long_form_labels>",
+        "start_line": 3
+      },
+      "message": "Sensitive data (medicare mbi) detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Medicare Mbi Detected",
+      "severity": "High"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected sensitive data (mrn) in this file.\n\n**Location:** <golden:medical_long_form_labels> (line 4)\n**Confidence:** MEDIUM (80.0%)\n**Detected by:** medicalid validator\n\n**Context:**\n```\npatient identification number: 4472901\n```\n\n**Additional Information:**\n- context_impact: 10\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "MRN"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "medicalid"
+        }
+      ],
+      "location": {
+        "end_line": 4,
+        "file": "<golden:medical_long_form_labels>",
+        "start_line": 4
+      },
+      "message": "Sensitive data (mrn) detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Mrn Detected",
+      "severity": "High"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/medical_long_form_labels.json.json
+++ b/internal/goldencorpus/testdata/golden/medical_long_form_labels.json.json
@@ -1,0 +1,186 @@
+{
+  "results": [
+    {
+      "confidence": 85,
+      "confidence_level": "MEDIUM",
+      "filename": "<golden:medical_long_form_labels>",
+      "line_number": 3,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0.6666666666666666,
+        "context_doctype": "Unknown",
+        "context_domain": "Healthcare",
+        "context_impact": 10,
+        "original_confidence": 85,
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "subtype": "MBI",
+        "validation_path": "document"
+      },
+      "text": "1EG4TE5MK73",
+      "type": "MEDICARE_MBI",
+      "validator": "medicalid"
+    },
+    {
+      "confidence": 80,
+      "confidence_level": "MEDIUM",
+      "filename": "<golden:medical_long_form_labels>",
+      "line_number": 2,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0.6666666666666666,
+        "context_doctype": "Unknown",
+        "context_domain": "Healthcare",
+        "context_impact": 10,
+        "original_confidence": 80,
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "subtype": "INSURANCE_MEMBER_ID",
+        "validation_path": "document"
+      },
+      "text": "X9876543210",
+      "type": "INSURANCE_MEMBER_ID",
+      "validator": "medicalid"
+    },
+    {
+      "confidence": 80,
+      "confidence_level": "MEDIUM",
+      "filename": "<golden:medical_long_form_labels>",
+      "line_number": 3,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0.6666666666666666,
+        "context_doctype": "Unknown",
+        "context_domain": "Healthcare",
+        "context_impact": 10,
+        "original_confidence": 80,
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "subtype": "INSURANCE_MEMBER_ID",
+        "validation_path": "document"
+      },
+      "text": "1EG4TE5MK73",
+      "type": "INSURANCE_MEMBER_ID",
+      "validator": "medicalid"
+    },
+    {
+      "confidence": 80,
+      "confidence_level": "MEDIUM",
+      "filename": "<golden:medical_long_form_labels>",
+      "line_number": 6,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0.6666666666666666,
+        "context_doctype": "Unknown",
+        "context_domain": "Healthcare",
+        "context_impact": 10,
+        "original_confidence": 80,
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "subtype": "INSURANCE_MEMBER_ID",
+        "validation_path": "document"
+      },
+      "text": "W1122009988",
+      "type": "INSURANCE_MEMBER_ID",
+      "validator": "medicalid"
+    },
+    {
+      "confidence": 80,
+      "confidence_level": "MEDIUM",
+      "filename": "<golden:medical_long_form_labels>",
+      "line_number": 4,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0.6666666666666666,
+        "context_doctype": "Unknown",
+        "context_domain": "Healthcare",
+        "context_impact": 10,
+        "original_confidence": 80,
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "subtype": "MRN",
+        "validation_path": "document"
+      },
+      "text": "4472901",
+      "type": "MRN",
+      "validator": "medicalid"
+    },
+    {
+      "confidence": 70,
+      "confidence_level": "MEDIUM",
+      "filename": "<golden:medical_long_form_labels>",
+      "line_number": 1,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0.6666666666666666,
+        "context_doctype": "Unknown",
+        "context_domain": "Healthcare",
+        "context_impact": 0,
+        "original_confidence": 70,
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "subtype": "INSURANCE_MEMBER_ID",
+        "validation_path": "document"
+      },
+      "text": "W1234567801",
+      "type": "INSURANCE_MEMBER_ID",
+      "validator": "medicalid"
+    },
+    {
+      "confidence": 70,
+      "confidence_level": "MEDIUM",
+      "filename": "<golden:medical_long_form_labels>",
+      "line_number": 5,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0.6666666666666666,
+        "context_doctype": "Unknown",
+        "context_domain": "Healthcare",
+        "context_impact": 0,
+        "original_confidence": 70,
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "subtype": "INSURANCE_MEMBER_ID",
+        "validation_path": "document"
+      },
+      "text": "P5551234567",
+      "type": "INSURANCE_MEMBER_ID",
+      "validator": "medicalid"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/medical_long_form_labels.junit.xml
+++ b/internal/goldencorpus/testdata/golden/medical_long_form_labels.junit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
+  <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
+    <testcase name="&lt;golden:medical_long_form_labels&gt;" classname="security-scan" time="0.001">
+      <failure message="7 security findings detected" type="SECURITY_FINDINGS">Line 3: MEDICARE_MBI detected with 85.0% confidence (MEDIUM)&#xA;Match: 1EG4TE5MK73&#xA;Validator: medicalid&#xA;Line 3: INSURANCE_MEMBER_ID detected with 80.0% confidence (MEDIUM)&#xA;Match: 1EG4TE5MK73&#xA;Validator: medicalid&#xA;Line 6: INSURANCE_MEMBER_ID detected with 80.0% confidence (MEDIUM)&#xA;Match: W1122009988&#xA;Validator: medicalid&#xA;Line 2: INSURANCE_MEMBER_ID detected with 80.0% confidence (MEDIUM)&#xA;Match: X9876543210&#xA;Validator: medicalid&#xA;Line 4: MRN detected with 80.0% confidence (MEDIUM)&#xA;Match: 4472901&#xA;Validator: medicalid&#xA;Line 5: INSURANCE_MEMBER_ID detected with 70.0% confidence (MEDIUM)&#xA;Match: P5551234567&#xA;Validator: medicalid&#xA;Line 1: INSURANCE_MEMBER_ID detected with 70.0% confidence (MEDIUM)&#xA;Match: W1234567801&#xA;Validator: medicalid</failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/internal/goldencorpus/testdata/golden/medical_long_form_labels.redact_format_preserving.txt
+++ b/internal/goldencorpus/testdata/golden/medical_long_form_labels.redact_format_preserving.txt
@@ -1,0 +1,17 @@
+=== REDACTED ===
+member identification number: ***********
+subscriber identification number: ***********
+medicare member identification number: ***********
+patient identification number: *******
+policyholder id: ***********
+member id: ***********
+X.509 certificate serial number: 0A1B2C3D4E5F6789
+policy identification for terraform module: MODULEVERSION123
+=== FINDINGS (sorted) ===
+type=INSURANCE_MEMBER_ID line=1 conf=medium match=W1234567801
+type=INSURANCE_MEMBER_ID line=2 conf=medium match=X9876543210
+type=INSURANCE_MEMBER_ID line=3 conf=medium match=1EG4TE5MK73
+type=INSURANCE_MEMBER_ID line=5 conf=medium match=P5551234567
+type=INSURANCE_MEMBER_ID line=6 conf=medium match=W1122009988
+type=MEDICARE_MBI line=3 conf=medium match=1EG4TE5MK73
+type=MRN line=4 conf=medium match=4472901

--- a/internal/goldencorpus/testdata/golden/medical_long_form_labels.redact_simple.txt
+++ b/internal/goldencorpus/testdata/golden/medical_long_form_labels.redact_simple.txt
@@ -1,0 +1,17 @@
+=== REDACTED ===
+member identification number: [INSURANCE_MEMBER_ID-REDACTED]
+subscriber identification number: [INSURANCE_MEMBER_ID-REDACTED]
+medicare member identification number: [MEDICARE_MBI-REDACTED]
+patient identification number: [MRN-REDACTED]
+policyholder id: [INSURANCE_MEMBER_ID-REDACTED]
+member id: [INSURANCE_MEMBER_ID-REDACTED]
+X.509 certificate serial number: 0A1B2C3D4E5F6789
+policy identification for terraform module: MODULEVERSION123
+=== FINDINGS (sorted) ===
+type=INSURANCE_MEMBER_ID line=1 conf=medium match=W1234567801
+type=INSURANCE_MEMBER_ID line=2 conf=medium match=X9876543210
+type=INSURANCE_MEMBER_ID line=3 conf=medium match=1EG4TE5MK73
+type=INSURANCE_MEMBER_ID line=5 conf=medium match=P5551234567
+type=INSURANCE_MEMBER_ID line=6 conf=medium match=W1122009988
+type=MEDICARE_MBI line=3 conf=medium match=1EG4TE5MK73
+type=MRN line=4 conf=medium match=4472901

--- a/internal/goldencorpus/testdata/golden/medical_long_form_labels.sarif.json
+++ b/internal/goldencorpus/testdata/golden/medical_long_form_labels.sarif.json
@@ -1,0 +1,454 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/refs/heads/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:medical_long_form_labels>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "member identification number: \nmember identification number: W1234567801"
+                  },
+                  "startLine": 1
+                },
+                "region": {
+                  "endColumn": 42,
+                  "snippet": {
+                    "text": "member identification number: W1234567801"
+                  },
+                  "startColumn": 31,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "INSURANCE_MEMBER_ID Detected in <golden:medical_long_form_labels> at line 1 (confidence: 70.0% - MEDIUM). Matched text: 'W1234567801'"
+          },
+          "properties": {
+            "confidence": 70,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 0.7,
+              "context_doctype": "Unknown",
+              "context_domain": "Healthcare",
+              "context_impact": 0,
+              "original_confidence": 70,
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "subtype": "INSURANCE_MEMBER_ID",
+              "validation_path": "document"
+            },
+            "validator": "medicalid"
+          },
+          "rank": 60,
+          "ruleId": "INSURANCE_MEMBER_ID"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:medical_long_form_labels>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "subscriber identification number: \nsubscriber identification number: X9876543210"
+                  },
+                  "startLine": 2
+                },
+                "region": {
+                  "endColumn": 46,
+                  "snippet": {
+                    "text": "subscriber identification number: X9876543210"
+                  },
+                  "startColumn": 35,
+                  "startLine": 2
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "INSURANCE_MEMBER_ID Detected in <golden:medical_long_form_labels> at line 2 (confidence: 80.0% - MEDIUM). Matched text: 'X9876543210'"
+          },
+          "properties": {
+            "confidence": 80,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 0.7,
+              "context_doctype": "Unknown",
+              "context_domain": "Healthcare",
+              "context_impact": 10,
+              "original_confidence": 80,
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "subtype": "INSURANCE_MEMBER_ID",
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "subscriber"
+            ],
+            "validator": "medicalid"
+          },
+          "rank": 65,
+          "ruleId": "INSURANCE_MEMBER_ID"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:medical_long_form_labels>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "medicare member identification number: \nmedicare member identification number: 1EG4TE5MK73"
+                  },
+                  "startLine": 3
+                },
+                "region": {
+                  "endColumn": 51,
+                  "snippet": {
+                    "text": "medicare member identification number: 1EG4TE5MK73"
+                  },
+                  "startColumn": 40,
+                  "startLine": 3
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "INSURANCE_MEMBER_ID Detected in <golden:medical_long_form_labels> at line 3 (confidence: 80.0% - MEDIUM). Matched text: '1EG4TE5MK73'"
+          },
+          "properties": {
+            "confidence": 80,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 0.7,
+              "context_doctype": "Unknown",
+              "context_domain": "Healthcare",
+              "context_impact": 10,
+              "original_confidence": 80,
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "subtype": "INSURANCE_MEMBER_ID",
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "medicare"
+            ],
+            "validator": "medicalid"
+          },
+          "rank": 65,
+          "ruleId": "INSURANCE_MEMBER_ID"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:medical_long_form_labels>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "policyholder id: \npolicyholder id: P5551234567"
+                  },
+                  "startLine": 5
+                },
+                "region": {
+                  "endColumn": 29,
+                  "snippet": {
+                    "text": "policyholder id: P5551234567"
+                  },
+                  "startColumn": 18,
+                  "startLine": 5
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "INSURANCE_MEMBER_ID Detected in <golden:medical_long_form_labels> at line 5 (confidence: 70.0% - MEDIUM). Matched text: 'P5551234567'"
+          },
+          "properties": {
+            "confidence": 70,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 0.7,
+              "context_doctype": "Unknown",
+              "context_domain": "Healthcare",
+              "context_impact": 0,
+              "original_confidence": 70,
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "subtype": "INSURANCE_MEMBER_ID",
+              "validation_path": "document"
+            },
+            "validator": "medicalid"
+          },
+          "rank": 60,
+          "ruleId": "INSURANCE_MEMBER_ID"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:medical_long_form_labels>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "member id: \nmember id: W1122009988"
+                  },
+                  "startLine": 6
+                },
+                "region": {
+                  "endColumn": 23,
+                  "snippet": {
+                    "text": "member id: W1122009988"
+                  },
+                  "startColumn": 12,
+                  "startLine": 6
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "INSURANCE_MEMBER_ID Detected in <golden:medical_long_form_labels> at line 6 (confidence: 80.0% - MEDIUM). Matched text: 'W1122009988'"
+          },
+          "properties": {
+            "confidence": 80,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 0.7,
+              "context_doctype": "Unknown",
+              "context_domain": "Healthcare",
+              "context_impact": 10,
+              "original_confidence": 80,
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "subtype": "INSURANCE_MEMBER_ID",
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "member id"
+            ],
+            "validator": "medicalid"
+          },
+          "rank": 65,
+          "ruleId": "INSURANCE_MEMBER_ID"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:medical_long_form_labels>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "medicare member identification number: \nmedicare member identification number: 1EG4TE5MK73"
+                  },
+                  "startLine": 3
+                },
+                "region": {
+                  "endColumn": 51,
+                  "snippet": {
+                    "text": "medicare member identification number: 1EG4TE5MK73"
+                  },
+                  "startColumn": 40,
+                  "startLine": 3
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "MEDICARE_MBI Detected in <golden:medical_long_form_labels> at line 3 (confidence: 85.0% - MEDIUM). Matched text: '1EG4TE5MK73'"
+          },
+          "properties": {
+            "confidence": 85,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 0.7,
+              "context_doctype": "Unknown",
+              "context_domain": "Healthcare",
+              "context_impact": 10,
+              "original_confidence": 85,
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "subtype": "MBI",
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "medicare"
+            ],
+            "validator": "medicalid"
+          },
+          "rank": 67.5,
+          "ruleId": "MEDICARE_MBI"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:medical_long_form_labels>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "patient identification number: \npatient identification number: 4472901"
+                  },
+                  "startLine": 4
+                },
+                "region": {
+                  "endColumn": 39,
+                  "snippet": {
+                    "text": "patient identification number: 4472901"
+                  },
+                  "startColumn": 32,
+                  "startLine": 4
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "MRN Detected in <golden:medical_long_form_labels> at line 4 (confidence: 80.0% - MEDIUM). Matched text: '4472901'"
+          },
+          "properties": {
+            "confidence": 80,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 0.7,
+              "context_doctype": "Unknown",
+              "context_domain": "Healthcare",
+              "context_impact": 10,
+              "original_confidence": 80,
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "subtype": "MRN",
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "patient"
+            ],
+            "validator": "medicalid"
+          },
+          "rank": 65,
+          "ruleId": "MRN"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/awslabs/ferret-scan",
+          "name": "Ferret Scan",
+          "rules": [
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type INSURANCE_MEMBER_ID was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/INSURANCE_MEMBER_ID.md",
+              "id": "INSURANCE_MEMBER_ID",
+              "shortDescription": {
+                "text": "INSURANCE_MEMBER_ID Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type MEDICARE_MBI was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/MEDICARE_MBI.md",
+              "id": "MEDICARE_MBI",
+              "shortDescription": {
+                "text": "MEDICARE_MBI Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type MRN was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/MRN.md",
+              "id": "MRN",
+              "shortDescription": {
+                "text": "MRN Detected"
+              }
+            }
+          ],
+          "semanticVersion": "0.0.0-development",
+          "version": "0.0.0-development"
+        }
+      },
+      "versionControlProvenance": [
+        {
+          "mappedTo": {
+            "uriBaseId": "%SRCROOT%"
+          },
+          "repositoryUri": "https://github.com/awslabs/ferret-scan",
+          "revisionId": "0.0.0-development"
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/internal/goldencorpus/testdata/golden/medical_long_form_labels.txt
+++ b/internal/goldencorpus/testdata/golden/medical_long_form_labels.txt
@@ -1,0 +1,9 @@
+LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH       FILE
+-------------------------------------------------------------------------------------
+[MEDIUM] medicalid    MEDICARE_MBI           85.00% line     3 1EG4TE5MK73 <golden:medical_long_form_labels>
+[MEDIUM] medicalid    INSURANCE_MEMBER_ID    80.00% line     2 X9876543210 <golden:medical_long_form_labels>
+[MEDIUM] medicalid    INSURANCE_MEMBER_ID    80.00% line     3 1EG4TE5MK73 <golden:medical_long_form_labels>
+[MEDIUM] medicalid    INSURANCE_MEMBER_ID    80.00% line     6 W1122009988 <golden:medical_long_form_labels>
+[MEDIUM] medicalid    MRN                    80.00% line     4 4472901     <golden:medical_long_form_labels>
+[MEDIUM] medicalid    INSURANCE_MEMBER_ID    70.00% line     1 W1234567801 <golden:medical_long_form_labels>
+[MEDIUM] medicalid    INSURANCE_MEMBER_ID    70.00% line     5 P5551234567 <golden:medical_long_form_labels>

--- a/internal/goldencorpus/testdata/golden/medical_long_form_labels.yaml
+++ b/internal/goldencorpus/testdata/golden/medical_long_form_labels.yaml
@@ -1,0 +1,155 @@
+results:
+    - text: 1EG4TE5MK73
+      line_number: 3
+      type: MEDICARE_MBI
+      confidence: 85
+      confidence_level: MEDIUM
+      filename: <golden:medical_long_form_labels>
+      validator: medicalid
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0.6666666666666666
+        context_doctype: Unknown
+        context_domain: Healthcare
+        context_impact: 10
+        original_confidence: 85
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        subtype: MBI
+        validation_path: document
+    - text: X9876543210
+      line_number: 2
+      type: INSURANCE_MEMBER_ID
+      confidence: 80
+      confidence_level: MEDIUM
+      filename: <golden:medical_long_form_labels>
+      validator: medicalid
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0.6666666666666666
+        context_doctype: Unknown
+        context_domain: Healthcare
+        context_impact: 10
+        original_confidence: 80
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        subtype: INSURANCE_MEMBER_ID
+        validation_path: document
+    - text: 1EG4TE5MK73
+      line_number: 3
+      type: INSURANCE_MEMBER_ID
+      confidence: 80
+      confidence_level: MEDIUM
+      filename: <golden:medical_long_form_labels>
+      validator: medicalid
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0.6666666666666666
+        context_doctype: Unknown
+        context_domain: Healthcare
+        context_impact: 10
+        original_confidence: 80
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        subtype: INSURANCE_MEMBER_ID
+        validation_path: document
+    - text: W1122009988
+      line_number: 6
+      type: INSURANCE_MEMBER_ID
+      confidence: 80
+      confidence_level: MEDIUM
+      filename: <golden:medical_long_form_labels>
+      validator: medicalid
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0.6666666666666666
+        context_doctype: Unknown
+        context_domain: Healthcare
+        context_impact: 10
+        original_confidence: 80
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        subtype: INSURANCE_MEMBER_ID
+        validation_path: document
+    - text: "4472901"
+      line_number: 4
+      type: MRN
+      confidence: 80
+      confidence_level: MEDIUM
+      filename: <golden:medical_long_form_labels>
+      validator: medicalid
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0.6666666666666666
+        context_doctype: Unknown
+        context_domain: Healthcare
+        context_impact: 10
+        original_confidence: 80
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        subtype: MRN
+        validation_path: document
+    - text: W1234567801
+      line_number: 1
+      type: INSURANCE_MEMBER_ID
+      confidence: 70
+      confidence_level: MEDIUM
+      filename: <golden:medical_long_form_labels>
+      validator: medicalid
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0.6666666666666666
+        context_doctype: Unknown
+        context_domain: Healthcare
+        context_impact: 0
+        original_confidence: 70
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        subtype: INSURANCE_MEMBER_ID
+        validation_path: document
+    - text: P5551234567
+      line_number: 5
+      type: INSURANCE_MEMBER_ID
+      confidence: 70
+      confidence_level: MEDIUM
+      filename: <golden:medical_long_form_labels>
+      validator: medicalid
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0.6666666666666666
+        context_doctype: Unknown
+        context_domain: Healthcare
+        context_impact: 0
+        original_confidence: 70
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        subtype: INSURANCE_MEMBER_ID
+        validation_path: document

--- a/internal/validators/medicalid/validator.go
+++ b/internal/validators/medicalid/validator.go
@@ -711,6 +711,12 @@ func (v *Validator) hasMedicareContext(lowerLine string) bool {
 		// SSN-based identifier the MBI replaced); it is still a Medicare
 		// identifier label and appears on older records/exports.
 		"hicn", "health insurance claim",
+		// "Member Identification Number" is the label printed on the physical
+		// Medicare card next to the MBI. Keywords match on whole tokens, so
+		// "member id" does not cover it — "identification" is not the token
+		// "id" — and without an entry here the card's own wording scored the
+		// MBI at LOW instead of HIGH.
+		"member identification",
 	}
 	for _, kw := range medicareKW {
 		if containsKeyword(lowerLine, kw) {
@@ -728,6 +734,9 @@ func (v *Validator) hasMRNKeyword(lowerLine string) bool {
 		// the MRN/account identifier; without it, the "account" soft suppressor
 		// would hard-drop the real MRN on this line.
 		"patient account",
+		// Long form of "patient id" — not reachable from the abbreviation,
+		// since keywords match whole tokens.
+		"patient identification",
 	}
 	for _, kw := range mrnKW {
 		if containsKeyword(lowerLine, kw) {
@@ -742,6 +751,13 @@ func (v *Validator) hasInsuranceContext(lowerLine string) bool {
 		"insurance", "member id", "member number", "subscriber",
 		"policy number", "group number", "health plan", "enrollee",
 		"covered", "copay", "deductible", "claims",
+		// Long-form spellings of the same card/EDI field labels. Keywords match
+		// whole tokens, so the abbreviated entries above do not cover them.
+		// Deliberately excludes "certificate number" and "policy
+		// identification": both are common in crypto (X.509) and IAM/Terraform
+		// contexts, where they produced false positives on build IDs and key
+		// material.
+		"member identification", "subscriber identification", "policyholder",
 		// Pharmacy-benefit card fields printed alongside the member ID on
 		// insurance cards (RxBIN / RxPCN / RxGRP).
 		"rxbin", "rxpcn", "rxgrp", "rx bin", "rx group",
@@ -758,6 +774,14 @@ func (v *Validator) hasInsuranceKeyword(lowerLine string) bool {
 	strongKW := []string{
 		"member id", "member number", "subscriber id", "policy number",
 		"insurance id", "group number", "enrollee id",
+		// Long forms of the same labels. This list also gates the
+		// all-uppercase-ID shape check in looksLikeNonInsuranceIDShape, so a
+		// card-style ID ("W1234567801") beside a long-form label was dropped
+		// outright rather than merely scored low. Kept narrow on purpose:
+		// "certificate number" and a bare "policy identification" also name
+		// X.509 and IAM objects, so they are not included.
+		"member identification", "subscriber identification",
+		"enrollee identification", "policyholder id",
 	}
 	for _, kw := range strongKW {
 		if containsKeyword(lowerLine, kw) {

--- a/internal/validators/medicalid/validator_test.go
+++ b/internal/validators/medicalid/validator_test.go
@@ -872,3 +872,80 @@ func TestMedicalIDValidator_IntrinsicValueFloor(t *testing.T) {
 		t.Errorf("floor %.1f must be inside the LOW band (0 < floor < 60)", intrinsicValueFloor)
 	}
 }
+
+// TestLongFormLabelRecall covers the label spellings printed on physical
+// insurance and Medicare cards and used in EDI 837 exports. Keyword matching is
+// whole-token, so "member id" cannot match "member identification number" —
+// "identification" is not the token "id". Before the long forms were added, the
+// wording on the card itself either scored LOW or, for an all-uppercase card ID,
+// produced no finding at all: hasInsuranceKeyword gates the uppercase-shape
+// check in looksLikeNonInsuranceIDShape, so the ID was dropped outright and
+// would have passed through redaction in cleartext.
+func TestLongFormLabelRecall(t *testing.T) {
+	v := NewValidator()
+
+	tests := []struct {
+		name     string
+		content  string
+		wantType string
+		minConf  float64
+	}{
+		{"medicare card member identification", "member identification number: 1EG4TE5MK73", "MEDICARE_MBI", 60},
+		{"insurance member identification", "member identification number: W1234567801", "INSURANCE_MEMBER_ID", 60},
+		{"subscriber identification", "subscriber identification number: W1234567801", "INSURANCE_MEMBER_ID", 60},
+		{"enrollee identification", "enrollee identification number: W1234567801", "INSURANCE_MEMBER_ID", 60},
+		{"policyholder id", "policyholder id: W1234567801", "INSURANCE_MEMBER_ID", 60},
+		{"patient identification", "patient identification number: 4472901", "MRN", 60},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matches, err := v.ValidateContent(tt.content, "test.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			for _, m := range matches {
+				if m.Type == tt.wantType && m.Confidence >= tt.minConf {
+					return
+				}
+			}
+			t.Errorf("no %s match with confidence >= %.0f in %q; got %v",
+				tt.wantType, tt.minConf, tt.content, summarize(matches))
+		})
+	}
+}
+
+// TestLongFormLabelNoTechFalsePositives locks the deliberate exclusions. A bare
+// "certificate number" names an X.509 certificate far more often than an
+// insurance one, and "policy identification" names an IAM or Terraform policy,
+// so neither is a keyword — adding them made build IDs and key material match
+// as insurance member IDs.
+func TestLongFormLabelNoTechFalsePositives(t *testing.T) {
+	v := NewValidator()
+
+	for _, content := range []string{
+		"X.509 certificate serial number: 0A1B2C3D4E5F6789",
+		"signing certificate number: SHA256ABCDEF1234",
+		"policy identification for terraform module: MODULEVERSION123",
+		"IAM policy identification number: AKIAIOSFODNN7EXAMPLE",
+	} {
+		matches, err := v.ValidateContent(content, "test.txt")
+		if err != nil {
+			t.Fatalf("ValidateContent: %v", err)
+		}
+		for _, m := range matches {
+			if m.Type == "INSURANCE_MEMBER_ID" {
+				t.Errorf("INSURANCE_MEMBER_ID false positive on %q (confidence %.0f)",
+					content, m.Confidence)
+			}
+		}
+	}
+}
+
+func summarize(matches []detector.Match) []string {
+	out := make([]string, 0, len(matches))
+	for _, m := range matches {
+		out = append(out, m.Type)
+	}
+	return out
+}


### PR DESCRIPTION
## Problem

Keyword matching is whole-token, so `"member id"` cannot match `member identification number` — `identification` is not the token `id`. That long form is the label **printed on physical Medicare and insurance cards** and used in EDI 837 exports, and it was reaching two different failure modes:

| Input | Before | After |
|---|---|---|
| `member identification number: 1EG4TE5MK73` | MEDICARE_MBI **LOW 40** | MEDIUM 75 |
| `patient identification number: 4472901` | MRN **LOW 55** | MEDIUM 80 |
| `member identification number: W1234567801` | **no finding** | INSURANCE_MEMBER_ID 70 |
| `subscriber identification number: X9876543210` | **no finding** | INSURANCE_MEMBER_ID 80 |
| `policyholder id: P5551234567` | **no finding** | INSURANCE_MEMBER_ID 70 |

The `no finding` rows are the serious half. `hasInsuranceKeyword` gates the all-uppercase shape check in `looksLikeNonInsuranceIDShape`, so a card-style ID beside a long-form label was dropped **outright** rather than merely scored low — and an undetected identifier passes through redaction in cleartext. On an 8-line fixture with 6 planted identifiers, the parent leaked 4 of 6 in cleartext; this branch leaks 0.

Measured on a 20-phrasing probe of real card/EDI labels, insurance recall goes from 6 to 11.

## Fix

Adds the long forms to the four affected keyword lists (`hasMedicareContext`, `hasMRNKeyword`, `hasInsuranceContext`, `hasInsuranceKeyword`).

**Deliberately narrow.** `certificate number` and a bare `policy identification` were tried and dropped: they name X.509 certificates and IAM/Terraform policies far more often than insurance objects, and adding them matched a build ID and an AWS access key as insurance member IDs. `TestLongFormLabelNoTechFalsePositives` locks those exclusions so a later widening pass has to break it on purpose.

## Testing

- **6 new recall tests**, each verified to FAIL on the parent (4 of them with `got []` — no finding at all) and pass here. Plus 1 FP test that passes both ways, which is what a guardrail should do.
- **Full suite** clean; `-race` clean on medicalid, goldencorpus, suppressions.
- **Golden corpus**: new `medical_long_form_labels` case — 9 files covering all 7 formats plus both byte-comparable redaction strategies. **Zero existing goldens change**, so this is purely additive to the golden net.
- **TP/FP A/B vs parent** on the real validator source tree: 472 findings both sides, per-type **IDENTICAL**, stable across repeated runs — zero new false positives. (The whole-`internal/` tree shows +17, all of which are this PR's own new fixture and its golden files detecting themselves.)
- **No O(n²)**: dense single-line inputs of 1250→10000 tokens scale sub-linearly (8× input → 2.3× time). The small delta is per-finding formatting of output the parent was silently dropping — per-finding cost is constant.
- **Redaction**, all 3 strategies: 6/6 identifiers masked, both tech decoys correctly left alone. The same-span MBI/INSURANCE double-emit on line 3 masks once, correctly.
- **Suppression** round-trip verified on the newly recalled findings, including hash stability across a manager reload.
- All 7 output formats emit `rc=0` and are deterministic (1/6 distinct digests).

## Merge order

Stacked on #182 (tip of the `#177 → #178 → #182` medicalid chain) because those PRs also touch `medicalid/validator.go`. Merges clean against main and every other open PR.

Merging this into the full 16-PR stack is conflict-free, but the golden net then needs `UPDATE_GOLDEN=1` for **pre-existing** reasons — `context_soft_negative_labels` and `context_keywords_snake_case` fail on the stack *without* this PR too. That's issue #195, and this branch's own goldens (`medical_long_form_labels`) also reorder there. Pure reordering in every case: identical finding multisets, counts and confidences. Whoever merges last regenerates.