### PR TITLE
fix(router): let text validators see metadata, so media files are scanned

### DIFF
--- a/internal/goldencorpus/testdata/golden/file_wav_metadata_pii.csv
+++ b/internal/goldencorpus/testdata/golden/file_wav_metadata_pii.csv
@@ -1,3 +1,6 @@
 Filename,Type,Confidence Level,Confidence %,Line Number,Text
 <TMPDIR>/clip.wav,DOCUMENT_COMMENTS,HIGH,100.0,7,contact 212-555-0142 or AKIAIOSFODNN7EXAMPLE
-<TMPDIR>/clip.wav,AUTHOR_INFO,MEDIUM,80.0,6,john.doe@example.com
+<TMPDIR>/clip.wav,AWS_ACCESS_KEY,MEDIUM,89.0,7,AKIAIOSFODNN7EXAMPLE
+<TMPDIR>/clip.wav,PHONE,MEDIUM,87.0,7,212-555-0142
+<TMPDIR>/clip.wav,AUTHOR_INFO,MEDIUM,85.0,6,john.doe@example.com
+<TMPDIR>/clip.wav,BUSINESS,LOW,30.0,6,john.doe@example.com

--- a/internal/goldencorpus/testdata/golden/file_wav_metadata_pii.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_wav_metadata_pii.gitlab-sast.json
@@ -55,7 +55,59 @@
     {
       "category": "sast",
       "confidence": "High",
-      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/clip.wav (line 6)\n**Confidence:** MEDIUM (80.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nArtist: john.doe@example.com\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "description": "Ferret Scan detected aws access key in this file.\n\n**Location:** <TMPDIR>/clip.wav (line 7)\n**Confidence:** MEDIUM (89.0%)\n**Detected by:** secrets validator\n\n**Matched value:**\n```\nAKIAIOSFODNN7EXAMPLE\n```\n\n**Additional Information:**\n- source: preprocessed_content\n\n**Remediation:**\nRemove AWS credentials immediately and rotate them. Use IAM roles or environment variables instead.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "AWS_ACCESS_KEY"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "secrets"
+        }
+      ],
+      "location": {
+        "end_line": 7,
+        "file": "clip.wav",
+        "start_line": 7
+      },
+      "message": "AWS access key detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Aws Access Key Detected",
+      "severity": "High"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected phone number in this file.\n\n**Location:** <TMPDIR>/clip.wav (line 7)\n**Confidence:** MEDIUM (87.0%)\n**Detected by:** phone validator\n\n**Context:**\n```\nComment: contact 212-555-0142 or AKIAIOSFODNN7EXAMPLE\n```\n\n**Additional Information:**\n- context_impact: -3\n- source: preprocessed_content\n\n**Remediation:**\nRemove phone numbers or replace with example numbers (e.g., 555-0123).",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "PHONE"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "phone"
+        }
+      ],
+      "location": {
+        "end_line": 7,
+        "file": "clip.wav",
+        "start_line": 7
+      },
+      "message": "Phone number detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Phone Number Detected",
+      "severity": "High"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/clip.wav (line 6)\n**Confidence:** MEDIUM (85.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nArtist: john.doe@example.com\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {
@@ -77,6 +129,32 @@
       "message": "Author information detected: [HIDDEN] (confidence: MEDIUM)",
       "name": "Author Info Detected",
       "severity": "High"
+    },
+    {
+      "category": "sast",
+      "confidence": "Low",
+      "description": "Ferret Scan detected sensitive data (business) in this file.\n\n**Location:** <TMPDIR>/clip.wav (line 6)\n**Confidence:** LOW (30.0%)\n**Detected by:** email validator\n\n**Context:**\n```\nArtist: john.doe@example.com\n```\n\n**Additional Information:**\n- context_impact: -20\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "BUSINESS"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "email"
+        }
+      ],
+      "location": {
+        "end_line": 6,
+        "file": "clip.wav",
+        "start_line": 6
+      },
+      "message": "Sensitive data (business) detected: [HIDDEN] (confidence: LOW)",
+      "name": "Business Detected",
+      "severity": "Medium"
     }
   ]
 }

--- a/internal/goldencorpus/testdata/golden/file_wav_metadata_pii.json.json
+++ b/internal/goldencorpus/testdata/golden/file_wav_metadata_pii.json.json
@@ -12,6 +12,8 @@
         "context_doctype": "Configuration",
         "context_domain": "Unknown",
         "context_impact": -0.04999999999999999,
