### PR TITLE
fix(socialmedia): make the @handle pattern compile, so handles are detected

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -340,7 +340,20 @@ validators:
       # Twitter/X - Microblogging platform
       twitter:
         - "(?i)https?://(?:www\\.)?(twitter|x)\\.com/[a-zA-Z0-9_]+" # Profile URLs
-        - "(?i)(?<!\\w)@[a-zA-Z0-9_]{1,15}(?!@|\\.[a-zA-Z])" # @mentions and handles
+        # @mentions and handles. Go uses RE2, which has NO lookaround: the previous
+        # form used a lookbehind (?<!\w) and a lookahead (?!@|\.[a-zA-Z]), so it
+        # failed to compile and was silently DROPPED — twitter loaded 2 of its 3
+        # patterns and no bare @handle was ever detected.
+        #
+        # \B before @ reproduces the lookbehind: @ is a non-word char, so \B holds
+        # only when the preceding char is also a non-word char (or start of line),
+        # which is what "not preceded by \w" means here. That alone rejects the
+        # email/domain case (bob@example.com).
+        #
+        # The trailing exclusions cannot be expressed in RE2 and are enforced in
+        # code instead, by isFalsePositiveHandle: a handle immediately followed by
+        # '.', '-' or '@' is a domain or federated address, not a bare handle.
+        - "(?i)\\B@[a-zA-Z0-9_]{1,15}\\b" # @mentions and handles
         - "(?i)(twitter|x)\\.com/[a-zA-Z0-9_]+"
 
       # GitHub - Code repository platform

--- a/docs/social-media-configuration.md
+++ b/docs/social-media-configuration.md
@@ -24,7 +24,7 @@ validators:
       # Configure patterns for platforms you want to detect
       twitter:
         - "(?i)https?://(?:www\\.)?(twitter|x)\\.com/[a-zA-Z0-9_]+"
-        - "(?i)(?<!\\w)@[a-zA-Z0-9_]{1,15}(?!@|\\.[a-zA-Z])"  # Avoids email false positives
+        - "(?i)\\B@[a-zA-Z0-9_]{1,15}\\b"  # Bare @handles; email/federated forms vetoed in code
 
       github:
         - "(?i)https?://(?:www\\.)?github\\.com/[a-zA-Z0-9_-]+(?:/[a-zA-Z0-9_.-]+)?"
@@ -85,7 +85,7 @@ validators:
       # Twitter/X - Microblogging (email-safe patterns)
       twitter:
         - "(?i)https?://(?:www\\.)?(twitter|x)\\.com/[a-zA-Z0-9_]+"
-        - "(?i)(?<!\\w)@[a-zA-Z0-9_]{1,15}(?!@|\\.[a-zA-Z])"  # Avoids @gmail from emails
+        - "(?i)\\B@[a-zA-Z0-9_]{1,15}\\b"  # Bare @handles; @gmail-from-email vetoed in code
         - "(?i)(twitter|x)\\.com/[a-zA-Z0-9_]+"
 
       # GitHub - Code repositories
@@ -189,7 +189,19 @@ validators:
 ### Email vs Social Media
 - **DO NOT** include email patterns in social media configuration
 - The dedicated EMAIL validator handles email addresses
-- The Twitter pattern `(?i)(?<!\\w)@[a-zA-Z0-9_]{1,15}(?!@|\\.[a-zA-Z])` prevents matching email domains like `@gmail`
+- The Twitter pattern `(?i)\\B@[a-zA-Z0-9_]{1,15}\\b` matches bare `@handles`. The leading
+  `\\B` is what keeps it off email domains like the `@gmail` in `user@gmail.com`: `@` is a
+  non-word character, so `\\B` holds only where the preceding character is also
+  non-word (or the line starts).
+- **Go uses RE2, which has no lookahead, lookbehind or backreferences.** A pattern
+  using them does not fail loudly — it fails to compile at use time, is skipped, and
+  is reported only under `FERRET_DEBUG=1`, so the check silently detects nothing.
+  This exact pattern previously shipped as `(?i)(?<!\\w)@[a-zA-Z0-9_]{1,15}(?!@|\\.[a-zA-Z])`
+  and never matched anything. `internal/config/yaml_regex_test.go` now compiles every
+  shipped pattern under RE2 to prevent a repeat.
+- Constraints RE2 cannot express are enforced in code instead, in
+  `isFalsePositiveHandle`: a handle immediately followed by `.`, `-` or `@` is a
+  domain or a federated (Mastodon-style) address rather than a bare handle.
 
 ### Pattern Guidelines
 - Use case-insensitive patterns: `(?i)`

