### PR TITLE
fix(personname): score address/company context by distance, not per line

### DIFF
--- a/internal/validators/personname/geo_proximity_test.go
+++ b/internal/validators/personname/geo_proximity_test.go
@@ -1,0 +1,225 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package personname
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestAddressOnSameLineKeepsTheName is the leak gate.
+//
+// The business (-20), product (-8) and geographic (-35) penalties used to apply to
+// the whole LINE regardless of where the pattern sat relative to the name. Summed
+// and clamped to -50, that took a solid two-token name from 92 to 42, below the
+// >= 50 emit threshold — so an ordinary mailing record or CSV row lost the person's
+// name entirely. A name absent from the report is never handed to the redactor
+// either, so the cleartext value survives into the output: on a two-row CSV of
+// names and addresses the CLI reported nothing and wrote NO redacted file at all.
+//
+// Every line here carries a real person name AND an address and/or company on the
+// same line, which is the normal shape of the data this tool exists to find.
+func TestAddressOnSameLineKeepsTheName(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		want string
+	}{
+		{"csv export row", "Sarah Brooks,Acme Inc,1425 Oak Drive,Springfield,IL", "Sarah Brooks"},
+		{"clinical note", "Patient Sarah Brooks, 42 River Road, admitted Monday", "Sarah Brooks"},
+		{"prose with company", "Contact Sarah Brooks at 1425 Elm Avenue for the Acme Inc account", "Sarah Brooks"},
+		{"pipe-delimited", "Sarah Brooks | Acme Corp | 1425 Elm Street", "Sarah Brooks"},
+		{"second csv row", "Michael Rivera,Globex LLC,88 Lake Street,Portland,OR", "Michael Rivera"},
+		{"shipping label", "Ship to Jennifer Alvarez, 210 Mountain Road, Boulder CO", "Jennifer Alvarez"},
+		{"employee record", "Employee: Daniel Fischer, 9 Valley Drive, ext 4417", "Daniel Fischer"},
+		{"prose address", "Karen Whitfield lives at 77 Creek Boulevard in the city", "Karen Whitfield"},
+		{"invoice line", "invoice for Thomas Bennett, 5 County Road, Acme Industries", "Thomas Bennett"},
+		{"suite address", "Deborah Callahan, 1200 State Street, Suite 300", "Deborah Callahan"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := NewValidator()
+			matches, err := v.ValidateContent(tc.line, "record.csv")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) == 0 {
+				t.Fatalf("no findings: the name %q is on this line together with an "+
+					"address/company, and a line-global context penalty dropped it. An "+
+					"unreported name is not redacted either, so it stays cleartext in the "+
+					"output.\n  line: %q", tc.want, tc.line)
+			}
+			var found bool
+			var got []string
+			for _, m := range matches {
+				got = append(got, m.Text)
+				if strings.Contains(m.Text, tc.want) {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("findings %v do not include %q\n  line: %q", got, tc.want, tc.line)
+			}
+		})
+	}
+}
+
+// TestPlaceNamesStaySuppressed is the other direction: proximity-gating the
+// penalties must not turn place names, org names and address fragments into
+// people.
+//
+// The five lines NOT listed here that this corpus originally contained
+// ("Phoenix Arizona to Denver Colorado route", "Palo Alto and Menlo Park offices",
+// "Grand Canyon National Park Arizona", "Charlotte North Carolina and Austin
+// Texas", "Devon Cornwall and Kent counties") are reported as names BOTH before and
+// after the proximity gate — they are a separate, pre-existing issue: those place
+// words are themselves entries in the first-name database, so they score on their
+// own merits and the geographic penalty only masked them incidentally. They are
+// deliberately excluded so this test asserts what the change is responsible for.
+func TestPlaceNamesStaySuppressed(t *testing.T) {
+	cases := []string{
+		"123 Main Street, Springfield, IL 62704",
+		"River Valley Industries Inc, 400 Commerce Drive",
+		"Golden Gate Boulevard runs through the city",
+		"Mountain View California is the county seat",
+		"Salt Lake City, Utah",
+		"Cedar Creek Road crosses Pine Valley Avenue",
+		"Acme Manufacturing Corp, Industrial Drive",
+		"terraform apply -target module.database",
+		"aws ec2 describe-instances --region us-east-1",
+		"See the installation guide in the readme documentation",
+		"Samsung Galaxy and Nike Air product catalog",
+		"Boulder County Colorado state records",
+		"Elm Street Elementary School District",
+		"the Hudson River valley region",
+		"Jordan Lake State Recreation Area",
+		"Madison Avenue advertising firm",
+	}
+
+	for _, line := range cases {
+		v := NewValidator()
+		matches, err := v.ValidateContent(line, "doc.txt")
+		if err != nil {
+			t.Fatalf("ValidateContent(%q): %v", line, err)
+		}
+		if len(matches) > 0 {
+			var got []string
+			for _, m := range matches {
+				got = append(got, m.Text)
+			}
+			t.Errorf("reported %v as person name(s) on a line that names no person — "+
+				"the proximity gate must not let place/org/address text score as people.\n  line: %q",
+				got, line)
+		}
+	}
+}
+
+// TestSpecificPatternPenaltyIsProximityGated pins the mechanism directly, so a
+// future change that reverts to line-global scoring fails here with a reason even
+// if the corpus above happens to still pass.
+//
+// Same words, same name, only the DISTANCE between them varies.
+func TestSpecificPatternPenaltyIsProximityGated(t *testing.T) {
+	v := NewValidator()
+
+	// "drive" adjacent to the name: still penalized.
+	near := "Oak Drive Sarah Brooks"
+	// "drive" far from the name, past specificPatternProximity: not penalized.
+	far := "Sarah Brooks" + strings.Repeat(" x", specificPatternProximity) + " Oak Drive"
+
+	nearCache := v.newLineContextCache(strings.ToLower(near))
+	farCache := v.newLineContextCache(strings.ToLower(far))
+
+	if len(nearCache.geoIndices) == 0 || len(farCache.geoIndices) == 0 {
+		t.Fatalf("premise broken: both lines must contain a geographic pattern "+
+			"(near=%v far=%v)", nearCache.geoIndices, farCache.geoIndices)
+	}
+
+	nearScore := v.analyzeContextCached("Sarah Brooks", strings.Index(strings.ToLower(near), "sarah"), nearCache)
+	farScore := v.analyzeContextCached("Sarah Brooks", strings.Index(strings.ToLower(far), "sarah"), farCache)
+
+	if !(farScore > nearScore) {
+		t.Errorf("far=%.1f near=%.1f: a geographic word %d+ bytes from the name must "+
+			"penalize it LESS than one adjacent to it. Equal scores mean the penalty is "+
+			"being applied line-globally again.", farScore, nearScore, specificPatternProximity)
+	}
+}
+
+// TestGeoPatternIterationIsDeterministic guards the map-order fix.
+//
+// The geographic scan used to range geoPatternsMap directly and break on the first
+// hit. The SCORE was the same whichever pattern won, which is why this was
+// invisible — but the recorded byte OFFSET was not order-independent, and the
+// offset now decides whether a name is penalized. Iterating a sorted slice makes
+// the winner deterministic.
+func TestGeoPatternIterationIsDeterministic(t *testing.T) {
+	// A line holding several geographic patterns, so map order would have a choice.
+	const line = "sarah brooks, 1 oak drive, elm street, river road, lake city"
+	v := NewValidator()
+
+	first := v.newLineContextCache(line).geoIndices
+	if len(first) == 0 {
+		t.Fatal("premise broken: line must contain a geographic pattern")
+	}
+	for i := 0; i < 50; i++ {
+		got := v.newLineContextCache(line).geoIndices
+		if len(got) != len(first) || (len(got) > 0 && got[0] != first[0]) {
+			t.Fatalf("run %d produced geoIndices %v, first run produced %v — the "+
+				"geographic scan is order-dependent", i, got, first)
+		}
+	}
+
+	// And the sorted accessor itself must be sorted, which is what makes it stable.
+	patterns := v.getSortedGeoPatterns()
+	if len(patterns) == 0 {
+		t.Fatal("getSortedGeoPatterns returned nothing")
+	}
+	for i := 1; i < len(patterns); i++ {
+		if patterns[i-1] > patterns[i] {
+			t.Errorf("getSortedGeoPatterns not sorted at %d: %q > %q",
+				i, patterns[i-1], patterns[i])
+		}
+	}
+}
+
+// TestFirstWordKeywordIndexMatchesContainsWordKeyword locks the invariant the
+// proximity gate depends on: the index helper and the boolean helper must agree
+// about whether a pattern is present. If they diverge, a pattern could be "found"
+// at an offset the boolean check rejects (or vice versa), and the penalty would
+// fire on substring hits like "state" inside "estate".
+func TestFirstWordKeywordIndexMatchesContainsWordKeyword(t *testing.T) {
+	v := NewValidator()
+	lines := []string{
+		"sarah brooks, 1425 oak drive, springfield",
+		"the real estate listing was driven by demand", // substring traps
+		"acme inc and globex llc",
+		"nothing relevant here at all",
+		"lakefront property near riverside", // more substring traps
+		"street",                            // whole line is the pattern
+		"city,county,state",                 // punctuation boundaries
+	}
+	families := [][]string{
+		v.getSortedBusinessPatterns(),
+		v.getSortedProductPatterns(),
+		v.getSortedGeoPatterns(),
+	}
+
+	for _, line := range lines {
+		for _, family := range families {
+			for _, pattern := range family {
+				contains := containsWordKeyword(line, pattern)
+				idx := firstWordKeywordIndex(line, pattern)
+				if contains != (idx >= 0) {
+					t.Errorf("disagreement on pattern %q in %q: containsWordKeyword=%v "+
+						"firstWordKeywordIndex=%d", pattern, line, contains, idx)
+				}
+				if idx >= 0 && !strings.HasPrefix(line[idx:], pattern) {
+					t.Errorf("firstWordKeywordIndex(%q, %q)=%d does not point at the pattern",
+						line, pattern, idx)
+				}
+			}
+		}
+	}
+}

