### PR TITLE
ci: test stacked pull requests, and gate gofmt

### DIFF
--- a/.github/workflows/ferret-scan.yml
+++ b/.github/workflows/ferret-scan.yml
@@ -4,9 +4,11 @@
 name: Ferret Scan Security Check
 
 on:
-  # Run on pull requests
+  # Run on pull requests. No `branches:` filter on purpose — see go-test.yml: a
+  # [main, master, develop] filter gave stacked PRs (base = another feature branch)
+  # zero checks, and a secret introduced on a stacked branch would have reached main
+  # having never been scanned by the tool itself.
   pull_request:
-    branches: [main, master, develop]
     paths:
       - '**.py'
       - '**.js'

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,8 +1,13 @@
 name: Go Tests
 
 on:
+  # No `branches:` filter. This job must run on EVERY pull request, including one
+  # whose base is another feature branch. Stacked PRs are how larger changes land
+  # here, and with a [main, master, develop] filter they received literally zero
+  # checks: `gh pr checks` reported "no checks reported on the branch" while a
+  # sibling PR based on main got the full matrix. A stacked PR is exactly the case
+  # that most needs testing, because it carries its own diff plus its base's.
   pull_request:
-    branches: [main, master, develop]
     paths:
       - '**.go'
       - 'go.mod'
@@ -50,6 +55,24 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
+
+      - name: Gofmt
+        # Formatting is platform-independent, so gate it on one runner instead of
+        # failing three times for the same file. Linux is the fastest of the three.
+        #
+        # `gofmt -l` prints offending files and exits 0, so the exit status alone
+        # proves nothing — the output has to be inspected. Restricted to first-party
+        # trees so a vendored or generated file cannot fail the build.
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          unformatted="$(gofmt -l ./cmd ./internal ./pkg)"
+          if [ -n "$unformatted" ]; then
+            echo "::error::gofmt reported unformatted files; run 'gofmt -w' on them:"
+            echo "$unformatted"
+            exit 1
+          fi
+          echo "gofmt clean"
+        shell: bash
 
       - name: Go vet
         run: go vet ./...

--- a/docs/testing/TEST_PLAN.md
+++ b/docs/testing/TEST_PLAN.md
@@ -27,9 +27,13 @@ Each dimension names what it protects, the minimum bar, and how to run it.
 
 - `go build ./...` — compiles.
 - `go vet ./...` — clean.
-- `gofmt -l <touched dirs>` — empty output. (Known pre-existing exception:
-  `internal/config/config.go` reports under gofmt on `main`; prove any gofmt hit is
-  pre-existing by stashing your change and re-running before dismissing it.)
+- `gofmt -l ./cmd ./internal ./pkg` — empty output, with **no exceptions**. The
+  previously documented `internal/config/config.go` exception is gone: that file was
+  reformatted by an unrelated change and `main` is now gofmt-clean. CI enforces this
+  on every PR (`Gofmt` step in `go-test.yml`), so an unformatted file is a build
+  failure rather than a judgement call.
+- Note `gofmt -l` prints offending files but still **exits 0**, so never trust its
+  exit status — inspect the output.
 
 ### 2. Unit + full regression suite
 


### PR DESCRIPTION
## Stacked PRs were getting zero checks

Both PR-triggered workflows filtered on `branches: [main, master, develop]`, so a pull request whose base is **another feature branch** ran nothing at all. Measured on the currently open stack:

| PR | base | `gh pr checks` |
|---|---|---|
| #207 | `main` | full matrix — Analyze (go) pass, CodeQL pass, … |
| **#209** | `fix/dms-coordinate-parsing` | **"no checks reported on the branch"** |
| #212 | `main` | full matrix |
| **#213** | `fix/dob-context-fabrication` | **"no checks reported on the branch"** |

#209 and #213 are ordinary Go changes. They were merge-ready on my local testing alone — no vet, no cross-platform matrix, no race detector, on any of the three OSes.

A stacked PR is the case that most *needs* CI, not least: it carries its own diff plus its base's, and it's the shape larger changes land in here.

The same filter was on `ferret-scan.yml`, the tool's **own self-scan**. That's the sharper end of it — a secret introduced on a stacked branch could reach `main` having never been scanned by ferret-scan itself.

Fix: drop `branches:` from `pull_request`. The `paths:` filter still applies, and `push:` keeps its `main`/`master` filter, so this adds PR coverage without adding push noise.

## Gofmt was documented but never enforced

Formatting was a manual TEST_PLAN step with no gate. The new step:

- runs on **ubuntu only** — formatting is platform-independent, and three identical failures are noise;
- restricts to `./cmd ./internal ./pkg`, so a vendored or generated file can't fail the build;
- inspects `gofmt -l`'s **output**, not its exit status.

That last point matters: `gofmt -l` prints offending files and still **exits 0**. The naive `run: gofmt -l ./...` form is a vacuous gate that can never fail. Verified non-vacuous by appending a badly formatted function and confirming the step fails:

```
caught: internal/config/config.go
```

then reverting.

It also already caught something real — a stray probe file left in `internal/validators/personname/` by a background analysis run showed up as unformatted while I was validating the combined stack.

## The TEST_PLAN exception was stale

Dimension 1 claimed `internal/config/config.go` was a known gofmt exception on `main`. It isn't anymore — the file was reformatted by an unrelated change (cbd1162), and `gofmt -l ./cmd ./internal ./pkg` is empty on `main`.

Left as-is, that note tells a future reader to dismiss a **real** CI failure as pre-existing. Replaced with the no-exceptions rule, a pointer to the CI step, and the `gofmt -l` exit-status caveat.

## Verification

- Full suite `exit=0` (59 packages); `gofmt`/`vet`/`build` clean.
- **`actionlint` reports the same 3 pre-existing warnings before and after** this change (3 on `main`, 3 with the change) — the new step introduces none.
- Structural check confirms `pull_request` has no `branches:` filter while `push:` retains its own.
- Merges clean in order behind #207 → #208 → #209 → #210 → #211 → #212 → #213; the combined 8-branch stack builds and passes.

Once this lands, #209 and #213 will need a no-op push (or a rebase) to pick up their first real CI run.
