### PR TITLE
fix(observability): stop logging document content in --debug output (BSC4)

### DIFF
--- a/internal/core/scanner.go
+++ b/internal/core/scanner.go
@@ -65,9 +65,15 @@ type ScanConfig struct {
 	// enforce no-payload-bytes at the destination, futureproofing the
 	// no-leak guarantee against any change that might accidentally start
 	// logging content. In-process callers should pass io.Discard or a
-	// structured logger writer that filters payload bytes; the internal
-	// observer never emits PII today, but LogWriter is the chokepoint
-	// that makes the no-leak property enforceable rather than aspirational.
+	// structured logger writer that filters payload bytes.
+	//
+	// Note the scope of that guarantee: LogWriter is NOT what enforces it.
+	// Individual validators and preprocessors receive their observer only
+	// from cmd/main.go, which hardcodes os.Stderr, so no-payload-bytes on
+	// this path is upheld by the per-package TestNoPayloadInDebugLog gates
+	// (which assert on input bytes, not on writer identity), not by the
+	// writer wired here. A test that captures LogWriter and finds no
+	// payload proves nothing about validator debug output.
 	LogWriter io.Writer
 }
 

--- a/internal/preprocessors/audio_metadata_preprocessor.go
+++ b/internal/preprocessors/audio_metadata_preprocessor.go
@@ -328,14 +328,17 @@ func (amp *AudioMetadataPreprocessor) logSuccessfulProcessing(filePath string, a
 				audioMeta.Duration.String(), audioMeta.Bitrate, audioMeta.SampleRate, audioMeta.Channels))
 	}
 
-	// Log interesting metadata if present (but be careful about privacy-sensitive information)
+	// Log the presence of interesting metadata, not its values: artist/title/album
+	// are document content that the metadata validator scans for PII (a personal
+	// name in an Artist tag is a finding), so they must not reach the log (BSC4).
 	if audioMeta.Artist != "" && audioMeta.Title != "" {
 		amp.observer.Debug().LogDetail("audio_metadata_preprocessor",
-			fmt.Sprintf("Track info found: %s - %s", audioMeta.Artist, audioMeta.Title))
+			fmt.Sprintf("Track info found: artist [HIDDEN] (len=%d) - title [HIDDEN] (len=%d)",
+				len(audioMeta.Artist), len(audioMeta.Title)))
 	}
 
 	if audioMeta.Album != "" && audioMeta.Year > 0 {
 		amp.observer.Debug().LogDetail("audio_metadata_preprocessor",
-			fmt.Sprintf("Album info: %s (%d)", audioMeta.Album, audioMeta.Year))
+			fmt.Sprintf("Album info: [HIDDEN] (len=%d) (%d)", len(audioMeta.Album), audioMeta.Year))
 	}
 }