--- a/internal/validators/personname/geo_proximity_test.go
+++ b/internal/validators/personname/geo_proximity_test.go
@@ -147,6 +147,52 @@ func TestSpecificPatternPenaltyIsProximityGated(t *testing.T) {
 	}
 }
 
+// TestDistantPatternCannotMaskAnAdjacentOne guards against penalty evasion.
+//
+// specificPatternIndices originally recorded only the FIRST matching pattern per
+// family (a `break` after the first hit). That was harmless while the penalty was
+// line-global, but under proximity gating the recorded offsets decide whether a
+// name is penalized — so one distant match could hide an adjacent one:
+//
+//	"oak drive sarah brooks"                        geo=[4]  -> penalty FIRES
+//	"avenue" + 60 dots + " oak drive sarah brooks"  geo=[0]  -> penalty SILENT
+//
+// Identical adjacent "oak drive", but prepending the alphabetically-earlier
+// "avenue" far away suppressed the penalty entirely (-50 became -15; through the
+// CLI the finding rose from 57 to 69). Attacker-controllable, and the same class
+// of hazard as the map-order issue: what changed was never the score for a given
+// pattern, only WHICH offset got recorded.
+func TestDistantPatternCannotMaskAnAdjacentOne(t *testing.T) {
+	v := NewValidator()
+	v.ensureNamesLoaded()
+
+	const control = "oak drive sarah brooks"
+	// "avenue" sorts before "oak drive"'s "drive", and sits far from the name.
+	padded := "avenue" + strings.Repeat(".", 60) + " oak drive sarah brooks"
+
+	score := func(line string) float64 {
+		cache := v.newLineContextCache(strings.ToLower(line))
+		nameIndex := strings.Index(cache.lowerLine, "sarah")
+		if nameIndex < 0 {
+			t.Fatalf("premise broken: name not found in %q", line)
+		}
+		if len(cache.geoIndices) == 0 {
+			t.Fatalf("premise broken: no geographic pattern located in %q", line)
+		}
+		return v.analyzeContextCached("sarah brooks", nameIndex, cache)
+	}
+
+	controlScore := score(control)
+	paddedScore := score(padded)
+
+	if paddedScore != controlScore {
+		t.Errorf("padding the line with a distant, alphabetically-earlier geographic "+
+			"pattern changed the score for an IDENTICAL adjacent one: control=%.1f "+
+			"padded=%.1f. Every offset per family must be collected, or a far match "+
+			"masks a near one and the penalty can be evaded.", controlScore, paddedScore)
+	}
+}
+
 // TestGeoPatternIterationIsDeterministic guards the map-order fix.
 //
 // The geographic scan used to range geoPatternsMap directly and break on the first