+        "correlation_boost": 5,
+        "cross_path_correlation": true,
         "full_field": "Comment: contact 212-555-0142 or AKIAIOSFODNN7EXAMPLE",
         "metadata_type": "DOCUMENT_COMMENTS",
         "original_confidence": 100,
@@ -41,7 +43,92 @@
       "validator": "metadata"
     },
     {
-      "confidence": 80,
+      "confidence": 89,
+      "confidence_level": "MEDIUM",
+      "filename": "<TMPDIR>/clip.wav",
+      "line_number": 7,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0,
+        "context_doc_type": "Configuration",
+        "context_doctype": "Configuration",
+        "context_domain": "Unknown",
+        "correlation_boost": 5,
+        "cross_path_correlation": true,
+        "detection_method": "keyword_pattern",
+        "environment_type": "test",
+        "original_confidence": 84,
+        "secret_type": "AWS_ACCESS_KEY",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0.125
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "config_file_boost": true,
+          "has_entropy": true,
+          "min_length": true,
+          "not_common_word": true,
+          "not_test_data": true,
+          "specific_pattern": true,
+          "test_environment_penalty": true,
+          "valid_format": true
+        },
+        "validation_path": "document"
+      },
+      "text": "AKIAIOSFODNN7EXAMPLE",
+      "type": "AWS_ACCESS_KEY",
+      "validator": "secrets"
+    },
+    {
+      "confidence": 87,
+      "confidence_level": "MEDIUM",
+      "filename": "<TMPDIR>/clip.wav",
+      "line_number": 7,
+      "metadata": {
+        "clean_number": "2125550142",
+        "confidence_adjustment": 0,
+        "context_confidence": 0,
+        "context_doctype": "Configuration",
+        "context_domain": "Unknown",
+        "context_impact": -3,
+        "correlation_boost": 5,
+        "country": "US/CA",
+        "cross_path_correlation": true,
+        "format": "XXX-XXX-XXXX",
+        "original_confidence": 82,
+        "original_file": "<TMPDIR>/clip.wav",
+        "pattern_name": "US_Dashed",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0.125
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "not_repeating": true,
+          "not_sequential": true,
+          "not_ssn_pattern": true,
+          "not_test_number": false,
+          "not_timestamp": true,
+          "reasonable_length": true,
+          "valid_country": true,
+          "valid_digits": true,
+          "valid_format": true
+        },
+        "validation_path": "document"
+      },
+      "text": "212-555-0142",
+      "type": "PHONE",
+      "validator": "phone"
+    },
+    {
+      "confidence": 85,
       "confidence_level": "MEDIUM",
       "filename": "<TMPDIR>/clip.wav",
       "line_number": 6,
@@ -51,6 +138,8 @@
         "context_doctype": "Configuration",
         "context_domain": "Unknown",
         "context_impact": 0,
+        "correlation_boost": 5,
+        "cross_path_correlation": true,
         "full_field": "Artist: john.doe@example.com",
         "metadata_type": "AUTHOR_INFO",
         "original_confidence": 80,
@@ -80,6 +169,49 @@
       "text": "john.doe@example.com",
       "type": "AUTHOR_INFO",
       "validator": "metadata"
+    },
+    {
+      "confidence": 30,
+      "confidence_level": "LOW",
+      "filename": "<TMPDIR>/clip.wav",
+      "line_number": 6,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0,
+        "context_doctype": "Configuration",
+        "context_domain": "Unknown",
+        "context_impact": -20,
+        "correlation_boost": 5,
+        "cross_path_correlation": true,
+        "domain": "example.com",
+        "email_provider": "BUSINESS",
+        "original_confidence": 25,
+        "original_file": "<TMPDIR>/clip.wav",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0.125
+        },
+        "source": "preprocessed_content",
+        "tld": "com",
+        "username": "john.doe",
+        "validation_checks": {
+          "business_pattern": true,
+          "no_consecutive_dots": true,
+          "not_test_email": false,
+          "reasonable_length": true,
+          "valid_domain": true,
+          "valid_format": true,
+          "valid_tld": true,
+          "valid_username": true
+        },
+        "validation_path": "document"
+      },
+      "text": "john.doe@example.com",
+      "type": "BUSINESS",
+      "validator": "email"
     }
   ]
 }

--- a/internal/goldencorpus/testdata/golden/file_wav_metadata_pii.junit.xml
+++ b/internal/goldencorpus/testdata/golden/file_wav_metadata_pii.junit.xml
@@ -2,7 +2,7 @@
 <testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
   <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
     <testcase name="clip.wav" classname="security-scan" time="0.001">