--- a/internal/preprocessors/image_metadata_preprocessor.go
+++ b/internal/preprocessors/image_metadata_preprocessor.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -130,13 +131,24 @@ func (imp *ImageMetadataPreprocessor) processImageMetadataWithRetry(filePath str
 func (imp *ImageMetadataPreprocessor) formatImageMetadata(exifData *meta_extract_exiflib.ExifData) string {
 	var metadataText strings.Builder
 
-	// Debug: Log all GPS-related tags
+	// Debug: log which GPS tags are present, never their values (BSC4 — a
+	// coordinate is location PII and the metadata validator reports it as a
+	// finding). Tag names are sorted so the log is stable across runs; ranging
+	// the map directly emitted them in a different order every time.
+	//
+	// Deliberately not exifData.GetSortedKeys(): that helper drops GPSLatitude,
+	// GPSLongitude and GPSTimeStamp, which are the tags this loop exists to show.
 	if imp.observer != nil && imp.observer.Debug() != nil {
-		for key, value := range exifData.Tags {
+		gpsKeys := make([]string, 0, len(exifData.Tags))
+		for key := range exifData.Tags {
 			if strings.Contains(strings.ToLower(key), "gps") {
-				imp.observer.Debug().LogDetail("image_metadata_preprocessor",
-					fmt.Sprintf("GPS tag found: %s = %s", key, value))
+				gpsKeys = append(gpsKeys, key)
 			}
+		}
+		sort.Strings(gpsKeys)
+		for _, key := range gpsKeys {
+			imp.observer.Debug().LogDetail("image_metadata_preprocessor",
+				fmt.Sprintf("GPS tag found: %s = [HIDDEN] (len=%d)", key, len(exifData.Tags[key])))
 		}
 	}
 
@@ -173,7 +185,7 @@ func (imp *ImageMetadataPreprocessor) formatImageMetadata(exifData *meta_extract
 
 			if imp.observer != nil && imp.observer.Debug() != nil {
 				imp.observer.Debug().LogDetail("image_metadata_preprocessor",
-					fmt.Sprintf("Consolidated GPS coordinates: %s", consolidatedGPS))
+					fmt.Sprintf("Consolidated GPS coordinates: [HIDDEN] (len=%d)", len(consolidatedGPS)))
 			}
 		}
 	}
@@ -401,18 +413,20 @@ func (imp *ImageMetadataPreprocessor) logSuccessfulProcessing(filePath string, e
 	imp.observer.Debug().LogDetail("image_metadata_preprocessor",
 		fmt.Sprintf("Successfully extracted %d metadata tags from %s image: %s", tagCount, ext, filepath.Base(filePath)))
 
-	// Log interesting metadata if present
-	if camera, exists := exifData.Tags["Make"]; exists {
-		if model, exists := exifData.Tags["Model"]; exists {
+	// Log the PRESENCE of interesting metadata, not its values: camera make/model
+	// is reported as a DEVICE_INFO finding and a coordinate is location PII, so
+	// neither may reach the log (BSC4).
+	if _, exists := exifData.Tags["Make"]; exists {
+		if _, exists := exifData.Tags["Model"]; exists {
 			imp.observer.Debug().LogDetail("image_metadata_preprocessor",
-				fmt.Sprintf("Camera info: %s %s", camera, model))
+				"Camera info present (Make + Model): [HIDDEN]")
 		}
 	}
 
-	if gpsLat, hasLat := exifData.Tags["GPSLatitudeDecimal"]; hasLat {
-		if gpsLong, hasLong := exifData.Tags["GPSLongitudeDecimal"]; hasLong {
+	if _, hasLat := exifData.Tags["GPSLatitudeDecimal"]; hasLat {
+		if _, hasLong := exifData.Tags["GPSLongitudeDecimal"]; hasLong {
 			imp.observer.Debug().LogDetail("image_metadata_preprocessor",
-				fmt.Sprintf("GPS coordinates found: %s, %s", gpsLat, gpsLong))
+				"GPS coordinates found: [HIDDEN]")
 		}
 	}
 }

--- a/internal/preprocessors/nopayload_log_test.go
+++ b/internal/preprocessors/nopayload_log_test.go
@@ -1,0 +1,175 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package preprocessors
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/observability"
+	audiolib "github.com/awslabs/ferret-scan/v2/internal/preprocessors/meta-extractors/meta-extract-audiolib"
+	exiflib "github.com/awslabs/ferret-scan/v2/internal/preprocessors/meta-extractors/meta-extract-exiflib"
+	pdflib "github.com/awslabs/ferret-scan/v2/internal/preprocessors/meta-extractors/meta-extract-pdflib"
+)
+
+// debugObserver returns an observer whose debug output lands in buf.
+func debugObserver(buf *bytes.Buffer) *observability.StandardObserver {
+	debugObs := observability.NewDebugObserver(buf)
+	observer := debugObs.StandardObserver
+	observer.DebugObserver = debugObs
+	return observer
+}
+
+// assertNoPayload fails for every sentinel found in the captured log.
+func assertNoPayload(t *testing.T, log *bytes.Buffer, sentinels, mustContain []string) {
+	t.Helper()
+	got := log.String()
+
+	// Non-vacuity: an empty log, or one that skipped the site under test, would
+	// pass the sentinel loop while proving nothing.
+	if log.Len() == 0 {
+		t.Fatal("no debug output captured, so this test cannot detect a leak")
+	}
+	for _, want := range mustContain {
+		if !strings.Contains(got, want) {
+			t.Errorf("log path %q was not exercised, so this test does not cover it.\n--- log ---\n%s", want, got)
+		}
+	}
+	for _, s := range sentinels {
+		if strings.Contains(got, s) {
+			t.Errorf("document content %q leaked into the observability log (BSC4).\n--- log ---\n%s", s, got)
+		}
+	}
+}
+
+// TestImageMetadataNoPayloadInDebugLog is the BSC4 gate for the image
+// preprocessor. Its GPS debug loop logged every GPS tag's VALUE — a coordinate
+// is location PII that the metadata validator reports as a finding, so scanning
+// a geotagged photo with --debug wrote the subject's location to stderr.
+//
+// The tags are set directly rather than extracted from a JPEG fixture: these are
+// in-package methods over a plain map, and validateFilePath rejects temp-dir
+// paths for some extractors anyway.
+func TestImageMetadataNoPayloadInDebugLog(t *testing.T) {
+	var log bytes.Buffer
+	imp := NewImageMetadataPreprocessor()
+	imp.SetObserver(debugObserver(&log))
+
+	exifData := &exiflib.ExifData{
+		FilePath: "nopayload.jpg",
+		Tags: map[string]string{
+			"GPSLatitudeDecimal":  "36.3506111",
+			"GPSLongitudeDecimal": "-94.2088333",
+			"GPSAltitude":         "313.7 metres",
+			"GPSLatitudeRef":      "N",
+			"GPSDateStamp":        "2026:07:04",
+			"Make":                "ZyxwvutCam",
+			"Model":               "Qwertyuiop X900",
+			"ImageDescription":    "patient 219-09-9996",
+		},
+	}
+
+	// formatImageMetadata deletes the consolidated GPS keys, so run the
+	// presence-only logger first while the tags are still there.
+	imp.logSuccessfulProcessing("nopayload.jpg", exifData)
+	imp.formatImageMetadata(exifData)
+
+	assertNoPayload(t, &log,
+		[]string{
+			"36.3506111", "94.2088333", "313.7", "2026:07:04",
+			"ZyxwvutCam", "Qwertyuiop", "219-09-9996",
+		},
+		[]string{
+			"GPS tag found: GPSAltitude",
+			"Consolidated GPS coordinates: [HIDDEN]",
+			"Camera info present",
+			"GPS coordinates found: [HIDDEN]",
+		})
+}
+
+// TestImageMetadataGPSLogOrderIsStable pins the determinism half of the same
+// fix: the GPS loop used to range the tag map directly, so the debug lines came
+// out in a different order on every run. Map iteration order is randomized per
+// range, so repeating the call is a real (if probabilistic) check.
+func TestImageMetadataGPSLogOrderIsStable(t *testing.T) {
+	tagsOf := func() map[string]string {
+		return map[string]string{
+			"GPSLatitudeRef":     "N",
+			"GPSLongitudeRef":    "W",
+			"GPSAltitude":        "313.7 metres",
+			"GPSDateStamp":       "2026:07:04",
+			"GPSImgDirection":    "12.5",
+			"GPSSpeed":           "0",
+			"GPSSpeedRef":        "K",
+			"GPSDestBearing":     "90",
+			"GPSInfoIFDPointer":  "878",
+			"GPSImgDirectionRef": "T",
+		}
+	}
+
+	var first string
+	for i := 0; i < 20; i++ {
+		var log bytes.Buffer
+		imp := NewImageMetadataPreprocessor()
+		imp.SetObserver(debugObserver(&log))
+		imp.formatImageMetadata(&exiflib.ExifData{FilePath: "x.jpg", Tags: tagsOf()})
+
+		var lines []string
+		for _, l := range strings.Split(log.String(), "\n") {
+			if strings.Contains(l, "GPS tag found:") {
+				lines = append(lines, l)
+			}
+		}
+		if len(lines) == 0 {
+			t.Fatal("no GPS tag lines logged, so this test cannot detect reordering")
+		}
+		joined := strings.Join(lines, "\n")
+		if i == 0 {
+			first = joined
+			continue
+		}
+		if joined != first {
+			t.Fatalf("GPS debug log order varies between runs (run %d):\n--- first ---\n%s\n--- run %d ---\n%s", i, first, i, joined)
+		}
+	}
+}
+
+// TestAudioMetadataNoPayloadInDebugLog is the BSC4 gate for the audio
+// preprocessor: Artist/Title/Album are document content the metadata validator
+// scans for PII (a personal name in an Artist tag is a finding).
+func TestAudioMetadataNoPayloadInDebugLog(t *testing.T) {
+	var log bytes.Buffer
+	amp := NewAudioMetadataPreprocessor()
+	amp.SetObserver(debugObserver(&log))
+
+	amp.logSuccessfulProcessing("nopayload.mp3", &audiolib.AudioMetadata{
+		Artist: "Zyxwvut Qwertyuiop",
+		Title:  "Interview with 219-09-9995",
+		Album:  "Acmehealthcorp Sessions",
+		Year:   2026,
+	})
+
+	assertNoPayload(t, &log,
+		[]string{"Zyxwvut", "Qwertyuiop", "219-09-9995", "Acmehealthcorp"},
+		[]string{"Track info found: artist [HIDDEN]", "Album info: [HIDDEN]"})
+}
+
+// TestPDFMetadataNoPayloadInDebugLog is the BSC4 gate for the PDF preprocessor:
+// Producer strings routinely carry internal tool and host names.
+func TestPDFMetadataNoPayloadInDebugLog(t *testing.T) {
+	var log bytes.Buffer
+	pmp := NewPDFMetadataPreprocessor()
+	pmp.SetObserver(debugObserver(&log))
+
+	pmp.buildPDFMetadataText(&pdflib.Metadata{
+		Producer:   "ZyxwvutPDF 9.1 on qwertyuiop-build01.corp.internal",
+		Title:      "Chart",
+		Properties: map[string]string{},
+	})
+
+	assertNoPayload(t, &log,
+		[]string{"ZyxwvutPDF", "qwertyuiop-build01", "corp.internal"},
+		[]string{"Adding Producer to metadata content: [HIDDEN]"})
+}

--- a/internal/preprocessors/pdf_metadata_preprocessor.go
+++ b/internal/preprocessors/pdf_metadata_preprocessor.go
@@ -189,10 +189,12 @@ func (pmp *PDFMetadataPreprocessor) buildPDFMetadataText(meta *metaextractpdflib
 	metadataText.WriteString(formatter.FormatMetadataField("Keywords", meta.Keywords))
 	metadataText.WriteString(formatter.FormatMetadataField("Creator", meta.Creator))
 
-	// Producer field with debug logging
+	// Producer field with debug logging. The value is document metadata that the
+	// metadata validator scans (Producer strings carry internal tool and host
+	// names), so log only its length (BSC4).
 	if meta.Producer != "" {
 		metadataText.WriteString(formatter.FormatMetadataField("Producer", meta.Producer))
-		pmp.LogDebugInfo(fmt.Sprintf("Adding Producer to metadata content: %s", meta.Producer))
+		pmp.LogDebugInfo(fmt.Sprintf("Adding Producer to metadata content: [HIDDEN] (len=%d)", len(meta.Producer)))
 	}
 
 	// Dates

--- a/internal/redactors/plaintext/nopayload_log_test.go
+++ b/internal/redactors/plaintext/nopayload_log_test.go
@@ -1,0 +1,98 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package plaintext
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/observability"
+	"github.com/awslabs/ferret-scan/v2/internal/redactors"
+)
+
+// TestNoPayloadInRedactionLog is the BSC4 gate for the plaintext redactor: no
+// byte of the content being redacted may reach the observability log.
+//
+// This leak had a different shape from the validator ones — the value was not
+// interpolated into a debug string but placed in STRUCTURED event metadata
+// ("match_text"), so a keyword sweep for format specifiers missed it entirely.
+// It was also the worst-placed instance: the redactor sees every confirmed
+// finding, so scanning with --enable-redaction --debug wrote each SSN, card and
+// email in cleartext to stderr, one line per redaction, at the exact moment the
+// tool was masking them in the output file.
+//
+// The assertion is on the INPUT bytes rather than on a field name, so it also
+// fails for a leak introduced at a site that does not exist yet.
+func TestNoPayloadInRedactionLog(t *testing.T) {
+	content := strings.Join([]string{
+		"Patient ssn 219-09-9993 seen on Monday.",
+		"Card 5500-0000-0000-0004 charged.",
+		"Mail nobody@acmehealthcorp.example for records.",
+	}, "\n")
+
+	matches := []detector.Match{
+		{Text: "219-09-9993", Type: "SSN", LineNumber: 1, Confidence: 90, Validator: "ssn"},
+		{Text: "5500-0000-0000-0004", Type: "MASTERCARD", LineNumber: 2, Confidence: 95, Validator: "creditcard"},
+		{Text: "nobody@acmehealthcorp.example", Type: "BUSINESS", LineNumber: 3, Confidence: 45, Validator: "email"},
+	}
+
+	sentinels := []string{
+		"219-09-9993",
+		"5500-0000-0000-0004",
+		"nobody@acmehealthcorp.example",
+		"acmehealthcorp",
+		"Patient",
+	}
+
+	for _, strategy := range []redactors.RedactionStrategy{
+		redactors.RedactionSimple,
+		redactors.RedactionFormatPreserving,
+		redactors.RedactionSynthetic,
+	} {
+		t.Run(strategy.String(), func(t *testing.T) {
+			var log bytes.Buffer
+			debugObs := observability.NewDebugObserver(&log)
+			observer := debugObs.StandardObserver
+			observer.DebugObserver = debugObs
+
+			ptr := NewPlainTextRedactor(nil, observer)
+
+			redacted, mappings, err := ptr.RedactString(content, matches, strategy)
+			if err != nil {
+				t.Fatalf("RedactString error: %v", err)
+			}
+
+			// Non-vacuity, part 1: redaction must actually have happened, or the
+			// log would be empty and the sentinel loop would prove nothing.
+			if len(mappings) != len(matches) {
+				t.Fatalf("redacted %d of %d matches; the log would not cover every path", len(mappings), len(matches))
+			}
+			for _, s := range []string{"219-09-9993", "5500-0000-0000-0004", "nobody@acmehealthcorp.example"} {
+				if strings.Contains(redacted, s) {
+					t.Errorf("value %q survived redaction in the output", s)
+				}
+			}
+
+			got := log.String()
+
+			// Non-vacuity, part 2: the events under test must be present.
+			if log.Len() == 0 {
+				t.Fatal("no observability output captured, so this test cannot detect a leak")
+			}
+			for _, want := range []string{"position_correlation", "redaction_applied"} {
+				if !strings.Contains(got, want) {
+					t.Errorf("event %q was not emitted, so this test does not cover it.\n--- log ---\n%s", want, got)
+				}
+			}
+
+			for _, s := range sentinels {
+				if strings.Contains(got, s) {
+					t.Errorf("document content %q leaked into the observability log (BSC4).\n--- log ---\n%s", s, got)
+				}
+			}
+		})
+	}
+}

--- a/internal/redactors/plaintext/redactor.go
+++ b/internal/redactors/plaintext/redactor.go
@@ -242,8 +242,13 @@ func (ptr *PlainTextRedactor) redactText(originalText string, matches []detector
 				confidence = correlatedPos.ConfidenceScore
 				correlationUsed = true
 
+				// The match's own bytes are the sensitive value being redacted, so
+				// they must not reach the log (BSC4) — the line, span and length
+				// locate it precisely without disclosing it, which is what the
+				// sibling match_skip event below already does.
 				ptr.logEvent("position_correlation_success", true, map[string]interface{}{
-					"match_text":         match.Text,
+					"match_line":         match.LineNumber,
+					"match_length":       len(match.Text),
 					"match_type":         match.Type,
 					"confidence":         confidence,
 					"correlation_method": correlatedPos.Method.String(),
@@ -253,7 +258,8 @@ func (ptr *PlainTextRedactor) redactText(originalText string, matches []detector
 			} else {
 				// Log correlation failure
 				logData := map[string]interface{}{
-					"match_text":       match.Text,
+					"match_line":       match.LineNumber,
+					"match_length":     len(match.Text),
 					"match_type":       match.Type,
 					"error":            correlationErr,
 					"threshold":        ptr.confidenceThreshold,
@@ -296,9 +302,10 @@ func (ptr *PlainTextRedactor) redactText(originalText string, matches []detector
 			if err != nil {
 				// Log warning but continue with other matches
 				ptr.logEvent("position_warning", false, map[string]interface{}{
-					"warning":    err.Error(),
-					"match_text": match.Text,
-					"match_type": match.Type,
+					"warning":      err.Error(),
+					"match_line":   match.LineNumber,
+					"match_length": len(match.Text),
+					"match_type":   match.Type,
 				})
 				continue
 			}

--- a/internal/validators/cloudresources/cloudresources.go
+++ b/internal/validators/cloudresources/cloudresources.go
@@ -254,7 +254,9 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 
 		// Public-by-design resources are not sensitive; drop them outright.
 		if isPublicResource(text) {
-			v.logDetail(fmt.Sprintf("Match filtered (public-by-design resource): %q", text))
+			// The resource type is tool-owned; the text is document content and
+			// must not reach the log (BSC4).
+			v.logDetail(fmt.Sprintf("Match filtered (public-by-design resource): %s [HIDDEN] (len=%d)", resourceType, len(text)))
 			continue
 		}
 
@@ -276,7 +278,7 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 			} else {
 				suppressedLowConf++
 			}
-			v.logDetail(fmt.Sprintf("Match filtered (confidence %.1f%% < %.0f): %q", confidence, acceptThreshold, text))
+			v.logDetail(fmt.Sprintf("Match filtered (confidence %.1f%% < %.0f): %s [HIDDEN] (len=%d)", confidence, acceptThreshold, resourceType, len(text)))
 			continue
 		}
 

--- a/internal/validators/cloudresources/nopayload_log_test.go
+++ b/internal/validators/cloudresources/nopayload_log_test.go
@@ -1,0 +1,78 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudresources
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/observability"
+)
+
+// TestNoPayloadInDebugLog is the BSC4 gate for this validator: no byte of the
+// scanned document may reach the observability log.
+//
+// This validator's own README documents [HIDDEN] as the convention, yet both
+// filter paths logged the raw matched identifier — which for an ARN embeds the
+// bucket or role name, and for a subscription ID the GUID itself, i.e. the exact
+// values the finding exists to protect.
+//
+// The assertion is on the INPUT bytes rather than on a list of known-bad format
+// strings, so it also fails for a leak introduced at a site that does not exist
+// yet.
+func TestNoPayloadInDebugLog(t *testing.T) {
+	// Line 1 trips the public-by-design filter (a published GCP dataset project);
+	// line 2 scores under the accept floor via the same-line test keyword.
+	content := strings.Join([]string{
+		"net: projects/bigquery-public-data/global/networks/qwertyuiop",
+		"# example: arn:aws:s3:::zyxwvutqwerty-private-bucket/keypath",
+	}, "\n")
+
+	// Every distinctive substring of the input. A filtered match is still
+	// document content, so the bucket and project names must not appear.
+	sentinels := []string{
+		"bigquery-public-data",
+		"qwertyuiop",
+		"zyxwvutqwerty-private-bucket",
+		"keypath",
+		"arn:aws:s3:::",
+		"projects/",
+	}
+
+	var log bytes.Buffer
+	debugObs := observability.NewDebugObserver(&log)
+	observer := debugObs.StandardObserver
+	observer.DebugObserver = debugObs
+
+	v := NewValidator()
+	v.SetObserver(observer)
+
+	if _, err := v.ValidateContent(content, "nopayload.txt"); err != nil {
+		t.Fatalf("ValidateContent error: %v", err)
+	}
+
+	got := log.String()
+
+	// Non-vacuity: an empty log, or one that never reached a filter path, would
+	// pass the sentinel loop below while proving nothing. Both filter sites are
+	// asserted individually because they were fixed independently.
+	if log.Len() == 0 {
+		t.Fatal("no debug output captured, so this test cannot detect a leak")
+	}
+	for _, want := range []string{
+		"Match filtered (public-by-design resource)",
+		"Match filtered (confidence",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("filter path %q was not exercised, so this test does not cover it.\n--- log ---\n%s", want, got)
+		}
+	}
+
+	for _, s := range sentinels {
+		if strings.Contains(got, s) {
+			t.Errorf("document content %q leaked into the observability log (BSC4).\n--- log ---\n%s", s, got)
+		}
+	}
+}

--- a/internal/validators/intellectualproperty/nopayload_log_test.go
+++ b/internal/validators/intellectualproperty/nopayload_log_test.go
@@ -1,0 +1,76 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package intellectualproperty
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/observability"
+)
+
+// TestNoPayloadInDebugLog is the BSC4 gate for this validator: no byte of the
+// scanned document may reach the observability log.
+//
+// PR #123 masked the one stderr site but left three untouched: the legal-notice
+// and reconstruction analyses logged every match's raw text, and the
+// reconstructed text is a concatenation spanning the surrounding content.
+//
+// The assertion is on the INPUT bytes rather than on a list of known-bad format
+// strings, so it also fails for a leak introduced at a site that does not exist
+// yet.
+func TestNoPayloadInDebugLog(t *testing.T) {
+	// A legal notice dense enough to trigger reconstruction, carrying bystander
+	// values that must not be logged even though this validator never reports
+	// them.
+	content := strings.Join([]string{
+		"CONFIDENTIAL AND PROPRIETARY - Copyright (c) 2026 Zyxwvut Holdings Ltd.",
+		"All Rights Reserved. Contact ssn 219-09-9997 for licensing.",
+		"Trade Secret: the Qwertyuiop process must not be disclosed.",
+	}, "\n")
+
+	sentinels := []string{
+		"219-09-9997",
+		"Zyxwvut",
+		"Qwertyuiop",
+		"CONFIDENTIAL AND PROPRIETARY",
+		"All Rights Reserved",
+		"Trade Secret",
+	}
+
+	var log bytes.Buffer
+	debugObs := observability.NewDebugObserver(&log)
+	observer := debugObs.StandardObserver
+	observer.DebugObserver = debugObs
+
+	v := NewValidator()
+	v.SetObserver(observer)
+
+	if _, err := v.ValidateContent(content, "nopayload.txt"); err != nil {
+		t.Fatalf("ValidateContent error: %v", err)
+	}
+
+	got := log.String()
+
+	// Non-vacuity: an empty log, or one that never reached the analysis paths,
+	// would pass the sentinel loop below while proving nothing.
+	if log.Len() == 0 {
+		t.Fatal("no debug output captured, so this test cannot detect a leak")
+	}
+	for _, want := range []string{
+		"Legal notice analysis for",
+		"Match 1: [HIDDEN]",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("log path %q was not exercised, so this test does not cover it.\n--- log ---\n%s", want, got)
+		}
+	}
+
+	for _, s := range sentinels {
+		if strings.Contains(got, s) {
+			t.Errorf("document content %q leaked into the observability log (BSC4).\n--- log ---\n%s", s, got)
+		}
+	}
+}

--- a/internal/validators/intellectualproperty/validator.go
+++ b/internal/validators/intellectualproperty/validator.go
@@ -3103,8 +3103,9 @@ func (v *Validator) logReconstructionDetails(originalMatches []detector.Match, r
 	v.observer.Debug().LogDetail("intellectualproperty",
 		fmt.Sprintf("  Original matches: %d", len(originalMatches)))
 
+	// The reconstructed text is document content (BSC4: never log matched values).
 	v.observer.Debug().LogDetail("intellectualproperty",
-		fmt.Sprintf("  Reconstructed text: '%s'", reconstructedMatch.Text))
+		fmt.Sprintf("  Reconstructed text: [HIDDEN] (len=%d)", len(reconstructedMatch.Text)))
 
 	v.observer.Debug().LogDetail("intellectualproperty",
 		fmt.Sprintf("  Final confidence: %.1f%%", reconstructedMatch.Confidence))
@@ -3152,8 +3153,8 @@ func (v *Validator) logReconstructionDetails(originalMatches []detector.Match, r
 			}
 		}
 		v.observer.Debug().LogDetail("intellectualproperty",
-			fmt.Sprintf("    Match %d: '%s' (type: %s, confidence: %.1f%%, line: %d)",
-				i+1, match.Text, ipType, match.Confidence, match.LineNumber))
+			fmt.Sprintf("    Match %d: [HIDDEN] (len=%d) (type: %s, confidence: %.1f%%, line: %d)",
+				i+1, len(match.Text), ipType, match.Confidence, match.LineNumber))
 	}
 
 	// Also log to stderr in debug mode for comprehensive audit trail
