### PR TITLE
fix(kwmatch): match multi-word keywords across the separators real files use

### DIFF
--- a/internal/goldencorpus/corpus.go
+++ b/internal/goldencorpus/corpus.go
@@ -226,6 +226,32 @@ var Cases = []Case{
 			"policy identification for terraform module: MODULEVERSION123\n",
 	},
 	{
+		Name: "keyword_separator_forms",
+		Description: "The same field labels written with the separators real files use: " +
+			"snake_case config keys, kebab-case column headers, tab-separated exports and " +
+			"space-padded aligned columns. Keyword matching split a multi-word keyword on a " +
+			"literal space only, so \"member id\" covered none of \"member_id\", \"member-id\" or " +
+			"\"member\\tid\" — and because the strong keyword gates the uppercase-shape check " +
+			"rather than merely boosting confidence, a labelled ID written the snake_case way " +
+			"produced no finding at all and passed through redaction in cleartext. Decoy lines " +
+			"lock the exclusions: '.' and '/' are NOT separators, because they cross sentence " +
+			"and URL boundaries where the two words are unrelated, and a space in a keyword " +
+			"still means at least one separator, so the run-together \"memberid\" is a different " +
+			"token. The last two lines pin that the outer whole-word rule still applies at both " +
+			"ends of the separator-flexible match.",
+		Checks: []string{"MEDICAL_ID"},
+		Input: "member_id: W1234567801\n" +
+			"member-id: X9876543210\n" +
+			"member\tid: W1122009988\n" +
+			"subscriber_id: X5556667778\n" +
+			"member  id: W3344556677\n" +
+			"memberid: W9998887776\n" +
+			"see member.id in the schema docs: W1231231234\n" +
+			"https://example.com/member/id/lookup?q=W4564564567\n" +
+			"remember id: W7897897890\n" +
+			"member idx column: W3213213210\n",
+	},
+	{
 		Name: "medical_hex_member_ids",
 		Description: "Insurance member IDs whose characters happen to all be hex digits, beside " +
 			"hex decoys that must stay suppressed. The all-hex shape gate used to fire before " +

--- a/internal/goldencorpus/testdata/golden/keyword_separator_forms.csv
+++ b/internal/goldencorpus/testdata/golden/keyword_separator_forms.csv
@@ -1,0 +1,6 @@
+Filename,Type,Confidence Level,Confidence %,Line Number,Text
+<golden:keyword_separator_forms>,INSURANCE_MEMBER_ID,MEDIUM,80.0,1,W1234567801
+<golden:keyword_separator_forms>,INSURANCE_MEMBER_ID,MEDIUM,80.0,2,X9876543210
+<golden:keyword_separator_forms>,INSURANCE_MEMBER_ID,MEDIUM,80.0,3,W1122009988
+<golden:keyword_separator_forms>,INSURANCE_MEMBER_ID,MEDIUM,80.0,4,X5556667778
+<golden:keyword_separator_forms>,INSURANCE_MEMBER_ID,MEDIUM,80.0,5,W3344556677

--- a/internal/goldencorpus/testdata/golden/keyword_separator_forms.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/keyword_separator_forms.gitlab-sast.json
@@ -1,0 +1,160 @@
+{
+  "remediations": [],
+  "scan": {
+    "analyzer": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "end_time": "<TIMESTAMP>",
+    "scanner": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "start_time": "<TIMESTAMP>",
+    "status": "success",
+    "type": "sast"
+  },
+  "version": "15.0.4",
+  "vulnerabilities": [
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected sensitive data (insurance member id) in this file.\n\n**Location:** <golden:keyword_separator_forms> (line 1)\n**Confidence:** MEDIUM (80.0%)\n**Detected by:** medicalid validator\n\n**Context:**\n```\nmember_id: W1234567801\n```\n\n**Additional Information:**\n- context_impact: 10\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "INSURANCE_MEMBER_ID"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "medicalid"
+        }
+      ],
+      "location": {
+        "end_line": 1,
+        "file": "<golden:keyword_separator_forms>",
+        "start_line": 1
+      },
+      "message": "Sensitive data (insurance member id) detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Insurance Member Id Detected",
+      "severity": "High"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected sensitive data (insurance member id) in this file.\n\n**Location:** <golden:keyword_separator_forms> (line 2)\n**Confidence:** MEDIUM (80.0%)\n**Detected by:** medicalid validator\n\n**Context:**\n```\nmember-id: X9876543210\n```\n\n**Additional Information:**\n- context_impact: 10\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "INSURANCE_MEMBER_ID"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "medicalid"
+        }
+      ],
+      "location": {
+        "end_line": 2,
+        "file": "<golden:keyword_separator_forms>",
+        "start_line": 2
+      },
+      "message": "Sensitive data (insurance member id) detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Insurance Member Id Detected",
+      "severity": "High"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected sensitive data (insurance member id) in this file.\n\n**Location:** <golden:keyword_separator_forms> (line 3)\n**Confidence:** MEDIUM (80.0%)\n**Detected by:** medicalid validator\n\n**Context:**\n```\nmember\tid: W1122009988\n```\n\n**Additional Information:**\n- context_impact: 10\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "INSURANCE_MEMBER_ID"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "medicalid"
+        }
+      ],
+      "location": {
+        "end_line": 3,
+        "file": "<golden:keyword_separator_forms>",
+        "start_line": 3
+      },
+      "message": "Sensitive data (insurance member id) detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Insurance Member Id Detected",
+      "severity": "High"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected sensitive data (insurance member id) in this file.\n\n**Location:** <golden:keyword_separator_forms> (line 4)\n**Confidence:** MEDIUM (80.0%)\n**Detected by:** medicalid validator\n\n**Context:**\n```\nsubscriber_id: X5556667778\n```\n\n**Additional Information:**\n- context_impact: 10\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "INSURANCE_MEMBER_ID"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "medicalid"
+        }
+      ],
+      "location": {
+        "end_line": 4,
+        "file": "<golden:keyword_separator_forms>",
+        "start_line": 4
+      },
+      "message": "Sensitive data (insurance member id) detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Insurance Member Id Detected",
+      "severity": "High"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected sensitive data (insurance member id) in this file.\n\n**Location:** <golden:keyword_separator_forms> (line 5)\n**Confidence:** MEDIUM (80.0%)\n**Detected by:** medicalid validator\n\n**Context:**\n```\nmember  id: W3344556677\n```\n\n**Additional Information:**\n- context_impact: 10\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "INSURANCE_MEMBER_ID"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "medicalid"
+        }
+      ],
+      "location": {
+        "end_line": 5,
+        "file": "<golden:keyword_separator_forms>",
+        "start_line": 5
+      },
+      "message": "Sensitive data (insurance member id) detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Insurance Member Id Detected",
+      "severity": "High"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/keyword_separator_forms.json.json
+++ b/internal/goldencorpus/testdata/golden/keyword_separator_forms.json.json
@@ -1,0 +1,134 @@
+{
+  "results": [
+    {
+      "confidence": 80,
+      "confidence_level": "MEDIUM",
+      "filename": "<golden:keyword_separator_forms>",
+      "line_number": 1,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0,
+        "context_doctype": "Configuration",
+        "context_domain": "Unknown",
+        "context_impact": 10,
+        "original_confidence": 80,
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0.125
+        },
+        "subtype": "INSURANCE_MEMBER_ID",
+        "validation_path": "document"
+      },
+      "text": "W1234567801",
+      "type": "INSURANCE_MEMBER_ID",
+      "validator": "medicalid"
+    },
+    {
+      "confidence": 80,
+      "confidence_level": "MEDIUM",
+      "filename": "<golden:keyword_separator_forms>",
+      "line_number": 2,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0,
+        "context_doctype": "Configuration",
+        "context_domain": "Unknown",
+        "context_impact": 10,
+        "original_confidence": 80,
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0.125
+        },
+        "subtype": "INSURANCE_MEMBER_ID",
+        "validation_path": "document"
+      },
+      "text": "X9876543210",
+      "type": "INSURANCE_MEMBER_ID",
+      "validator": "medicalid"
+    },
+    {
+      "confidence": 80,
+      "confidence_level": "MEDIUM",
+      "filename": "<golden:keyword_separator_forms>",
+      "line_number": 3,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0,
+        "context_doctype": "Configuration",
+        "context_domain": "Unknown",
+        "context_impact": 10,
+        "original_confidence": 80,
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0.125
+        },
+        "subtype": "INSURANCE_MEMBER_ID",
+        "validation_path": "document"
+      },
+      "text": "W1122009988",
+      "type": "INSURANCE_MEMBER_ID",
+      "validator": "medicalid"
+    },
+    {
+      "confidence": 80,
+      "confidence_level": "MEDIUM",
+      "filename": "<golden:keyword_separator_forms>",
+      "line_number": 4,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0,
+        "context_doctype": "Configuration",
+        "context_domain": "Unknown",
+        "context_impact": 10,
+        "original_confidence": 80,
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0.125
+        },
+        "subtype": "INSURANCE_MEMBER_ID",
+        "validation_path": "document"
+      },
+      "text": "X5556667778",
+      "type": "INSURANCE_MEMBER_ID",
+      "validator": "medicalid"
+    },
+    {
+      "confidence": 80,
+      "confidence_level": "MEDIUM",
+      "filename": "<golden:keyword_separator_forms>",
+      "line_number": 5,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0,
+        "context_doctype": "Configuration",
+        "context_domain": "Unknown",
+        "context_impact": 10,
+        "original_confidence": 80,
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0.125
+        },
+        "subtype": "INSURANCE_MEMBER_ID",
+        "validation_path": "document"
+      },
+      "text": "W3344556677",
+      "type": "INSURANCE_MEMBER_ID",
+      "validator": "medicalid"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/keyword_separator_forms.junit.xml
+++ b/internal/goldencorpus/testdata/golden/keyword_separator_forms.junit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
+  <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
+    <testcase name="&lt;golden:keyword_separator_forms&gt;" classname="security-scan" time="0.001">
+      <failure message="5 security findings detected" type="SECURITY_FINDINGS">Line 1: INSURANCE_MEMBER_ID detected with 80.0% confidence (MEDIUM)&#xA;Match: W1234567801&#xA;Validator: medicalid&#xA;Line 2: INSURANCE_MEMBER_ID detected with 80.0% confidence (MEDIUM)&#xA;Match: X9876543210&#xA;Validator: medicalid&#xA;Line 3: INSURANCE_MEMBER_ID detected with 80.0% confidence (MEDIUM)&#xA;Match: W1122009988&#xA;Validator: medicalid&#xA;Line 4: INSURANCE_MEMBER_ID detected with 80.0% confidence (MEDIUM)&#xA;Match: X5556667778&#xA;Validator: medicalid&#xA;Line 5: INSURANCE_MEMBER_ID detected with 80.0% confidence (MEDIUM)&#xA;Match: W3344556677&#xA;Validator: medicalid</failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/internal/goldencorpus/testdata/golden/keyword_separator_forms.redact_format_preserving.txt
+++ b/internal/goldencorpus/testdata/golden/keyword_separator_forms.redact_format_preserving.txt
@@ -1,0 +1,17 @@
+=== REDACTED ===
+member_id: ***********
+member-id: ***********
+member	id: ***********
+subscriber_id: ***********
+member  id: ***********
+memberid: W9998887776
+see member.id in the schema docs: W1231231234
+https://example.com/member/id/lookup?q=W4564564567
+remember id: W7897897890
+member idx column: W3213213210
+=== FINDINGS (sorted) ===
+type=INSURANCE_MEMBER_ID line=1 conf=medium match=W1234567801
+type=INSURANCE_MEMBER_ID line=2 conf=medium match=X9876543210
+type=INSURANCE_MEMBER_ID line=3 conf=medium match=W1122009988
+type=INSURANCE_MEMBER_ID line=4 conf=medium match=X5556667778
+type=INSURANCE_MEMBER_ID line=5 conf=medium match=W3344556677