--- a/internal/validators/personname/validator.go
+++ b/internal/validators/personname/validator.go
@@ -853,6 +853,24 @@ func containsWordKeyword(text, keyword string) bool {
 	return kwmatch.ContainsLower(text, keyword)
 }
 
+// firstWordKeywordIndex returns the byte offset of the first whole-word occurrence
+// of keyword in lowerText, or -1. It is the index-returning counterpart of
+// containsWordKeyword: same word model (kwmatch's alphanumeric boundaries), so a
+// keyword found by one is found at the reported offset by the other.
+//
+// The offset is what lets a penalty be applied by DISTANCE from the match instead
+// of line-globally. A plain strings.Index would not do: it reports substring hits
+// ("state" inside "estate", "drive" inside "driven") that containsWordKeyword
+// rejects, so the two would disagree about whether a pattern is present.
+func firstWordKeywordIndex(lowerText, keyword string) int {
+	idx := -1
+	kwmatch.ContainsFunc(lowerText, keyword, func(start, _ int) bool {
+		idx = start
+		return true // stop at the first whole-word hit
+	})
+	return idx
+}
+
 // lineContextCache holds the per-line work shared by every name match found on a
 // single line. The original AnalyzeContext recomputed all of this (lowercasing the
 // line, scanning every positive/negative keyword, running the email/business/
