### PR TITLE
fix(suppressions): stop discarding last_seen_at updates and emitting duplicate rules

### DIFF
--- a/docs/suppression-system.md
+++ b/docs/suppression-system.md
@@ -62,7 +62,7 @@ rules:
       finding_type: "EMAIL"
       filename: "test-file.txt"
       line_number: "5"
-      confidence: "85"
+      confidence: "85.00"
       context_hash: "a1b2c3d4e5f6g7h8"
       match_text_hash: "h8g7f6e5d4c3b2a1"
 ```

--- a/internal/suppressions/generate_rules_test.go
+++ b/internal/suppressions/generate_rules_test.go
@@ -1,0 +1,191 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package suppressions
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+)
+
+// newLineMatch builds a match that occupies a distinct line, so each one gets a
+// distinct finding hash (the hash folds in LineNumber and FullLine).
+func newLineMatch(matchType, text string, line int) detector.Match {
+	return detector.Match{
+		Type:       matchType,
+		Text:       text,
+		Filename:   "f.txt",
+		LineNumber: line,
+		Confidence: 70,
+		Context:    detector.ContextInfo{FullLine: "value = " + text},
+	}
+}
+
+// A finding that appears more than once in a single scan must produce exactly
+// one rule. Previously the batch loop looked up existing hashes in a map that
+// was never updated with the hashes it appended, so N occurrences of the same
+// finding wrote N byte-identical rules differing only in their SUP- id.
+func TestGenerateSuppressionRules_DuplicateFindingYieldsOneRule(t *testing.T) {
+	sm := NewSuppressionManager(filepath.Join(t.TempDir(), "s.yaml"))
+
+	m := newLineMatch("SSN", "123-45-6789", 3)
+	if err := sm.GenerateSuppressionRules([]detector.Match{m, m, m}, "bulk", true); err != nil {
+		t.Fatalf("GenerateSuppressionRules failed: %v", err)
+	}
+
+	rules := sm.ListSuppressions()
+	if len(rules) != 1 {
+		t.Fatalf("expected 1 rule for one distinct finding, got %d", len(rules))
+	}
+}
+
+// Re-running a scan must refresh last_seen_at on rules that already exist.
+// Previously the lookup map held *SuppressionRule into config.Rules while the
+// same loop appended to that slice; once an append reallocated the backing
+// array, the update wrote into the abandoned copy and was lost on save. The
+// order matters — the pre-existing finding must come AFTER new ones for the
+// realloc to happen before the update.
+func TestGenerateSuppressionRules_UpdatesLastSeenAfterAppend(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "s.yaml")
+
+	seed := newLineMatch("SSN", "123-45-6789", 1)
+
+	sm := NewSuppressionManager(path)
+	if err := sm.GenerateSuppressionRules([]detector.Match{seed}, "bulk", true); err != nil {
+		t.Fatalf("seed failed: %v", err)
+	}
+	seeded := sm.ListSuppressions()
+	if len(seeded) != 1 || seeded[0].LastSeenAt == nil {
+		t.Fatalf("seed rule not written as expected: %+v", seeded)
+	}
+	seedSeenAt := *seeded[0].LastSeenAt
+
+	// Reload from disk the way a second CLI invocation would, then re-scan with
+	// enough NEW findings ahead of the seeded one to force a slice growth.
+	sm2 := NewSuppressionManager(path)
+	batch := make([]detector.Match, 0, 12)
+	for i := 2; i <= 12; i++ {
+		batch = append(batch, newLineMatch("EMAIL", "a@b.com", i))
+	}
+	batch = append(batch, seed)
+
+	// Guarantee a distinguishable timestamp regardless of clock granularity.
+	time.Sleep(2 * time.Millisecond)
+	if err := sm2.GenerateSuppressionRules(batch, "bulk", true); err != nil {
+		t.Fatalf("second pass failed: %v", err)
+	}
+
+	var found bool
+	for _, r := range sm2.ListSuppressions() {
+		if r.Hash != seeded[0].Hash {
+			continue
+		}
+		found = true
+		if r.LastSeenAt == nil {
+			t.Fatal("existing rule lost its last_seen_at")
+		}
+		if !r.LastSeenAt.After(seedSeenAt) {
+			t.Errorf("last_seen_at was not refreshed: still %v (seeded %v)", *r.LastSeenAt, seedSeenAt)
+		}
+	}
+	if !found {
+		t.Fatal("seeded rule missing from the rule set after the second pass")
+	}
+
+	// And the refresh must be persisted, not just held in memory.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if strings.Count(string(data), "- id:") != 12 {
+		t.Errorf("expected 12 rules on disk, got %d", strings.Count(string(data), "- id:"))
+	}
+}
+
+// The existing-rule path must not silently swallow new findings that arrive in
+// the same batch, and IDs must stay unique after the index fix.
+func TestGenerateSuppressionRules_MixedBatchIDsAreUnique(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "s.yaml")
+	sm := NewSuppressionManager(path)
+
+	first := newLineMatch("SSN", "123-45-6789", 1)
+	if err := sm.GenerateSuppressionRules([]detector.Match{first}, "bulk", true); err != nil {
+		t.Fatalf("seed failed: %v", err)
+	}
+
+	sm2 := NewSuppressionManager(path)
+	batch := []detector.Match{
+		first,                                    // existing -> touch
+		newLineMatch("EMAIL", "a@b.com", 2),      // new
+		newLineMatch("EMAIL", "a@b.com", 2),      // duplicate of the new one
+		newLineMatch("PHONE", "555-010-1234", 3), // new
+	}
+	if err := sm2.GenerateSuppressionRules(batch, "bulk", true); err != nil {
+		t.Fatalf("second pass failed: %v", err)
+	}
+
+	rules := sm2.ListSuppressions()
+	if len(rules) != 3 {
+		t.Fatalf("expected 3 distinct rules (1 seeded + 2 new), got %d", len(rules))
+	}
+
+	seenIDs := make(map[string]bool, len(rules))
+	seenHashes := make(map[string]bool, len(rules))
+	for _, r := range rules {
+		if seenIDs[r.ID] {
+			t.Errorf("duplicate rule ID %q", r.ID)
+		}
+		if seenHashes[r.Hash] {
+			t.Errorf("duplicate rule hash for ID %q", r.ID)
+		}
+		seenIDs[r.ID] = true
+		seenHashes[r.Hash] = true
+	}
+}
+
+// Generated metadata records confidence at the same precision the finding hash
+// consumes (%.2f). It used to be written at %.0f, so a user could not
+// reconstruct the hash from the rule file — and the troubleshooting guide's
+// "verify confidence formatting (2 decimal places)" advice was unfollowable.
+func TestGenerateSuppressionRules_ConfidenceMetadataMatchesHashPrecision(t *testing.T) {
+	sm := NewSuppressionManager(filepath.Join(t.TempDir(), "s.yaml"))
+
+	m := newLineMatch("SSN", "123-45-6789", 1)
+	m.Confidence = 84.5
+	if err := sm.GenerateSuppressionRules([]detector.Match{m}, "bulk", true); err != nil {
+		t.Fatalf("GenerateSuppressionRules failed: %v", err)
+	}
+
+	rules := sm.ListSuppressions()
+	if len(rules) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(rules))
+	}
+	if got := rules[0].Metadata["confidence"]; got != "84.50" {
+		t.Errorf("confidence metadata = %q, want %q", got, "84.50")
+	}
+}
+
+// Whatever else changes, a generated rule must still suppress the finding it
+// was generated from — the round trip is the whole point of the feature.
+func TestGenerateSuppressionRules_GeneratedRuleStillSuppresses(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "s.yaml")
+	sm := NewSuppressionManager(path)
+
+	m := newLineMatch("SSN", "123-45-6789", 7)
+	if err := sm.GenerateSuppressionRules([]detector.Match{m, m}, "bulk", true); err != nil {
+		t.Fatalf("GenerateSuppressionRules failed: %v", err)
+	}
+
+	// Fresh manager reading the file back, as a later scan would.
+	sm2 := NewSuppressionManager(path)
+	if ok, rule := sm2.IsSuppressed(m); !ok {
+		t.Error("generated rule does not suppress the finding it came from")
+	} else if rule == nil {
+		t.Error("suppressed but no rule returned")
+	}
+}

--- a/internal/suppressions/suppression.go
+++ b/internal/suppressions/suppression.go
@@ -331,7 +331,7 @@ func (sm *SuppressionManager) AddSuppression(match detector.Match, reason, creat
 			"finding_type":    match.Type,
 			"filename":        filepath.Base(match.Filename),
 			"line_number":     fmt.Sprintf("%d", match.LineNumber),
-			"confidence":      fmt.Sprintf("%.0f", match.Confidence),
+			"confidence":      fmt.Sprintf("%.2f", match.Confidence),
 			"context_hash":    sm.hashSensitiveData(match.Context.BeforeText + match.Context.AfterText),
 			"match_text_hash": sm.hashSensitiveData(match.Text),
 		},
@@ -491,10 +491,15 @@ func (sm *SuppressionManager) GenerateSuppressionRules(matches []detector.Match,
 		}
 	}
 
-	// Create a map of existing hashes for quick lookup
-	existingHashes := make(map[string]*SuppressionRule)
+	// Index existing hashes by their POSITION in sm.config.Rules, not by
+	// pointer. The loop below appends to sm.config.Rules, which reallocates the
+	// backing array once capacity is exceeded; a *SuppressionRule captured here
+	// would then point into the abandoned array and every LastSeenAt write
+	// through it would be silently lost. IsSuppressed already indexes by
+	// position for the same reason.
+	existingHashes := make(map[string]int, len(sm.config.Rules))
 	for i := range sm.config.Rules {
-		existingHashes[sm.config.Rules[i].Hash] = &sm.config.Rules[i]
+		existingHashes[sm.config.Rules[i].Hash] = i
 	}
 
 	addedCount := 0
@@ -516,9 +521,10 @@ func (sm *SuppressionManager) GenerateSuppressionRules(matches []detector.Match,
 		findingHash := sm.generateFindingHash(match)
 
 		// Check if already exists
-		if existingRule, exists := existingHashes[findingHash]; exists {
-			// Update last_seen_at for existing rule
-			existingRule.LastSeenAt = &now
+		if idx, exists := existingHashes[findingHash]; exists {
+			// Update last_seen_at for existing rule. Written through the live
+			// slice so it survives any reallocation caused by the appends below.
+			sm.config.Rules[idx].LastSeenAt = &now
 			updatedCount++
 			continue
 		}
@@ -551,13 +557,18 @@ func (sm *SuppressionManager) GenerateSuppressionRules(matches []detector.Match,
 				"finding_type":    match.Type,
 				"filename":        filepath.Base(match.Filename),
 				"line_number":     fmt.Sprintf("%d", match.LineNumber),
-				"confidence":      fmt.Sprintf("%.0f", match.Confidence),
+				"confidence":      fmt.Sprintf("%.2f", match.Confidence),
 				"context_hash":    sm.hashSensitiveData(match.Context.BeforeText + match.Context.AfterText),
 				"match_text_hash": sm.hashSensitiveData(match.Text),
 			},
 		}
 
 		sm.config.Rules = append(sm.config.Rules, rule)
+		// Record the new hash so a second occurrence of the SAME finding in this
+		// batch is treated as existing (last_seen_at touch) rather than emitting
+		// a second identical rule. Without this, a value repeated N times in a
+		// scan produced N byte-identical rules differing only in ID.
+		existingHashes[findingHash] = len(sm.config.Rules) - 1
 		addedCount++
 	}
 
@@ -677,7 +688,7 @@ func (sm *SuppressionManager) CreateSuppressionFromFindingWithExpiration(hash, r
 		"finding_type":    getString(findingData, "type"),
 		"filename":        filepath.Base(getString(findingData, "filename")),
 		"line_number":     fmt.Sprintf("%.0f", getFloat(findingData, "line_number")),
-		"confidence":      fmt.Sprintf("%.0f", getFloat(findingData, "confidence")),
+		"confidence":      fmt.Sprintf("%.2f", getFloat(findingData, "confidence")),
 		"context_hash":    sm.hashSensitiveData(""), // Empty context for web UI
 		"match_text_hash": sm.hashSensitiveData(getString(findingData, "text")),
 	}
@@ -767,7 +778,7 @@ func (sm *SuppressionManager) CreateSuppressionFromFindingWithState(hash, reason
 		"finding_type":    getString(findingData, "type"),
 		"filename":        filepath.Base(getString(findingData, "filename")),
 		"line_number":     fmt.Sprintf("%.0f", getFloat(findingData, "line_number")),
-		"confidence":      fmt.Sprintf("%.0f", getFloat(findingData, "confidence")),
+		"confidence":      fmt.Sprintf("%.2f", getFloat(findingData, "confidence")),
 		"context_hash":    "",
 		"match_text_hash": sm.hashSensitiveData(getString(findingData, "text")),
 	}


### PR DESCRIPTION
## Problem

Three defects in `GenerateSuppressionRules`, all observable end-to-end on a real tree (`--file internal/validators --recursive --generate-suppressions`):

### 1. `last_seen_at` writes were silently discarded (stale-pointer-after-append)

`existingHashes` was a `map[string]*SuppressionRule` holding `&sm.config.Rules[i]` — while the loop below **appends to that same slice**. Go grows the backing array (cap 1→2→4→8→…), and after the first reallocation every captured pointer refers to the abandoned array. Every `existingRule.LastSeenAt = &now` after that point wrote into memory nothing would ever read.

Measured: generate rules for one package, then re-scan the whole `internal/validators` tree with the same suppression file.

| | pre-existing rules re-observed | `last_seen_at` refreshed |
|---|---|---|
| main | 134 | **0** |
| this PR | 134 | **134** |

Rules that are still actively firing look untouched, so any age-based pruning or expiry review treats live suppressions as dead ones.

`IsSuppressed` already indexes by *position* for exactly this reason; this makes `GenerateSuppressionRules` consistent with it.

### 2. A finding repeated within one batch emitted N byte-identical rules

New hashes were never recorded in `existingHashes`, so the dedup check could only ever see rules loaded from disk — not ones appended moments earlier in the same run. A value that appears N times in a scan produced N rules differing only in generated ID.

Measured on the same tree: main writes **2091 rules for 2086 distinct hashes** (5 byte-identical duplicates); this PR writes **2086 rules, 0 duplicates**.

### 3. `confidence` metadata was `%.0f` while the finding hash uses `%.2f`

The suppression finding hash embeds confidence at `%.2f`, but the human-readable `confidence` metadata beside it was rendered `%.0f`. A rule for an 85.5% finding recorded `confidence: "85"`, which reads as a different finding than the hash it sits next to, and makes the metadata useless for reconstructing or reviewing why a rule exists.

`docs/suppression-system.md`'s own verification checklist already says *"Verify confidence level formatting (2 decimal places)"*, and `docs/user-guides/README-Suppressions.md` shows `"85.50"` / `"72.10"`. Only the one example in `suppression-system.md` disagreed — fixed here in a separate commit.

Four call sites updated: `AddSuppression`, `GenerateSuppressionRules`, and both web-UI paths (`CreateSuppressionFromFindingWithExpiration`, `CreateSuppressionFromFindingWithState`).

## Testing (per `docs/testing/TEST_PLAN.md`)

- **Suppression round trip.** Generate → enable → re-scan leaves 0 findings, on both integral and fractional confidences (`INTELLECTUAL_PROPERTY` at 93.5% exercises the `%.2f` path). Verified on both binaries.
- **Non-vacuity.** 4 of the 5 new tests fail on `main`; the fifth (`_GeneratedRuleStillSuppresses`) is the guard that the fix does not break the working path, and passes on both.
- **Regression.** Full suite green with `-race`: 59 packages, 0 failures, 0 races. Golden corpus green.
- **Determinism.** Rule IDs and hashes stable across runs; no duplicate IDs in a 2086-rule file.
- **Web.** Two of the four `%.2f` sites are the web-UI suppression-creation paths, so the metadata is now consistent between CLI-generated and UI-generated rules. No formatter or template changes.
- **Timing.** The pointer→index change removes an allocation per existing rule and adds none; the map is now pre-sized with `len(sm.config.Rules)`.
- **Build gates.** `go build`, `go vet`, `gofmt -l` all clean.

## Note for a follow-up (not this PR)

Confidence inside `generateFindingHash` means **any** confidence change invalidates every existing suppression rule for that finding. Removing it needs a hash-version migration path so users' existing suppression files keep working, which is its own PR — and it interacts with the confidence-band contract, so it should land after that is settled.
