### PR TITLE
fix(video): reach the "©xxx" QuickTime atom arms and strip the text header

### DIFF
--- a/internal/preprocessors/meta-extractors/meta-extract-videolib/atom_type_test.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-videolib/atom_type_test.go
@@ -1,0 +1,333 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package metaextractvideolib
+
+import (
+	"encoding/binary"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCanonicalBoxType_MatchesSourceLiterals is the root-cause test. Every "©xxx"
+// case arm in this file is a FIVE-byte Go string, because the source literal "©"
+// is the two-byte UTF-8 encoding c2 a9. A box type off the wire is four bytes with
+// a single 0xA9. The two are never equal, so all those arms were dead code:
+// ffmpeg-written titles, authors and comments fell through and the udta GPS atom
+// was never parsed.
+func TestCanonicalBoxType_MatchesSourceLiterals(t *testing.T) {
+	// The bug, stated as an assertion so it cannot silently come back.
+	if string(wireAtom("nam")) == "©nam" {
+		t.Fatal("premise changed: a 4-byte wire atom now equals the 5-byte source literal")
+	}
+
+	for _, suffix := range []string{"nam", "ART", "xyz", "cmt", "inf", "ed1", "too"} {
+		if got := canonicalBoxType(wireAtom(suffix)); got != "©"+suffix {
+			t.Errorf("canonicalBoxType(%q) = %q, want %q", suffix, got, "©"+suffix)
+		}
+	}
+
+	// Plain four-character types must pass through untouched.
+	for _, plain := range []string{"meta", "ilst", "data", "desc", "udta", "moov"} {
+		if got := canonicalBoxType([]byte(plain)); got != plain {
+			t.Errorf("canonicalBoxType(%q) = %q, want it unchanged", plain, got)
+		}
+	}
+
+	// Malformed input must not be reinterpreted.
+	if got := canonicalBoxType([]byte{0xA9, 'n'}); got != string([]byte{0xA9, 'n'}) {
+		t.Errorf("a short type was rewritten: %q", got)
+	}
+}
+
+// TestParseStringBox_StripsQuickTimeTextHeader covers the second defect. A udta
+// string box is not raw text: 2-byte big-endian length, 2-byte language, then the
+// characters. Returning the whole payload prefixed every value with four bytes of
+// binary, so the text handed to the validators — and to the redactor — was
+// corrupted at the front.
+func TestParseStringBox_StripsQuickTimeTextHeader(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []byte
+		want string
+		// clean marks inputs that are well-formed text atoms, for which the
+		// returned text must contain no binary. Malformed input falls back to the
+		// raw payload (see below), so it is exempt.
+		clean bool
+	}{
+		// The exact bytes ffmpeg writes for artist="Jordan Ellis".
+		{"ffmpeg artist", append([]byte{0x00, 0x0c, 0x55, 0xc4}, "Jordan Ellis"...), "Jordan Ellis", true},
+		{"language zero", quickTimeText("Deposition of Jordan Ellis"), "Deposition of Jordan Ellis", true},
+		{"empty", nil, "", true},
+
+		// Not every writer emits the header, so an unusable declared length falls
+		// back to the raw payload. That deliberately preserves content rather than
+		// truncating it — the same bytes main returned for every box — so this case
+		// is about not LOSING data, not about the result being clean.
+		{"bare text, no header", []byte("Jordan Ellis"), "Jordan Ellis", true},
+		{"declared length overruns payload", append([]byte{0xff, 0xff, 0x00, 0x00}, "short"...), "\xff\xff\x00\x00short", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseStringBox(tc.in)
+			if got != strings.TrimSpace(tc.want) {
+				t.Errorf("parseStringBox(% x) = %q, want %q", tc.in, got, tc.want)
+			}
+			if !tc.clean {
+				return
+			}
+			// For a well-formed atom no NUL or control byte may survive into the
+			// text the scanner reads and the redactor rewrites.
+			for _, b := range []byte(got) {
+				if b < 0x20 && b != '\t' && b != '\n' {
+					t.Errorf("control byte %#x survived into %q", b, got)
+					break
+				}
+			}
+		})
+	}
+}
+
+// TestExtractVideoMetadata_UdtaAtomsAreReached is the end-to-end form: a
+// QuickTime file whose metadata sits in udta string boxes — the layout ffmpeg
+// writes — must yield its title, author and description. On the previous code
+// every one of these was dropped and the file scanned as if it had no metadata at
+// all, so PII in a comment field was never reported and never redacted.
+func TestExtractVideoMetadata_UdtaAtomsAreReached(t *testing.T) {
+	udta := udtaTextAtom("nam", "Deposition of Jordan Ellis")
+	udta = append(udta, udtaTextAtom("ART", "Jordan Ellis")...)
+	udta = append(udta, udtaTextAtom("cmt", "Reach me at analyst@example.test or (415) 555-0142")...)
+	udta = append(udta, udtaTextAtom("inf", "Patient record on file")...)
+	udta = append(udta, udtaTextAtom("dir", "Directed by Morgan Reyes")...)
+	udta = append(udta, udtaTextAtom("prd", "Produced by Example Studios")...)
+
+	path := writeUdtaMP4(t, "clip.mov", udta)
+
+	md, err := ExtractVideoMetadata(path)
+	if err != nil {
+		t.Fatalf("ExtractVideoMetadata: %v", err)
+	}
+
+	if md.Title != "Deposition of Jordan Ellis" {
+		t.Errorf("Title = %q, want the ©nam value", md.Title)
+	}
+	if md.Author != "Jordan Ellis" {
+		t.Errorf("Author = %q, want the ©ART value", md.Author)
+	}
+	if !strings.Contains(md.Description, "analyst@example.test") {
+		t.Errorf("Description = %q, want the ©cmt value", md.Description)
+	}
+	if md.Properties["Information"] != "Patient record on file" {
+		t.Errorf("Information = %q, want the ©inf value", md.Properties["Information"])
+	}
+	if md.Properties["Director"] != "Directed by Morgan Reyes" {
+		t.Errorf("Director = %q", md.Properties["Director"])
+	}
+	if md.Properties["Producer"] != "Produced by Example Studios" {
+		t.Errorf("Producer = %q", md.Properties["Producer"])
+	}
+
+	// The emitted text is what the scanner reads and the redactor rewrites.
+	out := md.ToProcessedContent()
+	for _, want := range []string{
+		"Title: Deposition of Jordan Ellis",
+		"Author: Jordan Ellis",
+		"Description: Reach me at analyst@example.test or (415) 555-0142",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("processed content missing %q; got:\n%s", want, out)
+		}
+	}
+}
+
+// TestExtractVideoMetadata_UdtaGPSAtomIsReached: on the udta path the ©xyz atom is
+// binary fixed-point, and it is the authoritative coordinate. It was never parsed,
+// so a video with a recorded location produced no GPS finding.
+func TestExtractVideoMetadata_UdtaGPSAtomIsReached(t *testing.T) {
+	const wantLat, wantLon = 36.3506, -82.6985
+
+	gps := fixedPoint1616(wantLat)
+	gps = append(gps, fixedPoint1616(wantLon)...)
+	gps = append(gps, fixedPoint1616(0)...)
+
+	path := writeUdtaMP4(t, "clip.mov", mp4Box(wireAtom("xyz"), gps))
+
+	md, err := ExtractVideoMetadata(path)
+	if err != nil {
+		t.Fatalf("ExtractVideoMetadata: %v", err)
+	}
+
+	// 16.16 fixed point quantizes, so compare within one unit of that grid.
+	const eps = 2.0 / 65536.0
+	if math.Abs(md.GPSLatitude-wantLat) > eps || math.Abs(md.GPSLongitude-wantLon) > eps {
+		t.Errorf("GPS = (%.6f, %.6f), want (%.6f, %.6f)", md.GPSLatitude, md.GPSLongitude, wantLat, wantLon)
+	}
+	if out := md.ToProcessedContent(); !strings.Contains(out, "GPS_Coordinates:") {
+		t.Errorf("no GPS_Coordinates line, so the recorded location is never reported:\n%s", out)
+	}
+}
+
+// TestExtractVideoMetadata_EditDateIndex pins the index that the byte-length
+// confusion also broke: boxType[3:] sliced into the middle of the five-byte
+// literal and produced "d1", so the property would have been "EditDated1". Only
+// harmless while the arm was unreachable.
+func TestExtractVideoMetadata_EditDateIndex(t *testing.T) {
+	path := writeUdtaMP4(t, "clip.mov", udtaTextAtom("ed1", "2026-03-14 09:12:00"))
+
+	md, err := ExtractVideoMetadata(path)
+	if err != nil {
+		t.Fatalf("ExtractVideoMetadata: %v", err)
+	}
+
+	if _, ok := md.Properties["EditDate1"]; !ok {
+		t.Errorf("want property EditDate1, got %v", md.Properties)
+	}
+	if _, bad := md.Properties["EditDated1"]; bad {
+		t.Error("property key still built from the wrong slice offset (EditDated1)")
+	}
+}
+
+// TestParseIlstBox_UnknownTagsStillRecorded guards the recall side of the fix.
+// The unknown-tag branch tested len(boxType) == 4; once types are canonicalized a
+// "©too" is five bytes, so a naive fix would have silently DROPPED every
+// unrecognized iTunes tag — trading one recall bug for another. The key should now
+// be readable rather than mojibake, and the value must still be there.
+func TestParseIlstBox_UnknownTagsStillRecorded(t *testing.T) {
+	tags := mp4ItunesTag(wireAtom("too"), "Example Encoder 1.0")
+	tags = append(tags, mp4ItunesTag([]byte("keyw"), "confidential")...)
+
+	path := writeTestMP4(t, "clip.mp4", tags)
+
+	md, err := ExtractVideoMetadata(path)
+	if err != nil {
+		t.Fatalf("ExtractVideoMetadata: %v", err)
+	}
+
+	if got := md.Properties["©too"]; got != "Example Encoder 1.0" {
+		t.Errorf("unknown ©-prefixed tag dropped or misfiled: Properties[\"©too\"] = %q, all = %v", got, md.Properties)
+	}
+	if got := md.Properties["keyw"]; got != "confidential" {
+		t.Errorf("plain unknown tag regressed: %q", got)
+	}
+}
+
+// TestExtractVideoMetadata_RecognizedIlstTagsFillTypedFields: on the ilst path the
+// values were not lost, but they landed in Properties under an unreadable
+// mojibake key instead of Title/Author/CameraMake, so field-name-driven metadata
+// rules never fired on them.
+func TestExtractVideoMetadata_RecognizedIlstTagsFillTypedFields(t *testing.T) {
+	tags := mp4ItunesTag(wireAtom("nam"), "Quarterly review recording")
+	tags = append(tags, mp4ItunesTag(wireAtom("ART"), "Jordan Ellis")...)
+	tags = append(tags, mp4ItunesTag(wireAtom("mak"), "ExampleCam")...)
+	tags = append(tags, mp4ItunesTag(wireAtom("mod"), "XC-1")...)
+
+	path := writeTestMP4(t, "clip.mp4", tags)
+
+	md, err := ExtractVideoMetadata(path)
+	if err != nil {
+		t.Fatalf("ExtractVideoMetadata: %v", err)
+	}
+
+	if md.Title != "Quarterly review recording" || md.Author != "Jordan Ellis" {
+		t.Errorf("Title = %q, Author = %q", md.Title, md.Author)
+	}
+	if md.CameraMake != "ExampleCam" || md.CameraModel != "XC-1" {
+		t.Errorf("CameraMake = %q, CameraModel = %q", md.CameraMake, md.CameraModel)
+	}
+
+	// And no mojibake key survives in the emitted text.
+	out := md.ToProcessedContent()
+	if strings.Contains(out, "\xc2\xa9nam") || strings.Contains(out, "�") {
+		t.Errorf("emitted text still carries a mangled atom key:\n%s", out)
+	}
+}
+
+// TestExtractVideoMetadata_UdtaDeterministic: this fix newly populates several
+// properties, and Properties is a map. Emitted text must still be stable.
+//
+// Unlike the tests above, this one is a forward guard rather than a regression
+// test: it passes on the parent commit too, but only vacuously — the parent
+// extracted none of these properties, so there was nothing whose order could
+// vary. It earns its keep now that the fields are actually populated.
+func TestExtractVideoMetadata_UdtaDeterministic(t *testing.T) {
+	udta := udtaTextAtom("nam", "Deposition of Jordan Ellis")
+	udta = append(udta, udtaTextAtom("ART", "Jordan Ellis")...)
+	udta = append(udta, udtaTextAtom("cmt", "Comment field")...)
+	udta = append(udta, udtaTextAtom("dir", "Morgan Reyes")...)
+	udta = append(udta, udtaTextAtom("prd", "Example Studios")...)
+	udta = append(udta, udtaTextAtom("src", "Camera A")...)
+	udta = append(udta, udtaTextAtom("gen", "Legal")...)
+	udta = append(udta, udtaTextAtom("inf", "Information field")...)
+
+	path := writeUdtaMP4(t, "clip.mov", udta)
+
+	md, err := ExtractVideoMetadata(path)
+	if err != nil {
+		t.Fatalf("ExtractVideoMetadata: %v", err)
+	}
+
+	first := md.ToProcessedContent()
+	for i := 0; i < 200; i++ {
+		if got := md.ToProcessedContent(); got != first {
+			t.Fatalf("iter %d: emitted text is not stable:\n--- first ---\n%s\n--- iter ---\n%s", i, first, got)
+		}
+	}
+
+	// And re-extracting from the same bytes gives the same text.
+	for i := 0; i < 20; i++ {
+		again, err := ExtractVideoMetadata(path)
+		if err != nil {
+			t.Fatalf("re-extract %d: %v", i, err)
+		}
+		if got := again.ToProcessedContent(); got != first {
+			t.Fatalf("re-extract %d differs:\n--- first ---\n%s\n--- again ---\n%s", i, first, got)
+		}
+	}
+}
+
+// --- helpers -----------------------------------------------------------------
+
+// wireAtom builds a four-byte QuickTime atom type: the single byte 0xA9 followed
+// by the three-character suffix. Deliberately NOT built from a Go "©" literal,
+// which would be five bytes — the whole point of the bug under test.
+func wireAtom(suffix string) []byte {
+	return append([]byte{itunesAtomPrefix}, suffix...)
+}
+
+// quickTimeText wraps s in the udta text-atom payload: 2-byte length, 2-byte
+// language, then the characters.
+func quickTimeText(s string) []byte {
+	p := binary.BigEndian.AppendUint16(nil, uint16(len(s)))
+	p = binary.BigEndian.AppendUint16(p, 0)
+	return append(p, s...)
+}
+
+// udtaTextAtom builds a complete "©xxx" udta string box.
+func udtaTextAtom(suffix, text string) []byte {
+	return mp4Box(wireAtom(suffix), quickTimeText(text))
+}
+
+// fixedPoint1616 encodes a coordinate the way the ©xyz udta atom stores it.
+func fixedPoint1616(v float64) []byte {
+	return binary.BigEndian.AppendUint32(nil, uint32(int32(v*65536)))
+}
+
+// writeUdtaMP4 writes ftyp + moov/udta(children) + a stub mdat: the classic
+// QuickTime layout, with metadata directly under udta and no meta/ilst.
+func writeUdtaMP4(t *testing.T, name string, udtaChildren []byte) string {
+	t.Helper()
+
+	ftyp := mp4Box([]byte("ftyp"), []byte("qt  \x00\x00\x00\x00qt  "))
+	file := append(ftyp, mp4Box([]byte("moov"), mp4Box([]byte("udta"), udtaChildren))...)
+	file = append(file, mp4Box([]byte("mdat"), make([]byte, 64))...)
+
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, file, 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return path
+}