@@ -3211,8 +3212,8 @@ func (v *Validator) logLegalNoticeAnalysis(matches []detector.Match, analysis Le
 			}
 		}
 		v.observer.Debug().LogDetail("intellectualproperty",
-			fmt.Sprintf("  Match %d: '%s' (type: %s, line: %d, confidence: %.1f%%, position: %d)",
-				i+1, match.Text, ipType, match.LineNumber, match.Confidence, v.calculateCharacterPosition(match)))
+			fmt.Sprintf("  Match %d: [HIDDEN] (len=%d) (type: %s, line: %d, confidence: %.1f%%, position: %d)",
+				i+1, len(match.Text), ipType, match.LineNumber, match.Confidence, v.calculateCharacterPosition(match)))
 	}
 
 	// Log decision tree reasoning

--- a/internal/validators/socialmedia/nopayload_log_test.go
+++ b/internal/validators/socialmedia/nopayload_log_test.go
@@ -1,0 +1,92 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package socialmedia
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/observability"
+)
+
+// TestNoPayloadInDebugLog is the BSC4 gate for this validator: no byte of the
+// scanned document may reach the observability log.
+//
+// PR #123 masked the raw matched value at six sites but left a second, worse
+// shape untouched — the @handle false-positive filters logged the match AND the
+// whole source LINE. Because the line is arbitrary document content, an
+// unrelated SSN and card number sitting beside a filtered handle went straight
+// to the log, from a validator that reported no finding at all.
+//
+// This test asserts on the INPUT bytes rather than on a list of known-bad format
+// strings, so it also fails for a leak introduced at a site that does not exist
+// yet. It runs a configured validator (a bare NewValidator has no patterns and
+// would reach none of these paths) and drives every @handle filter branch.
+func TestNoPayloadInDebugLog(t *testing.T) {
+	// Each line trips a different filter — email domain, doc annotation, code
+	// comment, invalid handle format, partial domain — while carrying a bystander
+	// value that must not be logged.
+	lines := []string{
+		"Patient @acmehealthcorp SSN 219-09-9999 mail a@acmehealthcorp.com",
+		"// @param see card 5500-0000-0000-0004 for details",
+		"@1nvalid handle beside SSN 219-09-9998",
+		"contact @mycompany.com about card 4111-1111-1111-1111",
+		"Follow https://twitter.com/zyxwvutqwerty and https://linkedin.com/in/zyxwvut-qwerty",
+	}
+	content := strings.Join(lines, "\n")
+
+	// Every distinctive substring of the input. Includes the handles and profile
+	// URLs themselves: a filtered handle is still document content, and a
+	// detected one belongs in the finding, not the log (--show-match is a
+	// formatter-layer decision).
+	sentinels := []string{
+		"219-09-9999",
+		"219-09-9998",
+		"5500-0000-0000-0004",
+		"4111-1111-1111-1111",
+		"acmehealthcorp",
+		"mycompany",
+		"1nvalid",
+		"zyxwvutqwerty",
+		"zyxwvut-qwerty",
+	}
+
+	var log bytes.Buffer
+	debugObs := observability.NewDebugObserver(&log)
+	observer := debugObs.StandardObserver
+	observer.DebugObserver = debugObs
+
+	v := newConfiguredValidator()
+	v.SetObserver(observer)
+
+	if _, err := v.ValidateContent(content, "nopayload.txt"); err != nil {
+		t.Fatalf("ValidateContent error: %v", err)
+	}
+
+	got := log.String()
+
+	// Non-vacuity: the filters must actually have run and logged, or an empty log
+	// would pass this test while proving nothing. Assert both that there is
+	// output and that the specific filter paths under test were exercised.
+	if log.Len() == 0 {
+		t.Fatal("no debug output captured, so this test cannot detect a leak")
+	}
+	for _, want := range []string{
+		"is part of an email address",
+		"Filtered documentation annotation",
+		"Filtered invalid handle format",
+		"Filtered partial domain match",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("filter path %q was not exercised, so this test does not cover it.\n--- log ---\n%s", want, got)
+		}
+	}
+
+	for _, s := range sentinels {
+		if strings.Contains(got, s) {
+			t.Errorf("document content %q leaked into the observability log (BSC4).\n--- log ---\n%s", s, got)
+		}
+	}
+}

