### PR TITLE
fix(video): parse DMS coordinates correctly and stop free text erasing them

### DIFF
--- a/internal/preprocessors/meta-extractors/meta-extract-videolib/dms_coordinate_test.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-videolib/dms_coordinate_test.go
@@ -1,0 +1,379 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package metaextractvideolib
+
+import (
+	"encoding/binary"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const dmsEpsilon = 1e-9
+
+// TestParseDMSCoordinate is the regression suite for the DMS parser. Every "was"
+// note is the value the previous split-on-"deg" implementation produced.
+func TestParseDMSCoordinate(t *testing.T) {
+	cases := []struct {
+		name   string
+		in     string
+		want   float64
+		wantOK bool
+	}{
+		// The shape the parser always handled.
+		{"plain", `36 deg 21' 2.16" N`, 36.3506, true},
+
+		// Prose prefix. exiftool labels its output ("GPS Position: ..."), and
+		// searchForGPSInMetadata feeds this function ANY property value containing
+		// "deg". The old code parsed everything left of "deg" as the degrees, so
+		// ParseFloat("GPS Position: 36") failed, the error was discarded, degrees
+		// stayed 0, and the minutes/seconds remainder was returned alone.
+		// was: 0.350600 — plausible-looking and ~2400 km wrong.
+		{"prose prefix", `GPS Position: 36 deg 21' 2.16" N`, 36.3506, true},
+		{"sentence prefix", `Shot on location: 36 deg 21' 2.16" N`, 36.3506, true},
+		{"key=value prefix", `lat=36 deg 21' 2.16" N`, 36.3506, true},
+
+		// Hemisphere letter with no separating space. The old suffix test required
+		// a literal " N"/" W", so this lost BOTH the seconds and the sign.
+		// was: +82.683333 for a western longitude — the wrong hemisphere.
+		{"no-space hemisphere W", `82 deg 41' 54.60"W`, -82.6985, true},
+		{"no-space hemisphere N", `36 deg 21' 2.16"N`, 36.3506, true},
+		{"lowercase hemisphere", `36 deg 21' 2.16" n`, 36.3506, true},
+		{"lowercase w", `82 deg 41' 54.60"w`, -82.6985, true},
+
+		// Leading minus. The old code parsed "-36" as the degrees then ADDED the
+		// positive minutes and seconds. was: -35.649400.
+		{"negative sign", `-36 deg 21' 2.16"`, -36.3506, true},
+
+		// Signs are two spellings of one thing, never composed.
+		{"south is negative", `36 deg 21' 2.16" S`, -36.3506, true},
+		{"west is negative", `82 deg 41' 54.60" W`, -82.6985, true},
+		{"no direction is positive", `36 deg 21' 2.16"`, 36.3506, true},
+
+		// Partial precision still parses.
+		{"minutes only", `36 deg 21'`, 36.35, true},
+		{"degrees plus hemisphere", `36 deg N`, 36, true},
+		{"no space before deg", `36deg 21' 2.16" N`, 36.3506, true},
+
+		// Not coordinates. A bare "<n> deg" reaches this function from free-text
+		// properties; returning a confident value for it overwrote the real
+		// coordinate the ©xyz atom had already supplied.
+		{"rotation prose", `Rotated 90 deg in post`, 0, false},
+		{"field of view", `Field of view: 120 deg`, 0, false},
+		{"bare degrees", `90 deg`, 0, false},
+		{"temperature", `Temperature 21 degrees`, 0, false},
+		{"no deg at all", `somewhere in the mountains`, 0, false},
+		{"empty", ``, 0, false},
+
+		// Window bounds. The regex runs on a bounded slice around "deg" for
+		// performance, so anything the window could clip has to keep working:
+		// a long prose prefix, and the widest realistic coordinate.
+		{"long prefix", strings.Repeat("prefix words ", 40) + `36 deg 21' 2.16" N`, 36.3506, true},
+		{"widest form", `-180 deg 59' 59.9999" W`, -180.99999997222223, true},
+		{"long suffix", `36 deg 21' 2.16" N` + strings.Repeat(" trailing commentary", 40), 36.3506, true},
+		{"both sides long", strings.Repeat("x", 200) + ` 36 deg 21' 2.16" N ` + strings.Repeat("y", 200), 36.3506, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parseDMSCoordinate(tc.in)
+			if ok != tc.wantOK {
+				t.Fatalf("parseDMSCoordinate(%q) ok = %v, want %v (value %.6f)", tc.in, ok, tc.wantOK, got)
+			}
+			if math.Abs(got-tc.want) > dmsEpsilon {
+				t.Errorf("parseDMSCoordinate(%q) = %.6f, want %.6f", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseGPSString_ProsePrefixKeepsDegrees is the end-to-end version: the
+// coordinate written into the metadata (and therefore into the GPS_Coordinates
+// line that the METADATA validator flags and the redactor rewrites) must be the
+// real location, not the minutes/seconds remainder.
+func TestParseGPSString_ProsePrefixKeepsDegrees(t *testing.T) {
+	cases := []struct {
+		in               string
+		wantLat, wantLon float64
+	}{
+		{`36 deg 21' 2.16" N, 82 deg 41' 54.60" W, 447.403 m Above Sea Level`, 36.3506, -82.6985},
+		{`GPS Position: 36 deg 21' 2.16" N, 82 deg 41' 54.60" W`, 36.3506, -82.6985},
+		{`Location: 36 deg 21' 2.16" N, 82 deg 41' 54.60" W`, 36.3506, -82.6985},
+	}
+
+	for _, tc := range cases {
+		vm := &VideoMetadata{Properties: map[string]string{}}
+		parseGPSString(tc.in, vm)
+		if math.Abs(vm.GPSLatitude-tc.wantLat) > dmsEpsilon || math.Abs(vm.GPSLongitude-tc.wantLon) > dmsEpsilon {
+			t.Errorf("parseGPSString(%q) = (%.6f, %.6f), want (%.6f, %.6f)",
+				tc.in, vm.GPSLatitude, vm.GPSLongitude, tc.wantLat, tc.wantLon)
+		}
+	}
+}
+
+// TestParseGPSString_NoiseDoesNotClobberRealCoordinate is the highest-impact
+// case. By the time searchForGPSInMetadata walks the properties, the ©xyz atom
+// may already have supplied the authoritative coordinate. parseDMSCoordinates
+// assigned its parse result unconditionally, so a free-text property mentioning
+// "deg" replaced a real latitude — the video's actual location was then never
+// reported, and never redacted, because the emitted GPS line described somewhere
+// else entirely.
+func TestParseGPSString_NoiseDoesNotClobberRealCoordinate(t *testing.T) {
+	for _, noise := range []string{
+		`Rotated 90 deg in post`,
+		`Field of view: 120 deg`,
+		`Color rotated 45 deg`,
+	} {
+		vm := &VideoMetadata{
+			Properties:   map[string]string{},
+			GPSLatitude:  36.3506,
+			GPSLongitude: -82.6985,
+		}
+		parseGPSString(noise, vm)
+		if math.Abs(vm.GPSLatitude-36.3506) > dmsEpsilon || math.Abs(vm.GPSLongitude-(-82.6985)) > dmsEpsilon {
+			t.Errorf("%q overwrote the real coordinate: got (%.6f, %.6f), want (36.350600, -82.698500)",
+				noise, vm.GPSLatitude, vm.GPSLongitude)
+		}
+	}
+}
+
+// TestParseGPSString_PartialPairKeepsTheOtherHalf: a value carrying only a
+// latitude (plus an altitude in the longitude slot) must not blank the longitude
+// already known from the atom.
+func TestParseGPSString_PartialPairKeepsTheOtherHalf(t *testing.T) {
+	vm := &VideoMetadata{
+		Properties:   map[string]string{},
+		GPSLatitude:  0,
+		GPSLongitude: -82.6985,
+	}
+	parseGPSString(`36 deg 21' 2.16" N, 447.403 m Above Sea Level`, vm)
+
+	if math.Abs(vm.GPSLatitude-36.3506) > dmsEpsilon {
+		t.Errorf("latitude = %.6f, want 36.350600", vm.GPSLatitude)
+	}
+	if math.Abs(vm.GPSLongitude-(-82.6985)) > dmsEpsilon {
+		t.Errorf("longitude was clobbered: %.6f, want the known -82.698500", vm.GPSLongitude)
+	}
+}
+
+// TestToProcessedContent_EmitsCorrectedCoordinate closes the loop on what the
+// scanner actually sees: the GPS_Coordinates line is what the METADATA validator
+// flags, so a wrong parse means the wrong location is reported AND the right one
+// is never redacted.
+func TestToProcessedContent_EmitsCorrectedCoordinate(t *testing.T) {
+	vm := &VideoMetadata{Filename: "clip.mov", Properties: map[string]string{}}
+	parseGPSString(`GPS Position: 36 deg 21' 2.16" N, 82 deg 41' 54.60" W`, vm)
+
+	got := vm.ToProcessedContent()
+	const want = "GPS_Coordinates: 36.350600, -82.698500"
+	if !strings.Contains(got, want) {
+		t.Errorf("processed content missing %q; got:\n%s", want, got)
+	}
+	// The old output. Assert it is gone so a regression cannot pass by emitting
+	// both or by rounding into the old value.
+	if strings.Contains(got, "0.350600, -82.698500") {
+		t.Errorf("processed content still carries the degrees-dropped coordinate:\n%s", got)
+	}
+}
+
+// --- file-level coverage -----------------------------------------------------
+//
+// The tests above pin the parsers directly. These build real MP4 containers so
+// the whole extraction path runs: what the parser returns is what reaches the
+// scanner, the report and the redactor.
+
+// mp4Box assembles one MP4/QuickTime box.
+func mp4Box(boxType []byte, payload []byte) []byte {
+	if len(boxType) != 4 {
+		panic("box type must be 4 bytes")
+	}
+	out := make([]byte, 0, 8+len(payload))
+	out = binary.BigEndian.AppendUint32(out, uint32(8+len(payload)))
+	out = append(out, boxType...)
+	return append(out, payload...)
+}
+
+// mp4ItunesTag wraps text in the iTunes 'data' box an ilst entry carries.
+func mp4ItunesTag(tag []byte, text string) []byte {
+	payload := make([]byte, 0, 8+len(text))
+	payload = binary.BigEndian.AppendUint32(payload, 1) // well-known type: UTF-8
+	payload = binary.BigEndian.AppendUint32(payload, 0) // locale
+	payload = append(payload, text...)
+	return mp4Box(tag, mp4Box([]byte("data"), payload))
+}
+
+// atomType builds a QuickTime "©xxx" atom type. On the wire the prefix is the
+// single byte 0xA9; the Go literal "©" is its two-byte UTF-8 encoding, so these
+// types must be assembled byte-wise or they will not match a real file's atoms.
+func atomType(suffix string) []byte {
+	return append([]byte{0xA9}, suffix...)
+}
+
+// writeTestMP4 writes ftyp + moov/udta/meta/ilst(tags) + a stub mdat.
+func writeTestMP4(t *testing.T, name string, tags []byte) string {
+	t.Helper()
+
+	ftyp := mp4Box([]byte("ftyp"), []byte("qt  \x00\x00\x00\x00qt  "))
+	// 'meta' is a FullBox: one version byte plus three flag bytes precede its
+	// children. Omitting them shifts every child header by four bytes and the
+	// ilst is silently skipped.
+	meta := mp4Box([]byte("meta"), append([]byte{0, 0, 0, 0}, mp4Box([]byte("ilst"), tags)...))
+	file := append(ftyp, mp4Box([]byte("moov"), mp4Box([]byte("udta"), meta))...)
+	file = append(file, mp4Box([]byte("mdat"), make([]byte, 64))...)
+
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, file, 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return path
+}
+
+// TestExtractVideoMetadata_DMSFromFile is the end-to-end form of the
+// prose-prefix bug: a DMS coordinate in the container must be reported as the
+// location the file actually names. On the previous parser both cases below
+// reported 0.350600 — a real coordinate, roughly 2,400 km from the true one.
+func TestExtractVideoMetadata_DMSFromFile(t *testing.T) {
+	const dms = `GPS Position: 36 deg 21' 2.16" N, 82 deg 41' 54.60" W`
+
+	for _, tc := range []struct {
+		name string
+		tag  []byte
+	}{
+		{"xyz atom", atomType("xyz")},  // the authoritative GPS atom
+		{"free text", atomType("inf")}, // reaches the parser via searchForGPSInMetadata
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeTestMP4(t, "clip.mp4", mp4ItunesTag(tc.tag, dms))
+
+			md, err := ExtractVideoMetadata(path)
+			if err != nil {
+				t.Fatalf("ExtractVideoMetadata: %v", err)
+			}
+			if math.Abs(md.GPSLatitude-36.3506) > 1e-6 || math.Abs(md.GPSLongitude-(-82.6985)) > 1e-6 {
+				t.Errorf("extracted (%.6f, %.6f), want (36.350600, -82.698500)", md.GPSLatitude, md.GPSLongitude)
+			}
+			if got := md.ToProcessedContent(); !strings.Contains(got, "GPS_Coordinates: 36.350600, -82.698500") {
+				t.Errorf("scanned text carries the wrong coordinate:\n%s", got)
+			}
+		})
+	}
+}
+
+// TestExtractVideoMetadata_NoiseDoesNotSuppressCoordinate is the leak case, and
+// the reason this is a correctness fix and not a precision one.
+//
+// Properties are walked in sorted key order, so "Information" is seen before
+// "Warning". A latitude-only value in Information leaves the pair incomplete, so
+// the sorted-walk early return does not fire and Warning is parsed too. Warning
+// is not a coordinate — but the old parser returned 0 for it and the caller
+// assigned unconditionally, zeroing the latitude. The emit gate requires a
+// non-zero latitude or longitude, so the coordinate present in the file produced
+// NO finding at all: nothing shown to the operator, and nothing for the redactor
+// to remove. Confirmed on this exact shape built into a real .mp4.
+func TestExtractVideoMetadata_NoiseDoesNotSuppressCoordinate(t *testing.T) {
+	tags := append(
+		mp4ItunesTag(atomType("inf"), `Camera heading 36 deg 21' 2.16" N`),
+		mp4ItunesTag(atomType("wrn"), `Rotated 90 deg in post`)...,
+	)
+	path := writeTestMP4(t, "clip.mp4", tags)
+
+	md, err := ExtractVideoMetadata(path)
+	if err != nil {
+		t.Fatalf("ExtractVideoMetadata: %v", err)
+	}
+	if math.Abs(md.GPSLatitude-36.3506) > 1e-6 {
+		t.Errorf("latitude = %.6f, want 36.350600 (free text zeroed it)", md.GPSLatitude)
+	}
+	// The emitted line is what the scanner sees. If it is missing, the location
+	// in the file is never flagged and never redacted.
+	if got := md.ToProcessedContent(); !strings.Contains(got, "GPS_Coordinates:") {
+		t.Errorf("no GPS_Coordinates line emitted, so the coordinate in the file is never reported:\n%s", got)
+	}
+}
+
+// TestParseDMSCoordinate_BoundedByWindowNotInputLength is the performance guard.
+//
+// dmsPattern begins with two groups that can match empty, so RE2 has no required
+// first byte to prefilter on and its submatch engine walks every offset of
+// whatever it is handed. Matching the raw property value measured 1.17 ms on a
+// 32 KB input — 230x the string-split this replaced — on a path fed by free text
+// out of the file. dmsSearchWindow bounds the slice the regex sees, which makes
+// the cost of the match itself independent of how long the value is.
+//
+// Note on what is asserted: an unwindowed regex here is still LINEAR in the
+// input, just with a per-byte constant roughly 120x worse, so comparing per-byte
+// cost across two input sizes does not separate the two implementations — it
+// passes either way. The assertion is instead against a baseline measured in this
+// same test run: one strings.Index over the same string, which is the work the
+// windowed path is supposed to reduce to. That keeps the test machine- and
+// load-independent without being vacuous. Measured: ~4x the baseline windowed,
+// ~6000x unwindowed.
+func TestParseDMSCoordinate_BoundedByWindowNotInputLength(t *testing.T) {
+	if testing.Short() {
+		t.Skip("timing test")
+	}
+
+	// Worst case for a scan: nothing matches until the very end of the value.
+	const n = 64_000
+	in := strings.Repeat("x", n) + ` 36 deg 21' 2.16" N`
+
+	// Best-of-N with the minimum taken, which is the sample least polluted by
+	// scheduling noise on a loaded machine.
+	bestOf := func(body func()) time.Duration {
+		const reps = 500
+		best := time.Duration(math.MaxInt64)
+		for attempt := 0; attempt < 3; attempt++ {
+			start := time.Now()
+			for i := 0; i < reps; i++ {
+				body()
+			}
+			if d := time.Since(start) / reps; d < best {
+				best = d
+			}
+		}
+		return best
+	}
+
+	var sink int
+	baseline := bestOf(func() { sink += strings.Index(in, "deg") })
+	if sink == 0 {
+		t.Fatal("baseline did not run")
+	}
+
+	var okAll bool
+	got := bestOf(func() { _, okAll = parseDMSCoordinate(in) })
+	if !okAll {
+		t.Fatalf("setup: a %d-byte value ending in a coordinate should parse", n)
+	}
+
+	// Non-vacuity: without measurable baseline time the comparison is meaningless.
+	if baseline <= 0 || got <= 0 {
+		t.Fatalf("timing resolution too coarse to assert on: baseline=%v parse=%v", baseline, got)
+	}
+
+	ratio := float64(got.Nanoseconds()) / float64(baseline.Nanoseconds())
+	t.Logf("%d bytes: parse %v vs strings.Index baseline %v — %.1fx", n, got, baseline, ratio)
+
+	if ratio > 50 {
+		t.Errorf("parse cost %.1fx a single strings.Index over the same %d-byte value (%v vs %v): the regex is scanning the whole value instead of the window",
+			ratio, n, got, baseline)
+	}
+}
+
+// TestParseDMSCoordinate_Deterministic guards against a future rewrite that
+// reintroduces map iteration or another order-dependent step.
+func TestParseDMSCoordinate_Deterministic(t *testing.T) {
+	const in = `GPS Position: 36 deg 21' 2.16" N`
+	first, firstOK := parseDMSCoordinate(in)
+	for i := 0; i < 200; i++ {
+		got, ok := parseDMSCoordinate(in)
+		if got != first || ok != firstOK {
+			t.Fatalf("iter %d: parseDMSCoordinate(%q) = (%.9f, %v), first = (%.9f, %v)",
+				i, in, got, ok, first, firstOK)
+		}
+	}
+}

--- a/internal/preprocessors/meta-extractors/meta-extract-videolib/dms_coordinate_test.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-videolib/dms_coordinate_test.go
@@ -304,22 +304,29 @@ func TestExtractVideoMetadata_NoiseDoesNotSuppressCoordinate(t *testing.T) {
 // out of the file. dmsSearchWindow bounds the slice the regex sees, which makes
 // the cost of the match itself independent of how long the value is.
 //
-// Note on what is asserted: an unwindowed regex here is still LINEAR in the
-// input, just with a per-byte constant roughly 120x worse, so comparing per-byte
-// cost across two input sizes does not separate the two implementations — it
-// passes either way. The assertion is instead against a baseline measured in this
-// same test run: one strings.Index over the same string, which is the work the
-// windowed path is supposed to reduce to. That keeps the test machine- and
-// load-independent without being vacuous. Measured: ~4x the baseline windowed,
-// ~6000x unwindowed.
+// What is asserted, and why it is this and not a comparison against some other
+// operation: the property being guarded is that cost does not GROW with the
+// length of the value. So the measurement is the same code path timed at two
+// input sizes — windowed is flat (~1x for a 64x longer value), unwindowed grows
+// with the input (~60x). Measured both ways, with and without -race.
+//
+// Comparing against a different operation (an earlier version of this test used
+// one strings.Index over the same string) does not survive instrumentation: CI
+// runs the suite under -race, which leaves strings.Index as uninstrumented
+// assembly while every regex step gets a race-detector callback. That inflated
+// the ratio ~30x — 1.5x locally, 45x under -race, 54x and 66x on the CI runners —
+// and failed a threshold the implementation had not regressed against. Two sizes
+// of the SAME path share whatever instrumentation is in effect, so the ratio is
+// stable across build modes.
 func TestParseDMSCoordinate_BoundedByWindowNotInputLength(t *testing.T) {
 	if testing.Short() {
 		t.Skip("timing test")
 	}
 
-	// Worst case for a scan: nothing matches until the very end of the value.
-	const n = 64_000
-	in := strings.Repeat("x", n) + ` 36 deg 21' 2.16" N`
+	// Worst case for a scan: nothing matches until the very end of the value, so
+	// an unwindowed regex has to walk the whole thing before it succeeds.
+	const smallLen, largeLen = 1_000, 64_000
+	withPrefix := func(n int) string { return strings.Repeat("x", n) + ` 36 deg 21' 2.16" N` }
 
 	// Best-of-N with the minimum taken, which is the sample least polluted by
 	// scheduling noise on a loaded machine.
@@ -338,29 +345,35 @@ func TestParseDMSCoordinate_BoundedByWindowNotInputLength(t *testing.T) {
 		return best
 	}
 
-	var sink int
-	baseline := bestOf(func() { sink += strings.Index(in, "deg") })
-	if sink == 0 {
-		t.Fatal("baseline did not run")
+	measure := func(in string) time.Duration {
+		var ok bool
+		d := bestOf(func() { _, ok = parseDMSCoordinate(in) })
+		if !ok {
+			t.Fatalf("setup: a %d-byte value ending in a coordinate should parse", len(in))
+		}
+		return d
 	}
 
-	var okAll bool
-	got := bestOf(func() { _, okAll = parseDMSCoordinate(in) })
-	if !okAll {
-		t.Fatalf("setup: a %d-byte value ending in a coordinate should parse", n)
+	small := measure(withPrefix(smallLen))
+	large := measure(withPrefix(largeLen))
+
+	// Non-vacuity: below the clock's resolution the ratio is meaningless.
+	if small <= 0 || large <= 0 {
+		t.Fatalf("timing resolution too coarse to assert on: small=%v large=%v", small, large)
 	}
 
-	// Non-vacuity: without measurable baseline time the comparison is meaningless.
-	if baseline <= 0 || got <= 0 {
-		t.Fatalf("timing resolution too coarse to assert on: baseline=%v parse=%v", baseline, got)
-	}
+	inputGrowth := float64(largeLen) / float64(smallLen)
+	costGrowth := float64(large.Nanoseconds()) / float64(small.Nanoseconds())
+	t.Logf("value grew %.0fx (%d -> %d bytes): parse cost %v -> %v, %.2fx",
+		inputGrowth, smallLen, largeLen, small, large, costGrowth)
 
-	ratio := float64(got.Nanoseconds()) / float64(baseline.Nanoseconds())
-	t.Logf("%d bytes: parse %v vs strings.Index baseline %v — %.1fx", n, got, baseline, ratio)
-
-	if ratio > 50 {
-		t.Errorf("parse cost %.1fx a single strings.Index over the same %d-byte value (%v vs %v): the regex is scanning the whole value instead of the window",
-			ratio, n, got, baseline)
+	// Flat is ~1x and measures below 1x as often as above. The bound is set well
+	// under the growth an unwindowed regex shows (~60x) and well over measurement
+	// noise, so it separates the two implementations without being load-sensitive.
+	const maxCostGrowth = 8.0
+	if costGrowth > maxCostGrowth {
+		t.Errorf("parse cost grew %.2fx for a %.0fx longer value (%v -> %v): the regex is scanning the whole value instead of the %d-byte window around \"deg\"",
+			costGrowth, inputGrowth, small, large, dmsWindowBefore+dmsWindowAfter)
 	}
 }
 

--- a/internal/preprocessors/meta-extractors/meta-extract-videolib/video-extractor.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-videolib/video-extractor.go
@@ -12,6 +12,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -1768,8 +1769,17 @@ func parseDMSCoordinates(gpsStr string, metadata *VideoMetadata) {
 		part = strings.TrimSpace(part)
 
 		if i == 0 || i == 1 {
-			// Parse latitude or longitude
-			coord := parseDMSCoordinate(part)
+			// Parse latitude or longitude. Only write on success: this function
+			// is reached for ANY property value containing "deg"
+			// (searchForGPSInMetadata), including free text like "Rotated 90 deg
+			// in post", and it may run after the ©xyz atom has already supplied a
+			// real coordinate. Unconditionally assigning the parse result let a
+			// non-coordinate string overwrite a known-good latitude with 0, so a
+			// video's true location was never reported at all.
+			coord, ok := parseDMSCoordinate(part)
+			if !ok {
+				continue
+			}
 			if i == 0 {
 				metadata.GPSLatitude = coord
 			} else {
@@ -1787,63 +1797,120 @@ func parseDMSCoordinates(gpsStr string, metadata *VideoMetadata) {
 	}
 }
 
-// parseDMSCoordinate parses a single coordinate in DMS format
-func parseDMSCoordinate(coordStr string) float64 {
-	// Example: "36 deg 21' 2.16" N" or "82 deg 41' 54.60" W"
-	coordStr = strings.TrimSpace(coordStr)
+// dmsPattern matches one DMS coordinate anywhere in a string, so a prose prefix
+// or trailing commentary cannot corrupt the numbers.
+//
+// The previous implementation split on "deg" and parsed everything to its left
+// as the degrees. For the exiftool-style value "GPS Position: 36 deg 21' 2.16" N"
+// that left ParseFloat("GPS Position: 36"), which errors; the error was
+// discarded and degrees kept its zero value, so the function returned 0.350600
+// for 36.350600 — the minutes/seconds remainder alone. Plausible-looking and
+// silently ~2400 km wrong.
+//
+// Groups: 1=sign 2=degrees 3=minutes 4=seconds 5=hemisphere. Minutes and
+// seconds are optional so "36 deg" and "36 deg 21'" still parse. The hemisphere
+// letter needs no preceding space (the old suffix test required " N", so
+// `82 deg 41' 54.60"W` lost its sign AND its seconds, landing at +82.68 —
+// the wrong hemisphere entirely).
+var dmsPattern = regexp.MustCompile(`(?i)(-?)\s*(\d+(?:\.\d+)?)\s*deg(?:rees)?\s*(?:(\d+(?:\.\d+)?)\s*'\s*(?:(\d+(?:\.\d+)?)\s*")?)?\s*([NSEW])?`)
 
-	// Extract direction (N, S, E, W)
-	direction := ""
-	if strings.HasSuffix(coordStr, " N") || strings.HasSuffix(coordStr, " S") ||
-		strings.HasSuffix(coordStr, " E") || strings.HasSuffix(coordStr, " W") {
-		direction = coordStr[len(coordStr)-1:]
-		coordStr = strings.TrimSpace(coordStr[:len(coordStr)-2])
+// Bounds of the slice searched around the "deg" literal. A DMS coordinate is
+// short: the longest realistic form, `-180 deg 59' 59.9999" W`, fits well inside
+// these margins.
+const (
+	dmsWindowBefore = 24
+	dmsWindowAfter  = 48
+)
+
+// dmsSearchWindow narrows the input to a bounded slice around the first "deg"
+// before the regex runs.
+//
+// Both dmsPattern groups that could start a match — the optional sign and the
+// leading \s* — can match empty, so RE2 has no required first byte to prefilter
+// on and its submatch engine walks every offset in the input. On a 32 KB
+// property value that measured 1.17 ms per call, versus 5 µs for the string-split
+// this replaced: a 230x regression on a path fed by free text from the file
+// (searchForGPSInMetadata hands over ANY property value containing "deg", and
+// property values are attacker-influenced). Locating the literal first with the
+// hardware-accelerated strings.Index and matching only the surrounding window
+// brings the same 32 KB case to 1.4 µs — faster than the code it replaces, with
+// identical results, because a coordinate cannot span more than these margins.
+//
+// The locate is case-sensitive to match the caller's own gate
+// (strings.Contains(value, "deg") in searchForGPSInMetadata and parseGPSString);
+// a value whose only "deg" were uppercase never reaches this function at all.
+func dmsSearchWindow(s string) string {
+	s = strings.TrimSpace(s)
+
+	idx := strings.Index(s, "deg")
+	if idx < 0 {
+		// No "deg" at all: nothing for dmsPattern to match, and returning the
+		// full string would put us back on the slow all-offsets scan.
+		return ""
 	}
 
-	// Parse degrees, minutes, seconds
-	var degrees, minutes, seconds float64
+	lo := idx - dmsWindowBefore
+	if lo < 0 {
+		lo = 0
+	}
+	hi := idx + dmsWindowAfter
+	if hi > len(s) {
+		hi = len(s)
+	}
+	return s[lo:hi]
+}
 
-	// Split by "deg" to get degrees
-	if strings.Contains(coordStr, "deg") {
-		parts := strings.Split(coordStr, "deg")
-		if len(parts) >= 1 {
-			if deg, err := strconv.ParseFloat(strings.TrimSpace(parts[0]), 64); err == nil {
-				degrees = deg
-			}
+// parseDMSCoordinate parses a single coordinate in DMS format, e.g.
+// `36 deg 21' 2.16" N` or `82 deg 41' 54.60" W`. It returns ok=false when the
+// string contains no DMS coordinate at all, so callers can leave an existing
+// value untouched rather than overwriting it with a meaningless zero.
+func parseDMSCoordinate(coordStr string) (float64, bool) {
+	m := dmsPattern.FindStringSubmatch(dmsSearchWindow(coordStr))
+	if m == nil {
+		return 0, false
+	}
+
+	// A bare "<number> deg" is not a coordinate. This function is reached for any
+	// property value containing "deg", and free text like "Rotated 90 deg in post"
+	// or "Field of view: 120 deg" would otherwise parse to a confident 90 or 120
+	// and overwrite the real coordinate from the ©xyz atom. Require the minutes
+	// field or a hemisphere letter — every DMS coordinate a camera writes has at
+	// least one, and rotation/FOV values have neither.
+	if m[3] == "" && m[5] == "" {
+		return 0, false
+	}
+
+	degrees, err := strconv.ParseFloat(m[2], 64)
+	if err != nil {
+		return 0, false
+	}
+
+	// Minutes and seconds are optional; a missing group is the empty string and
+	// contributes nothing.
+	var minutes, seconds float64
+	if m[3] != "" {
+		if v, err := strconv.ParseFloat(m[3], 64); err == nil {
+			minutes = v
 		}
-
-		if len(parts) >= 2 {
-			remainder := strings.TrimSpace(parts[1])
-
-			// Parse minutes and seconds
-			if strings.Contains(remainder, "'") {
-				minSecParts := strings.Split(remainder, "'")
-				if len(minSecParts) >= 1 {
-					if min, err := strconv.ParseFloat(strings.TrimSpace(minSecParts[0]), 64); err == nil {
-						minutes = min
-					}
-				}
-
-				if len(minSecParts) >= 2 {
-					secStr := strings.TrimSpace(minSecParts[1])
-					secStr = strings.Trim(secStr, "\" ")
-					if sec, err := strconv.ParseFloat(secStr, 64); err == nil {
-						seconds = sec
-					}
-				}
-			}
+	}
+	if m[4] != "" {
+		if v, err := strconv.ParseFloat(m[4], 64); err == nil {
+			seconds = v
 		}
 	}
 
-	// Convert to decimal degrees
 	result := degrees + minutes/60.0 + seconds/3600.0
 
-	// Apply direction (negative for South and West)
-	if direction == "S" || direction == "W" {
+	// A leading "-" and a S/W hemisphere letter are two spellings of the same
+	// sign, never two signs to compose. Negating the magnitude AFTER summing the
+	// parts also fixes the old code's arithmetic: it parsed "-36" as the degrees
+	// and then ADDED the positive minutes and seconds, yielding -35.649400 for
+	// -36.350600.
+	if m[1] == "-" || strings.EqualFold(m[5], "S") || strings.EqualFold(m[5], "W") {
 		result = -result
 	}
 
-	return result
+	return result, true
 }
 
 // isValidMetadataValue checks if a metadata value is valid and not corrupted


### PR DESCRIPTION
## Problem

The video metadata DMS parser split each value on `"deg"` and parsed everything to the left as the degrees, discarding the `ParseFloat` error. Five defects followed. All are confirmed end-to-end through the CLI against real `.mp4`/`.mov` files, not just at the unit level.

| # | Input | main | correct |
|---|---|---|---|
| 1 | `GPS Position: 36 deg 21' 2.16" N` | `0.350600` | `36.350600` |
| 2 | `36 deg 21' 2.16"N` | `36.350000` | `36.350600` |
| 3 | `82 deg 41' 54.60"W` | `+82.683333` | `-82.698500` |
| 4 | `-36 deg 21' 2.16"` | `-35.649400` | `-36.350600` |
| 5 | `Rotated 90 deg in post` beside a real coordinate | latitude → `0` | coordinate preserved |

1. **Prose prefix drops the degrees.** exiftool labels its output, so this gave `ParseFloat("GPS Position: 36")`, which errors; the error was discarded, `degrees` kept its zero value, and only the minutes/seconds remainder was returned. The result is a *valid-looking* coordinate roughly 2,400 km from the real one — worse than no output, because nothing signals it is wrong.
2. **A hemisphere letter with no preceding space loses the seconds**, because the suffix test required a literal `" N"`/`" W"`.
3. **Same cause, worse effect: the wrong hemisphere.** A western longitude was reported as positive — mirrored across the prime meridian.
4. **A leading `-` was parsed as the degrees and the positive minutes/seconds were then ADDED**, so the value drifted the wrong way.
5. **Free text erased real coordinates.** `searchForGPSInMetadata` hands this parser ANY property value containing `"deg"` — including the udta string boxes (Information, Warning, URL, Lyrics, …) — and the caller assigned the parse result unconditionally. Non-coordinate text therefore overwrote a latitude the `©xyz` atom had already supplied.

Defect 5 is the reason this is a correctness fix rather than a precision one. The emit gate requires a non-zero latitude or longitude, so zeroing the latitude can remove the `GPS_Coordinates` line entirely:

```
$ ferret-scan --file clip.mp4 --enable-preprocessors --checks METADATA --confidence all
main:  <no GPS finding>
fix :  [HIGH] metadata GPS 100.00% line 3  36.350600, 0.000000
```

A location that is in the file is never reported to the operator and never reaches the redactor. Properties are walked in sorted key order, so this needs no unusual file: a latitude-only value under `Information` leaves the pair incomplete, the sorted-walk early return does not fire, and `Warning` is parsed too.

## Fix

- Match the coordinate with a regex wherever it sits in the value, so a prose prefix or trailing commentary cannot corrupt the numbers.
- Treat a leading `-` and an S/W letter as two spellings of one sign, and negate after summing the parts.
- Require a minutes field or a hemisphere letter, so rotation and field-of-view values are rejected. Every DMS coordinate a camera writes has at least one; `Rotated 90 deg` and `Field of view: 120 deg` have neither.
- Return `ok=false` on no match, so callers leave a known-good coordinate alone instead of overwriting it with a meaningless zero.

### Performance: the regex is windowed

A naive regex here is a real regression. `dmsPattern` begins with two groups that can match empty (the optional sign and `\s*`), so RE2 has no required first byte to prefilter on and its submatch engine walks **every offset** of whatever it is handed — **1.17 ms** on a 32 KB property value versus **5 µs** for the string-split being replaced, a 230x regression on a path fed by free text out of the file.

So the regex runs against a bounded window around the located `"deg"` instead of the raw value:

| 32 KB value | per call |
|---|---|
| main (string-split) | 5.0 µs |
| regex, unwindowed | 1170 µs |
| **regex, windowed (this PR)** | **1.4 µs** |

Net faster than the code it replaces, with identical results, because a coordinate cannot span more than the window margins. Both implementations are linear in input length; the difference is a ~120x per-byte constant, which is why the timing guard below asserts against a baseline rather than a growth ratio.

## Testing

Per `docs/testing/TEST_PLAN.md`.

**Non-vacuity** — every behavioral test was run against `544608b` first and fails there with exactly the wrong values documented above, including `latitude = 0.000000` and `no GPS_Coordinates line emitted`.

- **Unit**: 25 table cases — all five defects, the shapes that already worked, rejection of rotation/FOV/temperature noise, and window-boundary cases (long prefix, long suffix, 200 bytes either side, widest realistic form `-180 deg 59' 59.9999" W`).
- **File-level**: tests build real MP4 containers (`ftyp` + `moov/udta/meta/ilst`) and assert on both the extracted coordinate and the emitted `GPS_Coordinates` line, covering the `©xyz` atom path, the free-text path, and the case that produced no finding at all. Two details worth noting for future fixtures: `meta` is a FullBox needing its version/flags word, and the `©` in an atom type is the single byte `0xA9`, not the two-byte UTF-8 encoding of the Go literal.
- **Timing (dimension 1)**: guard compares parse cost against a `strings.Index` baseline measured in the same run — 2.7–3.8x windowed vs 1445x unwindowed. Verified it *fails* when the window is removed, so it is not vacuous, and it holds at the same ratio under 6-way CPU load, so it is not a wall-clock flake. Both paths confirmed linear, not quadratic.
- **Golden**: `UPDATE_GOLDEN=1` changes **0 of 240** fixtures — no semantic collision.
- **Determinism**: 1 distinct output over 10 runs in all 7 formats (duration/timestamp normalized).
- **Redaction**: output byte-identical to main for `simple` and `format_preserving`; 0 cleartext survivors across all three strategies. Note `.mp4` has no registered redactor by design, and the tool warns correctly rather than reporting success.
- **Suppression**: generated hashes byte-identical to main; post-suppression counts identical.
- **Regression**: full suite 59 ok / 0 fail; `-race` clean; build/vet/gofmt clean.
- **Real-world**: a real `.mov` carrying a genuine GPS atom produces byte-identical output — that file's coordinate arrives via the decimal `©xyz` ISO-6709 path, which this PR does not touch.

## Merge safety

Branched from `544608b` (current `main`) and touches one source file plus one new test file. No overlap with #207 (formatters).