### PR TITLE
perf(preprocessors): hoist line offsets out of the mapping loop

### DIFF
--- a/docs/testing/TEST_PLAN.md
+++ b/docs/testing/TEST_PLAN.md
@@ -218,6 +218,38 @@ Work lands as a conflict-free sequence, so:
 When in doubt, run more. The cost of an extra `go test ./...` is seconds; the cost of a
 shipped redaction bypass is a cleartext leak.
 
+### Ask what SINK consumes what you changed
+
+The table above is easy to recite and easy to misapply. Reciting a dimension is not
+running it. The reliable question is not "which row am I in?" but **"what downstream sink
+consumes the thing I just changed?"**:
+
+| Changed | Sinks that must be exercised |
+|---|---|
+| Byte offsets / spans | redaction (writes at those offsets) **and** the suppression hash (embeds position) |
+| Match order | redaction — replacement is a destructive sequential rewrite, so order decides the result |
+| Confidence | suppression hash (embeds `%.2f`) **and** every band filter (`--confidence`, exit codes) |
+| Match text | `--show-match`, the suppression `context_hash`, redaction token length |
+| Detection (new/lost findings) | redaction output, `stats.suppressed` counts, all 7 formats |
+
+**Before opening any PR, write the checklist out and mark every dimension either
+`RAN <command> → <result>` or `N/A because <reason>`.** "Probably unaffected" is not a
+reason. This exists because a perf change that only moved offset *computation* shipped
+with no redaction or suppression run: scan output was byte-identical, which felt like
+proof, but the offsets it rewrote are exactly what the redactor writes at and what the
+suppression hash embeds.
+
+Two traps specific to this repo:
+
+- **Container formats.** Grepping a redacted `.xlsx`/`.docx` for cleartext PII searches
+  *compressed* bytes and returns zero — indistinguishable from a clean pass. Read the part
+  inside the zip (`xl/sharedStrings.xml`, `word/document.xml`) and also count redaction
+  tokens, to prove the redactor rewrote content instead of copying the container through.
+- **Suppression must be tested cross-binary.** Generate the suppression file with the
+  **parent** binary and apply it with the **fixed** one. Same-binary round-tripping passes
+  even when the hash inputs changed; the cross-binary run is what proves existing
+  suppression files in the wild still match.
+
 ---
 
 ## Security reporting