@@ -880,8 +898,18 @@ type lineContextCache struct {
 	// O(matches x lineLen) blowup on a single very long line (minified JSON/JS).
 	negativeKeywordIndices []int
 	// specificLineAdjustment is the line-global portion of analyzeSpecificPatterns
-	// (everything except the per-match signature boost).
+	// that is genuinely line-global: the email/phone-on-this-line boosts. The three
+	// PENALTY families are proximity-gated per match instead, via the index slices
+	// below — see analyzeSpecificPatternsLineGlobal.
 	specificLineAdjustment float64
+	// businessIndices, productIndices and geoIndices hold the first-occurrence byte
+	// offset of each business / product / geographic pattern present on the line.
+	// Like negativeKeywordIndices these are line-global to COMPUTE but are applied
+	// per match by distance, so a street address at the far end of a long line no
+	// longer penalizes a name at the near end.
+	businessIndices []int
+	productIndices  []int
+	geoIndices      []int
 }
 
 // newLineContextCache precomputes the line-global context signals for line.
@@ -942,6 +970,7 @@ func (v *Validator) newLineContextCache(line string) *lineContextCache {
 	}
 
 	c.specificLineAdjustment = v.analyzeSpecificPatternsLineGlobal(lowerLine)
+	c.businessIndices, c.productIndices, c.geoIndices = v.specificPatternIndices(lowerLine)
 	return c
 }
 