--- a/internal/config/yaml_regex_test.go
+++ b/internal/config/yaml_regex_test.go
@@ -1,0 +1,161 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestShippedConfigPatternsCompile is the gate that was missing.
+//
+// Go's regexp package is RE2: it has NO lookahead, NO lookbehind, and no
+// backreferences. A pattern written in PCRE style is not a syntax error at load
+// time — it fails to compile at USE time, and every consumer of these patterns
+// skips a failed pattern and carries on. The only trace is a debug-only log line,
+// so a broken pattern is invisible in normal operation.
+//
+// That is not theoretical. The shipped twitter handle pattern was
+//
+//	(?i)(?<!\w)@[a-zA-Z0-9_]{1,15}(?!@|\.[a-zA-Z])
+//
+// which RE2 rejects ("invalid named capture", because it reads (?< as the start of
+// a named group). twitter therefore loaded 2 of its 3 patterns and NO bare @handle
+// was ever detected by SOCIAL_MEDIA, while the tool reported success. For a
+// detection tool a silently inert pattern is a false negative on every document.
+//
+// This test compiles every regex in the shipped config with the same engine that
+// will run it, so the failure surfaces here instead of as missing findings.
+func TestShippedConfigPatternsCompile(t *testing.T) {
+	path := shippedConfigPath(t)
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig(%s): %v", path, err)
+	}
+
+	var checked int
+	for validator, section := range cfg.Validators {
+		for key, raw := range section {
+			forEachPatternString(raw, func(pattern string) {
+				checked++
+				if _, err := regexp.Compile(pattern); err != nil {
+					t.Errorf("%s / %s: pattern does not compile under Go's RE2 engine, so it "+
+						"will be silently SKIPPED at runtime and can never match:\n  pattern: %s\n  error:   %v\n"+
+						"  hint:    RE2 has no lookahead/lookbehind — express the constraint in code instead.",
+						validator, key, pattern, err)
+				}
+			})
+		}
+	}
+
+	// Non-vacuity: this must actually have examined the patterns. If the config
+	// shape changes and the walk stops finding them, the test would otherwise pass
+	// while checking nothing.
+	if checked < 50 {
+		t.Fatalf("only %d patterns examined; the shipped config carries far more than "+
+			"that, so this test is no longer reaching them (config shape changed?)", checked)
+	}
+	t.Logf("compiled %d config patterns under RE2", checked)
+}
+
+// TestNoLookaroundInShippedConfig catches the mistake by SHAPE as well as by
+// compilation.
+//
+// Compilation is the real gate, but some lookaround spellings happen to compile as
+// something else entirely and are therefore worse than a hard failure: RE2 reads
+// `(?<name>x)` as a syntax error, but a stray `(?=` or `(?!` can parse in ways that
+// silently do not mean what the author intended. Flagging the syntax outright keeps
+// a PCRE habit from reaching the file.
+func TestNoLookaroundInShippedConfig(t *testing.T) {
+	data, err := os.ReadFile(shippedConfigPath(t))
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+
+	// Only flag these inside what looks like a pattern line, so prose in comments
+	// (including the comment explaining this very constraint) is not a false hit.
+	lookaround := []string{"(?=", "(?!", "(?<", "(?'"}
+
+	for i, line := range strings.Split(string(data), "\n") {
+		code := line
+		if h := strings.Index(code, " #"); h >= 0 {
+			code = code[:h] // drop trailing comment
+		}
+		if !strings.Contains(code, "\"") {
+			continue
+		}
+		for _, tok := range lookaround {
+			if strings.Contains(code, tok) {
+				t.Errorf("config.yaml:%d contains %q — Go's RE2 engine has no lookaround, "+
+					"and a pattern using it is silently skipped at runtime:\n  %s",
+					i+1, tok, strings.TrimSpace(line))
+			}
+		}
+	}
+}
+
+// shippedConfigPath locates config.yaml at the repo root from this package's
+// directory, failing loudly rather than silently skipping if it moves.
+func shippedConfigPath(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join("..", "..", "config.yaml")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("shipped config not found at %s: %v (did it move? this test must not "+
+			"silently stop checking it)", path, err)
+	}
+	return path
+}
+
+// forEachPatternString walks a decoded YAML value and calls fn for every string
+// that looks like a regex. The config nests patterns as strings, []any of strings,
+// and map[string]any of either, so the walk has to handle all three.
+//
+// "Looks like a regex" is deliberately loose — a plain keyword like "twitter" is
+// also a valid regex, and compiling it costs nothing. The filter only skips
+// obviously-not-a-pattern values so the non-vacuity floor stays meaningful.
+func forEachPatternString(v any, fn func(string)) {
+	switch val := v.(type) {
+	case string:
+		if looksLikeRegex(val) {
+			fn(val)
+		}
+	case []any:
+		for _, item := range val {
+			forEachPatternString(item, fn)
+		}
+	case map[string]any:
+		for _, item := range val {
+			forEachPatternString(item, fn)
+		}
+	case map[any]any: // YAML can decode to this shape
+		for _, item := range val {
+			forEachPatternString(item, fn)
+		}
+	}
+}
+
+func looksLikeRegex(s string) bool {
+	return strings.ContainsAny(s, `\[](){}|^$*+?`)
+}
+
+// TestEarliestPatternErrorIsActionable documents, with a live example, what this
+// suite protects against: a PCRE-only pattern compiles fine in a PCRE engine and
+// dies in RE2. Kept as a test so the claim stays true rather than becoming a stale
+// comment.
+func TestEarliestPatternErrorIsActionable(t *testing.T) {
+	const pcreOnly = `(?i)(?<!\w)@[a-zA-Z0-9_]{1,15}(?!@|\.[a-zA-Z])`
+	_, err := regexp.Compile(pcreOnly)
+	if err == nil {
+		t.Fatalf("premise broken: %s now compiles under RE2, so the lookaround "+
+			"restriction this suite guards has changed", pcreOnly)
+	}
+	if !strings.Contains(fmt.Sprint(err), "invalid") {
+		t.Logf("note: RE2 rejection message changed: %v", err)
+	}
+}

