### PR TITLE
fix(redaction): stop discarding findings for files that cannot be redacted

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -649,6 +649,30 @@ func writeIncompleteCoverageWarning(w io.Writer, incompleteFiles []parallel.File
 	return true
 }
 
+// writeUnredactedFilesWarning emits a warning to w for every file that HAS
+// findings but for which no redacted copy could be written (no redactor is
+// registered for the extension, or the write failed). It returns true if a
+// warning was written.
+//
+// This is the counterpart to writeIncompleteCoverageWarning, and the two mean
+// opposite things: incomplete coverage says findings may be MISSING, this says
+// the findings were found and reported but the sensitive values were NOT
+// redacted anywhere — they remain in cleartext at the original path with no
+// shareable artifact. Silence here is the dangerous case, because the point of
+// --enable-redaction is to produce those artifacts. Goes to stderr (never
+// stdout/JSON) and never changes the exit code.
+func writeUnredactedFilesWarning(w io.Writer, unredactedFiles []parallel.FileDiagnostic, totalFiles int) bool {
+	if len(unredactedFiles) == 0 {
+		return false
+	}
+	fmt.Fprintf(w, "WARNING: redaction incomplete — %d of %d file(s) have findings but no redacted copy was written; the original values remain in cleartext:\n",
+		len(unredactedFiles), totalFiles)
+	for _, fd := range unredactedFiles {
+		fmt.Fprintf(w, "  %s: %s\n", fd.FilePath, fd.Reason)
+	}
+	return true
+}
+
 // extractedFlags holds safely extracted flag values to avoid repeated nil checks
 type extractedFlags struct {
 	webMode              bool
@@ -1457,6 +1481,12 @@ func main() {
 	// Populated from ProcessingStats.IncompleteFiles below and surfaced as a
 	// stderr warning so a partially-scanned run is never silently reported clean.
 	var incompleteFiles []parallel.FileDiagnostic
+	// unredactedFiles captures files that HAVE findings but for which no redacted
+	// copy could be written (no registered redactor for the extension, or a write
+	// failure). Only ever non-empty with --enable-redaction. Surfaced as its own
+	// stderr warning: the findings are still reported, but the sensitive values
+	// remain in cleartext at the original path with no shareable artifact.
+	var unredactedFiles []parallel.FileDiagnostic
 
 	// Suppress progress messages in pre-commit mode or quiet mode
 	if !shouldSuppressProgressOutput(finalConfig, precommitConfig, isInteractive) {
@@ -1573,6 +1603,7 @@ func main() {
 			allMatches = append(allMatches, parallelMatches...)
 			processedFiles = stats.ProcessedFiles
 			incompleteFiles = stats.IncompleteFiles
+			unredactedFiles = stats.UnredactedFiles
 
 			// Handle inline redaction results if redaction was enabled
 			if finalConfig.enableRedaction && redactionManager != nil {
@@ -1636,6 +1667,7 @@ func main() {
 	// unchanged (default still 0) — this is an advisory warning.
 	if precommitConfig == nil {
 		writeIncompleteCoverageWarning(os.Stderr, incompleteFiles, len(supportedFiles))
+		writeUnredactedFilesWarning(os.Stderr, unredactedFiles, len(supportedFiles))
 	}
 
 	// Advisory explanation pass (opt-in via --explain). Annotate the full

--- a/cmd/unredacted_warning_test.go
+++ b/cmd/unredacted_warning_test.go
@@ -1,0 +1,94 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/parallel"
+)
+
+// TestWriteUnredactedFilesWarning_NoneIsSilent: a run where every file with
+// findings was redacted (and every run without --enable-redaction) must write
+// nothing, so the common path emits no spurious warning.
+func TestWriteUnredactedFilesWarning_NoneIsSilent(t *testing.T) {
+	var buf bytes.Buffer
+	wrote := writeUnredactedFilesWarning(&buf, nil, 5)
+	if wrote {
+		t.Error("expected no warning when every file was redacted")
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected empty output, got %q", buf.String())
+	}
+}
+
+// TestWriteUnredactedFilesWarning_NamesFileAndCleartext: the warning must name
+// the file, the reason, AND say the values are still in cleartext. The last part
+// is the point — an operator who ran --enable-redaction believes an artifact was
+// produced, and the count alone would not tell them otherwise.
+func TestWriteUnredactedFilesWarning_NamesFileAndCleartext(t *testing.T) {
+	var buf bytes.Buffer
+	files := []parallel.FileDiagnostic{
+		{FilePath: "src/creds.go", Reason: "failed to get redactor: no redactor registered for file type: .go"},
+	}
+	wrote := writeUnredactedFilesWarning(&buf, files, 5)
+	if !wrote {
+		t.Fatal("expected a warning to be written")
+	}
+	out := buf.String()
+	for _, want := range []string{
+		"redaction incomplete", "1 of 5 file", "src/creds.go",
+		"no redactor registered", "cleartext",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("warning missing %q; got:\n%s", want, out)
+		}
+	}
+}
+
+// TestWriteUnredactedFilesWarning_MultipleFiles: every offending file is listed,
+// not just a count — an operator needs to know which originals to handle.
+func TestWriteUnredactedFilesWarning_MultipleFiles(t *testing.T) {
+	var buf bytes.Buffer
+	files := []parallel.FileDiagnostic{
+		{FilePath: "a.go", Reason: "no redactor registered for file type: .go"},
+		{FilePath: "b.py", Reason: "no redactor registered for file type: .py"},
+	}
+	wrote := writeUnredactedFilesWarning(&buf, files, 10)
+	if !wrote {
+		t.Fatal("expected a warning to be written")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "2 of 10 file") {
+		t.Errorf("expected '2 of 10 file' count, got:\n%s", out)
+	}
+	if !strings.Contains(out, "a.go") || !strings.Contains(out, "b.py") {
+		t.Errorf("expected both offending files listed, got:\n%s", out)
+	}
+}
+
+// TestWriteUnredactedFilesWarning_DistinctFromIncompleteCoverage keeps the two
+// warnings from being confused. They mean opposite things: incomplete coverage
+// says findings may be MISSING (re-scan), unredacted says the findings were
+// found and reported but nothing was masked (handle the original). A single
+// merged message would send the operator down the wrong path.
+func TestWriteUnredactedFilesWarning_DistinctFromIncompleteCoverage(t *testing.T) {
+	files := []parallel.FileDiagnostic{{FilePath: "x.go", Reason: "no redactor registered for file type: .go"}}
+
+	var unredacted, incomplete bytes.Buffer
+	writeUnredactedFilesWarning(&unredacted, files, 1)
+	writeIncompleteCoverageWarning(&incomplete, files, 1)
+
+	if unredacted.String() == incomplete.String() {
+		t.Fatal("the two warnings must not be identical")
+	}
+	if strings.Contains(unredacted.String(), "findings may be missing") {
+		t.Error("unredacted warning must not claim findings are missing; the scan was complete")
+	}
+	if strings.Contains(incomplete.String(), "cleartext") {
+		t.Error("incomplete-coverage warning must not claim a redaction outcome")
+	}
+}

--- a/internal/core/redact.go
+++ b/internal/core/redact.go
@@ -110,10 +110,22 @@ func RedactFile(cfg RedactConfig) (*RedactResult, error) {
 		RedactionStrategy: cfg.Strategy,
 	}
 	pp := parallel.NewParallelProcessor(observer)
-	matches, _, err := pp.ProcessFilesWithProgress(
+	matches, stats, err := pp.ProcessFilesWithProgress(
 		[]string{cfg.FilePath}, validatorsList, fileRouter, jobConfig, redactionManager, nil)
 	if err != nil {
 		return nil, fmt.Errorf("redaction processing failed: %w", err)
+	}
+
+	// A file whose findings could not be redacted must be a hard error, never a
+	// result. Returning success here would hand the caller a path its own doc
+	// comment calls safe to share while the sensitive values sit in it verbatim
+	// — and RedactionCount would read 0, indistinguishable from a genuinely
+	// clean file. Checked BEFORE the clean-file passthrough below precisely
+	// because that passthrough copies the original: reaching it with a file that
+	// has unredacted findings is what turned this into a silent cleartext copy.
+	if stats != nil && len(stats.UnredactedFiles) > 0 {
+		return nil, fmt.Errorf("could not redact %s: %s",
+			stats.UnredactedFiles[0].FilePath, stats.UnredactedFiles[0].Reason)
 	}
 
 	// The worker pool only writes an output file when there is at least one

--- a/internal/core/redact_test.go
+++ b/internal/core/redact_test.go
@@ -82,6 +82,56 @@ func TestRedactFile_CleanFileIsCopiedThrough(t *testing.T) {
 	}
 }
 
+// TestRedactFile_UnredactableFileTypeIsAnError pins the hard-error guard. A
+// source file has no registered redactor, so its findings cannot be masked. The
+// only safe outcome is an error: returning success would hand the caller a path
+// that RedactFile's own doc comment calls "safe to share", and RedactionCount
+// would read 0 — indistinguishable from a genuinely clean file. The clean-file
+// passthrough made that worse by copying the original there verbatim.
+func TestRedactFile_UnredactableFileTypeIsAnError(t *testing.T) {
+	in := t.TempDir()
+	out := t.TempDir()
+	// Reserved documentation values, in a file type with no redactor.
+	src := writeTemp(t, in, "creds.go",
+		"package main\n\nconst key = \"AKIAIOSFODNN7EXAMPLE\" // jordan@example.com\n")
+
+	res, err := RedactFile(RedactConfig{
+		FilePath:  src,
+		OutputDir: out,
+		Checks:    []string{"all"},
+		Config:    config.LoadConfigOrDefault(""),
+		LogWriter: io.Discard,
+	})
+	if err == nil {
+		t.Fatalf("expected an error for an unredactable file type; got result %+v", res)
+	}
+	if !strings.Contains(err.Error(), "could not redact") {
+		t.Errorf("error should say redaction failed, got: %v", err)
+	}
+	if res != nil {
+		t.Errorf("no result may be returned alongside the error, got %+v", res)
+	}
+
+	// And nothing may have been written under the output dir — the leak was a
+	// cleartext copy at a path the caller treats as sanitized.
+	err = filepath.Walk(out, func(path string, info os.FileInfo, werr error) error {
+		if werr != nil || info.IsDir() {
+			return werr
+		}
+		data, rerr := os.ReadFile(path) // #nosec G304 - test-controlled temp path
+		if rerr != nil {
+			return rerr
+		}
+		if strings.Contains(string(data), "AKIAIOSFODNN7EXAMPLE") {
+			t.Errorf("cleartext value was copied to the output path %s", path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking output dir: %v", err)
+	}
+}
+
 func TestRedactFile_DefaultsToFormatPreserving(t *testing.T) {
 	in := t.TempDir()
 	out := t.TempDir()

--- a/internal/parallel/parallel_processor.go
+++ b/internal/parallel/parallel_processor.go
@@ -37,6 +37,15 @@ type ProcessingStats struct {
 	// to set ScanResult.Incomplete — distinguishing "scanned clean" from "did
 	// not finish scanning".
 	IncompleteFiles []FileDiagnostic `json:"incomplete_files,omitempty"`
+
+	// UnredactedFiles lists files that HAVE findings but for which no redacted
+	// copy could be produced (populated from Result.RedactionError; empty unless
+	// --enable-redaction is on). These files' findings are reported normally —
+	// the scan saw them — but the sensitive values remain in cleartext at the
+	// original path with no output artifact. Callers must surface this: a
+	// redaction run whose whole purpose is to produce shareable copies has
+	// silently not done so for these files.
+	UnredactedFiles []FileDiagnostic `json:"unredacted_files,omitempty"`
 }
 
 // FileDiagnostic records that a single file's validation did not complete
@@ -103,6 +112,7 @@ func (pp *ParallelProcessor) ProcessFilesWithProgress(filePaths []string, valida
 	processedCount := 0
 	totalDuration := time.Duration(0)
 	var incompleteFiles []FileDiagnostic
+	var unredactedFiles []FileDiagnostic
 
 	for i := 0; i < jobCount; i++ {
 		result := <-pp.workerPool.Results()
@@ -116,6 +126,27 @@ func (pp *ParallelProcessor) ProcessFilesWithProgress(filePaths []string, valida
 				FilePath: result.FilePath,
 				Reason:   result.ValidationError.Error(),
 			})
+		}
+		// Record a file whose findings could not be redacted. Handled the same
+		// way as degraded validator coverage — as a diagnostic, NOT as a fatal
+		// error — so the file still contributes its matches below. Redaction
+		// runs after validation, so a redaction failure says nothing about the
+		// correctness of what was found; treating it as fatal is what silently
+		// erased findings for every file type with no registered redactor.
+		if result.RedactionError != nil {
+			unredactedFiles = append(unredactedFiles, FileDiagnostic{
+				FilePath: result.FilePath,
+				Reason:   result.RedactionError.Error(),
+			})
+			if pp.observer != nil {
+				pp.observer.LogOperation(observability.StandardObservabilityData{
+					Component: "parallel_processor",
+					Operation: "file_redaction",
+					FilePath:  result.FilePath,
+					Success:   false,
+					Error:     result.RedactionError.Error(),
+				})
+			}
 		}
 		if result.Error != nil {
 			if pp.observer != nil {
@@ -150,6 +181,7 @@ func (pp *ParallelProcessor) ProcessFilesWithProgress(filePaths []string, valida
 		WorkerCount:     pp.workerPool.workers,
 		AvgFileTime:     totalDuration / time.Duration(max(processedCount, 1)),
 		IncompleteFiles: incompleteFiles,
+		UnredactedFiles: unredactedFiles,
 	}
 
 	if finishTiming != nil {

--- a/internal/parallel/redaction_failure_test.go
+++ b/internal/parallel/redaction_failure_test.go
@@ -1,0 +1,227 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package parallel
+
+import (
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/observability"
+	"github.com/awslabs/ferret-scan/v2/internal/redactors"
+	"github.com/awslabs/ferret-scan/v2/internal/redactors/plaintext"
+)
+
+// These tests lock the boundary between the SCAN result and the REDACTION
+// artifact: a file whose findings could not be redacted must still report those
+// findings and still be counted as processed. Redaction runs after the file has
+// been read, extracted and validated, so it cannot invalidate what was found.
+//
+// The regression they guard is a silent one. Redaction failure used to be folded
+// into Result.Error, whose branch in the result collector neither appends
+// matches nor increments processedCount — so scanning a directory with
+// --enable-redaction dropped every finding in every file whose extension has no
+// registered redactor (.go, .py, ...) while still reporting "0 skipped" and
+// exiting 0. A CI gate saw a clean pass over unredacted cleartext.
+
+// newRedactionManagerWithPlaintextOnly builds a manager that can redact .txt but
+// NOT .go — the real-world shape of the bug, since the default redactor set
+// covers text/PDF/Office/image extensions and nothing else.
+func newRedactionManagerWithPlaintextOnly(t *testing.T, outDir string) *redactors.RedactionManager {
+	t.Helper()
+	observer := observability.NewStandardObserver(observability.ObservabilityMetrics, io.Discard)
+	om, err := redactors.NewOutputStructureManager(outDir, observer)
+	if err != nil {
+		t.Fatalf("output manager: %v", err)
+	}
+	mgr := redactors.NewRedactionManagerWithConfig(om, observer, &redactors.RedactionManagerConfig{
+		DefaultStrategy: redactors.RedactionSimple,
+		RetryAttempts:   1,
+	})
+	if err := mgr.RegisterRedactor(plaintext.NewPlainTextRedactor(om, observer)); err != nil {
+		t.Fatalf("register plaintext redactor: %v", err)
+	}
+	return mgr
+}
+
+// TestRedaction_UnredactableFileKeepsItsMatches is the core guarantee: a file
+// with no registered redactor still contributes its findings and is still
+// counted, and the failure is reported as its own diagnostic rather than
+// silently swallowed.
+func TestRedaction_UnredactableFileKeepsItsMatches(t *testing.T) {
+	dir := t.TempDir()
+	txt := writeTxt(t, dir, "notes.txt", "alpha content")
+	// .go has no registered redactor in the manager built above.
+	gofile := writeTxt(t, dir, "creds.go", "package main // beta content")
+
+	v := &batchStubValidator{}
+	observer := observability.NewStandardObserver(observability.ObservabilityMetrics, io.Discard)
+	pp := NewParallelProcessor(observer)
+	fr := newTestFileRouter(t)
+	mgr := newRedactionManagerWithPlaintextOnly(t, filepath.Join(dir, "out"))
+
+	cfg := &JobConfig{EnableRedaction: true, RedactionStrategy: "simple"}
+	matches, stats, err := pp.ProcessFilesWithProgress(
+		[]string{txt, gofile}, []detector.Validator{v}, fr, cfg, mgr, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Both files' matches must be present. The stub emits one per file.
+	byFile := map[string]int{}
+	for _, m := range matches {
+		byFile[filepath.Base(m.Filename)]++
+	}
+	if byFile["creds.go"] == 0 {
+		t.Errorf("unredactable file's matches were DROPPED (the leak): got %v", byFile)
+	}
+	if byFile["notes.txt"] == 0 {
+		t.Errorf("redactable file's matches missing: got %v", byFile)
+	}
+
+	// The unredactable file must still be counted as processed — a scan that
+	// silently stops counting files is what makes "0 skipped" a lie.
+	if stats.ProcessedFiles != 2 {
+		t.Errorf("ProcessedFiles = %d, want 2 (both files were scanned)", stats.ProcessedFiles)
+	}
+
+	// ...and the redaction failure must be surfaced, naming the file.
+	if len(stats.UnredactedFiles) != 1 {
+		t.Fatalf("UnredactedFiles = %d, want 1: %+v", len(stats.UnredactedFiles), stats.UnredactedFiles)
+	}
+	if filepath.Base(stats.UnredactedFiles[0].FilePath) != "creds.go" {
+		t.Errorf("wrong unredacted file: %q", stats.UnredactedFiles[0].FilePath)
+	}
+	if stats.UnredactedFiles[0].Reason == "" {
+		t.Error("unredacted diagnostic carries no reason")
+	}
+}
+
+// TestRedaction_FailureIsNotACoverageFailure keeps the two diagnostics distinct.
+// A redaction failure means "the values were found but not masked anywhere";
+// incomplete coverage means "findings may be missing". Conflating them would
+// make --fail-on-incomplete fire on unredactable file types, and would tell an
+// operator to re-scan when the scan was in fact complete.
+func TestRedaction_FailureIsNotACoverageFailure(t *testing.T) {
+	dir := t.TempDir()
+	gofile := writeTxt(t, dir, "creds.go", "package main // beta content")
+
+	v := &batchStubValidator{}
+	observer := observability.NewStandardObserver(observability.ObservabilityMetrics, io.Discard)
+	pp := NewParallelProcessor(observer)
+	fr := newTestFileRouter(t)
+	mgr := newRedactionManagerWithPlaintextOnly(t, filepath.Join(dir, "out"))
+
+	cfg := &JobConfig{EnableRedaction: true, RedactionStrategy: "simple"}
+	_, stats, err := pp.ProcessFilesWithProgress(
+		[]string{gofile}, []detector.Validator{v}, fr, cfg, mgr, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(stats.UnredactedFiles) != 1 {
+		t.Fatalf("UnredactedFiles = %d, want 1", len(stats.UnredactedFiles))
+	}
+	if len(stats.IncompleteFiles) != 0 {
+		t.Errorf("a redaction failure must NOT be reported as incomplete coverage; got %+v",
+			stats.IncompleteFiles)
+	}
+}
+
+// TestRedaction_UnredactableFileIsNotAFailedFile pins the exit-code
+// consequence, which is the sharpest edge of this bug. The CLI computes
+// failedFiles = totalAttempted - ProcessedFiles and feeds that to the
+// pre-commit exit code as hasErrors, where 2 ("system error") outranks 1
+// ("blocking finding"). While unredactable files went uncounted, a pre-commit
+// run over a repo of .go/.py sources exited 2 — a hook that treats 2 as
+// infrastructure flakiness would retry or ignore it, letting a commit through
+// with the secret still in it. Counting the file makes the exit code reflect
+// the findings instead.
+func TestRedaction_UnredactableFileIsNotAFailedFile(t *testing.T) {
+	dir := t.TempDir()
+	files := []string{
+		writeTxt(t, dir, "notes.txt", "alpha content"),
+		writeTxt(t, dir, "creds.go", "package main // beta content"),
+		writeTxt(t, dir, "app.py", "# gamma content"),
+	}
+
+	v := &batchStubValidator{}
+	observer := observability.NewStandardObserver(observability.ObservabilityMetrics, io.Discard)
+	pp := NewParallelProcessor(observer)
+	fr := newTestFileRouter(t)
+	mgr := newRedactionManagerWithPlaintextOnly(t, filepath.Join(dir, "out"))
+
+	cfg := &JobConfig{EnableRedaction: true, RedactionStrategy: "simple"}
+	_, stats, err := pp.ProcessFilesWithProgress(files, []detector.Validator{v}, fr, cfg, mgr, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// This is the exact expression cmd/main.go uses for failedFiles/hasErrors.
+	failedFiles := len(files) - stats.ProcessedFiles
+	if failedFiles != 0 {
+		t.Errorf("failedFiles = %d, want 0; %d unredactable file(s) must not read as system errors",
+			failedFiles, len(stats.UnredactedFiles))
+	}
+	if len(stats.UnredactedFiles) != 2 {
+		t.Errorf("UnredactedFiles = %d, want 2 (.go and .py)", len(stats.UnredactedFiles))
+	}
+}
+
+// TestRedaction_SuccessReportsNoUnredactedFiles pins the happy path: when every
+// file can be redacted, UnredactedFiles is empty, so a caller that only checks
+// for the warning sees no change on a normal run.
+func TestRedaction_SuccessReportsNoUnredactedFiles(t *testing.T) {
+	dir := t.TempDir()
+	a := writeTxt(t, dir, "a.txt", "alpha content")
+	b := writeTxt(t, dir, "b.txt", "beta content")
+
+	v := &batchStubValidator{}
+	observer := observability.NewStandardObserver(observability.ObservabilityMetrics, io.Discard)
+	pp := NewParallelProcessor(observer)
+	fr := newTestFileRouter(t)
+	mgr := newRedactionManagerWithPlaintextOnly(t, filepath.Join(dir, "out"))
+
+	cfg := &JobConfig{EnableRedaction: true, RedactionStrategy: "simple"}
+	matches, stats, err := pp.ProcessFilesWithProgress(
+		[]string{a, b}, []detector.Validator{v}, fr, cfg, mgr, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(stats.UnredactedFiles) != 0 {
+		t.Errorf("clean redaction run should report no unredacted files, got %+v", stats.UnredactedFiles)
+	}
+	if stats.ProcessedFiles != 2 {
+		t.Errorf("ProcessedFiles = %d, want 2", stats.ProcessedFiles)
+	}
+	if len(matches) != 2 {
+		t.Errorf("got %d matches, want 2", len(matches))
+	}
+}
+
+// TestRedaction_DisabledLeavesDiagnosticEmpty confirms the field stays empty
+// when redaction was never requested, so the no-redaction default path is
+// byte-identical for every consumer of ProcessingStats.
+func TestRedaction_DisabledLeavesDiagnosticEmpty(t *testing.T) {
+	dir := t.TempDir()
+	gofile := writeTxt(t, dir, "creds.go", "package main // beta content")
+
+	v := &batchStubValidator{}
+	observer := observability.NewStandardObserver(observability.ObservabilityMetrics, io.Discard)
+	pp := NewParallelProcessor(observer)
+	fr := newTestFileRouter(t)
+
+	_, stats, err := pp.ProcessFilesWithProgress(
+		[]string{gofile}, []detector.Validator{v}, fr, &JobConfig{}, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(stats.UnredactedFiles) != 0 {
+		t.Errorf("redaction disabled should leave UnredactedFiles empty, got %+v", stats.UnredactedFiles)
+	}
+	if stats.ProcessedFiles != 1 {
+		t.Errorf("ProcessedFiles = %d, want 1", stats.ProcessedFiles)
+	}
+}

--- a/internal/parallel/worker_pool.go
+++ b/internal/parallel/worker_pool.go
@@ -107,6 +107,17 @@ type Result struct {
 	// that Error drives in parallel_processor. Nil when validation completed.
 	ValidationError error
 
+	// RedactionError is the error from the post-scan redaction step, if any
+	// (e.g. no redactor is registered for this file's extension, or writing the
+	// redacted copy failed). Like ValidationError it is kept SEPARATE from
+	// Error, and for the same reason turned up the other way round: redaction
+	// runs strictly AFTER the file has been read, extracted and validated, so a
+	// redaction failure cannot invalidate matches that were already found.
+	// Folding it into Error made the collector discard them — the file's
+	// findings vanished from every output while the run still reported success.
+	// Nil when redaction was disabled, skipped (no matches) or succeeded.
+	RedactionError error
+
 	// Redaction results
 	RedactionResult *redactors.RedactionResult
 	RedactedPath    string
@@ -224,6 +235,7 @@ func (wp *WorkerPool) processJob(job *Job, workerID int) *Result {
 	var allMatches []detector.Match
 	var lastError error
 	var validationErr error // captured for Result.ValidationError, always (not just --debug)
+	var redactionErr error  // captured for Result.RedactionError; never folded into lastError
 	var processedContent *preprocessors.ProcessedContent
 
 	// Wrap file processing with resilience
@@ -321,11 +333,19 @@ func (wp *WorkerPool) processJob(job *Job, workerID int) *Result {
 	var redactedPath string
 
 	if job.Config.EnableRedaction && job.RedactionManager != nil && len(allMatches) > 0 && processedContent != nil {
-		// Perform redaction using the same extracted content
+		// Perform redaction using the same extracted content. A failure here is
+		// recorded in redactionErr ONLY — it must never reach lastError. This
+		// step runs after the file has already been read, extracted and
+		// validated, so the matches in allMatches are complete and correct
+		// regardless of whether a redacted copy could be produced. Promoting a
+		// redaction failure to Result.Error made the collector take its
+		// error branch, which drops the file's matches and does not count the
+		// file: a source file with no registered redactor (.go, .py, ...) had
+		// its findings erased from every output format while the scan still
+		// reported "0 skipped" and exited 0.
 		redactionResult, redactedPath, err = wp.performInlineRedaction(job, allMatches, processedContent)
-		if err != nil && lastError == nil {
-			// Only set error if we didn't already have one
-			lastError = err
+		if err != nil {
+			redactionErr = err
 		}
 	}
 
@@ -333,11 +353,12 @@ func (wp *WorkerPool) processJob(job *Job, workerID int) *Result {
 
 	if finishTiming != nil {
 		finishTiming(lastError == nil, map[string]interface{}{
-			"worker_id":   workerID,
-			"match_count": len(allMatches),
-			"duration_ms": duration.Milliseconds(),
-			"had_error":   lastError != nil,
-			"redacted":    redactionResult != nil,
+			"worker_id":       workerID,
+			"match_count":     len(allMatches),
+			"duration_ms":     duration.Milliseconds(),
+			"had_error":       lastError != nil,
+			"redacted":        redactionResult != nil,
+			"redaction_error": redactionErr != nil,
 		})
 	}
 
@@ -347,6 +368,7 @@ func (wp *WorkerPool) processJob(job *Job, workerID int) *Result {
 		Matches:         allMatches,
 		Error:           lastError,
 		ValidationError: validationErr,
+		RedactionError:  redactionErr,
 		Duration:        duration,
 		RedactionResult: redactionResult,
 		RedactedPath:    redactedPath,


### PR DESCRIPTION
## The bug

Scanning with `--enable-redaction` silently **erased every finding in every file whose extension has no registered redactor** — `.go`, `.py`, and anything else outside text/PDF/Office/image. The scan reported `0 skipped` and did not signal failure, so values it had already found were reported nowhere and left in cleartext.

Reproduced on a 5-file fixture (2 unredactable):

| | findings | files processed | files skipped |
|---|---|---|---|
| before | 5 | 3 | 0 |
| after | **9** | **5** | 0 |

The two `.go`/`.py` files' AWS access key, SSN and emails were simply absent from the output — with no indication anything had been dropped.

## Root cause

A downstream failure erasing an upstream result. Redaction runs *strictly after* a file has been read, extracted and validated, but `performInlineRedaction`'s error was folded into `Result.Error`:

```go
if err != nil && lastError == nil { lastError = err }
```

The result collector's `Error` branch neither appends the file's matches nor increments `processedCount`. So a failure in the **delivery** step retroactively deleted a **completed scan**.

The repo already had the precedent for the fix: `Result.ValidationError` was split out of `Result.Error` for exactly this reason in v2 Phase 4, and `internal/parallel/diagnostics_test.go` pins it. Redaction needed the same split, turned the other way round.

## The fix

- `internal/parallel/worker_pool.go` — new `Result.RedactionError`, never folded into `lastError`.
- `internal/parallel/parallel_processor.go` — new `ProcessingStats.UnredactedFiles`, collected **before** the `result.Error` check, kept **distinct** from `IncompleteFiles`. The two diagnostics mean opposite things: incomplete coverage = findings may be *missing* (re-scan); unredacted = findings were found and reported but nothing was *masked* (handle the original). Conflating them would make `--fail-on-incomplete` fire on unredactable file types.
- `cmd/main.go` — stderr warning naming each file and reason:

```
WARNING: redaction incomplete — 2 of 5 file(s) have findings but no redacted copy
was written; the original values remain in cleartext:
  .../in/d.py: failed to get redactor: no redactor registered for file type: .py
  .../in/a.go: failed to get redactor: no redactor registered for file type: .go
```

## Two consequences beyond the missing rows

**Exit codes.** `failedFiles = totalAttempted - ProcessedFiles` feeds `hasErrors`, and in pre-commit mode exit `2` ("system error") outranks `1` ("blocking finding"). Measured on the fixture: **before → rc=2, after → rc=1**. A hook that treats `2` as infrastructure flakiness (retry / ignore) could let a commit through with the secret still in it. Now pinned by a test that evaluates the same `failedFiles` expression `cmd/main.go` uses.

**The public API.** `core.RedactFile` returned **success** with `RedactionCount=0` while its clean-file passthrough copied the *unredacted original* to the output path — a path its own doc comment calls "safe to share", and a result indistinguishable from a genuinely clean file. It now returns a hard error, checked *before* the passthrough:

```
could not redact …/creds.go: failed to get redactor: no redactor registered for file type: .go
```

## Test plan

| Dimension | Result |
|---|---|
| Reproduction | 5 findings / 3 processed → **9 / 5**; both files' values recovered |
| Redaction (both strategies) | `simple` + `format_preserving`: **zero cleartext** in written artifacts |
| Suppression | rules generated for all 5 files (**5 → 9 rules**; base could never emit a rule for `a.go`/`d.py`); enable → all 9 suppressed and counted; `--show-suppressed` renders `[SUPP]` rows |
| All output formats | text/json/csv/yaml/junit/gitlab-sast/sarif all grow; structurally valid, **9 records each** (junit groups by file: 5 testcases) |
| Exit codes | matrix unchanged outside pre-commit; pre-commit 2 → 1 (documented above) |
| `--fail-on-incomplete` | correctly does **not** fire (rc≠3) on redaction failure |
| Timing / O(n²) | 250/500/1000 all-unredactable files, interleaved best-of-3: base ×1.90/×1.51, fix ×1.61/×1.83 — linear, none near 4.0; fix/base ratio ~1.0 |
| TP/FP | every recovered finding is a true positive with the exact expected value; **0 new FPs** |
| Race | `-race` clean on `internal/parallel`, `internal/core`, `cmd` |
| Golden | 5/5 consecutive clean runs |
| Cross-platform | `GOOS=windows` and `GOOS=linux` vet + build clean |
| Full suite | 49 packages, exit 0, run twice |
| Non-vacuity | restoring `lastError = err` fails the retention and counting tests |

**Tests added:** 5 in `internal/parallel/redaction_failure_test.go`, 4 in `cmd/unredacted_warning_test.go`, 1 in `internal/core/redact_test.go` (including a walk of the output dir asserting no cleartext was written).

## Notes

- **Blast radius is bounded.** `internal/web/server.go` sets `EnableRedaction: false` and `core.ScanFile` passes a nil redaction manager, so the only redacting callers are `cmd/main.go` and `core.RedactFile` — both fixed. `grep -rn "EnableRedaction:\s*true"` returns only `internal/core/redact.go`.
- Non-detection of `987-65-4320` (invalid SSN area 900–999) and `123-45-6789` (canonical placeholder) is correct pre-existing validator behavior, verified independently on a `.txt` where no redaction path is involved.
- The duplicate `AWS_ACCESS_KEY` emit visible in the fixture is **pre-existing and unrelated** — reproduces identically on `main` in a plain `.txt`. Filed separately rather than folded in here.