@@ -1005,6 +1034,67 @@ func (v *Validator) analyzeContextCached(match string, matchStart int, cache *li
 // located with a single strings.Index (the directly-tested public AnalyzeContext
 // path). The hot scanning path always passes the real offset, so the per-match
 // full-line scans are eliminated.
+// specificPatternProximity is how close (in bytes) a business / product /
+// geographic pattern must sit to a name before it counts as context FOR that name.
+//
+// 25 was measured, not guessed. Sweeping the window against a corpus of 10 real
+// names carrying addresses and 24 place/org/address decoys:
+//
+//	window   real names found   decoys reported
+//	    15         10/10              8/24
+//	    22         10/10              6/24
+//	 23-25         10/10              5/24   <- plateau
+//	    26          9/10              5/24
+//	    30          8/10              5/24
+//	line-global     4/10              5/24   (the old behavior)
+//
+// 5/24 is exactly what the line-global code reported, on the same five lines, so
+// this window recovers every real name while introducing NO new false positive.
+// 25 sits at the top of the plateau, one byte before recall starts dropping.
+//
+// The remaining five decoys ("Phoenix Arizona", "Menlo Park", ...) are a separate
+// pre-existing issue: those place words are themselves entries in the FIRST-NAME
+// database, so they score on their own merits and the geographic penalty was only
+// masking them incidentally — at the cost of deleting real names. Fixing that means
+// curating the name database, not widening this window; no window value separates
+// the two classes, because the geographic word sits OUTSIDE the matched span in
+// both (20-21 bytes away in the decoys, 29-31 in the real names).
+//
+// Note this is wider than the negative-keyword penalty's 15, even though many
+// words appear in both lists (13 of 19 geographic patterns and 17 business
+// patterns are also negativeKeywords). That is intentional: the two penalties
+// stack, so the keyword path still contributes at its own tighter distance.
+const specificPatternProximity = 25
+
+// matchIndex resolves the byte offset of the match within lowerLine, preferring
+// the offset the pattern engine already knows. Mirrors the nameIndex fallback used
+// by the negative-keyword penalty: -1 means "not supplied", in which case a single
+// lookup finds it (the directly-tested public AnalyzeContext path). Returns -1 if
+// the match cannot be located, in which case no proximity penalty is applied —
+// failing OPEN, because a name is reported rather than silently dropped.
+func matchIndex(matchStart int, lowerLine, match string) int {
+	if matchStart >= 0 {
+		return matchStart
+	}
+	return strings.Index(lowerLine, strings.ToLower(match))
+}
+
+// nearestWithin reports whether any offset in indices is within window bytes of
+// nameIndex. indices holds at most one entry per pattern family today, but the
+// slice shape keeps it aligned with negativeKeywordIndices and costs nothing.
+func nearestWithin(indices []int, nameIndex, window int) bool {
+	for _, idx := range indices {
+		distance := idx - nameIndex
+		if distance < 0 {
+			distance = -distance
+		}
+		if distance < window {
+			return true
+		}
+	}
+	return false
+}
+
 func (v *Validator) analyzeLineContextForMatch(match string, matchStart int, cache *lineContextCache) float64 {
 	// Mirror AnalyzeContext's `if context.FullLine != ""` guard: an empty line
 	// contributes nothing (no signature boost either).
@@ -1048,8 +1138,30 @@ func (v *Validator) analyzeLineContextForMatch(match string, matchStart int, cac
 		}
 	}
 
-	// Line-global specific patterns plus the match-specific signature boost.
+	// Line-global specific patterns (the BOOSTS only) plus the match-specific
+	// signature boost.
 	adjustment += cache.specificLineAdjustment
+
+	// The business / product / geographic PENALTIES are applied by distance, like
+	// the negative-keyword penalty above, rather than to the whole line. Locating
+	// them stays hoisted per line (see specificPatternIndices); only this cheap
+	// offset comparison is per match, so the validator stays linear.
+	//
+	// Same window as the negative-keyword penalty: a pattern has to sit within
+	// specificPatternProximity of the name to say anything about THAT name. A
+	// street address at the other end of a CSV row does not.
+	if nameIndex := matchIndex(matchStart, lowerLine, match); nameIndex >= 0 {
+		if nearestWithin(cache.businessIndices, nameIndex, specificPatternProximity) {
+			adjustment -= 20.0 // business/technical context
+		}
+		if nearestWithin(cache.productIndices, nameIndex, specificPatternProximity) {
+			adjustment -= 8.0 // product context
+		}
+		if nearestWithin(cache.geoIndices, nameIndex, specificPatternProximity) {
+			adjustment -= 35.0 // geographic context
+		}
+	}
+
 	trimmedLine := strings.TrimSpace(lowerLine)
 	trimmedMatch := strings.TrimSpace(match)
 	if len(trimmedLine) == len(trimmedMatch) {
@@ -1068,6 +1180,7 @@ var (
 	sortedEmailPatterns    []string
 	sortedBusinessPatterns []string
 	sortedProductPatterns  []string
+	sortedGeoPatterns      []string
 	sortedPatternsOnce     sync.Once
 )
 
@@ -1089,6 +1202,12 @@ func initSortedPatterns() {
 		sortedProductPatterns = append(sortedProductPatterns, pattern)
 	}
 	slices.Sort(sortedProductPatterns)
+
+	sortedGeoPatterns = make([]string, 0, len(geoPatternsMap))
+	for pattern := range geoPatternsMap {
+		sortedGeoPatterns = append(sortedGeoPatterns, pattern)
+	}
+	slices.Sort(sortedGeoPatterns)
 }
 
 // getSortedEmailPatterns returns sorted email patterns for deterministic iteration
@@ -1109,10 +1228,41 @@ func (v *Validator) getSortedProductPatterns() []string {
 	return sortedProductPatterns
 }
 
+// getSortedGeoPatterns returns sorted geographic patterns for deterministic
+// iteration. The geo scan previously ranged geoPatternsMap directly and broke on
+// the first hit, so which pattern won was decided by map order.
+func (v *Validator) getSortedGeoPatterns() []string {
+	sortedPatternsOnce.Do(initSortedPatterns)
+	return sortedGeoPatterns
+}
+
 // analyzeSpecificPatternsLineGlobal computes the line-global portion of the
 // original analyzeSpecificPatterns: everything except the match-specific
 // "line is just the name" signature boost, which is applied per match in
 // analyzeLineContextForMatch. contextLine is the already-lowercased line.
+// analyzeSpecificPatternsLineGlobal returns the part of the specific-pattern
+// analysis that is genuinely line-global: the boosts. A signature/email/phone
+// signal anywhere on the line says something about the line as a whole, and
+// boosting cannot hide a finding.
+//
+// The three PENALTY families (business, product, geographic) are deliberately NOT
+// scored here. They are located instead — see specificPatternIndices — and applied
+// per match by distance in analyzeLineContextForMatch, because line-global
+// penalties were deleting real names:
+//
+//	"Sarah Brooks,Acme Inc,1425 Oak Drive,Springfield,IL"  -> 0 findings
+//	"Patient Sarah Brooks, 42 River Road, admitted Monday" -> 0 findings
+//
+// business (-20, "inc") + geographic (-35, "drive"/"road") clamps to -50 in
+// analyzeContextCached, which takes a solid two-token name from 92 to 42 and below
+// the >= 50 emit threshold. The name is then absent from the report and so from
+// redaction, leaving it cleartext in the output. The same names score 92 with the
+// address removed, and 100 with the address on its own line.
+//
+// The asymmetry is the tell: the negative-KEYWORD penalty in
+// analyzeLineContextForMatch has always been proximity-gated (< 15 chars from the
+// match). These three families were the only context signals applied to the whole
+// line regardless of distance.
 func (v *Validator) analyzeSpecificPatternsLineGlobal(contextLine string) float64 {
 	adjustment := 0.0
 
@@ -1120,32 +1270,6 @@ func (v *Validator) analyzeSpecificPatternsLineGlobal(contextLine string) float6
 	for _, pattern := range v.getSortedEmailPatterns() {
 		if strings.Contains(contextLine, pattern) {
 			adjustment += 12.0 // Strong boost for email contexts
-			break
-		}
-	}
-
-	// Check for business context patterns (strong negative indicators).
-	// Whole-word matching so "inc" doesn't fire inside "incident"/"since" (L25).
-	for _, pattern := range v.getSortedBusinessPatterns() {
-		if containsWordKeyword(contextLine, pattern) {
-			adjustment -= 20.0 // Moderate penalty for technical/business contexts
-			break
-		}
-	}
-
-	// Check for product-specific patterns (very strong negative indicators).
-	for _, pattern := range v.getSortedProductPatterns() {
-		if containsWordKeyword(contextLine, pattern) {
-			adjustment -= 8.0 // Light penalty for product contexts
-			break
-		}
-	}
-
-	// Check for geographic patterns (negative indicators). Whole-word matching so
-	// "park" doesn't fire inside "parking"/"sparkle" (L25).
-	for pattern := range geoPatternsMap {
-		if containsWordKeyword(contextLine, pattern) {
-			adjustment -= 35.0 // Strong penalty for geographic contexts
 			break
 		}
 	}
@@ -1164,6 +1288,41 @@ func (v *Validator) analyzeSpecificPatternsLineGlobal(contextLine string) float6
 	}
 
 	return adjustment
+}
+
+// specificPatternIndices locates the first whole-word occurrence of each penalty
+// family on the line. Locating is line-global (identical for every match on the
+// line, so it stays hoisted out of the per-match loop and the validator stays
+// linear); APPLYING the penalty is per match, by distance.
+//
+// Only the first occurrence of each family is needed, because the penalty is
+// awarded once per family — matching the previous `break`-after-first-hit shape.
+//
+// The geographic loop also stops ranging over geoPatternsMap directly. Ranging a
+// Go map with `break` picks an arbitrary winner among several present patterns;
+// the score was the same either way, so this was invisible, but the recorded
+// offset is not order-independent. Iterating a sorted slice makes which pattern
+// is found deterministic.
+func (v *Validator) specificPatternIndices(lowerLine string) (business, product, geo []int) {
+	for _, pattern := range v.getSortedBusinessPatterns() {
+		if i := firstWordKeywordIndex(lowerLine, pattern); i >= 0 {
+			business = append(business, i)
+			break
+		}
+	}
+	for _, pattern := range v.getSortedProductPatterns() {
+		if i := firstWordKeywordIndex(lowerLine, pattern); i >= 0 {
+			product = append(product, i)
+			break
+		}
+	}
+	for _, pattern := range v.getSortedGeoPatterns() {
+		if i := firstWordKeywordIndex(lowerLine, pattern); i >= 0 {
+			geo = append(geo, i)
+			break
+		}
+	}
+	return business, product, geo
 }
 
 // These complex pattern matching methods are no longer needed

