### PR TITLE
test(complexity): assert the guard measured something before trusting its timing

### DIFF
--- a/internal/goldencorpus/complexity_generators_test.go
+++ b/internal/goldencorpus/complexity_generators_test.go
@@ -1,0 +1,204 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package goldencorpus
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/config"
+	"github.com/awslabs/ferret-scan/v2/internal/validators/socialmedia"
+)
+
+// Distinct-value generators for the complexity guard.
+//
+// WHY THESE EXIST. The guard scales its input by repeating a unit and comparing
+// runtime at two sizes. If the unit is repeated VERBATIM, every validator that
+// dedups candidates collapses the repeats: the match count stays flat as the
+// input grows, so the per-match work never grows either — and a per-match
+// quadratic measures as linear and PASSES.
+//
+// That is not hypothetical. The dob subtest reported normal growth on a 4x input
+// while the validator was in fact quadratic: 22s on a 64KB single line, ~4x per
+// doubling. Its unit held four dates, extractDates dedups per line, so the
+// subtest compared 4 matches against 4 matches. Two more subtests (ipaddress,
+// socialmedia) matched NOTHING at all and timed a reject path.
+//
+// Rules for anything added here:
+//
+//  1. Emit a DISTINCT value per index. Distinctness is what makes the match count
+//     grow with the input, which is what the timing is supposed to be a function of.
+//  2. Do not let the value space WRAP within the sizes used. A wrapped generator
+//     silently caps the match count at large n, which understates growth exactly
+//     where a quadratic would show up.
+//  3. Emit values that actually MATCH. Every generator here is covered by
+//     TestComplexityGeneratorsAreNonVacuous below, which is the standing check
+//     that a validator change has not quietly turned a subtest into a no-op.
+//  4. Avoid values the validator suppresses for reasons unrelated to the value
+//     itself. See genPersonName for a concrete trap.
+
+// genPublicIP emits distinct ROUTABLE addresses.
+//
+// The previous static unit used 203.0.113.42 (TEST-NET-3), 10.0.0.5 and
+// 192.168.1.1 (RFC1918) and 8.8.8.8 (well-known resolver) — all four vetoed, so
+// the subtest produced zero matches. These two /16s are ordinary public space
+// that survives the vetoes. Both octets are bounded to 251 so no generated octet
+// can reach 255 and form a broadcast-looking address.
+func genPublicIP(i int) string {
+	return fmt.Sprintf("ip 172.217.%d.%d host 151.101.%d.%d ",
+		i%256, (i/256)%251, (i*7)%256, (i*13)%251)
+}
+
+// genPhone emits distinct numbers inside the reserved 555-01xx range so the
+// values cannot correspond to a real subscriber. 10,000 distinct per prefix is
+// far above the repetition counts used here.
+func genPhone(i int) string {
+	return fmt.Sprintf("call 212-555-%04d or 415-555-%04d ", i%10000, (i*3)%10000)
+}
+
+// genDOB emits distinct plausible dates of birth, each with an explicit label so
+// the keyword-gated context path (the O(n^2)-prone one) is exercised rather than
+// short-circuited. 12 x 28 x 110 is ~37k distinct dates, well above the sizes
+// used, so the value space does not wrap.
+func genDOB(i int) string {
+	return fmt.Sprintf("date of birth %02d/%02d/%04d ", 1+i%12, 1+i%28, 1900+i%110)
+}
+
+// genIntellectualProperty emits a distinct legal-notice line per index. This
+// validator consolidates its candidates into one aggregate finding, so the
+// target asserts a floor of 1 rather than match growth; the distinct indices
+// still make the CANDIDATE count (the thing whose per-item cost is under test)
+// grow with the input.
+func genIntellectualProperty(i int) string {
+	return fmt.Sprintf("Copyright %d Acme%d. Confidential and Proprietary. Trade Secret %d. ",
+		1990+i%40, i, i)
+}
+
+// genSocialMediaProfile emits distinct profile URLs, one per line.
+//
+// Two measured constraints shape this:
+//
+//   - "@handle" text does NOT match. The shipped config's handle pattern is PCRE
+//     and RE2 rejects it, so it is dropped silently; only the URL patterns fire.
+//     A generator built on "@alice" would be vacuous.
+//   - One per line, and both measured sizes above maxClusterMatches. On a single
+//     line the clustering stage is O(M^2), and it is SKIPPED above that cap — so
+//     an input straddling the cap measured the big size as FASTER than the base
+//     (226ms at 400 matches vs 213ms at 1600), which is a meaningless ratio.
+func genSocialMediaProfile(i int) string {
+	return fmt.Sprintf("follow twitter.com/user%d on socials\n", i)
+}
+
+// pnFirst and pnLast are literal name lists rather than draws from the embedded
+// name database, and they deliberately EXCLUDE surnames that double as place
+// words ("Lake", "River", "Brooks", "Ford", "Hill").
+//
+// The trap: personname applies its geographic/business/product context penalties
+// LINE-GLOBALLY. One surname that is also a geo word contributes -35 to every
+// other name on that line, and the total clamps at -50, which is enough to push
+// a solid two-token name from 92 below the 50 emit threshold. Drawing names from
+// the database produced 1164 findings at one size and ZERO at the next (the
+// added surname was "Lake") — a generator that goes vacuous precisely as it
+// scales. 60 x 60 = 3600 distinct combinations, above the sizes used here.
+var pnFirst = []string{
+	"Aaron", "Abigail", "Adam", "Adrian", "Alan", "Albert", "Alexis", "Alfred",
+	"Amanda", "Amber", "Andrea", "Angela", "Anita", "Anthony", "Arthur", "Ashley",
+	"Barbara", "Benjamin", "Bernard", "Beverly", "Bradley", "Brenda", "Brian", "Bruce",
+	"Carl", "Carmen", "Carol", "Catherine", "Cecil", "Charles", "Cheryl", "Christina",
+	"Clara", "Clifford", "Colleen", "Craig", "Crystal", "Curtis", "Cynthia", "Dale",
+	"Daniel", "Darlene", "David", "Dawn", "Deborah", "Dennis", "Diana", "Dolores",
+	"Donald", "Doris", "Dorothy", "Douglas", "Duane", "Dustin", "Earl", "Edith",
+	"Edward", "Eileen", "Elaine", "Eleanor",
+}
+
+var pnLast = []string{
+	"Abbott", "Acosta", "Adkins", "Aguilar", "Albright", "Alvarez", "Anderson", "Andrews",
+	"Archer", "Arnold", "Ashby", "Atkinson", "Ayers", "Bagley", "Bailey", "Baldwin",
+	"Ballard", "Barker", "Barnett", "Barrett", "Bartlett", "Bass", "Bateman", "Bauer",
+	"Beasley", "Bennett", "Benson", "Bergeron", "Bishop", "Blackwell", "Blair", "Blevins",
+	"Bolton", "Bond", "Booker", "Boone", "Bowden", "Bowman", "Boyer", "Bradshaw",
+	"Brady", "Brennan", "Briggs", "Bryant", "Buckley", "Burgess", "Burnett", "Burton",
+	"Bush", "Butler", "Byrd", "Cabrera", "Cahill", "Cain", "Caldwell", "Calhoun",
+	"Callahan", "Cameron", "Campos", "Cantrell",
+}
+
+// genPersonName emits a distinct first+last pair per index. The index arithmetic
+// advances both components so consecutive repetitions do not share a surname.
+func genPersonName(i int) string {
+	return fmt.Sprintf("contact %s %s and ",
+		pnFirst[i%len(pnFirst)], pnLast[(i/len(pnFirst)+i)%len(pnLast)])
+}
+
+// newConfiguredSocialMedia returns a socialmedia validator with the shipped
+// patterns loaded.
+//
+// SOCIAL_MEDIA is config-gated: a bare NewValidator leaves patternsConfigured
+// false and ValidateContent returns an empty slice immediately. The complexity
+// subtest was therefore timing that early return — a no-op that could not fail
+// no matter how the scanning code changed.
+func newConfiguredSocialMedia() validatorUnderTest {
+	v := socialmedia.NewValidator()
+	if cfg, err := config.LoadConfig(repoConfigPath); err == nil {
+		v.Configure(cfg)
+	}
+	// A load failure leaves the validator unconfigured, which
+	// TestComplexityGeneratorsAreNonVacuous reports as a vacuous target rather
+	// than letting it pass silently.
+	return v
+}
+
+// repoConfigPath is the shipped config, relative to this package's directory.
+const repoConfigPath = "../../config.yaml"
+
+// TestComplexityGeneratorsAreNonVacuous is the standing guard on the guard.
+//
+// Every timing assertion in this package is only as meaningful as the match count
+// underneath it: a ceiling passes trivially if the validator stops matching, and
+// a growth ratio is noise if the match count is flat. This test pins both
+// properties for every target INDEPENDENTLY of the timing, so a validator change
+// that silences a subtest fails here with a clear reason instead of leaving a
+// green no-op behind.
+//
+// It runs at a small size and asserts nothing about time, so it stays fast and
+// is not skipped in -short mode.
+func TestComplexityGeneratorsAreNonVacuous(t *testing.T) {
+	for _, tgt := range complexityTargets {
+		tgt := tgt
+		t.Run(tgt.name, func(t *testing.T) {
+			if (tgt.unit == "") == (tgt.gen == nil) {
+				t.Fatalf("%s: exactly one of unit/gen must be set", tgt.name)
+			}
+
+			const smallReps = 200
+			small := buildComplexityInput(tgt.unit, tgt.gen, smallReps)
+			large := buildComplexityInput(tgt.unit, tgt.gen, smallReps*2)
+
+			mSmall, err := tgt.new().ValidateContent(small, "<generators>")
+			if err != nil {
+				t.Fatalf("%s: ValidateContent(small): %v", tgt.name, err)
+			}
+			mLarge, err := tgt.new().ValidateContent(large, "<generators>")
+			if err != nil {
+				t.Fatalf("%s: ValidateContent(large): %v", tgt.name, err)
+			}
+
+			if len(mSmall) == 0 {
+				t.Fatalf("%s: 0 matches on %d bytes — this target is VACUOUS, so its "+
+					"timing assertions measure a reject path and can never fail. Either the "+
+					"input no longer matches (check vetoes/config gating) or the validator "+
+					"changed.", tgt.name, len(small))
+			}
+
+			// Match growth is what makes per-match cost a function of input size.
+			// Consolidating validators are exempt, and say so in the target.
+			if tgt.wantMatchGrowth && len(mLarge) <= len(mSmall) {
+				t.Errorf("%s: doubling the input did not increase matches (%d -> %d). The "+
+					"per-match cost therefore does not grow with input size, which is what "+
+					"lets a per-match quadratic pass the ratio check. Make the generator emit "+
+					"distinct values, or clear wantMatchGrowth if this validator consolidates.",
+					tgt.name, len(mSmall), len(mLarge))
+			}
+		})
+	}
+}