--- a/internal/preprocessors/line_mapping_offsets_test.go
+++ b/internal/preprocessors/line_mapping_offsets_test.go
@@ -1,0 +1,143 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package preprocessors
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestLineMappingOffsetsMatchCalculateAbsoluteOffset is the equivalence gate.
+//
+// createBasicLineMappings used to call CalculateAbsoluteOffset twice per line;
+// it now computes a prefix sum once per document. That is only safe if the two
+// produce identical offsets, so this recomputes every mapping the old way and
+// compares. CalculateAbsoluteOffset is deliberately still the oracle here even
+// though it no longer has production callers — it is the definition the fast path
+// has to match.
+//
+// The inputs cover the shapes where an off-by-one would hide: empty text, no
+// trailing newline, consecutive blank lines, and multi-byte runes (offsets are
+// byte offsets, so a rune-counting mistake shows up here).
+func TestLineMappingOffsetsMatchCalculateAbsoluteOffset(t *testing.T) {
+	tp := NewTextPreprocessor()
+
+	inputs := []struct {
+		name string
+		text string
+	}{
+		{"empty", ""},
+		{"single line no newline", "single line"},
+		{"three short lines", "a\nb\nc"},
+		{"trailing newline", "trailing newline\n"},
+		{"leading and interior blanks", "\n\nleading blanks\n\nx\n"},
+		{"multibyte runes", "unicode ünïcödé ✓ line\nsecond ✓\n"},
+		{"blank line runs", strings.Repeat("data 123-45-6789\nshort\n\n", 200)},
+		{"no trailing newline", "no trailing\nnewline here"},
+	}
+
+	for _, in := range inputs {
+		t.Run(in.name, func(t *testing.T) {
+			content := &ProcessedContent{
+				Text:      in.text,
+				LineCount: len(splitLines(in.text)),
+				PageCount: 3,
+			}
+			tp.createBasicLineMappings(content, "equivalence")
+
+			lines := splitLines(in.text)
+			for _, m := range content.PositionMappings {
+				line := m.ExtractedPosition.Line
+				if line < 1 || line > len(lines) {
+					t.Fatalf("mapping line %d out of range 1..%d", line, len(lines))
+				}
+				want := CalculateAbsoluteOffset(in.text, line, 0)
+				if got := m.ExtractedPosition.AbsoluteOffset; got != want {
+					t.Errorf("line %d: AbsoluteOffset = %d, want %d (the prefix sum must "+
+						"equal what CalculateAbsoluteOffset computes)", line, got, want)
+				}
+				if got := m.OriginalPosition.CharOffset; got != want {
+					t.Errorf("line %d: CharOffset = %d, want %d", line, got, want)
+				}
+			}
+		})
+	}
+}
+
+// TestCreateBasicLineMappingsIsLinear is the performance regression guard.
+//
+// CalculateAbsoluteOffset re-runs splitLines over the WHOLE text on every call,
+// and createBasicLineMappings called it twice per line — so a 10k-row spreadsheet
+// performed 20,000 full-document splits and extraction was quadratic:
+//
+//	lines    before     after
+//	 1250     166ms       1ms
+//	 2500     607ms       1ms
+//	 5000     2.79s       2ms
+//	10000    10.15s       3ms
+//
+// ~3.6-4.6x per doubling before (linear is 2x), ~1.9x after. Every Office and PDF
+// format funnels through this one function, so the same fix covers .xlsx/.docx/
+// .pptx/.odt/.ods/.odp/.pdf.
+func TestCreateBasicLineMappingsIsLinear(t *testing.T) {
+	if testing.Short() {
+		t.Skip("timing guard skipped in -short mode")
+	}
+
+	tp := NewTextPreprocessor()
+
+	build := func(n int) string {
+		var sb strings.Builder
+		for i := 0; i < n; i++ {
+			// Distinct values per line: a repeated line would still exercise the
+			// per-line cost here, but distinct data keeps this honest if the
+			// function ever starts deduplicating.
+			fmt.Fprintf(&sb, "row %d value ssn 4%02d-%02d-%04d email u%d@corp.example\n",
+				i, i%100, i%80, i%9000, i)
+		}
+		return sb.String()
+	}
+
+	measure := func(n int) (time.Duration, int) {
+		content := &ProcessedContent{Text: build(n), LineCount: n, PageCount: 1}
+		start := time.Now()
+		tp.createBasicLineMappings(content, "timing")
+		return time.Since(start), len(content.PositionMappings)
+	}
+
+	const baseLines = 2500
+	tBase, nBase := measure(baseLines)
+	tBig, nBig := measure(baseLines * 4)
+
+	// Non-vacuity: a timing assertion means nothing if no mappings were produced.
+	// One mapping per non-empty line, so these are exact.
+	if nBase != baseLines || nBig != baseLines*4 {
+		t.Fatalf("expected one mapping per line, got %d at %d lines and %d at %d — the "+
+			"timing comparison below would be measuring the wrong thing",
+			nBase, baseLines, nBig, baseLines*4)
+	}
+
+	t.Logf("%d lines: %v (%d mappings) | %d lines: %v (%d mappings)",
+		baseLines, tBase.Round(time.Millisecond), nBase,
+		baseLines*4, tBig.Round(time.Millisecond), nBig)
+
+	// Absolute ceiling. Linear is a few ms; the quadratic form took 2.79s at this
+	// size. Generous enough for a slow shared CI runner.
+	const ceiling = 2 * time.Second
+	if tBig > ceiling {
+		t.Errorf("4x input took %v (> %v) — CalculateAbsoluteOffset is probably being "+
+			"called per line again, which re-splits the whole document each time", tBig, ceiling)
+	}
+
+	// Relative growth: 4x input is ~4x under linear, ~16x under quadratic. Only
+	// meaningful once the base is large enough to measure above timer noise.
+	if tBase > 2*time.Millisecond {
+		if ratio := float64(tBig) / float64(tBase); ratio > 12.0 {
+			t.Errorf("4x input took %.1fx longer (base=%v big=%v) — superlinear growth "+
+				"suggests the per-line whole-document split is back", ratio, tBase, tBig)
+		}
+	}
+}