--- a/internal/preprocessors/meta-extractors/meta-extract-videolib/atom_type_test.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-videolib/atom_type_test.go
@@ -246,6 +246,40 @@ func TestExtractVideoMetadata_RecognizedIlstTagsFillTypedFields(t *testing.T) {
 	}
 }
 
+// TestExtractIlstGPS_ReportedOnceNotTwice pins the one user-visible change in
+// finding COUNT, so nobody reading a 2 -> 1 drop mistakes it for lost recall.
+//
+// With the ©xyz arm unreachable, the ilst default arm stored the coordinate under
+// the raw atom type as a property name. The emitted text then carried the same
+// location twice: once as the real GPS_Coordinates line (the Apple raw-byte
+// fallback still found it) and once as "\xa9xyz: 36 deg 21' 2.16\" N, ...", which
+// the metadata validator flagged as a second, separate VIDEO_METADATA finding.
+// One coordinate in the file, two findings in the report, one of them keyed on
+// mojibake. Routing the atom to its handler reports it once.
+func TestExtractIlstGPS_ReportedOnceNotTwice(t *testing.T) {
+	const dms = `36 deg 21' 2.16" N, 82 deg 41' 54.60" W`
+	path := writeTestMP4(t, "clip.mp4", mp4ItunesTag(wireAtom("xyz"), dms))
+
+	md, err := ExtractVideoMetadata(path)
+	if err != nil {
+		t.Fatalf("ExtractVideoMetadata: %v", err)
+	}
+
+	out := md.ToProcessedContent()
+	if !strings.Contains(out, "GPS_Coordinates: 36.350600, -82.698500") {
+		t.Errorf("the coordinate is not reported in its typed field:\n%s", out)
+	}
+
+	// The duplicate was a whole extra emitted line keyed on the raw atom type.
+	// Assert on the wire form, since that is what leaked into the key.
+	if strings.Contains(out, "\xa9xyz") || strings.Contains(out, "©xyz") {
+		t.Errorf("the raw atom type is still emitted as a property, so the coordinate is reported twice:\n%s", out)
+	}
+	if n := strings.Count(out, dms); n != 0 {
+		t.Errorf("the unparsed DMS string is emitted %d time(s) alongside the parsed coordinate:\n%s", n, out)
+	}
+}
+
 // TestExtractVideoMetadata_UdtaDeterministic: this fix newly populates several
 // properties, and Properties is a map. Emitted text must still be stable.
 //