--- a/internal/goldencorpus/complexity_guard_test.go
+++ b/internal/goldencorpus/complexity_guard_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/awslabs/ferret-scan/v2/internal/validators/personname"
 	"github.com/awslabs/ferret-scan/v2/internal/validators/phone"
 	"github.com/awslabs/ferret-scan/v2/internal/validators/secrets"
-	"github.com/awslabs/ferret-scan/v2/internal/validators/socialmedia"
 	"github.com/awslabs/ferret-scan/v2/internal/validators/ssn"
 	"github.com/awslabs/ferret-scan/v2/internal/validators/vin"
 )
@@ -52,42 +51,79 @@ type validatorUnderTest interface {
 // so the timing reflects the validator's own scanning cost, not orchestration.
 // Each builder returns a fresh validator and a single-line unit of input that
 // the validator will scan densely.
+//
+// A target supplies its input EITHER as `unit` (repeated verbatim) or as `gen`
+// (called with 0..reps-1 to emit a distinct value per repetition). Prefer `gen`:
+// complexity_generators_test.go documents why identical repeats can silently
+// defeat this whole guard. `unit` is kept for the validators whose per-match cost
+// does not depend on value distinctness.
 var complexityTargets = []struct {
-	name      string
-	new       func() validatorUnderTest
-	unit      string // one "row" of input; repeated to scale size
+	name string
+	new  func() validatorUnderTest
+	unit string // one "row" of input; repeated to scale size (mutually exclusive with gen)
+	// gen builds repetition i. Use when the validator dedups candidates, so
+	// repeating one value would pin the match count flat as the input grows.
+	gen       func(i int) string
 	threshold time.Duration
+	// minMatches, when > 0, is the floor asserted at BOTH measured sizes. It is
+	// what makes the timing numbers mean something: see TestValidatorComplexityIsSubQuadratic.
+	minMatches int
+	// wantMatchGrowth requires the big input to yield strictly more matches than
+	// the base input. Set for targets whose per-match cost is the thing under
+	// test; leave false where the validator legitimately consolidates.
+	wantMatchGrowth bool
+	// baseReps overrides the default base repetition count. Needed when a target
+	// has to land on a particular side of an internal size/count cap for the two
+	// measurements to exercise the SAME code path (see socialmedia).
+	baseReps int
 }{
 	{
 		name: "ssn",
 		new:  func() validatorUnderTest { return ssn.NewValidator() },
 		// Dense near-SSN tokens on one line stress the per-match context rescan.
-		unit:      "ssn 449-87-4100 and 555-12-3456 and 111-22-3333 ",
-		threshold: 5 * time.Second,
+		unit:            "ssn 449-87-4100 and 555-12-3456 and 111-22-3333 ",
+		minMatches:      800,
+		wantMatchGrowth: true,
+		threshold:       5 * time.Second,
 	},
 	{
-		name:      "ipaddress",
-		new:       func() validatorUnderTest { return ipaddress.NewValidator() },
-		unit:      "ip 203.0.113.42 host 10.0.0.5 gw 192.168.1.1 dns 8.8.8.8 ",
-		threshold: 5 * time.Second,
+		name: "ipaddress",
+		new:  func() validatorUnderTest { return ipaddress.NewValidator() },
+		// The old unit ("203.0.113.42 / 10.0.0.5 / 192.168.1.1 / 8.8.8.8") produced
+		// ZERO matches: TEST-NET-3, RFC1918 and the well-known public resolver are
+		// all vetoed, so this subtest timed the reject path and asserted nothing.
+		// genPublicIP emits distinct routable addresses that survive the vetoes.
+		gen:             genPublicIP,
+		threshold:       5 * time.Second,
+		minMatches:      500,
+		wantMatchGrowth: true,
 	},
 	{
-		name:      "email",
-		new:       func() validatorUnderTest { return email.NewValidator() },
-		unit:      "mail a@b.com x@y.org user@example.net admin@corp.co ",
-		threshold: 5 * time.Second,
+		name:            "email",
+		new:             func() validatorUnderTest { return email.NewValidator() },
+		unit:            "mail a@b.com x@y.org user@example.net admin@corp.co ",
+		minMatches:      1000,
+		wantMatchGrowth: true,
+		threshold:       5 * time.Second,
 	},
 	{
-		name:      "phone",
-		new:       func() validatorUnderTest { return phone.NewValidator() },
-		unit:      "call 212-555-0142 or 415-555-0199 or 312-555-0123 ",
-		threshold: 5 * time.Second,
+		name: "phone",
+		new:  func() validatorUnderTest { return phone.NewValidator() },
+		// The old unit repeated three numbers, so per-line dedup pinned the match
+		// count at 3 at EVERY size: the per-match cost never grew and a quadratic
+		// per-match path would have measured as linear.
+		gen:             genPhone,
+		threshold:       5 * time.Second,
+		minMatches:      500,
+		wantMatchGrowth: true,
 	},
 	{
-		name:      "creditcard",
-		new:       func() validatorUnderTest { return creditcard.NewValidator() },
-		unit:      "card 4532015112830366 5425233430109903 374245455400126 ",
-		threshold: 5 * time.Second,
+		name:            "creditcard",
+		new:             func() validatorUnderTest { return creditcard.NewValidator() },
+		unit:            "card 4532015112830366 5425233430109903 374245455400126 ",
+		minMatches:      800,
+		wantMatchGrowth: true,
+		threshold:       5 * time.Second,
 	},
 	// The 13 remaining text-mode validators (METADATA excluded — it scans
 	// extracted file metadata, not text windows). Each unit is a dense,
@@ -96,63 +132,90 @@ var complexityTargets = []struct {
 	// keyword so the per-match context scan — the O(n^2)-prone path — is
 	// actually exercised, not short-circuited by an empty candidate set.
 	{
-		name:      "address",
-		new:       func() validatorUnderTest { return address.NewValidator() },
-		unit:      "ship to 123 Main St and 456 Oak Ave and 789 Elm Blvd, Springfield IL 62704 ",
-		threshold: 5 * time.Second,
+		name:            "address",
+		new:             func() validatorUnderTest { return address.NewValidator() },
+		unit:            "ship to 123 Main St and 456 Oak Ave and 789 Elm Blvd, Springfield IL 62704 ",
+		minMatches:      800,
+		wantMatchGrowth: true,
+		threshold:       5 * time.Second,
 	},
 	{
-		name:      "bankaccount",
-		new:       func() validatorUnderTest { return bankaccount.NewValidator() },
-		unit:      "routing 026009593 account 1234567890 iban DE89370400440532013000 swift BOFAUS3N ",
-		threshold: 5 * time.Second,
+		name:            "bankaccount",
+		new:             func() validatorUnderTest { return bankaccount.NewValidator() },
+		unit:            "routing 026009593 account 1234567890 iban DE89370400440532013000 swift BOFAUS3N ",
+		minMatches:      1000,
+		wantMatchGrowth: true,
+		threshold:       5 * time.Second,
 	},
 	{
-		name:      "cloudresources",
-		new:       func() validatorUnderTest { return cloudresources.NewValidator() },
-		unit:      "arn:aws:iam::123456789012:role/Admin arn:aws:s3:::my-bucket/key i-0abcd1234ef567890 ",
-		threshold: 5 * time.Second,
+		name:            "cloudresources",
+		new:             func() validatorUnderTest { return cloudresources.NewValidator() },
+		unit:            "arn:aws:iam::123456789012:role/Admin arn:aws:s3:::my-bucket/key i-0abcd1234ef567890 ",
+		minMatches:      500,
+		wantMatchGrowth: true,
+		threshold:       5 * time.Second,
 	},
 	{
-		name:      "dob",
-		new:       func() validatorUnderTest { return dob.NewValidator() },
-		unit:      "dob 03/14/1987 born 05/22/1990 birthdate 1978-11-02 date of birth 12/01/1985 ",
-		threshold: 5 * time.Second,
+		name: "dob",
+		new:  func() validatorUnderTest { return dob.NewValidator() },
+		// The old unit repeated four dates, which extractDates dedups per line: the
+		// match count was 4 at every size. This validator was in fact quadratic
+		// (22s on a 64KB single line) while THIS SUBTEST reported normal growth —
+		// the concrete miss that motivated hardening the whole file.
+		gen:             genDOB,
+		threshold:       5 * time.Second,
+		minMatches:      300,
+		wantMatchGrowth: true,
 	},
 	{
-		name:      "driverslicense",
-		new:       func() validatorUnderTest { return driverslicense.NewValidator() },
-		unit:      "driver license D1234567 dl 12345678 licence D123-4567-8901 dmv A9876543 ",
-		threshold: 5 * time.Second,
+		name:            "driverslicense",
+		new:             func() validatorUnderTest { return driverslicense.NewValidator() },
+		unit:            "driver license D1234567 dl 12345678 licence D123-4567-8901 dmv A9876543 ",
+		minMatches:      1000,
+		wantMatchGrowth: true,
+		threshold:       5 * time.Second,
 	},
 	{
-		name:      "intellectualproperty",
-		new:       func() validatorUnderTest { return intellectualproperty.NewValidator() },
-		unit:      "Copyright 2026 Acme. Confidential and Proprietary. Trade Secret. Patent Pending. ",
-		threshold: 5 * time.Second,
+		name: "intellectualproperty",
+		new:  func() validatorUnderTest { return intellectualproperty.NewValidator() },
+		gen:  genIntellectualProperty,
+		// This validator CONSOLIDATES: thousands of candidates become one
+		// aggregate finding, so a match-growth requirement would be wrong here.
+		// The floor still holds the timing honest (1 real finding, not 0).
+		threshold:  5 * time.Second,
+		minMatches: 1,
 	},
 	{
-		name:      "medicalid",
-		new:       func() validatorUnderTest { return medicalid.NewValidator() },
-		unit:      "npi 1234567893 dea FC9825487 mbi 1EG4-TE5-MK73 mrn 8432197 patient record ",
-		threshold: 5 * time.Second,
+		name:            "medicalid",
+		new:             func() validatorUnderTest { return medicalid.NewValidator() },
+		unit:            "npi 1234567893 dea FC9825487 mbi 1EG4-TE5-MK73 mrn 8432197 patient record ",
+		minMatches:      1000,
+		wantMatchGrowth: true,
+		threshold:       5 * time.Second,
 	},
 	{
-		name:      "otp",
-		new:       func() validatorUnderTest { return otp.NewValidator() },
-		unit:      "2fa secret JBSWY3DPEHPK3PXP totp KRUGKIDROVUWG2ZA backup code abcd-efgh-1234 ",
-		threshold: 5 * time.Second,
+		name:            "otp",
+		new:             func() validatorUnderTest { return otp.NewValidator() },
+		unit:            "2fa secret JBSWY3DPEHPK3PXP totp KRUGKIDROVUWG2ZA backup code abcd-efgh-1234 ",
+		minMatches:      800,
+		wantMatchGrowth: true,
+		threshold:       5 * time.Second,
 	},
 	{
-		name:      "passport",
-		new:       func() validatorUnderTest { return passport.NewValidator() },
-		unit:      "passport 512345678 travel document L8837362 visa passport no 987654321 ",
-		threshold: 5 * time.Second,
+		name:            "passport",
+		new:             func() validatorUnderTest { return passport.NewValidator() },
+		unit:            "passport 512345678 travel document L8837362 visa passport no 987654321 ",
+		minMatches:      500,
+		wantMatchGrowth: true,
+		threshold:       5 * time.Second,
 	},
 	{
 		name: "personname",
 		new:  func() validatorUnderTest { return personname.NewValidator() },
-		unit: "contact Maria Delgado and James Wilson and Sarah Chen and Robert Brown ",
+		// The old unit repeated four names -> 4 matches at every size.
+		gen:             genPersonName,
+		minMatches:      300,
+		wantMatchGrowth: true,
 		// personname and secrets are the heaviest validators per byte
 		// (dictionary lookups per candidate token; entropy + multi-pattern
 		// secret scanning). They scale LINEARLY — the ratio check below is the
@@ -164,22 +227,44 @@ var complexityTargets = []struct {
 		threshold: 15 * time.Second,
 	},
 	{
-		name:      "secrets",
-		new:       func() validatorUnderTest { return secrets.NewValidator() },
-		unit:      "AWS_KEY=AKIAIOSFODNN7EXAMPLE token=ghp_1234567890abcdefghij1234567890abcdef ",
-		threshold: 15 * time.Second, // see personname note: heavy-but-linear
+		name:            "secrets",
+		new:             func() validatorUnderTest { return secrets.NewValidator() },
+		unit:            "AWS_KEY=AKIAIOSFODNN7EXAMPLE token=ghp_1234567890abcdefghij1234567890abcdef ",
+		minMatches:      500,
+		wantMatchGrowth: true,
+		threshold:       15 * time.Second, // see personname note: heavy-but-linear
 	},
 	{
-		name:      "socialmedia",
-		new:       func() validatorUnderTest { return socialmedia.NewValidator() },
-		unit:      "follow @alice_smith and @bob.jones and twitter.com/carol on socials ",
-		threshold: 5 * time.Second,
+		name: "socialmedia",
+		// This validator is CONFIG-GATED: NewValidator alone leaves
+		// patternsConfigured false, so ValidateContent returns immediately at
+		// validator.go's "patterns configured" check. The old subtest measured
+		// that early return — a ~42ns no-op that could never fail. Configure it
+		// from the shipped config.yaml so the real scan runs.
+		new: newConfiguredSocialMedia,
+		// URL-shaped profiles, one per line. Two constraints, both measured:
+		//   - "@handle" text does NOT match: the shipped config's handle regex is
+		//     PCRE and RE2 rejects it, so it is silently dropped (tracked
+		//     separately). Only URL patterns actually fire.
+		//   - Both sizes must sit on the SAME side of maxClusterMatches (1000),
+		//     because above it clustering is skipped. Straddling the cap compared
+		//     two different code paths and made the big input measure 4x FASTER
+		//     than the base (226ms at 400 matches vs 213ms at 1600). These sizes
+		//     stay above it, where the path is linear.
+		gen: genSocialMediaProfile,
+		// 1200 base / 4800 big: both above maxClusterMatches, per the note above.
+		baseReps:        1200,
+		threshold:       5 * time.Second,
+		minMatches:      1100,
+		wantMatchGrowth: true,
 	},
 	{
-		name:      "vin",
-		new:       func() validatorUnderTest { return vin.NewValidator() },
-		unit:      "vin 1HGCM82633A004352 vehicle 2FMDK3GC4BBA12345 vin JH4KA7561PC008269 ",
-		threshold: 5 * time.Second,
+		name:            "vin",
+		new:             func() validatorUnderTest { return vin.NewValidator() },
+		unit:            "vin 1HGCM82633A004352 vehicle 2FMDK3GC4BBA12345 vin JH4KA7561PC008269 ",
+		minMatches:      500,
+		wantMatchGrowth: true,
+		threshold:       5 * time.Second,
 	},
 }
 
@@ -196,15 +281,43 @@ func TestValidatorComplexityIsSubQuadratic(t *testing.T) {
 		t.Run(tgt.name, func(t *testing.T) {
 			// Two single-line inputs: base and 4x. A single long line is the
 			// worst case for the per-line rescan pattern.
-			const baseReps = 400
-			baseLine := strings.Repeat(tgt.unit, baseReps)
-			bigLine := strings.Repeat(tgt.unit, baseReps*4) // 4x size
+			baseReps := 400
+			if tgt.baseReps > 0 {
+				baseReps = tgt.baseReps
+			}
+			baseLine := buildComplexityInput(tgt.unit, tgt.gen, baseReps)
+			bigLine := buildComplexityInput(tgt.unit, tgt.gen, baseReps*4) // 4x size
 
 			// Absolute ceiling: even the big input must finish quickly. With
 			// bounded execution and linear scanning this is generous; an O(n^2)
 			// blowup on a dense line would blow past it.
-			tBase := timeValidate(t, tgt.new(), baseLine)
-			tBig := timeValidate(t, tgt.new(), bigLine)
+			tBase, nBase := timeValidate(t, tgt.new(), baseLine)
+			tBig, nBig := timeValidate(t, tgt.new(), bigLine)
+
+			// NON-VACUITY FLOOR. Both assertions below are ceilings or ratios, and
+			// both pass trivially when the validator matches nothing: a reject path
+			// is fast and its ratio is noise. Three subtests in this file were
+			// silently in that state (ipaddress and socialmedia matched nothing;
+			// dob matched a flat 4) while dob was quadratic in production. Assert
+			// the measurement had something to measure BEFORE trusting the timing.
+			if tgt.minMatches > 0 {
+				if nBase < tgt.minMatches {
+					t.Fatalf("%s: base input produced %d matches, want >= %d — the timing "+
+						"assertions below would be measuring a reject path, not the scan",
+						tgt.name, nBase, tgt.minMatches)
+				}
+				if nBig < tgt.minMatches {
+					t.Fatalf("%s: 4x input produced %d matches, want >= %d — a validator that "+
+						"stops matching as input grows makes a timing ceiling meaningless",
+						tgt.name, nBig, tgt.minMatches)
+				}
+			}
+			if tgt.wantMatchGrowth && nBig <= nBase {
+				t.Errorf("%s: 4x input produced %d matches vs %d at base — the match count "+
+					"must grow with the input, otherwise per-match cost is constant and a "+
+					"per-match O(n^2) path passes the ratio check below",
+					tgt.name, nBig, nBase)
+			}
 
 			if tBig > tgt.threshold {
 				t.Errorf("%s: 4x input took %v (> %v ceiling) — possible O(n^2) regression on a single long line",
@@ -227,12 +340,32 @@ func TestValidatorComplexityIsSubQuadratic(t *testing.T) {
 	}
 }
 
-// timeValidate runs ValidateContent once and returns the wall-clock duration.
-func timeValidate(t *testing.T, v validatorUnderTest, content string) time.Duration {
+// timeValidate runs ValidateContent once and returns the wall-clock duration AND
+// the match count. The count is not decoration: it is what the caller uses to
+// prove the duration measured real scanning work rather than an early return.
+// Discarding it (as this helper used to) is how three subtests in this file
+// became no-ops without any test failing.
+func timeValidate(t *testing.T, v validatorUnderTest, content string) (time.Duration, int) {
 	t.Helper()
 	start := time.Now()
-	if _, err := v.ValidateContent(content, "<complexity>"); err != nil {
+	matches, err := v.ValidateContent(content, "<complexity>")
+	elapsed := time.Since(start)
+	if err != nil {
 		t.Fatalf("ValidateContent error: %v", err)
 	}
-	return time.Since(start)
+	return elapsed, len(matches)
+}
+
+// buildComplexityInput scales a target's input to reps repetitions, from either a
+// static unit or a per-index generator. Exactly one of the two is set; the
+// non-vacuity test enforces that.
+func buildComplexityInput(unit string, gen func(int) string, reps int) string {
+	if gen == nil {
+		return strings.Repeat(unit, reps)
+	}
+	var sb strings.Builder
+	for i := 0; i < reps; i++ {
+		sb.WriteString(gen(i))
+	}
+	return sb.String()
 }


### PR DESCRIPTION
Stacked on #212 (base `fix/dob-context-fabrication`) — it has to be, because the proof this PR works is that it **fails on #212's pre-fix validator**. Rebase to `main` after #212 lands.

## The problem

The complexity guard scales an input, times two sizes and compares. Every assertion was a ceiling or a ratio, and `timeValidate` **discarded the match count** — so a validator that matched nothing produced a fast, stable, *passing* subtest. Three of eighteen targets were in exactly that state:

| target | matches | why |
|---|---|---|
| `ipaddress` | **0** | unit was TEST-NET-3 + two RFC1918 + `8.8.8.8` — all four vetoed, so it timed the reject path |
| `socialmedia` | **0** | config-gated; a bare `NewValidator` leaves `patternsConfigured` false, so `ValidateContent` returns immediately (~42ns no-op) |
| `dob` | **4, flat** | unit repeated four dates and `extractDates` dedups per line |

## This caused a real miss, not a hypothetical one

`dob` was quadratic in production — **22s on a 64KB single line, ~4× per doubling** — while this file reported its growth as normal. With 4 matches at both sizes the per-match cost never grew, so the per-match quadratic was invisible.

Reverted onto the pre-fix validator, the hardened subtest fails:

```
dob: 4x input took 14.1x longer (base=328ms big=4.63s) — superlinear growth
     suggests an O(n^2) regression
```

and passes on the fixed one. That true-positive/true-negative pair is the whole argument for this change.

## What changed

- `timeValidate` returns the match count; the guard asserts a per-target `minMatches` floor **at both sizes** before reading the clock.
- `wantMatchGrowth` requires the big input to yield more matches than the base — constant match count is precisely what lets a per-match quadratic hide. `intellectualproperty` is exempt and documents why: it consolidates thousands of candidates into one aggregate finding.
- Targets may supply a `gen` (distinct value per index) instead of a static `unit`. Six now do.
- **`TestComplexityGeneratorsAreNonVacuous`** pins non-vacuity and growth for all 18 targets *independently of any timing*, so a validator change that silences a subtest fails with a reason instead of going quietly green. It asserts nothing about time and runs in `-short`.

## Generator constraints, all found by measurement

Each is recorded at its definition, because each one silently defeats the guard:

- **Distinctness is not enough — the value space must not wrap.** A wrapped generator caps the match count at large *n*, understating growth exactly where a quadratic shows up.
- **`personname` uses literal name lists that exclude surnames doubling as place words.** Drawing from the embedded name database gave 1164 findings at one size and **zero** at the next: the added surname was `Lake`, and this validator applies its geographic penalty *line-globally*, so one geo-word zeroes every name on the line. A generator that goes vacuous as it scales is worse than a static one. (That suppression is a separate product bug — a name plus a street address on one line loses the name — filed on its own, not fixed here.)
- **`socialmedia` needs both sizes on the same side of `maxClusterMatches` (1000).** Straddling that documented cap measured the **big input as faster than the base** (226ms at 400 matches vs 213ms at 1600), because clustering is skipped above it. A meaningless ratio. Now `baseReps` 1200 → 4800, both above the cap.
- **`@handle` text cannot be used**: the shipped config's handle pattern is PCRE, RE2 rejects it, and it is dropped silently. Only URL patterns fire.

## Verification

- Full suite `exit=0` (59 packages); `-race` clean; `gofmt`/`vet` clean.
- `UPDATE_GOLDEN=1` → **zero golden diff** (test-only change).
- **Mutation-tested all three new assertion kinds**: reverted each broken target and confirmed the specific failure fires with an actionable message (vacuous / no match growth / below floor).
- 10 uncached repeat runs, no flake.
- Margins are deliberately wide for slow shared CI runners: ratios **3.25–4.92** against the 12× limit, and the worst absolute time uses **4.7%** of its ceiling (the old `personname` case sat at 6s of a 15s ceiling).
- Merges clean in order behind #207 → #208 → #209 → #210 → #211 → #212; the combined 7-branch stack builds and passes.