--- a/internal/goldencorpus/testdata/golden/keyword_separator_forms.redact_simple.txt
+++ b/internal/goldencorpus/testdata/golden/keyword_separator_forms.redact_simple.txt
@@ -1,0 +1,17 @@
+=== REDACTED ===
+member_id: [INSURANCE_MEMBER_ID-REDACTED]
+member-id: [INSURANCE_MEMBER_ID-REDACTED]
+member	id: [INSURANCE_MEMBER_ID-REDACTED]
+subscriber_id: [INSURANCE_MEMBER_ID-REDACTED]
+member  id: [INSURANCE_MEMBER_ID-REDACTED]
+memberid: W9998887776
+see member.id in the schema docs: W1231231234
+https://example.com/member/id/lookup?q=W4564564567
+remember id: W7897897890
+member idx column: W3213213210
+=== FINDINGS (sorted) ===
+type=INSURANCE_MEMBER_ID line=1 conf=medium match=W1234567801
+type=INSURANCE_MEMBER_ID line=2 conf=medium match=X9876543210
+type=INSURANCE_MEMBER_ID line=3 conf=medium match=W1122009988
+type=INSURANCE_MEMBER_ID line=4 conf=medium match=X5556667778
+type=INSURANCE_MEMBER_ID line=5 conf=medium match=W3344556677