--- a/internal/validators/socialmedia/validator.go
+++ b/internal/validators/socialmedia/validator.go
@@ -4647,8 +4647,10 @@ func (v *Validator) logClusteringAnalysis(matches []detector.Match, analysis Soc
 		fmt.Sprintf("  Proximity Score: %.2f", analysis.ProximityScore))
 	v.observer.Debug().LogDetail("socialmedia",
 		fmt.Sprintf("  Platforms: %v", analysis.PlatformGrouping))
+	// UserIdentifiers holds usernames extracted from the document, so only the
+	// count may be logged (BSC4).
 	v.observer.Debug().LogDetail("socialmedia",
-		fmt.Sprintf("  User Identifiers: %v", analysis.UserIdentifiers))
+		fmt.Sprintf("  User Identifiers: %d [HIDDEN]", len(analysis.UserIdentifiers)))
 	v.observer.Debug().LogDetail("socialmedia",
 		fmt.Sprintf("  Should Reconstruct: %t", analysis.ShouldReconstruct))
 	v.observer.Debug().LogDetail("socialmedia",
@@ -4742,11 +4744,13 @@ func (v *Validator) isPartOfEmailAddress(match, line string) bool {
 
 	// If we find a complete email address that contains our match, it's a false positive
 	if emailRegex.MatchString(line) {
-		// Log the filtering for debugging
+		// Log the filtering for debugging. Neither the handle nor the line may be
+		// logged (BSC4): the line is whole-document content and routinely carries
+		// other sensitive values. The reason plus lengths is enough to debug.
 		if v.observer != nil && v.observer.Debug() != nil {
 			v.observer.Debug().LogDetail("socialmedia",
-				fmt.Sprintf("Filtered social media false positive: '%s' is part of email address in line: %s",
-					match, line))
+				fmt.Sprintf("Filtered social media false positive: handle [HIDDEN] (len=%d) is part of an email address in line [HIDDEN] (len=%d)",
+					len(match), len(line)))
 		}
 		return true
 	}
@@ -4777,9 +4781,13 @@ func (v *Validator) isFalsePositiveHandle(match, line string, matchOffset int) b
 	usernameLower := strings.ToLower(username)
 	for _, pattern := range docPatterns {
 		if usernameLower == pattern {
+			// The annotation keyword comes from the tool-owned docPatterns list
+			// above, not from the document, so naming it discloses nothing. The
+			// match and the line must still be masked (BSC4).
 			if v.observer != nil && v.observer.Debug() != nil {
 				v.observer.Debug().LogDetail("socialmedia",
-					fmt.Sprintf("Filtered documentation annotation: '%s' in line: %s", match, line))
+					fmt.Sprintf("Filtered documentation annotation %q: handle [HIDDEN] (len=%d) in line [HIDDEN] (len=%d)",
+						pattern, len(match), len(line)))
 			}
 			return true
 		}
@@ -4789,7 +4797,8 @@ func (v *Validator) isFalsePositiveHandle(match, line string, matchOffset int) b
 	if strings.Contains(lineLower, "//") || strings.Contains(lineLower, "/*") || strings.Contains(lineLower, "*/") {
 		if v.observer != nil && v.observer.Debug() != nil {
 			v.observer.Debug().LogDetail("socialmedia",
-				fmt.Sprintf("Filtered code comment annotation: '%s' in line: %s", match, line))
+				fmt.Sprintf("Filtered code comment annotation: handle [HIDDEN] (len=%d) in line [HIDDEN] (len=%d)",
+					len(match), len(line)))
 		}
 		return true
 	}