--- a/internal/validators/socialmedia/handle_detection_test.go
+++ b/internal/validators/socialmedia/handle_detection_test.go
@@ -1,0 +1,201 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package socialmedia
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/config"
+)
+
+// configuredValidator returns a validator loaded from the SHIPPED config, which is
+// the only way SOCIAL_MEDIA does anything: a bare NewValidator leaves
+// patternsConfigured false and ValidateContent returns immediately.
+//
+// Loading the real config on purpose — these tests are about whether the shipped
+// patterns work, so a hand-written pattern here would test nothing.
+func configuredValidator(t *testing.T) *Validator {
+	t.Helper()
+	path := filepath.Join("..", "..", "..", "config.yaml")
+	cfg, err := config.LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig(%s): %v", path, err)
+	}
+	v := NewValidator()
+	v.Configure(cfg)
+	if !v.patternsConfigured || len(v.compiledPatterns) == 0 {
+		t.Fatalf("validator not configured from %s: patternsConfigured=%v compiled=%d",
+			path, v.patternsConfigured, len(v.compiledPatterns))
+	}
+	return v
+}
+
+// TestBareHandlesAreDetected is the recall gate for the RE2 fix.
+//
+// The shipped twitter handle pattern used a PCRE lookbehind and lookahead, which
+// Go's RE2 engine rejects. A pattern that fails to compile is SKIPPED and logged
+// only under FERRET_DEBUG=1, so twitter loaded 2 of its 3 patterns and no bare
+// @handle was ever reported — silently, on every document.
+func TestBareHandlesAreDetected(t *testing.T) {
+	v := configuredValidator(t)
+
+	cases := []struct {
+		name string
+		line string
+		want string
+	}{
+		{"prose", "Follow our team lead @sarah_devops on twitter for updates", "@sarah_devops"},
+		{"labelled", "My handle is @jdoe_2024 and the account is active", "@jdoe_2024"},
+		{"parenthetical", "Contact: @company_support (twitter handle)", "@company_support"},
+		{"digits", "ping @ops_team_7 about the incident", "@ops_team_7"},
+		{"start of line", "@release_bot posted the changelog", "@release_bot"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			matches, err := v.ValidateContent(tc.line, "notes.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) == 0 {
+				t.Fatalf("no findings for %q — the handle pattern is not matching. If the "+
+					"config pattern was rewritten, check it compiles under RE2: a failed "+
+					"pattern is skipped silently.\n  line: %q", tc.want, tc.line)
+			}
+			var found bool
+			var got []string
+			for _, m := range matches {
+				got = append(got, m.Text)
+				if strings.Contains(m.Text, tc.want) {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("findings %v do not include %q\n  line: %q", got, tc.want, tc.line)
+			}
+		})
+	}
+}
+
+// TestHandleFalsePositivesStaySuppressed covers the constraints the PCRE lookahead
+// used to express, which now live in isFalsePositiveHandle because RE2 cannot
+// express them. Losing these would turn every email address into a "handle".
+func TestHandleFalsePositivesStaySuppressed(t *testing.T) {
+	v := configuredValidator(t)
+
+	cases := []struct {
+		name string
+		line string
+	}{
+		{"email address", "email me at bob@example.com instead"},
+		{"email in prose", "send it to alice.smith@corp.internal today"},
+		{"federated address", "federated user @alice@mastodon.social posts often"},
+		{"hyphenated domain", "contact@my-company.com is the alias"},
+		{"code comment", "// @param handle is a code annotation"},
+		{"block comment", "/* @author bob */"},
+		{"leading underscore", "the @_private flag"},
+		{"single char", "wildcard @a matches"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			matches, err := v.ValidateContent(tc.line, "code.go")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			for _, m := range matches {
+				if strings.HasPrefix(m.Text, "@") || strings.Contains(m.Text, "@") {
+					t.Errorf("reported %q as a social media handle on a line that carries "+
+						"none: %q", m.Text, tc.line)
+				}
+			}
+		})
+	}
+}
+
+// TestHandleSurvivesURLOnSameLine is the code-comment-veto fix.
+//
+// The veto asked only whether the line contained "//" ANYWHERE, which is true of
+// every line carrying a URL ("https://"). A handle in ordinary prose next to a
+// link was therefore discarded. The marker now has to appear BEFORE the handle, and
+// a "//" that is part of a URL scheme does not count at all.
+func TestHandleSurvivesURLOnSameLine(t *testing.T) {
+	v := configuredValidator(t)
+
+	lines := []string{
+		"Follow @maria_ops - details at https://example.com/team",
+		"see s3://our-bucket/report and ping @data_eng",
+		"docs at http://internal.example.com maintained by @docs_team",
+	}
+
+	for _, line := range lines {
+		matches, err := v.ValidateContent(line, "README.md")
+		if err != nil {
+			t.Fatalf("ValidateContent(%q): %v", line, err)
+		}
+		var handles []string
+		for _, m := range matches {
+			if strings.HasPrefix(m.Text, "@") {
+				handles = append(handles, m.Text)
+			}
+		}
+		if len(handles) == 0 {
+			t.Errorf("no handle reported on %q — a URL on the line must not veto an "+
+				"unrelated handle (the \"//\" of a scheme is not a comment marker)", line)
+		}
+	}
+}
+
+// TestRealCommentStillVetoes is the other direction: the veto must keep working
+// where it is correct, including on a line that ALSO contains a URL.
+func TestRealCommentStillVetoes(t *testing.T) {
+	v := configuredValidator(t)
+
+	lines := []string{
+		"// see https://example.com and ask @someone", // comment precedes both
+		"code(); // @reviewer please check",           // trailing comment before handle
+		"/* @author @maintainer */",                   // block comment
+	}
+
+	for _, line := range lines {
+		matches, err := v.ValidateContent(line, "main.go")
+		if err != nil {
+			t.Fatalf("ValidateContent(%q): %v", line, err)
+		}
+		for _, m := range matches {
+			if strings.HasPrefix(m.Text, "@") {
+				t.Errorf("reported %q on a line where a comment marker precedes the "+
+					"handle: %q", m.Text, line)
+			}
+		}
+	}
+}
+
+// TestEarliestCommentMarker unit-tests the helper the veto depends on, including
+// the URL-scheme exemption that is the entire point of it.
+func TestEarliestCommentMarker(t *testing.T) {
+	cases := []struct {
+		line string
+		want int
+	}{
+		{"// @param handle", 0},
+		{"code(); // trailing comment", 8},
+		{"follow @maria - see https://example.com/team", -1},
+		{"see s3://bucket/key and @handle", -1},
+		{"/* @author bob */", 0},
+		{"x = 1 /* note */", 6},
+		{"plain prose with @handle", -1},
+		{"http://a and // real comment", 13},
+		{"", -1},
+		{"//", 0},
+	}
+
+	for _, tc := range cases {
+		if got := earliestCommentMarker(tc.line); got != tc.want {
+			t.Errorf("earliestCommentMarker(%q) = %d, want %d", tc.line, got, tc.want)
+		}
+	}
+}