-      <failure message="2 security findings detected" type="SECURITY_FINDINGS">Line 7: DOCUMENT_COMMENTS detected with 100.0% confidence (HIGH)&#xA;Match: contact 212-555-0142 or AKIAIOSFODNN7EXAMPLE&#xA;Validator: metadata&#xA;Line 6: AUTHOR_INFO detected with 80.0% confidence (MEDIUM)&#xA;Match: john.doe@example.com&#xA;Validator: metadata</failure>
+      <failure message="5 security findings detected" type="SECURITY_FINDINGS">Line 7: DOCUMENT_COMMENTS detected with 100.0% confidence (HIGH)&#xA;Match: contact 212-555-0142 or AKIAIOSFODNN7EXAMPLE&#xA;Validator: metadata&#xA;Line 7: AWS_ACCESS_KEY detected with 89.0% confidence (MEDIUM)&#xA;Match: AKIAIOSFODNN7EXAMPLE&#xA;Validator: secrets&#xA;Line 7: PHONE detected with 87.0% confidence (MEDIUM)&#xA;Match: 212-555-0142&#xA;Validator: phone&#xA;Line 6: AUTHOR_INFO detected with 85.0% confidence (MEDIUM)&#xA;Match: john.doe@example.com&#xA;Validator: metadata&#xA;Line 6: BUSINESS detected with 30.0% confidence (LOW)&#xA;Match: john.doe@example.com&#xA;Validator: email</failure>
     </testcase>
   </testsuite>
 </testsuites>

--- a/internal/goldencorpus/testdata/golden/file_wav_metadata_pii.sarif.json
+++ b/internal/goldencorpus/testdata/golden/file_wav_metadata_pii.sarif.json
@@ -35,6 +35,8 @@
               "context_doctype": "Configuration",
               "context_domain": "Unknown",
               "context_impact": -0,
+              "correlation_boost": 5,
+              "cross_path_correlation": true,
               "full_field": "Comment: contact 212-555-0142 or AKIAIOSFODNN7EXAMPLE",
               "metadata_type": "DOCUMENT_COMMENTS",
               "original_confidence": 100,
@@ -73,6 +75,140 @@
                   "uri": "file://<TMPDIR>/clip.wav"
                 },
                 "region": {
+                  "startLine": 7
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "AWS_ACCESS_KEY Detected in clip.wav at line 7 (confidence: 89.0% - MEDIUM). Matched text: 'AKIAIOSFODNN7EXAMPLE'"
+          },
+          "properties": {
+            "confidence": 89,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 0,
+              "context_doc_type": "Configuration",
+              "context_doctype": "Configuration",
+              "context_domain": "Unknown",
+              "correlation_boost": 5,
+              "cross_path_correlation": true,
+              "detection_method": "keyword_pattern",
+              "environment_type": "test",
+              "original_confidence": 84,
+              "secret_type": "AWS_ACCESS_KEY",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0.1
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "config_file_boost": true,
+                "has_entropy": true,
+                "min_length": true,
+                "not_common_word": true,
+                "not_test_data": true,
+                "specific_pattern": true,
+                "test_environment_penalty": true,
+                "valid_format": true
+              },
+              "validation_path": "document"
+            },
+            "validator": "secrets"
+          },
+          "rank": 69.5,
+          "ruleId": "AWS_ACCESS_KEY"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/clip.wav"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "Comment: contact \nComment: contact 212-555-0142 or AKIAIOSFODNN7EXAMPLE\n or AKIAIOSFODNN7EXAMPLE"
+                  },
+                  "startLine": 7
+                },
+                "region": {
+                  "endColumn": 30,
+                  "snippet": {
+                    "text": "Comment: contact 212-555-0142 or AKIAIOSFODNN7EXAMPLE"
+                  },
+                  "startColumn": 18,
+                  "startLine": 7
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Phone Number Detected in clip.wav at line 7 (confidence: 87.0% - MEDIUM). Matched text: '212-555-0142'"
+          },
+          "properties": {
+            "confidence": 87,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "clean_number": "2125550142",
+              "confidence_adjustment": 0,
+              "context_confidence": 0,
+              "context_doctype": "Configuration",
+              "context_domain": "Unknown",
+              "context_impact": -3,
+              "correlation_boost": 5,
+              "country": "US/CA",
+              "cross_path_correlation": true,
+              "format": "XXX-XXX-XXXX",
+              "original_confidence": 82,
+              "original_file": "<TMPDIR>/clip.wav",
+              "pattern_name": "US_Dashed",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0.1
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "not_repeating": true,
+                "not_sequential": true,
+                "not_ssn_pattern": true,
+                "not_test_number": false,
+                "not_timestamp": true,
+                "reasonable_length": true,
+                "valid_country": true,
+                "valid_digits": true,
+                "valid_format": true
+              },
+              "validation_path": "document"
+            },
+            "negativeKeywords": [
+              "example"
+            ],
+            "positiveKeywords": [
+              "contact"
+            ],
+            "validator": "phone"
+          },
+          "rank": 68.5,
+          "ruleId": "PHONE"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/clip.wav"
+                },
+                "region": {
                   "endColumn": 29,
                   "snippet": {
                     "text": "Artist: john.doe@example.com"
@@ -84,10 +220,10 @@
             }
           ],
           "message": {
-            "text": "AUTHOR_INFO Detected in clip.wav at line 6 (confidence: 80.0% - MEDIUM). Matched text: 'john.doe@example.com'"
+            "text": "AUTHOR_INFO Detected in clip.wav at line 6 (confidence: 85.0% - MEDIUM). Matched text: 'john.doe@example.com'"
           },
           "properties": {
-            "confidence": 80,
+            "confidence": 85,
             "confidenceLevel": "MEDIUM",
             "metadata": {
               "confidence_adjustment": 0,
@@ -95,6 +231,8 @@
               "context_doctype": "Configuration",
               "context_domain": "Unknown",
               "context_impact": 0,
+              "correlation_boost": 5,
+              "cross_path_correlation": true,
               "full_field": "Artist: john.doe@example.com",
               "metadata_type": "AUTHOR_INFO",
               "original_confidence": 80,
@@ -123,8 +261,81 @@
             },
             "validator": "metadata"
           },