@@ -4799,7 +4808,8 @@ func (v *Validator) isFalsePositiveHandle(match, line string, matchOffset int) b
 	if len(username) < 2 || strings.HasPrefix(username, "_") || regexp.MustCompile(`^\d`).MatchString(username) {
 		if v.observer != nil && v.observer.Debug() != nil {
 			v.observer.Debug().LogDetail("socialmedia",
-				fmt.Sprintf("Filtered invalid handle format: '%s' in line: %s", match, line))
+				fmt.Sprintf("Filtered invalid handle format: handle [HIDDEN] (len=%d) in line [HIDDEN] (len=%d)",
+					len(match), len(line)))
 		}
 		return true
 	}
@@ -4812,7 +4822,8 @@ func (v *Validator) isFalsePositiveHandle(match, line string, matchOffset int) b
 		if nextChar == '-' || nextChar == '.' {
 			if v.observer != nil && v.observer.Debug() != nil {
 				v.observer.Debug().LogDetail("socialmedia",
-					fmt.Sprintf("Filtered partial domain match: '%s' in line: %s", match, line))
+					fmt.Sprintf("Filtered partial domain match (followed by %q): handle [HIDDEN] (len=%d) in line [HIDDEN] (len=%d)",
+						string(nextChar), len(match), len(line)))
 			}
 			return true
 		}