--- a/internal/preprocessors/meta-extractors/meta-extract-videolib/video-extractor.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-videolib/video-extractor.go
@@ -578,6 +578,35 @@ func parseMvhdBox(data []byte, metadata *VideoMetadata) error {
 	return nil
 }
 
+// itunesAtomPrefix is the byte QuickTime/iTunes atom types are prefixed with —
+// "©nam", "©ART", "©xyz" and friends. On the wire it is this SINGLE byte inside a
+// four-byte type, but the Go source literal "©" is its two-byte UTF-8 encoding
+// (c2 a9), which makes `"©nam"` a FIVE-byte string. Comparing a four-byte wire
+// type against it can never be true, so every such case arm was unreachable:
+//
+//	string([]byte{0xA9, 'n', 'a', 'm'}) == "©nam"  // false
+//
+// canonicalBoxType translates the wire form into the spelling the case arms use,
+// so they compare equal without every literal in the file having to be written as
+// an escape.
+const itunesAtomPrefix = 0xA9
+
+// canonicalBoxType returns the four-byte box type as the case arms below spell
+// it: a leading 0xA9 becomes the "©" rune. Any other type is returned unchanged,
+// so plain types ("meta", "data", "desc") are unaffected.
+func canonicalBoxType(raw []byte) string {
+	if len(raw) == 4 && raw[0] == itunesAtomPrefix {
+		return "©" + string(raw[1:])
+	}
+	return string(raw)
+}
+
+// isFourCC reports whether raw is a well-formed four-byte box type. Callers use
+// this instead of len() on a canonicalized type, whose "©" prefix is two bytes.
+func isFourCC(raw []byte) bool {
+	return len(raw) == 4
+}
+
 // parseUdtaBoxWithContext parses the user data box containing metadata with context
 func parseUdtaBoxWithContext(ctx context.Context, data []byte, metadata *VideoMetadata) error {
 	offset := 0
@@ -595,7 +624,7 @@ func parseUdtaBoxWithContext(ctx context.Context, data []byte, metadata *VideoMe
 		}
 
 		size := binary.BigEndian.Uint32(data[offset : offset+4])
-		boxType := string(data[offset+4 : offset+8])
+		boxType := canonicalBoxType(data[offset+4 : offset+8])
 
 		if size < BoxHeaderSize || offset+int(size) > len(data) {
 			break
@@ -663,11 +692,14 @@ func parseUdtaBoxWithContext(ctx context.Context, data []byte, metadata *VideoMe
 		case "©url":
 			metadata.Properties["URL"] = parseStringBox(boxData)
 		case "©ed1", "©ed2", "©ed3", "©ed4", "©ed5", "©ed6", "©ed7", "©ed8", "©ed9":
-			// Edit dates
-			editNum := boxType[3:]
+			// Edit dates. Index off the END, not a fixed offset: "©" is two bytes
+			// in Go source, so boxType[3:] sliced into the middle of the type and
+			// produced "d1" instead of "1" — harmless only while these arms were
+			// unreachable.
+			editNum := boxType[len(boxType)-1:]
 			dateStr := parseStringBox(boxData)
 			if date, err := parseDate(dateStr); err == nil {
-				metadata.Properties["EditDate"+string(editNum)] = date.Format("2006-01-02 15:04:05")
+				metadata.Properties["EditDate"+editNum] = date.Format("2006-01-02 15:04:05")
 			}
 		}
 
@@ -738,7 +770,7 @@ func parseIlstBoxWithContext(ctx context.Context, data []byte, metadata *VideoMe
 		}
 
 		size := binary.BigEndian.Uint32(data[offset : offset+4])
-		boxType := string(data[offset+4 : offset+8])
+		boxType := canonicalBoxType(data[offset+4 : offset+8])
 
 		if size < BoxHeaderSize || offset+int(size) > len(data) {
 			break
@@ -771,8 +803,11 @@ func parseIlstBoxWithContext(ctx context.Context, data []byte, metadata *VideoMe
 			case "©xyz":
 				parseGPSString(value, metadata)
 			default:
-				// Store unknown tags in properties
-				if len(boxType) == 4 {
+				// Store unknown tags in properties. The length test is on the raw
+				// four-byte wire type, not on boxType: a canonicalized "©too" is
+				// five bytes in Go, and testing len(boxType) == 4 here would drop
+				// every unrecognized iTunes tag instead of recording it.
+				if isFourCC(data[offset+4 : offset+8]) {
 					metadata.Properties[boxType] = value
 				}
 			}
@@ -814,11 +849,32 @@ func parseItunesTag(data []byte) string {
 	return ""
 }
 
-// parseStringBox parses a simple string box
+// parseStringBox parses a QuickTime udta string box.
+//
+// These boxes are not raw text: the payload is a 2-byte big-endian text length
+// followed by a 2-byte language code, then the characters. ffmpeg writes exactly
+// this form, so returning the whole payload prefixed every extracted title,
+// author and comment with four bytes of binary — e.g. "\x00\x0cU\xc4Jordan
+// Ellis" rendered as " U<?>Jordan Ellis". That corrupts the text the validators
+// then scan and the redactor must rewrite, and it is why the leading bytes showed
+// up as replacement characters in reports.
+//
+// The header is only honored when it is self-consistent; some writers emit bare
+// text, so an implausible declared length falls back to the raw payload rather
+// than truncating real content.
 func parseStringBox(data []byte) string {
 	if len(data) == 0 {
 		return ""
 	}
+
+	const textHeaderSize = 4
+	if len(data) >= textHeaderSize {
+		textLen := int(binary.BigEndian.Uint16(data[0:2]))
+		if textLen > 0 && textHeaderSize+textLen <= len(data) {
+			return strings.TrimSpace(string(data[textHeaderSize : textHeaderSize+textLen]))
+		}
+	}
+
 	return strings.TrimSpace(string(data))
 }
 


### PR DESCRIPTION
> Stacked on #208 (`fix/dms-coordinate-parsing`). Base retargets to `main` when #208 merges.

## The bug

Every `case "©nam"`-style arm in the udta and ilst parsers was unreachable.

On the wire a QuickTime/iTunes atom type is four bytes with a single leading `0xA9`. The Go source literal `"©"` is its **two-byte UTF-8 encoding** (`c2 a9`), so `"©nam"` is a **five-byte** string and can never equal a four-byte wire type:

```go
string([]byte{0xA9, 'n', 'a', 'm'}) == "©nam"  // false
```

34 arms across the two parsers. They then failed *differently*:

| | mechanism | observed on `main` |
|---|---|---|
| `parseUdtaBoxWithContext` | **no `default` arm** — values dropped outright | an ordinary `ffmpeg -metadata title=… artist=… comment=… description=…` `.mov` loses **all** of them; a fixture with PII in the title reports **"No matches found."** The `©xyz` GPS atom is never parsed. |
| `parseIlstBoxWithContext` | `default` stores the raw type as a Properties key | values survive under a mojibake key (`"\xa9ART"`), so typed `Title`/`Author`/`CameraMake` stay **empty** and the metadata rules that key off field names never fire. A real camera file carries `©too`. |

Reachability is not hypothetical — plain `ffmpeg` writes exactly these atoms. What masked this for iPhone files is the separate Apple raw-byte fallback (`searchAppleMetadataInData` greps for `com.apple.quicktime.location.ISO6709`), which is why a real `.mov` still produced a coordinate.

## The fix

`canonicalBoxType` translates the wire form into the spelling the arms use, so they compare equal without rewriting every literal in the file as an escape. Applied at the two call sites that have `©` arms; the other seven (moov/meta/trak/mdia/minf/stbl/parseItunesTag) are untouched.

Two coupled defects the now-reachable arms exposed:

- **`parseStringBox` returned the whole udta payload.** A QuickTime text box is a 2-byte big-endian length + 2-byte language code *before* the characters. Titles came out as `"\x00\x0cU\xc4Jordan Ellis"` — four bytes of binary prefixing the text the validators scan and the redactor must rewrite, which is where the replacement characters in reports came from. An implausible declared length still falls back to the raw payload rather than truncating real content.
- **`boxType[3:]` in the edit-date arms** lands mid-type in a five-byte literal → `EditDated1` instead of `EditDate1`.

### The naive fix would have been a recall regression

The ilst `default` arm tested `len(boxType) == 4`. After canonicalization a `©too` key is five bytes, so leaving that test in place would have **dropped every unrecognized iTunes tag** — turning a display bug into lost data. The length test now runs on the raw wire bytes (`isFourCC`), and `TestParseIlstBox_UnknownTagsStillRecorded` guards it.

## Before / after

Two fixtures, `main` vs this branch (`--enable-preprocessors --confidence all --checks all`).

**udta (`©nam`/`©ART`/`©cmt`/`©inf`, the shape `ffmpeg -metadata` writes):**

```
main:  No matches found.
this:  [HIGH] metadata GPS 100.00% line 6  36.350586, -82.698486
```

The extracted text goes from 5 lines to 11, with `Title`, `Author`, `Copyright`,
`CameraMake`, `CameraModel` and `Software` populated instead of empty.

To be precise about what this PR does and does not do: the recovered *values*
(the name, email and SSN in that fixture's title/comment/information atoms) are
now extracted and appear in the metadata text, but they still do not produce
typed PERSON_NAME/EMAIL/SSN findings. That is a **separate, already-identified
bug** in the routing layer — `content_router.go:161` sets `DocumentBody = ""` for
pure-metadata files, so only the METADATA validator ever sees the extracted text
and it matches field *names*, not PII in values. Filed separately; this PR is the
extraction half, which that fix depends on.

**ilst (`©nam`/`©ART`/`©mak`/`©mod`/`©swr`/`©cpy`/`©xyz`):**

```
main:  [HIGH] GPS            line  3  36.350600, -82.698500
       [HIGH] VIDEO_METADATA line 12  36 deg 21' 2.16" N, 82 deg 41' 54.60" W
                                      field: "\xa9xyz: 36 deg 21' 2.16\" N, ..."
this:  [HIGH] GPS            line  6  36.350600, -82.698500
```

The finding count drops 2 → 1 and that is the fix working: `main` reported the
same coordinate **twice** — once correctly, and once as a duplicate under the
mojibake key `\xa9xyz`, because the `©xyz` arm was unreachable and the `default`
arm stored the raw atom type as a property name. Routing it to its handler
reports it once.

## Test plan

Per `docs/testing/TEST_PLAN.md`:

- **D1** build / vet / gofmt clean.
- **D2** 59/59 packages. 7 new behavioral tests, **all 7 fail on the parent commit** (verified with a shim reproducing parent `canonicalBoxType` semantics).
- **D3** golden corpus **0 of 240** changed — also 0/240 on the full in-order merge result (`main` → #207 → #208 → this).
- **D4** whole-file extraction within run-to-run noise of the parent, and **sub-linear**: 40× the atom count costs 12.5× the time. The helper microbenchmark is 2–3× slower in isolation and invisible at file scale.
- **D5** redaction — text output **byte-identical** to the parent for `simple` and `format_preserving`; **0 cleartext survivors** across all three strategies. `.mp4` correctly warns "redaction incomplete … remain in cleartext" (no registered binary redactor, by design). Synthetic surrogates are randomized per run by design, so a parent-vs-fix diff there is not a signal.
- **D6** suppression round-trip: generated-rule count matches finding count exactly (2 rules / 2 findings, 1/1, 0/0); enabling the rules suppresses **all** findings; `--show-suppressed` accounts for every one. Note `--generate-suppressions` writes `enabled: false` by design, so an unedited generated file suppresses nothing.
- **D7** 7 output formats × 5 fixtures verified.
- **D10** this PR *is* the dead-code fix — 34 unreachable arms.
- **D11** determinism: **1 distinct output** over 10 runs × 7 formats × 5 fixtures.
- **D13** `-race` clean across 4 preprocessor packages.

The included determinism test is a forward guard and is labelled as such in the source: it passes on the parent too, vacuously.