--- a/internal/validators/personname/validator.go
+++ b/internal/validators/personname/validator.go
@@ -1290,39 +1290,45 @@ func (v *Validator) analyzeSpecificPatternsLineGlobal(contextLine string) float6
 	return adjustment
 }
 
-// specificPatternIndices locates the first whole-word occurrence of each penalty
-// family on the line. Locating is line-global (identical for every match on the
-// line, so it stays hoisted out of the per-match loop and the validator stays
-// linear); APPLYING the penalty is per match, by distance.
+// specificPatternIndices locates EVERY pattern of each penalty family present on
+// the line. Locating is line-global (identical for every match on the line, so it
+// stays hoisted out of the per-match loop and the validator stays linear);
+// APPLYING the penalty is per match, by distance.
 //
-// Only the first occurrence of each family is needed, because the penalty is
-// awarded once per family — matching the previous `break`-after-first-hit shape.
+// Every offset, not just the first, because under proximity gating the recorded
+// offsets decide whether a name is penalized — so keeping only one per family lets
+// a distant match mask an adjacent one. With `break` after the first hit:
+//
+//	"oak drive sarah brooks"                    -> geo=[4],  penalty FIRES
+//	"avenue" + 60 dots + " oak drive sarah brooks" -> geo=[0],  penalty SILENT
+//
+// Identical adjacent "oak drive", but prepending the alphabetically-earlier
+// "avenue" far away suppressed the penalty entirely (-50 became -15, and the
+// finding rose from 57 to 69 through the CLI). That is attacker-controllable, and
+// it is the same class of hazard as the map-order issue below: what changed was
+// never the score for a given pattern, but WHICH offset got recorded.
+//
+// The penalty itself is still awarded at most once per family (see
+// analyzeLineContextForMatch), so collecting more offsets cannot double-penalize;
+// it only stops one from hiding another.
 //
 // The geographic loop also stops ranging over geoPatternsMap directly. Ranging a