### PR DESCRIPTION
## Problem

PR #123 masked the raw matched value at six sites. A systematic sweep of every log call in the tree found **15 more**, in three shapes it missed.

**Shape 1 — logs the whole source LINE, not just the match.** The five `SOCIAL_MEDIA` `@handle` false-positive filters logged both the handle *and* the entire line it sat on. The line is arbitrary document content, so an unrelated SSN or card number sitting beside a filtered handle went to the log — from a validator that reported **no finding at all**.

**Shape 2 — raw value in STRUCTURED event metadata, invisible to a format-specifier sweep.** The plaintext redactor put `match.Text` in a `"match_text"` metadata field. This is the worst-placed instance: the redactor sees *every confirmed finding*, so `--enable-redaction --debug` wrote each SSN, card and email in cleartext to stderr **at the exact moment the tool was masking them in the output file**. Its own sibling `match_skip` event already logged `match_line` instead, so the fix follows a convention that was already in the file.

**Shape 3 — media metadata values.** GPS coordinates (location PII, and a reported finding), camera make/model, audio Artist/Title/Album, PDF Producer.

## Sites fixed (15)

| Component | Sites |
|---|---|
| `socialmedia` | 5 `@handle` filters (match + full line) + clustering log (usernames extracted from the document) |
| `intellectualproperty` | reconstruction text + 2 per-match analysis loops |
| `cloudresources` | 2 filter paths — in a validator whose **own README documents `[HIDDEN]`** as the convention |
| `redactors/plaintext` | 3 structured-metadata sites |
| image preprocessor | GPS tag values, consolidated coordinates, camera make/model |
| audio preprocessor | Artist / Title / Album |
| pdf preprocessor | Producer (carries internal tool and host names) |

