### PR TITLE
fix(formatters): honor --limit in every format and stop gitlab-sast bypassing --confidence

### DIFF
--- a/cmd/stdin.go
+++ b/cmd/stdin.go
@@ -400,7 +400,7 @@ func runStdinRedaction(
 	//     they run the command without redirects. In that case suppress
 	//     the findings emit and print a one-line tip pointing at the
 	//     pipe shapes that capture them.
-	formatted, formatErr := formatStdinFindings(matches, suppressedMatches, finalCfg, precommitConfig)
+	formatted, formatErr := formatStdinFindings(matches, suppressedMatches, finalCfg, in.limit, precommitConfig)
 	if formatErr != nil {
 		printPrecommitError(precommitConfig,
 			fmt.Sprintf("Error formatting results: %v", formatErr),
@@ -452,18 +452,24 @@ func formatStdinFindings(
 	matches []detector.Match,
 	suppressedMatches []detector.SuppressedMatch,
 	finalCfg *finalConfiguration,
+	limit int,
 	precommitConfig *precommit.PrecommitConfig,
 ) (string, error) {
 	formatter, exists := formatters.Get(finalCfg.format)
 	if !exists {
 		return "", fmt.Errorf("unsupported output format %q", finalCfg.format)
 	}
+	// Limit is passed through so the findings report from the redaction path is
+	// capped exactly like the non-redaction path's. It only ever bounds the
+	// report: the caller already redacted against the FULL match set, so a
+	// smaller report can never mean less redacted content.
 	opts := formatters.FormatterOptions{
 		ConfidenceLevel: parseConfidenceLevels(finalCfg.confidenceLevels),
 		Verbose:         finalCfg.verbose,
 		NoColor:         finalCfg.noColor,
 		ShowMatch:       finalCfg.showMatch,
 		PrecommitMode:   precommitConfig != nil && precommitConfig.QuietMode,
+		Limit:           limit,
 	}
 	if finalCfg.showSuppressed {
 		return formatter.Format(matches, suppressedMatches, opts)

--- a/cmd/stdin_limit_test.go
+++ b/cmd/stdin_limit_test.go
@@ -1,0 +1,86 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+)
+
+// stdinLimitMatches builds n LOW-confidence findings on distinct lines.
+func stdinLimitMatches(n int) []detector.Match {
+	out := make([]detector.Match, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, detector.Match{
+			Text:       fmt.Sprintf("user%02d@example.com", i),
+			LineNumber: i + 1,
+			Type:       "BUSINESS",
+			Confidence: 48,
+			Filename:   "<stdin>",
+			Validator:  "email",
+		})
+	}
+	return out
+}
+
+func stdinLimitConfig(format string) *finalConfiguration {
+	return &finalConfiguration{
+		format:           format,
+		confidenceLevels: "all",
+		noColor:          true,
+		showMatch:        true,
+	}
+}
+
+// TestFormatStdinFindings_HonorsLimit covers the redaction branch of --stdin.
+// runStdinRedaction formats its findings through this helper, which never
+// received the --limit value, so `--stdin --enable-redaction --limit 3` emitted
+// every finding while the same flags without --enable-redaction emitted 3.
+//
+// Correctness note: capping the report cannot reduce redaction coverage.
+// runStdinRedaction calls RedactString with the full match slice BEFORE
+// formatting, so the limit only ever bounds how much of the report is printed.
+func TestFormatStdinFindings_HonorsLimit(t *testing.T) {
+	matches := stdinLimitMatches(30)
+
+	got, err := formatStdinFindings(matches, nil, stdinLimitConfig("text"), 3, nil)
+	if err != nil {
+		t.Fatalf("formatStdinFindings: %v", err)
+	}
+
+	rows := 0
+	for _, line := range strings.Split(got, "\n") {
+		if strings.HasPrefix(line, "[") && strings.Contains(line, "line ") {
+			rows++
+		}
+	}
+	if rows != 3 {
+		t.Errorf("emitted %d finding rows with limit=3, want 3", rows)
+	}
+}
+
+// TestFormatStdinFindings_ZeroMeansUnlimited pins the escape hatch on the same
+// path, and keeps the test above from passing for the wrong reason (a helper
+// that always truncated would satisfy it too).
+func TestFormatStdinFindings_ZeroMeansUnlimited(t *testing.T) {
+	matches := stdinLimitMatches(30)
+
+	got, err := formatStdinFindings(matches, nil, stdinLimitConfig("text"), 0, nil)
+	if err != nil {
+		t.Fatalf("formatStdinFindings: %v", err)
+	}
+
+	rows := 0
+	for _, line := range strings.Split(got, "\n") {
+		if strings.HasPrefix(line, "[") && strings.Contains(line, "line ") {
+			rows++
+		}
+	}
+	if rows != 30 {
+		t.Errorf("emitted %d finding rows with limit=0, want all 30", rows)
+	}
+}

--- a/internal/formatters/csv/formatter.go
+++ b/internal/formatters/csv/formatter.go
@@ -46,6 +46,11 @@ func (f *Formatter) Format(matches []detector.Match, suppressedMatches []detecto
 	// changed run to run on an unchanged scan.
 	shared.SortSuppressedByPriority(suppressedMatches)
 
+	// Honor --limit, after the sort so the rows kept are the highest-confidence
+	// ones. Without this the CSV emitted every finding while the same scan's
+	// text and JSON output stopped at the cap.
+	filteredMatches, _, _ = shared.ApplyLimit(filteredMatches, options)
+
 	// In pre-commit mode, return empty string if no matches to reduce noise
 	if options.PrecommitMode && len(filteredMatches) == 0 && len(suppressedMatches) == 0 {
 		return "", nil

--- a/internal/formatters/gitlab-sast/formatter.go
+++ b/internal/formatters/gitlab-sast/formatter.go
@@ -77,6 +77,12 @@ func (f *Formatter) Format(matches []detector.Match, suppressedMatches []detecto
 		log.Printf("GitLab SAST Formatter: Processing %d matches, %d suppressed matches", len(matches), len(suppressedMatches))
 	}
 
+	// Apply the confidence filter every other formatter applies. This one never
+	// did, so `--confidence high` still shipped every LOW-confidence finding into
+	// GitLab's security dashboard — the operator's filter was silently ignored on
+	// the one output a security dashboard consumes.
+	matches = shared.FilterMatchesByConfidence(matches, options)
+
 	// Create the GitLab security report structure with proper metadata
 	report := &GitLabSecurityReport{
 		Version:         GitLabSASTSchemaVersion, // Use constant from models.go
@@ -140,6 +146,10 @@ func (f *Formatter) Format(matches []detector.Match, suppressedMatches []detecto
 	sort.SliceStable(sortedMatches, func(i, j int) bool {
 		return shared.LessByPriority(sortedMatches[i], sortedMatches[j])
 	})
+
+	// Honor --limit, after the sort so the vulnerabilities kept are the
+	// highest-confidence ones rather than an arbitrary prefix.
+	sortedMatches, _, _ = shared.ApplyLimit(sortedMatches, options)
 
 	// Process each match with proper error handling
 	processedCount := 0

--- a/internal/formatters/junit/formatter.go
+++ b/internal/formatters/junit/formatter.go
@@ -88,6 +88,11 @@ func (f *Formatter) Format(matches []detector.Match, suppressedMatches []detecto
 	// testcases moved around.
 	shared.SortSuppressedByPriority(suppressedMatches)
 
+	// Honor --limit before grouping, so the per-file <testcase> split and the
+	// suite's Tests/Failures counters describe the findings the report actually
+	// carries.
+	filteredMatches, _, _ = shared.ApplyLimit(filteredMatches, options)
+
 	// Group matches by file for better organization
 	fileGroups := f.groupMatchesByFile(filteredMatches)
 

--- a/internal/formatters/sarif/formatter.go
+++ b/internal/formatters/sarif/formatter.go
@@ -67,6 +67,11 @@ func (f *Formatter) Format(matches []detector.Match, suppressedMatches []detecto
 	// `results` array of two SARIF reports of one unchanged scan is comparable.
 	shared.SortSuppressedByPriority(suppressedMatches)
 
+	// Honor --limit before the report is built, so tool.driver.rules is derived
+	// from the results actually emitted rather than from findings the report
+	// never mentions.
+	filteredMatches, _, _ = shared.ApplyLimit(filteredMatches, options)
+
 	// Fresh per-call rule manager + mapper so the rules array derives only from
 	// THIS call's matches (no cross-call accumulation).
 	ruleManager := NewRuleManager()

--- a/internal/formatters/shared/limit_parity_test.go
+++ b/internal/formatters/shared/limit_parity_test.go
@@ -1,0 +1,305 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package shared_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/formatters"
+	csvfmt "github.com/awslabs/ferret-scan/v2/internal/formatters/csv"
+	gitlabfmt "github.com/awslabs/ferret-scan/v2/internal/formatters/gitlab-sast"
+	jsonfmt "github.com/awslabs/ferret-scan/v2/internal/formatters/json"
+	junitfmt "github.com/awslabs/ferret-scan/v2/internal/formatters/junit"
+	sariffmt "github.com/awslabs/ferret-scan/v2/internal/formatters/sarif"
+	textfmt "github.com/awslabs/ferret-scan/v2/internal/formatters/text"
+	yamlfmt "github.com/awslabs/ferret-scan/v2/internal/formatters/yaml"
+)
+
+// allLevels enables every confidence band, the posture `--confidence all` gives.
+func allLevels() map[string]bool {
+	return map[string]bool{"high": true, "medium": true, "low": true}
+}
+
+// countFindings extracts the number of findings a format actually rendered.
+// Each format needs its own counter because they nest findings differently:
+// JUnit packs every finding into a single <failure> body, so counting
+// <testcase> elements would report the file count instead.
+type formatUnderTest struct {
+	name  string
+	newf  func() formatters.Formatter
+	count func(t *testing.T, out string) int
+}
+
+func formatsUnderTest() []formatUnderTest {
+	return []formatUnderTest{
+		{
+			name: "text",
+			newf: func() formatters.Formatter { return textfmt.NewFormatter() },
+			count: func(t *testing.T, out string) int {
+				n := 0
+				for _, line := range strings.Split(out, "\n") {
+					if strings.HasPrefix(line, "[") && strings.Contains(line, "line ") {
+						n++
+					}
+				}
+				return n
+			},
+		},
+		{
+			name:  "json",
+			newf:  func() formatters.Formatter { return jsonfmt.NewFormatter() },
+			count: func(t *testing.T, out string) int { return countJSONResults(t, out) },
+		},
+		{
+			name: "yaml",
+			newf: func() formatters.Formatter { return yamlfmt.NewFormatter() },
+			count: func(t *testing.T, out string) int {
+				return strings.Count(out, "line_number:")
+			},
+		},
+		{
+			name: "csv",
+			newf: func() formatters.Formatter { return csvfmt.NewFormatter() },
+			count: func(t *testing.T, out string) int {
+				lines := strings.Split(strings.TrimSpace(out), "\n")
+				if len(lines) <= 1 {
+					return 0
+				}
+				return len(lines) - 1 // drop the header row
+			},
+		},
+		{
+			name: "junit",
+			newf: func() formatters.Formatter { return junitfmt.NewFormatter() },
+			count: func(t *testing.T, out string) int {
+				// Every finding contributes one "Line N:" detail line inside the
+				// single <failure> body.
+				return strings.Count(out, "Line ")
+			},
+		},
+		{
+			name: "sarif",
+			newf: func() formatters.Formatter { return sariffmt.NewFormatter() },
+			count: func(t *testing.T, out string) int {
+				var doc struct {
+					Runs []struct {
+						Results []json.RawMessage `json:"results"`
+					} `json:"runs"`
+				}
+				if err := json.Unmarshal([]byte(out), &doc); err != nil {
+					t.Fatalf("sarif output is not valid JSON: %v", err)
+				}
+				n := 0
+				for _, r := range doc.Runs {
+					n += len(r.Results)
+				}
+				return n
+			},
+		},
+		{
+			name: "gitlab-sast",
+			newf: func() formatters.Formatter { return gitlabfmt.NewFormatter() },
+			count: func(t *testing.T, out string) int {
+				var doc struct {
+					Vulnerabilities []json.RawMessage `json:"vulnerabilities"`
+				}
+				if err := json.Unmarshal([]byte(out), &doc); err != nil {
+					t.Fatalf("gitlab-sast output is not valid JSON: %v", err)
+				}
+				return len(doc.Vulnerabilities)
+			},
+		},
+	}
+}
+
+// countJSONResults tolerates the two shapes the JSON formatter emits: a bare
+// `[]` for a zero-finding scan and an object with a results array otherwise.
+func countJSONResults(t *testing.T, out string) int {
+	t.Helper()
+	trimmed := strings.TrimSpace(out)
+	if trimmed == "" || strings.HasPrefix(trimmed, "[") {
+		var arr []json.RawMessage
+		if err := json.Unmarshal([]byte(trimmed), &arr); err != nil {
+			t.Fatalf("json output is neither object nor array: %v", err)
+		}
+		return len(arr)
+	}
+	var doc struct {
+		Results []json.RawMessage `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(trimmed), &doc); err != nil {
+		t.Fatalf("json output is not valid JSON: %v", err)
+	}
+	return len(doc.Results)
+}
+
+// lowMatches builds n distinct LOW-confidence findings.
+func lowMatches(n int) []detector.Match {
+	out := make([]detector.Match, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, detector.Match{
+			Text:       fmt.Sprintf("user%02d@example.com", i),
+			LineNumber: i + 1,
+			Type:       "BUSINESS",
+			Confidence: 48,
+			Filename:   "many.txt",
+			Validator:  "email",
+		})
+	}
+	return out
+}
+
+// TestLimit_EveryFormatHonorsIt is the parity contract behind --limit: one scan
+// rendered seven ways must report the same number of findings. CSV, JUnit,
+// SARIF and GitLab SAST ignored the option entirely, so a CI job asking for 3
+// findings received all 30 in exactly the formats CI consumes — the unbounded
+// report size ba4f31d set out to bound.
+func TestLimit_EveryFormatHonorsIt(t *testing.T) {
+	const total, limit = 30, 3
+	matches := lowMatches(total)
+
+	for _, f := range formatsUnderTest() {
+		t.Run(f.name, func(t *testing.T) {
+			out, err := f.newf().Format(matches, nil, formatters.FormatterOptions{
+				ConfidenceLevel: allLevels(),
+				NoColor:         true,
+				ShowMatch:       true,
+				Limit:           limit,
+			})
+			if err != nil {
+				t.Fatalf("Format: %v", err)
+			}
+			if got := f.count(t, out); got != limit {
+				t.Errorf("rendered %d findings with Limit=%d, want %d", got, limit, limit)
+			}
+		})
+	}
+}
+
+// TestLimit_ZeroMeansUnlimited pins the documented escape hatch, and doubles as
+// the guard that the truncation is opt-in: at Limit 0 every format must still
+// render everything, which is the posture the golden corpus is generated in.
+func TestLimit_ZeroMeansUnlimited(t *testing.T) {
+	const total = 30
+	matches := lowMatches(total)
+
+	for _, f := range formatsUnderTest() {
+		t.Run(f.name, func(t *testing.T) {
+			out, err := f.newf().Format(matches, nil, formatters.FormatterOptions{
+				ConfidenceLevel: allLevels(),
+				NoColor:         true,
+				ShowMatch:       true,
+				Limit:           0,
+			})
+			if err != nil {
+				t.Fatalf("Format: %v", err)
+			}
+			if got := f.count(t, out); got != total {
+				t.Errorf("rendered %d findings with Limit=0, want all %d", got, total)
+			}
+		})
+	}
+}
+
+// TestLimit_KeepsHighestConfidence asserts the truncation happens after the
+// priority sort. Truncating the caller's arrival order instead would drop the
+// HIGH-confidence finding and keep noise — the worst possible subset for a tool
+// whose output gates a commit.
+func TestLimit_KeepsHighestConfidence(t *testing.T) {
+	matches := append(lowMatches(10), detector.Match{
+		Text:       "449-87-4100",
+		LineNumber: 99,
+		Type:       "SSN",
+		Confidence: 100,
+		Filename:   "many.txt",
+		Validator:  "ssn",
+	})
+
+	for _, f := range formatsUnderTest() {
+		t.Run(f.name, func(t *testing.T) {
+			out, err := f.newf().Format(matches, nil, formatters.FormatterOptions{
+				ConfidenceLevel: allLevels(),
+				NoColor:         true,
+				ShowMatch:       true,
+				Limit:           1,
+			})
+			if err != nil {
+				t.Fatalf("Format: %v", err)
+			}
+			if !strings.Contains(out, "SSN") {
+				t.Errorf("Limit=1 dropped the only HIGH finding; output kept LOW noise instead:\n%s",
+					truncateForLog(out))
+			}
+		})
+	}
+}
+
+// TestConfidenceFilter_EveryFormatHonorsIt covers the second half of the same
+// parity contract. GitLab SAST was the one formatter that never applied the
+// confidence filter, so `--confidence high` shipped every LOW-confidence
+// finding straight into a GitLab security dashboard while every other format
+// correctly rendered none.
+func TestConfidenceFilter_EveryFormatHonorsIt(t *testing.T) {
+	matches := lowMatches(30) // all 48% == LOW
+	highOnly := map[string]bool{"high": true}
+
+	for _, f := range formatsUnderTest() {
+		t.Run(f.name, func(t *testing.T) {
+			out, err := f.newf().Format(matches, nil, formatters.FormatterOptions{
+				ConfidenceLevel: highOnly,
+				NoColor:         true,
+				ShowMatch:       true,
+				Limit:           0,
+			})
+			if err != nil {
+				t.Fatalf("Format: %v", err)
+			}
+			if got := f.count(t, out); got != 0 {
+				t.Errorf("rendered %d LOW findings under --confidence high, want 0", got)
+			}
+		})
+	}
+}
+
+// TestConfidenceFilter_HighSurvives is the non-vacuity partner of the test
+// above: a filter that rejected everything would pass it for the wrong reason.
+func TestConfidenceFilter_HighSurvives(t *testing.T) {
+	matches := append(lowMatches(5), detector.Match{
+		Text:       "449-87-4100",
+		LineNumber: 99,
+		Type:       "SSN",
+		Confidence: 100,
+		Filename:   "many.txt",
+		Validator:  "ssn",
+	})
+	highOnly := map[string]bool{"high": true}
+
+	for _, f := range formatsUnderTest() {
+		t.Run(f.name, func(t *testing.T) {
+			out, err := f.newf().Format(matches, nil, formatters.FormatterOptions{
+				ConfidenceLevel: highOnly,
+				NoColor:         true,
+				ShowMatch:       true,
+				Limit:           0,
+			})
+			if err != nil {
+				t.Fatalf("Format: %v", err)
+			}
+			if got := f.count(t, out); got != 1 {
+				t.Errorf("rendered %d findings under --confidence high, want exactly the 1 HIGH", got)
+			}
+		})
+	}
+}
+
+func truncateForLog(s string) string {
+	if len(s) > 400 {
+		return s[:400] + "…"
+	}
+	return s
+}

--- a/internal/formatters/shared/structures.go
+++ b/internal/formatters/shared/structures.go
@@ -236,6 +236,21 @@ func FilterMatchesByConfidence(matches []detector.Match, options formatters.Form
 	return filtered
 }
 
+// ApplyLimit truncates an already-filtered, already-sorted slice to
+// options.Limit, reporting the pre-truncation total and whether anything was
+// dropped. A Limit of 0 or less means unlimited.
+//
+// Order matters: callers must filter by confidence and sort by priority BEFORE
+// truncating, or the surviving findings are an arbitrary subset rather than the
+// highest-confidence ones the user asked to see.
+func ApplyLimit(matches []detector.Match, options formatters.FormatterOptions) (display []detector.Match, total int, truncated bool) {
+	total = len(matches)
+	if options.Limit > 0 && total > options.Limit {
+		return matches[:options.Limit], total, true
+	}
+	return matches, total, false
+}
+
 // GetConfidenceLevel returns the confidence level as a string
 func GetConfidenceLevel(confidence float64) string {
 	switch {
@@ -317,8 +332,6 @@ func SortMatchesByPriority(matches []detector.Match) {
 
 // ConvertMatchesToJSONFormat converts detector matches to JSON/YAML format
 func ConvertMatchesToJSONFormat(matches []detector.Match, suppressedMatches []detector.SuppressedMatch, options formatters.FormatterOptions) JSONResponse {
-	totalFindings := len(matches)
-
 	// Sort by confidence descending, then type ascending (same priority order as
 	// text), then line/filename/text ascending as a TOTAL order. The final
 	// tiebreakers matter: confidence+type alone leaves same-(confidence,type)
@@ -335,11 +348,7 @@ func ConvertMatchesToJSONFormat(matches []detector.Match, suppressedMatches []de
 	SortSuppressedByPriority(suppressedMatches)
 
 	// Apply limit
-	truncated := false
-	if options.Limit > 0 && totalFindings > options.Limit {
-		matches = matches[:options.Limit]
-		truncated = true
-	}
+	matches, totalFindings, truncated := ApplyLimit(matches, options)
 
 	var jsonMatches []JSONMatch
 	for _, match := range matches {

--- a/internal/formatters/text/formatter.go
+++ b/internal/formatters/text/formatter.go
@@ -146,16 +146,9 @@ func (f *Formatter) sortMatchesByPriority(matches []detector.Match) {
 // writeFormattedOutput writes the formatted text output to the given writer,
 // applying limit truncation and summary header/footer.
 func (f *Formatter) writeFormattedOutput(w io.Writer, matches []detector.Match, suppressedMatches []detector.SuppressedMatch, options formatters.FormatterOptions) {
-	totalFindings := len(matches)
-
-	// Apply limit: determine how many findings to show
-	limit := options.Limit
-	truncated := false
-	displayMatches := matches
-	if limit > 0 && totalFindings > limit {
-		displayMatches = matches[:limit]
-		truncated = true
-	}
+	// Apply limit: determine how many findings to show. The summary keeps
+	// reporting the pre-truncation total.
+	displayMatches, totalFindings, truncated := shared.ApplyLimit(matches, options)
 
 	// Add headers for non-verbose mode
 	if !options.Verbose && (len(displayMatches) > 0 || len(suppressedMatches) > 0) {
@@ -191,7 +184,7 @@ func (f *Formatter) writeFormattedOutput(w io.Writer, matches []detector.Match, 
 
 	// Print truncation footer
 	if truncated {
-		remaining := totalFindings - limit
+		remaining := totalFindings - len(displayMatches)
 		footer := fmt.Sprintf("\n... and %d more findings (use --limit 0 to show all)\n", remaining)
 		fmt.Fprint(w, footer)
 	}


### PR DESCRIPTION
## Problem

`--limit` was implemented four times and applied by three formats.

`text`, `json` and `yaml` each carried their own copy of the arithmetic. `csv`, `junit`, `sarif` and `gitlab-sast` ignored the option entirely. At the shipped default of `--limit 200`, a scan finding 500 things emitted 200 rows as text and **500** as CSV, JUnit XML, SARIF and GitLab SAST — the four formats CI actually consumes, and the ones whose unbounded report size the limit exists to bound.

The adjacent and more serious defect: **`gitlab-sast` never called `FilterMatchesByConfidence` at all.** `--confidence high` over a set of LOW-confidence findings produced zero results in every other format and every one of them in the GitLab report. An operator's explicit filter was silently discarded on the single output a security dashboard ingests.

### Measured before → after (30 LOW-confidence EMAIL findings)

| flags | text | json | yaml | csv | junit | sarif | gitlab-sast |
|---|---|---|---|---|---|---|---|
| `--confidence all --limit 3` | 3 → 3 | 3 → 3 | 3 → 3 | **30 → 3** | **30 → 3** | **30 → 3** | **30 → 3** |
| `--confidence all --limit 0` | 30 → 30 | 30 → 30 | 30 → 30 | 30 → 30 | 30 → 30 | 30 → 30 | 30 → 30 |
| `--confidence high --limit 0` | 0 → 0 | 0 → 0 | 0 → 0 | 0 → 0 | 0 → 0 | 0 → 0 | **30 → 0** |

## Changes

- **`shared.ApplyLimit`** — one helper returning `(display, total, truncated)`, with the ordering contract documented: callers must filter by confidence and sort by priority **before** truncating, or the survivors are an arbitrary prefix instead of the highest-confidence findings the operator asked for. It replaces the duplicated arithmetic in `text` and `shared` rather than adding a fifth copy.
- **csv / junit / sarif / gitlab-sast** — apply it, each placed after that formatter's own sort. In `junit` it precedes grouping so the per-file `<testcase>` split and the suite's `Tests`/`Failures` counters describe what the report actually carries; in `sarif` it precedes `RuleManager` so `tool.driver.rules` is derived from emitted results rather than from findings the report never mentions.
- **gitlab-sast** — apply the confidence filter, placed *before* the empty-result early return so filtering to zero still emits a schema-valid empty report.
- **`cmd/stdin.go`** — pass the limit into `formatStdinFindings`, the redaction branch of `--stdin`, which never received it. So `--stdin --enable-redaction --limit 3` emitted every finding while the same flags without `--enable-redaction` emitted 3.

### Deliberately not added

A per-format truncation marker. A CSV comment row, a JUnit attribute or a SARIF properties bag emitted *unconditionally* would rewrite all 240 golden fixtures. Any future marker must stay gated on the `truncated` boolean.

### Out of scope

`internal/web/server.go` also builds `FormatterOptions` without `Limit`, but that is correct by design: the UI paginates client-side, `/export` deliberately exports all levels, and truncating `/scan` would break the browser's client-side suppression-hash recomputation.

## Safety: `--limit` cannot narrow detection

- Exit codes are computed from the full post-suppression set (`hasFindings := len(unsuppressedMatches) > 0`). Verified `rc=1` at limits 0/1/2/200 in all seven formats under `PRE_COMMIT=1 FERRET_PRECOMMIT_EXIT_ON=low`, on both this branch and main.
- `runStdinRedaction` calls `RedactString` with the **full** match slice before formatting, so a capped report never means less redacted content. Verified byte-identical redacted stdout between a limit-2 branch run and a limit-2 main run.
- Summary/stats keep reporting the pre-truncation total (`truncated: true`, `total_findings`), and the text footer still says "... and N more findings".

## Tests — all verified to FAIL on the parent commit

`internal/formatters/shared/limit_parity_test.go` runs one scan through all seven formats:

- limit honored, limit 0 unlimited
- **HIGH survives a limit of 1** — pins sort-then-truncate; truncating arrival order would keep LOW noise and drop the only HIGH finding
- confidence filter honored, plus a non-vacuity partner asserting the one HIGH *does* survive

On main (544608b) these fail exactly as predicted: `csv`/`junit`/`sarif`/`gitlab-sast` render 30 with `Limit=3`; `gitlab-sast` renders 30 LOW findings under `--confidence high`, and 6-of-6 where only 1 is HIGH.

`cmd/stdin_limit_test.go` covers the `--stdin --enable-redaction` findings report (fails on parent: 30 rows at limit 3).

## Verification (docs/testing/TEST_PLAN.md)

| Dimension | Result |
|---|---|
| Build / vet / gofmt | clean |
| Full suite `-count=1` | **59 ok / 0 fail** |
| Golden corpus | `UPDATE_GOLDEN=1` changes **0 of 240** fixtures — no semantic collision with the 9 fixtures #205 just added |
| Race | clean on all touched packages |
| Determinism | **1 distinct output over 10 runs** in all 7 formats (timestamp + `duration_seconds` normalized) |
| Timing / no O(n²) | linear N/2N/4N (500→4000 lines); `sarif` 0.214s vs main 0.250s and `gitlab-sast` 0.207s vs 0.266s at n=4000 — measurably *faster*, since fewer findings get serialized |
| Redaction (all strategies) | artifacts limit-invariant across limits 0/1/2/3/200 for `simple`, `format_preserving` and `synthetic`, with no cleartext survivor for any of 8 planted secrets. (`synthetic` is intentionally random per run, so it was checked structurally rather than by diff.) |
| Suppression | suppressed count stable at 8 under every limit; `suppressed` block uncapped in json/yaml/csv/junit/sarif |
| Pre-commit exit codes | `rc=1` at every limit × all 7 formats, identical to main |
| Recall / TP-FP | a real-world PDF byte-identical to main at `--limit 0` after normalizing the `duration_seconds` field |
| Web | untouched; `internal/web` tests pass |