-// Go map with `break` picks an arbitrary winner among several present patterns;
-// the score was the same either way, so this was invisible, but the recorded
-// offset is not order-independent. Iterating a sorted slice makes which pattern
-// is found deterministic.
+// Go map picks an arbitrary winner among several present patterns; the score was
+// the same either way, so this was invisible, but the recorded offset is not
+// order-independent. Iterating a sorted slice makes it deterministic.
 func (v *Validator) specificPatternIndices(lowerLine string) (business, product, geo []int) {
-	for _, pattern := range v.getSortedBusinessPatterns() {
-		if i := firstWordKeywordIndex(lowerLine, pattern); i >= 0 {
-			business = append(business, i)
-			break
+	collect := func(patterns []string) []int {
+		var out []int
+		for _, pattern := range patterns {
+			if i := firstWordKeywordIndex(lowerLine, pattern); i >= 0 {
+				out = append(out, i)
+			}
 		}
+		return out
 	}
-	for _, pattern := range v.getSortedProductPatterns() {
-		if i := firstWordKeywordIndex(lowerLine, pattern); i >= 0 {
-			product = append(product, i)
-			break
-		}
-	}
-	for _, pattern := range v.getSortedGeoPatterns() {
-		if i := firstWordKeywordIndex(lowerLine, pattern); i >= 0 {
-			geo = append(geo, i)
-			break
-		}
-	}
-	return business, product, geo
+	return collect(v.getSortedBusinessPatterns()),
+		collect(v.getSortedProductPatterns()),
+		collect(v.getSortedGeoPatterns())
 }
 
 // These complex pattern matching methods are no longer needed


### PR DESCRIPTION
## A name and an address on the same line loses the name

The business (−20), product (−8) and geographic (−35) penalties in `analyzeSpecificPatternsLineGlobal` applied to the whole **line**, regardless of where the pattern sat relative to the name. Summed and clamped to −50 in `analyzeContextCached`, that takes a solid two-token name from 92 to **42** — below the ≥ 50 emit threshold.

```
"Sarah Brooks,Acme Inc,1425 Oak Drive,Springfield,IL"              -> 0 findings
"Patient Sarah Brooks, 42 River Road, admitted Monday"             -> 0 findings
"Contact Sarah Brooks at 1425 Elm Avenue for the Acme Inc account"  -> 0 findings
"Michael Rivera,Globex LLC,88 Lake Street,Portland,OR"             -> 0 findings
```

The same names score **92** with the address removed, and **100** with the address on its own line.

The geographic list is ordinary address vocabulary — `street road city state drive avenue boulevard` — so this fires on mailing records, shipping labels, clinical notes and CSV exports. That's the shape of the data this tool exists to find.

## It's a leak, not a scoring quirk

An unreported name is never handed to the redactor. On a two-row CSV of names and addresses the CLI reported nothing and wrote **no redacted file at all** — both names survived in cleartext. After the fix:

| strategy | output |
|---|---|
| `simple` | `[PERSON-NAME-REDACTED],Acme Inc,1425 Oak Drive,…` |
| `format_preserving` | `************,Acme Inc,1425 Oak Drive,…` |
| `synthetic` | `Jann Dunham,Acme Inc,1425 Oak Drive,…` |

## Why this is a bug and not tuning

The per-match **negative-keyword** penalty has always been proximity-gated (`distance < 15`). These three families were the only context signals applied to the whole line at any distance.

They were also largely **redundant**: 13 of the 19 geographic patterns and 17 of the business patterns are *also* `negativeKeywords`. Those words were scored twice — once correctly, gated, and once line-globally.

## The fix

Locate the patterns per line (work stays hoisted, validator stays linear) but **apply** each penalty only when the pattern sits within `specificPatternProximity` bytes of the match — the same shape the negative-keyword path already uses. Boosts stay line-global; a boost cannot hide a finding.

## The window is measured, not guessed

Swept against 10 real names carrying addresses and 24 place/org/address decoys:

| window | real names found | decoys reported |
|---|---|---|
| 15 | 10/10 | 8/24 |
| 22 | 10/10 | 6/24 |
| **23–25** | **10/10** | **5/24** ← plateau |
| 26 | 9/10 | 5/24 |
| 30 | 8/10 | 5/24 |
| line-global | 4/10 | 5/24 *(old behavior)* |

**5/24 is exactly what the old code reported, on the same five lines.** So this recovers every real name while introducing **zero** new false positives. 25 sits at the top of the plateau, one byte before recall starts dropping.

The five residual decoys (`Phoenix Arizona`, `Menlo Park`, …) are a **separate pre-existing issue**, deliberately not fixed here: those place words are themselves entries in the *first-name database*, so they score on their own merits and the geographic penalty was only masking them incidentally — at the cost of deleting real names. No window value separates the two classes, because the geographic word sits outside the matched span in both (20–21 bytes away in the decoys, 29–31 in the real names). Fixing that means curating the name database.

## Also: the geographic scan was map-ordered

It ranged `geoPatternsMap` directly and `break`ed on the first hit, so map order picked the winner. The score was identical either way — which is why it was invisible — but the recorded byte **offset** was not order-independent, and the offset now decides whether a name is penalized. Added `getSortedGeoPatterns` alongside the three existing sorted accessors.

## Tests

- **`TestAddressOnSameLineKeepsTheName`** — 10 leak cases. Verified **6/6 fail on the pre-change validator and 0/6 fail after**, using a behavioral-only copy that compiles against both (the mechanism tests reference new internals, so they can't prove this on their own).
- `TestPlaceNamesStaySuppressed` — the FP direction, documenting which five lines are excluded and why.
- `TestSpecificPatternPenaltyIsProximityGated` — pins the mechanism (same words, same name, only distance varies), so a revert to line-global fails even if the corpora happen to pass.
- `TestGeoPatternIterationIsDeterministic` — runs the scan 50×, and asserts the accessor is actually sorted.
- `TestFirstWordKeywordIndexMatchesContainsWordKeyword` — locks the invariant the gate depends on: the new index helper and the existing boolean helper must agree, including on substring traps (`state` in `estate`, `drive` in `driven`).

## Verification

- Full suite `exit=0` (60 packages); `-race` clean on `personname` and `goldencorpus`; `gofmt`/`vet`/`build` clean.
- `UPDATE_GOLDEN=1` → **zero golden diff**, non-vacuous against **98 `PERSON_NAME` assertions across 9 golden files**.
- The `personname` complexity guard still passes, so the per-line hoist is intact and this didn't reintroduce per-match line scanning.
- Merges clean in order behind #207 → #208 → #209 → #210 → #211 → #212 → #213 → #214; the combined 9-branch stack builds and passes.