## Masking rule: tool-owned stays, document-owned goes

Blanket-masking would have destroyed debuggability. A keyword from a hardcoded `docPatterns` list, a `resourceType`, or the `nextChar` that triggered a veto discloses nothing about the document and is what makes the log useful — those stay. Anything derived from the scanned bytes becomes `[HIDDEN] (len=N)`.

## Determinism fix (bundled)

The image GPS loop ranged `exifData.Tags` directly, emitting its debug lines in a different order every run. Now uses a local sorted key slice — deliberately **not** `ExifData.GetSortedKeys()`, which excludes `GPSLatitude`, `GPSLongitude` and `GPSTimeStamp`, the very tags this loop exists to show. (Near-miss caught while writing it; there's a comment saying why.)

## Tests

A `TestNoPayloadInDebugLog` gate per package, each asserting on the **input bytes** rather than on a list of known-bad format strings — so each also fails for a leak introduced at a site that does not exist yet. Every gate has a non-vacuity floor (log must be non-empty **and** the specific filter path must appear in it), plus a determinism guard that repeats the GPS loop 20 times.

Proven to fail on the parent commit:

| Package | Leak assertions on parent |
|---|---|
| socialmedia | 9 |
| intellectualproperty | 2 |
| cloudresources | 6 |
| preprocessors | 13 (+ determinism guard trips) |
| redactors/plaintext | 12 (4 sentinels x 3 strategies) |

**The harness had to be per-package.** `core.ScanFile`/`ScanContent` never wire validator observers — `SetObserver` is called only from `cmd/main.go`, hardcoded to `os.Stderr`. A `ScanConfig.LogWriter` test captures bridge/router lines only and **passes vacuously**; I wrote one first, found it green on the parent too, and deleted it. `scanner.go`'s `LogWriter` doc claimed to be the chokepoint that makes no-payload-bytes "enforceable rather than aspirational" — it is not, and now says so, pointing at the gates that actually enforce it.

`pkg/redact` — the only external-importable API — **never leaked**, verified on the parent: it passes a nil observer to the redactor and wires validators only through the bridge. So the blast radius is CLI `--debug` only.

## Verification (TEST_PLAN)

- Full suite `rc=0` offline; `-race` clean on all touched packages
- Golden corpus regenerates with **zero diff** (240 fixtures x 7 formats + redaction)
- Complexity guards pass; **no timing regression** — 0.166s -> 0.143s on a 428 KB dense file (masking avoids stringifying the match)
- **End-to-end through the real CLI:** the shipped binary writes 7 sentinel occurrences of document content to stderr; the fixed binary writes **0**, with identical findings
- **Redaction:** all 3 strategies — output files and audit log byte-identical to parent; debug log now clean
- **Suppression:** generate + apply (disabled and enabled) clean; `match_text_hash` already hashed
- **All 7 output formats:** payload-free on stderr, while `--show-match` still reveals on stdout as designed
- Determinism: 10 repeat runs, only `duration_seconds` varies
- gosec: the 4 `G104` findings in the touched redactor file pre-exist (unrelated `os.Chmod`)

## Ordering

**This must land before any fix to the RE2-invalid `@handle` regex at `config.yaml:343`.** That regex is what gates the five socialmedia filter sites — fixing it first would *activate* the leak. Verified conflict-free against #207, #208 and #209 in any merge order.