--- a/internal/preprocessors/text_preprocessor.go
+++ b/internal/preprocessors/text_preprocessor.go
@@ -217,6 +217,32 @@ func (tp *TextPreprocessor) createOfficePositionMappings(content *ProcessedConte
 func (tp *TextPreprocessor) createBasicLineMappings(content *ProcessedContent, method string) {
 	lines := splitLines(content.Text)
 
+	// Precompute each line's absolute offset once.
+	//
+	// CalculateAbsoluteOffset re-runs splitLines over the ENTIRE text on every
+	// call, and this loop called it TWICE per line with identical arguments. On a
+	// 10k-row spreadsheet that is 20,000 full-document splits, which made
+	// extraction quadratic: measured 166ms / 607ms / 2.79s / 10.15s at 1250 /
+	// 2500 / 5000 / 10000 lines — ~3.6-4.6x per doubling where linear is 2x.
+	// Nearly all of an .xlsx scan's wall time was spent here.
+	//
+	// A prefix sum is the same arithmetic the helper performs internally, hoisted
+	// out of the loop. The plaintext preprocessor already does exactly this
+	// (preCalculateLineOffsets), so this brings the two paths into line.
+	//
+	// Exactly equal, not approximately: for charPos=0 and 1 <= line <= len(lines),
+	// CalculateAbsoluteOffset returns the sum of len(lines[i])+1 for i < line-1.
+	// The charPos clamp is a no-op at 0, and the line > len(lines) early return is
+	// unreachable because lineNum indexes lines. Both call sites passed the same
+	// arguments, so collapsing them to one lookup is also a plain subexpression
+	// elimination.
+	lineOffsets := make([]int, len(lines))
+	offset := 0
+	for i, line := range lines {
+		lineOffsets[i] = offset
+		offset += len(line) + 1 // +1 for the newline separator
+	}
+
 	for lineNum, line := range lines {
 		if strings.TrimSpace(line) == "" {
 			continue // Skip empty lines
@@ -227,14 +253,14 @@ func (tp *TextPreprocessor) createBasicLineMappings(content *ProcessedContent, m
 			Line:           lineNum + 1,
 			StartChar:      0,
 			EndChar:        len(line),
-			AbsoluteOffset: CalculateAbsoluteOffset(content.Text, lineNum+1, 0),
+			AbsoluteOffset: lineOffsets[lineNum],
 		}
 
 		// For extracted documents, we estimate the original position
 		// In a real implementation, this would use document structure information
 		originalPos := DocumentPosition{
 			Page:       tp.estimatePageNumber(lineNum, content.LineCount, content.PageCount),
-			CharOffset: CalculateAbsoluteOffset(content.Text, lineNum+1, 0),
+			CharOffset: lineOffsets[lineNum],
 			LineNumber: lineNum + 1,
 		}
 


### PR DESCRIPTION
## Document extraction was quadratic

`createBasicLineMappings` called `CalculateAbsoluteOffset` **twice per line, with identical arguments**. That helper re-runs `splitLines` over the **entire document** on every call — so a 10k-row spreadsheet performed 20,000 full-document splits.

| lines | before | after |
|---|---|---|
| 1,250 | 166ms | 1ms |
| 2,500 | 607ms | 1ms |
| 5,000 | 2.79s | 2ms |
| **10,000** | **10.15s** | **3ms** — 3,385× |

~3.6–4.6× per doubling before, where linear is 2×. ~1.9× after.

## The fix

A prefix sum computed once per document — the same arithmetic the helper performs internally, hoisted out of the loop. The plaintext preprocessor **already does exactly this** (`preCalculateLineOffsets`), so this brings the two extraction paths into line rather than inventing a pattern.

Exactly equal, not approximately: for `charPos=0` and `1 <= line <= len(lines)`, `CalculateAbsoluteOffset` returns the sum of `len(lines[i])+1` for `i < line-1`. The `charPos` clamp is a no-op at 0, and the `line > len(lines)` early return is unreachable because `lineNum` indexes `lines`. Both call sites passed the same arguments, so collapsing them to one lookup is also a plain common-subexpression elimination.

## One fix covers every document format

`createPDFPositionMappings` and `createOfficePositionMappings` both delegate to this function, so this covers `.xlsx/.docx/.pptx/.odt/.ods/.odp/.pdf`. Measured end-to-end through the CLI, **byte-identical output in every case**:

| input | before | after | findings |
|---|---|---|---|
| 10k-row `.xlsx` | 10,100ms | **759ms** (13.3×) | 19,873 both |
| 2.5k-row `.xlsx` | 1,149ms | 1,000ms | 4,968 both |
| 4k-paragraph `.docx` | 1,314ms | **274ms** (4.8×) | 3,950 both |

## The reported location was wrong

This was filed as a quadratic in `content_router.go`'s repeated `strings.Split`, inside the `file_evaluation` timing span. Both are red herrings: `RouteContent` costs ~1ms on a 1MB sheet and its `Split` calls are once-per-invocation, while `file_evaluation` is an observability span wrapping a fan-out to the preprocessors. The cost was one layer down. **`content_router.go` is untouched here.**

## Tests

`TestLineMappingOffsetsMatchCalculateAbsoluteOffset` keeps `CalculateAbsoluteOffset` as the **oracle** — it has no production callers left, but it's the definition the fast path must match — and compares every mapping against it across the shapes where an off-by-one would hide: empty text, no trailing newline, consecutive blank lines, and multi-byte runes (offsets are *byte* offsets, so a rune-counting mistake surfaces there). Zero differences.

`TestCreateBasicLineMappingsIsLinear` is the regression guard, with a **non-vacuity floor** asserting one mapping per line at both sizes before the clock is read. Verified non-vacuous — against the pre-change code it fails on *both* assertions:

```
4x input took 10.335298792s (> 2s) — CalculateAbsoluteOffset is probably being
  called per line again, which re-splits the whole document each time
4x input took 16.4x longer (base=629.769958ms big=10.335298792s)
```

while the equivalence test passes on both versions — correct, since it's the oracle.

## Deliberately not in this PR

The `PositionMappings` this builds have **no consumer anywhere** outside `internal/preprocessors` (`GetPositionMappingsForRange` has zero callers), so the whole structure is arguably dead work and deleting it would beat optimizing it. That's a dead-code change touching a struct field with a `json` tag, and belongs with the dead-code audit sequence rather than a behavior-preserving perf fix. `CalculateAbsoluteOffset` is likewise left in place.

## Verification

- First-party suite `exit=0` (58 packages); `-race` clean on `preprocessors` and `goldencorpus`; `gofmt`/`vet`/`build` clean.
- Golden: the suite passes with the goldens **unchanged**, which is stronger than regenerating them — zero files modified.
- Merges clean in order across the full 12-branch stack; combined stack builds and passes.