-          "rank": 65,
+          "rank": 67.5,
           "ruleId": "AUTHOR_INFO"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/clip.wav"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "Artist: \nArtist: john.doe@example.com"
+                  },
+                  "startLine": 6
+                },
+                "region": {
+                  "endColumn": 29,
+                  "snippet": {
+                    "text": "Artist: john.doe@example.com"
+                  },
+                  "startColumn": 9,
+                  "startLine": 6
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "BUSINESS Detected in clip.wav at line 6 (confidence: 30.0% - LOW). Matched text: 'john.doe@example.com'"
+          },
+          "properties": {
+            "confidence": 30,
+            "confidenceLevel": "LOW",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 0,
+              "context_doctype": "Configuration",
+              "context_domain": "Unknown",
+              "context_impact": -20,
+              "correlation_boost": 5,
+              "cross_path_correlation": true,
+              "domain": "example.com",
+              "email_provider": "BUSINESS",
+              "original_confidence": 25,
+              "original_file": "<TMPDIR>/clip.wav",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0.1
+              },
+              "source": "preprocessed_content",
+              "tld": "com",
+              "username": "john.doe",
+              "validation_checks": {
+                "business_pattern": true,
+                "no_consecutive_dots": true,
+                "not_test_email": false,
+                "reasonable_length": true,
+                "valid_domain": true,
+                "valid_format": true,
+                "valid_tld": true,
+                "valid_username": true
+              },
+              "validation_path": "document"
+            },
+            "negativeKeywords": [
+              "example"
+            ],
+            "validator": "email"
+          },
+          "rank": 40,
+          "ruleId": "BUSINESS"
         }
       ],
       "tool": {
@@ -147,6 +358,32 @@
             },
             {
               "fullDescription": {
+                "text": "Sensitive data of type AWS_ACCESS_KEY was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/AWS_ACCESS_KEY.md",
+              "id": "AWS_ACCESS_KEY",
+              "shortDescription": {
+                "text": "AWS_ACCESS_KEY Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type BUSINESS was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/BUSINESS.md",
+              "id": "BUSINESS",
+              "shortDescription": {
+                "text": "BUSINESS Detected"
+              }
+            },
+            {
+              "fullDescription": {
                 "text": "Sensitive data of type DOCUMENT_COMMENTS was detected in the scanned content."
               },
               "help": {
@@ -156,6 +393,19 @@
               "id": "DOCUMENT_COMMENTS",
               "shortDescription": {
                 "text": "DOCUMENT_COMMENTS Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "A phone number was detected in the scanned content. Phone numbers can be considered personally identifiable information (PII) depending on context and jurisdiction."
+              },
+              "help": {
+                "text": "Phone numbers may be considered PII under various privacy regulations. Evaluate whether this phone number should be present in the code. If it's for testing purposes, use clearly fake numbers (e.g., 555-0100 to 555-0199 in North America). For production use, store phone numbers in secure configuration systems with appropriate access controls."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/PHONE.md",
+              "id": "PHONE",
+              "shortDescription": {
+                "text": "Phone Number Detected"
               }
             }
           ],

--- a/internal/goldencorpus/testdata/golden/file_wav_metadata_pii.txt
+++ b/internal/goldencorpus/testdata/golden/file_wav_metadata_pii.txt
@@ -1,4 +1,7 @@
 LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH                          FILE
 --------------------------------------------------------------------------------------------------------
 [HIGH  ] metadata     DOCUMENT_COMMENTS     100.00% line     7 contact 212-555-0142 or AKI... clip.wav
-[MEDIUM] metadata     AUTHOR_INFO            80.00% line     6 john.doe@example.com           clip.wav
+[MEDIUM] secrets      AWS_ACCESS_KEY         89.00% line     7 AKIAIOSFODNN7EXAMPLE           clip.wav
+[MEDIUM] phone        PHONE                  87.00% line     7 212-555-0142                   clip.wav
+[MEDIUM] metadata     AUTHOR_INFO            85.00% line     6 john.doe@example.com           clip.wav
+[LOW   ] email        BUSINESS               30.00% line     6 john.doe@example.com           clip.wav

--- a/internal/goldencorpus/testdata/golden/file_wav_metadata_pii.yaml
+++ b/internal/goldencorpus/testdata/golden/file_wav_metadata_pii.yaml
@@ -13,6 +13,8 @@ results:
         context_doctype: Configuration
         context_domain: Unknown
         context_impact: -0.04999999999999999
+        correlation_boost: 5
+        cross_path_correlation: true
         full_field: 'Comment: contact 212-555-0142 or AKIAIOSFODNN7EXAMPLE'
         metadata_type: DOCUMENT_COMMENTS
         original_confidence: 100
@@ -34,10 +36,85 @@ results:
             contains_enhanced_phone: true
             likely_test_data: true
         validation_path: metadata
+    - text: AKIAIOSFODNN7EXAMPLE
+      line_number: 7
+      type: AWS_ACCESS_KEY
+      confidence: 89
+      confidence_level: MEDIUM
+      filename: <TMPDIR>/clip.wav
+      validator: secrets
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0
+        context_doc_type: Configuration
+        context_doctype: Configuration
+        context_domain: Unknown
+        correlation_boost: 5
+        cross_path_correlation: true
+        detection_method: keyword_pattern
+        environment_type: test
+        original_confidence: 84
+        secret_type: AWS_ACCESS_KEY
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0.125
+        source: preprocessed_content
+        validation_checks:
+            config_file_boost: true
+            has_entropy: true
+            min_length: true
+            not_common_word: true
+            not_test_data: true
+            specific_pattern: true
+            test_environment_penalty: true
+            valid_format: true
+        validation_path: document
+    - text: 212-555-0142
+      line_number: 7
+      type: PHONE
+      confidence: 87
+      confidence_level: MEDIUM
+      filename: <TMPDIR>/clip.wav
+      validator: phone
+      metadata:
+        clean_number: "2125550142"
+        confidence_adjustment: 0
+        context_confidence: 0
+        context_doctype: Configuration
+        context_domain: Unknown
+        context_impact: -3
+        correlation_boost: 5
+        country: US/CA
+        cross_path_correlation: true
+        format: XXX-XXX-XXXX
+        original_confidence: 82
+        original_file: <TMPDIR>/clip.wav
+        pattern_name: US_Dashed
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0.125
+        source: preprocessed_content
+        validation_checks:
+            not_repeating: true
+            not_sequential: true
+            not_ssn_pattern: true
+            not_test_number: false
+            not_timestamp: true
+            reasonable_length: true
+            valid_country: true
+            valid_digits: true
+            valid_format: true
+        validation_path: document
     - text: john.doe@example.com
       line_number: 6
       type: AUTHOR_INFO
-      confidence: 80
+      confidence: 85
       confidence_level: MEDIUM
       filename: <TMPDIR>/clip.wav
       validator: metadata
@@ -47,6 +124,8 @@ results:
         context_doctype: Configuration
         context_domain: Unknown
         context_impact: 0
+        correlation_boost: 5
+        cross_path_correlation: true
         full_field: 'Artist: john.doe@example.com'
         metadata_type: AUTHOR_INFO
         original_confidence: 80
@@ -70,3 +149,41 @@ results:
             contains_email_pattern: true
             likely_test_data: true
         validation_path: metadata
+    - text: john.doe@example.com
+      line_number: 6
+      type: BUSINESS
+      confidence: 30
+      confidence_level: LOW
+      filename: <TMPDIR>/clip.wav
+      validator: email
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0
+        context_doctype: Configuration
+        context_domain: Unknown
+        context_impact: -20
+        correlation_boost: 5
+        cross_path_correlation: true
+        domain: example.com
+        email_provider: BUSINESS
+        original_confidence: 25
+        original_file: <TMPDIR>/clip.wav
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0.125
+        source: preprocessed_content
+        tld: com
+        username: john.doe
+        validation_checks:
+            business_pattern: true
+            no_consecutive_dots: true
+            not_test_email: false
+            reasonable_length: true
+            valid_domain: true
+            valid_format: true
+            valid_tld: true
+            valid_username: true
+        validation_path: document

--- a/internal/router/content_router.go
+++ b/internal/router/content_router.go
@@ -157,8 +157,36 @@ func (cr *ContentRouter) RouteContent(processedContent *preprocessors.ProcessedC
 			routedContent.Metadata = append(routedContent.Metadata, *metadataContent)
 		}
 
-		// No document body content for pure metadata
-		routedContent.DocumentBody = ""
+		// The metadata text is ALSO the document body, so the text validators see it.
+		//
+		// This used to be set to "", and dual_path_bridge.go gates the entire
+		// document path on `DocumentBody != ""` — so for a file whose only text is
+		// its metadata, exactly 1 of the 19 validators ran: METADATA. That is the
+		// routing outcome for every media type (.jpg/.png/.gif/.tiff/.webp,
+		// .wav/.mp3/.flac/.m4a, .mp4/.mov), because only one preprocessor is capable
+		// for those extensions, so ProcessorType has no "+" and lands in this arm.
+		// (.pdf/.docx/.xlsx are unaffected: two preprocessors are capable, so they
+		// route through "combined_preprocessors", which keeps a body.)
+		//
+		// The METADATA validator cannot cover for that. It is a field-NAME allowlist
+		// scanner: validateWithPreprocessorRules skips any line whose key is not in
+		// the per-preprocessor SensitiveFields list, and for a line that does match
+		// it emits ONE coarse type for the whole field value. So an SSN, a PAN or an
+		// AWS key sitting inside a metadata value is either skipped outright or
+		// reported as a single AUTHOR_INFO/DOCUMENT_COMMENTS row — never typed, and
+		// never individually redactable.
+		//
+		// Measured: an EXIF ImageDescription carrying an SSN, an email and a phone
+		// number produced ZERO findings at any confidence, and because there were no
+		// findings the redaction pipeline wrote no output file at all — the tool
+		// affirmatively reported the file clean while the PII sat in it. The
+		// byte-identical text saved as .txt yielded SSN 83 / PHONE 47 / EMAIL 33.
+		//
+		// This is also what the golden corpus was locking in: the file_wav_metadata_pii
+		// case declares Checks EMAIL, PHONE and SECRETS, and its committed snapshot
+		// contained none of them — an AKIA-prefixed access key went undetected inside
+		// a DOCUMENT_COMMENTS blob.
+		routedContent.DocumentBody = processedContent.Text
 
 	case PreprocessorTypePlainText, PreprocessorTypeDocumentText:
 		// This is document body content - route to document validators

--- a/internal/router/pure_metadata_routing_test.go
+++ b/internal/router/pure_metadata_routing_test.go
@@ -1,0 +1,110 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package router
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/preprocessors"
+)
+
+// TestPureMetadataKeepsDocumentBody is the leak gate.
+//
+// RouteContent used to set DocumentBody = "" for a file whose ProcessedContent
+// came from a single *_metadata preprocessor. dual_path_bridge.go gates the entire
+// document path on `DocumentBody != ""`, so for those files exactly 1 of the 19
+// validators ran: METADATA.
+//
+// That is the routing outcome for EVERY media type — .jpg/.png/.gif/.tiff/.webp,
+// .wav/.mp3/.flac/.m4a, .mp4/.mov — because only one preprocessor is capable for
+// those extensions, so ProcessorType carries no "+" and lands in this arm.
+//
+// The METADATA validator cannot cover for it: it is a field-NAME allowlist scanner
+// that emits one coarse type per matching line, so an SSN or a card number inside a
+// metadata value is either skipped outright (the field name is not on the list) or
+// reported as a single AUTHOR_INFO/DOCUMENT_COMMENTS row. Measured end-to-end: an
+// EXIF ImageDescription carrying an SSN, an email and a phone number produced ZERO
+// findings of any type at any confidence, and the tool reported the file clean.
+func TestPureMetadataKeepsDocumentBody(t *testing.T) {
+	const metadataText = "ImageDescription: SSN 456-45-6789 email jane.smith@acmecorp.io\n"
+
+	for _, processorType := range []string{
+		"image_metadata",
+		"pdf_metadata",
+		"office_metadata",
+		"audio_metadata",
+		"video_metadata",
+	} {
+		t.Run(processorType, func(t *testing.T) {
+			cr := NewContentRouter()
+			routed, err := cr.RouteContent(&preprocessors.ProcessedContent{
+				Text:          metadataText,
+				ProcessorType: processorType,
+				OriginalPath:  "asset.bin",
+			})
+			if err != nil {
+				t.Fatalf("RouteContent: %v", err)
+			}
+
+			if routed.DocumentBody == "" {
+				t.Fatalf("DocumentBody is empty for %s. dual_path_bridge gates the whole "+
+					"document path on DocumentBody != \"\", so every text validator is "+
+					"skipped and only METADATA runs — an SSN in this text goes unreported "+
+					"and the file is declared clean.", processorType)
+			}
+			if !strings.Contains(routed.DocumentBody, "456-45-6789") {
+				t.Errorf("DocumentBody does not carry the metadata text for %s: %q",
+					processorType, routed.DocumentBody)
+			}
+
+			// The metadata path must keep working — this widens coverage, it does not
+			// move the text from one path to the other.
+			if len(routed.Metadata) == 0 {
+				t.Errorf("%s: Metadata is empty; the metadata path must still receive the "+
+					"content as well as the document path", processorType)
+			}
+		})
+	}
+}
+
+// TestCombinedPreprocessorsUnaffected pins the boundary of the change.
+//
+// .pdf/.docx/.xlsx have TWO capable preprocessors, so ProcessorType contains "+",
+// identifyPreprocessorType returns "combined_preprocessors", and they route down a
+// different branch that always preserved a body. Those file types must be
+// byte-identical before and after.
+func TestCombinedPreprocessorsUnaffected(t *testing.T) {
+	cr := NewContentRouter()
+	routed, err := cr.RouteContent(&preprocessors.ProcessedContent{
+		Text:          "quarterly numbers\n",
+		ProcessorType: "Text Extractor+office_metadata",
+		OriginalPath:  "report.docx",
+	})
+	if err != nil {
+		t.Fatalf("RouteContent: %v", err)
+	}
+	if routed.DocumentBody == "" {
+		t.Error("combined-preprocessor routing lost its document body; this branch is " +
+			"not the one being changed and must be unaffected")
+	}
+}
+
+// TestPlainTextRoutingUnaffected is the other boundary: a plain text file already
+// took the document path, and must be unchanged.
+func TestPlainTextRoutingUnaffected(t *testing.T) {
+	cr := NewContentRouter()
+	const body = "SSN 456-45-6789\n"
+	routed, err := cr.RouteContent(&preprocessors.ProcessedContent{
+		Text:          body,
+		ProcessorType: "plaintext",
+		OriginalPath:  "notes.txt",
+	})
+	if err != nil {
+		t.Fatalf("RouteContent: %v", err)
+	}
+	if routed.DocumentBody != body {
+		t.Errorf("plain-text DocumentBody = %q, want %q", routed.DocumentBody, body)
+	}
+}


### PR DESCRIPTION
## Media files were scanned by 1 of 19 validators

`RouteContent` set `DocumentBody = ""` for any file whose `ProcessedContent` came from a single `*_metadata` preprocessor. `dual_path_bridge.go` gates the **entire** document path on `DocumentBody != ""` — so for those files exactly one validator ran: METADATA.

That's the routing outcome for **every** media type — `.jpg .jpeg .png .gif .tiff .webp`, `.wav .mp3 .flac .m4a`, `.mp4 .m4v .mov` — because only one preprocessor is capable for those extensions, so `ProcessorType` carries no `"+"` and lands in this arm. (`.pdf`/`.docx`/`.xlsx` are unaffected: two preprocessors are capable, so they route through `combined_preprocessors`, which always kept a body.)

The METADATA validator can't cover for it. It's a field-**name** allowlist scanner: it skips any line whose key isn't in the per-preprocessor `SensitiveFields` list, and for a line that matches it emits **one coarse type for the whole field value**. So an SSN or a card number inside a metadata value is either skipped outright or reported as a single `AUTHOR_INFO`/`DOCUMENT_COMMENTS` row — never typed, never individually redactable. `ImageDescription` isn't on the image list at all.

Measured on a JPEG whose EXIF `ImageDescription` carries **non-reserved** PII (`SSN 456-45-6789 email jane.smith@acmecorp.io phone 415-555-0132`):

| | before | after |
|---|---|---|
| SSN | — | **HIGH 100** |
| BUSINESS (email) | — | **HIGH 93** |
| PHONE | — | **MEDIUM 82** |

Before: no findings at any confidence. The tool reported the file **clean**.

## The golden corpus was certifying the leak

`file_wav_metadata_pii` declares `Checks: EMAIL, PHONE, SECRETS, METADATA` — and its committed snapshot contained **no EMAIL, no PHONE, no SECRETS row**. An `AKIA`-prefixed access key sat undetected inside a `DOCUMENT_COMMENTS` blob.

## The fix

One line: hand the metadata text to the document path as well as the metadata path. Both paths now see it; nothing moves from one to the other.

## TP/FP, measured on purpose-built corpora

This widens what 18 validators look at, and metadata is dense `key:value` numerics — exactly the shape the metadata validator's own comments record fighting off (`phoneBasic` lost its optional separator because a bare 10-digit run matched timestamps). So I measured rather than assumed:

| corpus | before | after |
|---|---|---|
| **5 JPEGs with real PII in EXIF** | **0 findings** | **10** — SSN 100, VISA 100, PASSPORT 100, DATE_OF_BIRTH 90, ABA_ROUTING 85, US_BANK_ACCOUNT 85, PHONE 100/85, BUSINESS 85 |
| **10 JPEGs with benign camera/software metadata** | 1 finding | 4 |

The three new false positives: two `PHONE LOW 5` on camera/lens **serial numbers**, one `PERSON_NAME MEDIUM 68` on an **album title**.

I'm shipping that trade deliberately. The alternative is a tool that reports a photo carrying a credit card number as clean. The FP shapes are recorded in the commit so follow-up has a starting point — the mitigation, if wanted, is to feed only the **value** side of each `key:value` line rather than the whole line, not to revert.

## Two further effects, both measured

1. **Confidence drift.** `applyCrossPathConfidenceAdjustments` adds a flat `+5` *cross_path_correlation* boost when **both** paths produce matches. Pure-metadata files previously had only one populated path, so it never fired for them; now it does. That's why 4 of the 5 WAV golden rows shift confidence rather than just the count. The boost's stated intent — two independent paths corroborate — is arguably now correctly satisfied, so it's left alone.
2. **Cost.** On an adversarial 24KB single-line EXIF description packed with 2000 distinct SSN-shaped tokens: **64ms → 140ms** (min of 3). ~2.2×, and it buys **1996 findings where there were 0**. Linear, not quadratic — this exposes the validators' existing per-line behavior to a new, container-bounded input.

## Deliberately not bundled

Each is independently golden-affecting:

- The one **equal-span duplicate** this surfaces (`METADATA AUTHOR_INFO` and `email BUSINESS` for the same address on the same line). Contained sub-spans are already handled by `redactors.ResolveOverlaps`, so the redaction sink is safe; the equal-span pair is report noise and belongs with the known same-span arbitration work.
- Adding `imagedescription` and friends to the `image_metadata` `SensitiveFields` list — now defence-in-depth, since the text validators cover it.

## Verification

- First-party suite `exit=0` (58 packages); `-race` clean on `router`, `goldencorpus`, `pkg/redact`; `gofmt`/`vet`/`build` clean.
- The **5 metadata subtests fail on the pre-change code** with the reason spelled out, and pass after.
- `TestCombinedPreprocessorsUnaffected` and `TestPlainTextRoutingUnaffected` pin the boundary, so `.docx`/`.pdf`/`.txt` routing is provably untouched.
- Golden: exactly **7 files change**, all the one `file_wav_metadata_pii` case, and the delta only **adds** rows plus the `+5` boost shift.
- Merges clean in order across the full 11-branch stack; combined stack builds and passes.