--- a/internal/validators/socialmedia/validator.go
+++ b/internal/validators/socialmedia/validator.go
@@ -4725,6 +4725,39 @@ func (v *Validator) getPlatformDisplayName(platform string) string {
 
 // isPartOfEmailAddress checks if a social media match is actually part of an email address
 // This prevents false positives where email domain parts are detected as social media handles
+// earliestCommentMarker returns the byte offset of the first code-comment marker
+// in lowerLine, or -1 if there is none.
+//
+// A "//" that is part of a URL scheme ("https://", "s3://") is NOT a comment
+// marker: skipping those is what stops a link on the line from discarding an
+// unrelated handle. The scheme test is "the // is immediately preceded by ':'",
+// which is what every URL scheme looks like and what no line comment looks like.
+func earliestCommentMarker(lowerLine string) int {
+	best := -1
+	consider := func(idx int) {
+		if idx >= 0 && (best < 0 || idx < best) {
+			best = idx
+		}
+	}
+
+	for from := 0; ; {
+		i := strings.Index(lowerLine[from:], "//")
+		if i < 0 {
+			break
+		}
+		i += from
+		if i == 0 || lowerLine[i-1] != ':' { // ':' => URL scheme, not a comment
+			consider(i)
+			break
+		}
+		from = i + 2
+	}
+
+	consider(strings.Index(lowerLine, "/*"))
+	consider(strings.Index(lowerLine, "*/"))
+	return best
+}
+
 func (v *Validator) isPartOfEmailAddress(match, line string) bool {
 	// This is specifically designed to catch cases where Twitter handle patterns (@username)
 	// match the domain part of email addresses (e.g., @example from user@example.com)
@@ -4793,8 +4826,17 @@ func (v *Validator) isFalsePositiveHandle(match, line string, matchOffset int) b
 		}
 	}
 