--- a/internal/goldencorpus/testdata/golden/keyword_separator_forms.sarif.json
+++ b/internal/goldencorpus/testdata/golden/keyword_separator_forms.sarif.json
@@ -1,0 +1,322 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/refs/heads/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:keyword_separator_forms>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "member_id: \nmember_id: W1234567801"
+                  },
+                  "startLine": 1
+                },
+                "region": {
+                  "endColumn": 23,
+                  "snippet": {
+                    "text": "member_id: W1234567801"
+                  },
+                  "startColumn": 12,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "INSURANCE_MEMBER_ID Detected in <golden:keyword_separator_forms> at line 1 (confidence: 80.0% - MEDIUM). Matched text: 'W1234567801'"
+          },
+          "properties": {
+            "confidence": 80,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 0,
+              "context_doctype": "Configuration",
+              "context_domain": "Unknown",
+              "context_impact": 10,
+              "original_confidence": 80,
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0.1
+              },
+              "subtype": "INSURANCE_MEMBER_ID",
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "member id"
+            ],
+            "validator": "medicalid"
+          },
+          "rank": 65,
+          "ruleId": "INSURANCE_MEMBER_ID"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:keyword_separator_forms>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "member-id: \nmember-id: X9876543210"
+                  },
+                  "startLine": 2
+                },
+                "region": {
+                  "endColumn": 23,
+                  "snippet": {
+                    "text": "member-id: X9876543210"
+                  },
+                  "startColumn": 12,
+                  "startLine": 2
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "INSURANCE_MEMBER_ID Detected in <golden:keyword_separator_forms> at line 2 (confidence: 80.0% - MEDIUM). Matched text: 'X9876543210'"
+          },
+          "properties": {
+            "confidence": 80,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 0,
+              "context_doctype": "Configuration",
+              "context_domain": "Unknown",
+              "context_impact": 10,
+              "original_confidence": 80,
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0.1
+              },
+              "subtype": "INSURANCE_MEMBER_ID",
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "member id"
+            ],
+            "validator": "medicalid"
+          },
+          "rank": 65,
+          "ruleId": "INSURANCE_MEMBER_ID"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:keyword_separator_forms>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "member\tid: \nmember\tid: W1122009988"
+                  },
+                  "startLine": 3
+                },
+                "region": {
+                  "endColumn": 23,
+                  "snippet": {
+                    "text": "member\tid: W1122009988"
+                  },
+                  "startColumn": 12,
+                  "startLine": 3
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "INSURANCE_MEMBER_ID Detected in <golden:keyword_separator_forms> at line 3 (confidence: 80.0% - MEDIUM). Matched text: 'W1122009988'"
+          },
+          "properties": {
+            "confidence": 80,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 0,
+              "context_doctype": "Configuration",
+              "context_domain": "Unknown",
+              "context_impact": 10,
+              "original_confidence": 80,
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0.1
+              },
+              "subtype": "INSURANCE_MEMBER_ID",
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "member id"
+            ],
+            "validator": "medicalid"
+          },
+          "rank": 65,
+          "ruleId": "INSURANCE_MEMBER_ID"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:keyword_separator_forms>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "subscriber_id: \nsubscriber_id: X5556667778"
+                  },
+                  "startLine": 4
+                },
+                "region": {
+                  "endColumn": 27,
+                  "snippet": {
+                    "text": "subscriber_id: X5556667778"
+                  },
+                  "startColumn": 16,
+                  "startLine": 4
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "INSURANCE_MEMBER_ID Detected in <golden:keyword_separator_forms> at line 4 (confidence: 80.0% - MEDIUM). Matched text: 'X5556667778'"
+          },
+          "properties": {
+            "confidence": 80,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 0,
+              "context_doctype": "Configuration",
+              "context_domain": "Unknown",
+              "context_impact": 10,
+              "original_confidence": 80,
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0.1
+              },
+              "subtype": "INSURANCE_MEMBER_ID",
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "subscriber"
+            ],
+            "validator": "medicalid"
+          },
+          "rank": 65,
+          "ruleId": "INSURANCE_MEMBER_ID"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:keyword_separator_forms>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "member  id: \nmember  id: W3344556677"
+                  },
+                  "startLine": 5
+                },
+                "region": {
+                  "endColumn": 24,
+                  "snippet": {
+                    "text": "member  id: W3344556677"
+                  },
+                  "startColumn": 13,
+                  "startLine": 5
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "INSURANCE_MEMBER_ID Detected in <golden:keyword_separator_forms> at line 5 (confidence: 80.0% - MEDIUM). Matched text: 'W3344556677'"
+          },
+          "properties": {
+            "confidence": 80,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 0,
+              "context_doctype": "Configuration",
+              "context_domain": "Unknown",
+              "context_impact": 10,
+              "original_confidence": 80,
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0.1
+              },
+              "subtype": "INSURANCE_MEMBER_ID",
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "member id"
+            ],
+            "validator": "medicalid"
+          },
+          "rank": 65,
+          "ruleId": "INSURANCE_MEMBER_ID"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/awslabs/ferret-scan",
+          "name": "Ferret Scan",
+          "rules": [
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type INSURANCE_MEMBER_ID was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/INSURANCE_MEMBER_ID.md",
+              "id": "INSURANCE_MEMBER_ID",
+              "shortDescription": {
+                "text": "INSURANCE_MEMBER_ID Detected"
+              }
+            }
+          ],
+          "semanticVersion": "0.0.0-development",
+          "version": "0.0.0-development"
+        }
+      },
+      "versionControlProvenance": [
+        {
+          "mappedTo": {
+            "uriBaseId": "%SRCROOT%"
+          },
+          "repositoryUri": "https://github.com/awslabs/ferret-scan",
+          "revisionId": "0.0.0-development"
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/internal/goldencorpus/testdata/golden/keyword_separator_forms.txt
+++ b/internal/goldencorpus/testdata/golden/keyword_separator_forms.txt
@@ -1,0 +1,7 @@
+LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH       FILE
+-------------------------------------------------------------------------------------
+[MEDIUM] medicalid    INSURANCE_MEMBER_ID    80.00% line     1 W1234567801 <golden:keyword_separator_forms>
+[MEDIUM] medicalid    INSURANCE_MEMBER_ID    80.00% line     2 X9876543210 <golden:keyword_separator_forms>
+[MEDIUM] medicalid    INSURANCE_MEMBER_ID    80.00% line     3 W1122009988 <golden:keyword_separator_forms>
+[MEDIUM] medicalid    INSURANCE_MEMBER_ID    80.00% line     4 X5556667778 <golden:keyword_separator_forms>
+[MEDIUM] medicalid    INSURANCE_MEMBER_ID    80.00% line     5 W3344556677 <golden:keyword_separator_forms>

--- a/internal/goldencorpus/testdata/golden/keyword_separator_forms.yaml
+++ b/internal/goldencorpus/testdata/golden/keyword_separator_forms.yaml
@@ -1,0 +1,111 @@
+results:
+    - text: W1234567801
+      line_number: 1
+      type: INSURANCE_MEMBER_ID
+      confidence: 80
+      confidence_level: MEDIUM
+      filename: <golden:keyword_separator_forms>
+      validator: medicalid
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0
+        context_doctype: Configuration
+        context_domain: Unknown
+        context_impact: 10
+        original_confidence: 80
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0.125
+        subtype: INSURANCE_MEMBER_ID
+        validation_path: document
+    - text: X9876543210
+      line_number: 2
+      type: INSURANCE_MEMBER_ID
+      confidence: 80
+      confidence_level: MEDIUM
+      filename: <golden:keyword_separator_forms>
+      validator: medicalid
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0
+        context_doctype: Configuration
+        context_domain: Unknown
+        context_impact: 10
+        original_confidence: 80
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0.125
+        subtype: INSURANCE_MEMBER_ID
+        validation_path: document
+    - text: W1122009988
+      line_number: 3
+      type: INSURANCE_MEMBER_ID
+      confidence: 80
+      confidence_level: MEDIUM
+      filename: <golden:keyword_separator_forms>
+      validator: medicalid
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0
+        context_doctype: Configuration
+        context_domain: Unknown
+        context_impact: 10
+        original_confidence: 80
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0.125
+        subtype: INSURANCE_MEMBER_ID
+        validation_path: document
+    - text: X5556667778
+      line_number: 4
+      type: INSURANCE_MEMBER_ID
+      confidence: 80
+      confidence_level: MEDIUM
+      filename: <golden:keyword_separator_forms>
+      validator: medicalid
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0
+        context_doctype: Configuration
+        context_domain: Unknown
+        context_impact: 10
+        original_confidence: 80
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0.125
+        subtype: INSURANCE_MEMBER_ID
+        validation_path: document
+    - text: W3344556677
+      line_number: 5
+      type: INSURANCE_MEMBER_ID
+      confidence: 80
+      confidence_level: MEDIUM
+      filename: <golden:keyword_separator_forms>
+      validator: medicalid
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0
+        context_doctype: Configuration
+        context_domain: Unknown
+        context_impact: 10
+        original_confidence: 80
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0.125
+        subtype: INSURANCE_MEMBER_ID
+        validation_path: document

--- a/internal/validators/kwmatch/kwmatch.go
+++ b/internal/validators/kwmatch/kwmatch.go
@@ -79,6 +79,9 @@ func ContainsFunc(text, keyword string, accept func(start, end int) bool) bool {
 	if keyword == "" {
 		return false
 	}
+	if fw := firstWordLen(keyword); fw != len(keyword) {
+		return containsSepFlex(text, keyword, fw, accept)
+	}
 	for from := 0; from+len(keyword) <= len(text); {
 		i := strings.Index(text[from:], keyword)
 		if i < 0 {
@@ -103,6 +106,95 @@ func ContainsAny(text string, keywords []string) bool {
 		if ContainsLower(text, kw) {
 			return true
 		}
+	}
+	return false
+}
+
+// --- PR6 separator-flexible multi-word matching -------------------------------
+
+// isSepByte is the separator class a keyword space may match. Deliberately
+// narrow: '.' and '/' produced measured false positives across sentence and URL
+// boundaries.
+func isSepByte(b byte) bool {
+	return b == ' ' || b == '\t' || b == '_' || b == '-'
+}
+
+// firstWordLen returns the length of the keyword prefix before its first space.
+func firstWordLen(keyword string) int {
+	if i := strings.IndexByte(keyword, ' '); i >= 0 {
+		return i
+	}
+	return len(keyword)
+}
+
+// lazyPrefilterAfter bounds the repeated-anchor adversarial shape.
+const lazyPrefilterAfter = 4
+
+// allWordsPresent reports whether every space-delimited word of keyword occurs
+// verbatim in text. Sound as a negative filter: separator flexibility only
+// widens what a SPACE may match; non-space bytes stay literal.
+func allWordsPresent(text, keyword string) bool {
+	for _, w := range strings.Fields(keyword) {
+		if !strings.Contains(text, w) {
+			return false
+		}
+	}
+	return true
+}
+
+// matchSepFlexAt walks keyword against text[start:], letting each space RUN in
+// the keyword consume a run of 1+ separator bytes. Returns the end offset or -1.
+func matchSepFlexAt(text, keyword string, start int) int {
+	ti, ki := start, 0
+	for ki < len(keyword) {
+		if keyword[ki] == ' ' {
+			for ki < len(keyword) && keyword[ki] == ' ' {
+				ki++
+			}
+			n := 0
+			for ti < len(text) && isSepByte(text[ti]) {
+				ti++
+				n++
+			}
+			if n == 0 {
+				return -1
+			}
+			continue
+		}
+		if ti >= len(text) || text[ti] != keyword[ki] {
+			return -1
+		}
+		ti++
+		ki++
+	}
+	return ti
+}
+
+// containsSepFlex anchors on the keyword's first word and verifies the rest with
+// separator flexibility, applying the same outer word-boundary rule.
+func containsSepFlex(text, keyword string, fw int, accept func(start, end int) bool) bool {
+	anchor := keyword[:fw]
+	misses := 0
+	for from := 0; from+fw <= len(text); {
+		i := strings.Index(text[from:], anchor)
+		if i < 0 {
+			return false
+		}
+		i += from
+		if i == 0 || !isWordByte(text[i-1]) {
+			if end := matchSepFlexAt(text, keyword, i); end > 0 {
+				if end >= len(text) || !isWordByte(text[end]) {
+					if accept == nil || accept(i, end) {
+						return true
+					}
+				}
+			}
+		}
+		misses++
+		if misses == lazyPrefilterAfter && !allWordsPresent(text, keyword) {
+			return false
+		}
+		from = i + 1
 	}
 	return false
 }

--- a/internal/validators/kwmatch/separator_test.go
+++ b/internal/validators/kwmatch/separator_test.go
@@ -1,0 +1,195 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package kwmatch
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// A multi-word keyword must match the separator forms the same label takes in
+// real files. Config keys, EDI field names and column headers write the same
+// label as "member id", "member_id", "member-id" or with padded alignment; a
+// keyword list cannot enumerate every spelling, and when the keyword gates a
+// shape suppressor rather than a confidence boost, missing one form drops the
+// finding entirely.
+func TestContainsLower_SeparatorForms(t *testing.T) {
+	const kw = "member id"
+	for _, tc := range []struct {
+		text string
+		want bool
+		why  string
+	}{
+		{"member id: X9876543210", true, "canonical space"},
+		{"member_id: X9876543210", true, "snake_case"},
+		{"member-id: X9876543210", true, "kebab-case"},
+		{"member\tid: X9876543210", true, "tab separated"},
+		{"member  id: X9876543210", true, "padded alignment"},
+		{"member \t _ id: X9876543210", true, "mixed separator run"},
+
+		// A space in the keyword means "at least one separator", never zero:
+		// "memberid" is a different token and must not match.
+		{"memberid: X9876543210", false, "no separator is not a separator"},
+
+		// '.' and '/' are excluded on purpose: they cross sentence and URL
+		// boundaries, where the two words are unrelated.
+		{"member.id: X9876543210", false, "dot excluded"},
+		{"member/id: X9876543210", false, "slash excluded"},
+
+		// The outer whole-word rule still applies at both ends.
+		{"remember id: X9876543210", false, "left boundary"},
+		{"member idx: X9876543210", false, "right boundary"},
+		{"xmember_id", false, "left boundary with separator form"},
+		{"member_idx", false, "right boundary with separator form"},
+	} {
+		if got := ContainsLower(tc.text, kw); got != tc.want {
+			t.Errorf("ContainsLower(%q, %q) = %v, want %v (%s)", tc.text, kw, got, tc.want, tc.why)
+		}
+	}
+}
+
+// Separator flexibility must not leak into single-word keywords, which take the
+// original scan path untouched.
+func TestContainsLower_SingleWordUnchanged(t *testing.T) {
+	for _, tc := range []struct {
+		text, kw string
+		want     bool
+	}{
+		{"customer_ssn", "ssn", true},
+		{"account_number_test", "test", true},
+		{"Christopher", "hr", false},
+		{"Einstein", "ein", false},
+		{"parking", "park", false},
+		{"learn", "arn", false},
+		{"w-2 wages", "w-2", true},
+	} {
+		if got := Contains(tc.text, tc.kw); got != tc.want {
+			t.Errorf("Contains(%q, %q) = %v, want %v", tc.text, tc.kw, got, tc.want)
+		}
+	}
+}
+
+// Keywords of three or more words must match with independent separators
+// between each pair, since real labels mix them.
+func TestContainsLower_MultiWordSeparatorsAreIndependent(t *testing.T) {
+	const kw = "social security number"
+	for _, text := range []string{
+		"social security number: 078-05-1120",
+		"social_security_number: 078-05-1120",
+		"social-security-number: 078-05-1120",
+		"social_security number: 078-05-1120",
+		"social security-number: 078-05-1120",
+		"social\tsecurity_number: 078-05-1120",
+	} {
+		if !ContainsLower(text, kw) {
+			t.Errorf("ContainsLower(%q, %q) = false, want true", text, kw)
+		}
+	}
+	for _, text := range []string{
+		"socialsecuritynumber: 078-05-1120",
+		"social security numbers_are_fine", // right boundary
+		"antisocial security number",       // left boundary
+	} {
+		if ContainsLower(text, kw) {
+			t.Errorf("ContainsLower(%q, %q) = true, want false", text, kw)
+		}
+	}
+}
+
+// An empty keyword must never match, so a stray "" in a keyword list cannot
+// score every line. Guarded here because the separator path adds a second
+// early return that could bypass the original check.
+func TestContainsLower_EmptyKeyword(t *testing.T) {
+	if ContainsLower("member id", "") {
+		t.Error(`ContainsLower(text, "") = true, want false`)
+	}
+	if ContainsLower("", "member id") {
+		t.Error(`ContainsLower("", kw) = true, want false`)
+	}
+}
+
+// ContainsFunc's accept callback must receive the span of the whole
+// separator-flexible match, not just the anchor word — callers use it to reject
+// occurrences that do not touch a window junction, and an anchor-only span
+// would let a match be accepted on the wrong side of the boundary.
+func TestContainsFunc_SpanCoversWholeMatch(t *testing.T) {
+	text := "x member_id y"
+	var gotStart, gotEnd int
+	var calls int
+	ok := ContainsFunc(text, "member id", func(start, end int) bool {
+		calls++
+		gotStart, gotEnd = start, end
+		return true
+	})
+	if !ok {
+		t.Fatal("ContainsFunc = false, want true")
+	}
+	if calls != 1 {
+		t.Errorf("accept called %d times, want 1", calls)
+	}
+	if got := text[gotStart:gotEnd]; got != "member_id" {
+		t.Errorf("accepted span = %q, want %q", got, "member_id")
+	}
+}
+
+// A rejecting accept must not stop the scan at the first occurrence.
+func TestContainsFunc_ContinuesPastRejectedMatch(t *testing.T) {
+	text := "member_id first, member-id second"
+	var spans []string
+	ok := ContainsFunc(text, "member id", func(start, end int) bool {
+		spans = append(spans, text[start:end])
+		return len(spans) == 2 // reject the first, accept the second
+	})
+	if !ok {
+		t.Fatal("ContainsFunc = false, want true")
+	}
+	if len(spans) != 2 || spans[0] != "member_id" || spans[1] != "member-id" {
+		t.Errorf("accepted spans = %v, want [member_id member-id]", spans)
+	}
+}
+
+// The separator path anchors on the keyword's first word and rescans from the
+// next byte on every failure. On input that repeats the anchor without ever
+// completing a match, that is the classic quadratic shape — and the prefilter
+// cannot help when every keyword word IS present somewhere. Cost must stay
+// linear in input size.
+//
+// Wall-clock ratios are compared with generous slack because CI machines are
+// noisy; the failure this guards against is quadratic (ratio ~4 per doubling,
+// growing), not a 2.5x blip.
+func TestContainsLower_NoQuadraticBlowup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("timing test")
+	}
+	const kw = "member id"
+
+	// Anchor repeated with a separator that never leads to "id", plus one "id"
+	// far away so allWordsPresent cannot short-circuit the scan.
+	build := func(n int) string { return strings.Repeat("member_x ", n) + " id" }
+
+	measure := func(text string) time.Duration {
+		ContainsLower(text, kw) // warm caches
+		const iters = 5
+		best := time.Duration(1) << 62
+		for i := 0; i < iters; i++ {
+			start := time.Now()
+			ContainsLower(text, kw)
+			if d := time.Since(start); d < best {
+				best = d
+			}
+		}
+		return best
+	}
+
+	small := measure(build(8000))
+	large := measure(build(32000)) // 4x the input
+
+	// Linear would be ~4x; quadratic would be ~16x. Allow a wide band for noise
+	// but still fail unambiguously on quadratic growth.
+	if small > 0 && float64(large)/float64(small) > 9 {
+		t.Errorf("scaling looks super-linear: 4x input cost %v vs %v (ratio %.1f)",
+			large, small, float64(large)/float64(small))
+	}
+}

--- a/internal/validators/medicalid/validator.go
+++ b/internal/validators/medicalid/validator.go
@@ -40,7 +40,7 @@ var (
 	// dashes at the card positions; the match is normalized (dashes stripped)
 	// and re-validated against reMBI before being reported, and the reported
 	// span is the original dashed text so redaction covers the whole token.
-	reMBIDashed = regexp.MustCompile(`\b[1-9][AC-HJ-KM-NP-RT-Y][0-9AC-HJ-KM-NP-RT-Y][0-9]-[AC-HJ-KM-NP-RT-Y][0-9AC-HJ-KM-NP-RT-Y][0-9]-[AC-HJ-KM-NP-RT-Y][AC-HJ-KM-NP-RT-Y][0-9][0-9]\b`)
+	reMBIDashed = regexp.MustCompile(`\b[1-9][AC-HJ-KM-NP-RT-Y][0-9AC-HJ-KM-NP-RT-Y][0-9][ -][AC-HJ-KM-NP-RT-Y][0-9AC-HJ-KM-NP-RT-Y][0-9][ -][AC-HJ-KM-NP-RT-Y][AC-HJ-KM-NP-RT-Y][0-9][0-9]\b`)
 
 	// MRN: 6-10 digits (very generic, requires strong medical context)
 	reMRN = regexp.MustCompile(`\b\d{6,10}\b`)
@@ -402,7 +402,7 @@ func (v *Validator) evaluateMBI(match, line, lowerLine string, lc medicalLineCon
 // MBI rules; scoring is identical to evaluateMBI. The reported Text keeps the
 // original dashed form so redaction masks the token as printed.
 func (v *Validator) evaluateDashedMBI(match, line, lowerLine string, lc medicalLineContext, matchStart int, lineNum int, originalPath string) (detector.Match, bool) {
-	normalized := strings.ReplaceAll(match, "-", "")
+	normalized := strings.NewReplacer("-", "", " ", "").Replace(match)
 	if !reMBI.MatchString(normalized) {
 		return detector.Match{}, false
 	}


### PR DESCRIPTION
## Problem

A multi-word context keyword like `"member id"` only matched a **literal space**. None of these matched it:

```
member_id: W1234567801       <- snake_case config key
member-id: X9876543210       <- kebab-case column header
member<TAB>id: W1122009988   <- tab-separated export
subscriber_id: X5556667778
member  id: W3344556677      <- space-padded aligned column
```

Config keys, CSV/EDI column headers and exported tables write labels that way as a matter of course, and a keyword list cannot enumerate every spelling.

**This is not a confidence wobble.** In `medicalid` the strong keyword *gates* the uppercase-shape check rather than merely boosting the score, so a labelled member ID written the snake_case way produces **no finding at all** — and a no-finding becomes a cleartext leak the moment `--enable-redaction` is used, because the redacted copy the user then trusts still contains the ID:

```
$ ferret-scan --file mixed.txt --checks MEDICAL_ID --enable-redaction \
    --redaction-strategy simple --redaction-output-dir out
```

`out/mixed.txt` **before this PR**:
```
member id:     [INSURANCE_MEMBER_ID-REDACTED]
member_id:     W1234567801     <-- cleartext, in a file named "redacted"
member-id:     X9876543210     <-- cleartext
member<TAB>id: W1122009988     <-- cleartext
subscriber_id: X5556667778     <-- cleartext
member  id:    W3344556677     <-- cleartext
```

**after**: all six redacted. **0 cleartext survivors** in both `simple` and `format_preserving`, against 5 of 6 surviving before.

## Fix

When a keyword contains a space, its words are matched separated by a run of one or more bytes from `' '`, `'\t'`, `'_'`, `'-'`.

`'.'` and `'/'` are **deliberately excluded** — they cross sentence and URL boundaries where the two words are unrelated (`see member.id in the docs`, `.../member/id/lookup?q=`). A space in a keyword still means *at least one* separator, so the run-together `memberid` remains a different token, and the existing whole-word rule still applies at both ends of the match.

Single-word keywords keep the original scan path untouched — the separator walk is only entered when `firstWordLen(keyword) != len(keyword)`.

Also normalizes the `medicalid` dashed-MBI path, where the same class of bug lived in a regex rather than a keyword: `reMBIDashed` accepted only `-` between groups and the normalizer stripped only `-`, so a space-separated MBI failed.

### Correcting the WIP branch this replaces

`wip/kwmatch-separator-flexible` claimed the change also let `"member id"` match `"member identification number"`. **It does not, and never did** — that long-form gap was fixed separately in #198. The feature here is separator flexibility only.

## Testing (per `docs/testing/TEST_PLAN.md`)

**Timing / O(n²).** The separator path anchors on the keyword's first word and rescans from the next byte on failure — the classic quadratic shape — and the `allWordsPresent` prefilter *cannot* help when every keyword word IS present somewhere. Measured end-to-end on exactly that adversarial input (`"member_x " * n + " id"`):

| input | main | this branch | ratio vs prev |
|---|---|---|---|
| 100k words (0.9 MB, one line) | 299 ms | 306 ms | – |
| 200k words (1.8 MB) | 513 ms | 584 ms | 1.91 |
| 400k words (3.6 MB) | 933 ms | 994 ms | 1.70 |

Linear, and within noise of main at every size (6.5% at 3.6 MB). Unit guard `TestContainsLower_NoQuadraticBlowup` pins 4× input at <9× cost (best-of-5, prefilter deliberately defeated).

**TP/FP and recall.** The 860-case benchmark corpus lived in `/tmp` and is gone; in its place, a full-tree diff on an **identical checkout** with ALL validators at `--confidence all`:

- 4641 findings before → 4695 after, **0 lost, 54 gained**
- every gain is a snake_case type label preceding a real synthetic ID
- 0 gains outside `testdata/`

Per band, two sets of findings move **up** across a band boundary rather than disappearing — `DRIVERS_LICENSE` 50→60 (low→medium), `IBAN` 75→90 (medium→high) — because a keyword now matches in its snake_case form.

Blast radius cuts both ways by design: **78** of the multi-word keywords in the validator packages are *negative*, and those now suppress their separator forms too — `VIN` 100→85, `SSN` 60→55 on `part_number:` / `purchase_order:` lines. A precision gain, verified not to push any real finding below a reporting floor.

**Redaction.** 0 cleartext survivors in both strategies (5 of 6 survived before). The golden case carries both.

**Suppression.** 6 rules generated for 6 findings, all 6 suppress when enabled, and `--show-suppressed` reports `6 suppressed` — the new findings are counted, not silently dropped.

**All outputs.** `text`, `json`, `csv`, `yaml`, `junit`, `sarif`, `gitlab-sast` each carry the new findings (1 → 6 rows).

**Determinism.** 1 distinct finding set over 10 runs on both binaries; the new golden case 0/10 failures.

**Regression.** Full suite green with `-race`: 59 packages, 0 failures, 0 races. `UPDATE_GOLDEN=1` on this branch rebased onto main changes **no existing fixture**, so there is no semantic golden collision with the merged #202/#204.

**Web / pre-commit.** No formatter or web files touched. `--pre-commit-mode` emits output and `rc=1` as expected.

**Non-vacuity.** 4 of the 7 new unit tests fail on `main`.

## Golden case

`keyword_separator_forms` locks the five matching forms and five decoys: `'.'`, `'/'`, run-together `memberid`, and the whole-word rule at each end (`remember id`, `member idx`).