-	// Code comment context (// @something or /* @something)
-	if strings.Contains(lineLower, "//") || strings.Contains(lineLower, "/*") || strings.Contains(lineLower, "*/") {
+	// Code comment context (// @something or /* @something).
+	//
+	// The comment marker must appear BEFORE the handle to be commenting on it. The
+	// previous form asked only whether the line contained "//" anywhere, which is
+	// true of every line carrying a URL ("https://") — so a handle in ordinary
+	// prose alongside a link was discarded:
+	//
+	//	"Follow @sarah_devops - details at https://example.com/team"
+	//
+	// A comment marker to the RIGHT of the handle says nothing about it.
+	if idx := earliestCommentMarker(lineLower); idx >= 0 && matchOffset >= 0 && idx < matchOffset {
 		if v.observer != nil && v.observer.Debug() != nil {
 			v.observer.Debug().LogDetail("socialmedia",
 				fmt.Sprintf("Filtered code comment annotation: handle [HIDDEN] (len=%d) in line [HIDDEN] (len=%d)",
@@ -4814,12 +4856,19 @@ func (v *Validator) isFalsePositiveHandle(match, line string, matchOffset int) b
 		return true
 	}
 
-	// Partial domain matches (e.g., @my from contact@my-company.com)
-	// Look for patterns where the handle is immediately followed by a hyphen or dot
+	// Partial domain matches (e.g., @my from contact@my-company.com) and federated
+	// addresses (@user@mastodon.social).
+	//
+	// This is where the trailing half of the handle pattern's intent lives. The
+	// config pattern originally spelled it as a lookahead, (?!@|\.[a-zA-Z]), which
+	// RE2 cannot express — so the check has to happen here. '@' covers the
+	// federated form: a bare @user@instance is a Mastodon-style address, and the
+	// mastodon patterns claim the URL forms of it, so emitting the leading @user as
+	// a Twitter handle would be both wrong and a duplicate span.
 	matchIndex := matchOffset
 	if matchIndex >= 0 && matchIndex+len(match) < len(line) {
 		nextChar := line[matchIndex+len(match)]
-		if nextChar == '-' || nextChar == '.' {
+		if nextChar == '-' || nextChar == '.' || nextChar == '@' {
 			if v.observer != nil && v.observer.Debug() != nil {
 				v.observer.Debug().LogDetail("socialmedia",
 					fmt.Sprintf("Filtered partial domain match (followed by %q): handle [HIDDEN] (len=%d) in line [HIDDEN] (len=%d)",


### PR DESCRIPTION
Stacked on #210 **deliberately** — see "Why this order matters" below. Rebase to `main` after #210 lands.

## The shipped @handle pattern never compiled

```yaml
- "(?i)(?<!\\w)@[a-zA-Z0-9_]{1,15}(?!@|\\.[a-zA-Z])"
```

Go's `regexp` is **RE2**: no lookbehind, no lookahead. RE2 reads `(?<` as the start of a named group and rejects the whole pattern:

```
error parsing regexp: invalid named capture
```

A pattern that fails to compile is **skipped and carried on from**. So `twitter` loaded 2 of its 3 patterns and SOCIAL_MEDIA never reported a bare `@handle` on any document — while the scan reported success. The only trace is a debug-only line:

```
$ FERRET_DEBUG=1 ferret-scan --file handles.txt --checks SOCIAL_MEDIA
[DEBUG] Social Media: Invalid twitter pattern: ... invalid named capture
[DEBUG] Social Media: twitter loaded 2 patterns
```

For a detection tool, a silently inert pattern is a false negative on **every** input. Measured: **0 of 4** real handles found before, **4 of 4** after, redacted under all three strategies.

## The fix

`(?i)\B@[a-zA-Z0-9_]{1,15}\b`

`\B` before `@` reproduces the lookbehind exactly for this case: `@` is a non-word character, so `\B` holds only where the preceding character is also non-word (or the line starts) — which is what "not preceded by `\w`" means, and it's what keeps the pattern off the `@example` in `bob@example.com`.

The trailing exclusion can't be expressed in RE2, so it moves into code beside the two checks already there. `isFalsePositiveHandle` already rejected a handle immediately followed by `.` or `-` (a domain); it now also rejects `@`, the federated Mastodon form (`@user@instance`). The mastodon patterns claim the URL forms of that, so emitting the leading `@user` as a Twitter handle would be both wrong *and* a duplicate span.

## Second bug, exposed by the first being fixed

The code-comment veto asked whether the line contained `//` **anywhere** — true of every line carrying a URL:

```
"Follow @maria_ops - details at https://example.com/team"   -> no finding
```

A comment marker only comments on what *follows* it, and the `//` of a URL scheme isn't a comment marker at all. `earliestCommentMarker` skips a `//` preceded by `:`, and the veto now requires the marker to precede the handle. Real comments still veto, including on a line that also holds a URL.

## Why this order matters

The vetoes this change activates log through sites that **#210 rewrote** to stop printing the matched handle and the full line. Landing this first would have made a live BSC4 payload leak *reachable* — a handle and its surrounding line written to the debug log.

Confirmed after the change: `--debug` output contains none of the handles or lines, and #210's `TestNoPayloadInDebugLog` still passes with the paths now live.

## Tests

**`internal/config/yaml_regex_test.go` is the gate that was missing.** It compiles every regex in the shipped config with the same engine that will run it (84 patterns), and separately flags lookaround by shape. Both were verified to **fail when the old PCRE pattern is put back**:

```
social_media / platform_patterns: pattern does not compile under Go's RE2 engine,
  so it will be silently SKIPPED at runtime and can never match
config.yaml:356 contains "(?<" — Go's RE2 engine has no lookaround
```

The compile test carries a non-vacuity floor so it can't pass while walking nothing. Sweeping the whole config found **exactly 1 invalid pattern of 196**, so this was the only instance.

`handle_detection_test.go` covers recall (5 handle shapes), the false positives the lookahead used to express (email, federated, hyphenated domain, comments, leading underscore, single char), the URL-on-same-line case in **both** directions, and `earliestCommentMarker` directly including the scheme exemption.

## Verification

- First-party suite `exit=0` (58 packages); `-race` clean on `socialmedia`, `config`, `goldencorpus`; `gofmt`/`vet`/`build` clean.
- `UPDATE_GOLDEN=1` → **zero golden diff**. The corpus has no SOCIAL_MEDIA case at all — that gap is tracked separately, and is why this needed hand-built end-to-end proof.
- **Redaction** under `simple` / `format_preserving` / `synthetic`, with the URL on the line left intact while the handle is replaced.
- **Suppression** generate → enable → apply takes 4 findings to 0, with 5 `[SUPP]` lines, so they're counted rather than dropped.
- **Timing** with the third pattern now active is linear: 110ms / 218ms / 442ms for 1200 / 2400 / 4800 profiles.
- Merges clean in order across the full 10-branch stack (#207 → #208 → #209 → #210 → this → #211 → #212 → #213 → #214 → #215); combined stack builds and passes.
