### PR TITLE
fix(passport): report one finding per MRZ, not one per matching pattern

### DIFF
--- a/internal/validators/passport/duplicate_span_test.go
+++ b/internal/validators/passport/duplicate_span_test.go
@@ -1,0 +1,217 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package passport
+
+import (
+	stdctx "context"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+)
+
+// buildMRZLine1 returns an ICAO 9303 TD3 line 1 padded with "<" fillers to the
+// requested total length. 44 is the canonical width; 45 exercises the nested-span
+// case, where MRZ_TD3 matches the first 44 bytes and MRZ matches all 45.
+func buildMRZLine1(total int) string {
+	const head = "P<GBRSMITH<<JOHN<ALBERT"
+	if total <= len(head) {
+		return head[:total]
+	}
+	return head + strings.Repeat("<", total-len(head))
+}
+
+func scan(t *testing.T, content string) []detector.Match {
+	t.Helper()
+	v := NewValidator()
+	matches, err := v.ValidateContentCtx(stdctx.Background(), content, "/test/passport.txt")
+	if err != nil {
+		t.Fatalf("ValidateContentCtx: %v", err)
+	}
+	return matches
+}
+
+// TestOneMRZYieldsOneFinding is the core gate.
+//
+// The MRZ patterns overlap by construction — MRZ is `[A-Z0-9<]{38,40}` and
+// MRZ_TD3 is `[A-Z0-9<]{39}`, so every MRZ_TD3 hit is also an MRZ hit — and the
+// emit loop appended every surviving hit from every pattern. One physical passport
+// line therefore produced two PASSPORT findings.
+//
+// Both overlap shapes are covered, because they fail differently: at 44 chars the
+// two spans are IDENTICAL, and at 45+ the TD3 span is a strict PREFIX of the MRZ
+// span. An exact-span dedup key would fix the first and miss the second.
+func TestOneMRZYieldsOneFinding(t *testing.T) {
+	for _, width := range []int{44, 45, 46} {
+		t.Run(strings.TrimSpace(string(rune('0'+width/10))+string(rune('0'+width%10))+" chars"), func(t *testing.T) {
+			line := buildMRZLine1(width)
+			content := "passport holder machine readable zone icao\n" + line + "\n"
+
+			matches := scan(t, content)
+			if len(matches) != 1 {
+				var got []string
+				for _, m := range matches {
+					country, _ := m.Metadata["country"].(string)
+					got = append(got, country+":"+m.Text)
+				}
+				t.Fatalf("line-1 width %d produced %d findings, want 1 — one physical MRZ is "+
+					"one document. Overlapping patterns claiming the same bytes must be folded, "+
+					"or the report double-counts one passport and --generate-suppressions writes "+
+					"two rules for one leak.\n  got: %v", width, len(matches), got)
+			}
+
+			// The survivor must be the WIDEST span any pattern could claim, not a
+			// narrower one — reporting the TD3 prefix when MRZ matched more would
+			// hash a value that appears nowhere complete in the file.
+			//
+			// "Widest any pattern could claim" is not always the whole line: MRZ is
+			// `[A-Z0-9<]{38,40}` after a 5-char head, so it tops out at 45 bytes. At
+			// 46+ chars NOTHING matches the full token, which is a pre-existing
+			// pattern-width ceiling and not a dedup artifact (tracked separately).
+			// So the bound asserted here is min(len(line), 45).
+			wantLen := len(line)
+			if wantLen > 45 {
+				wantLen = 45
+			}
+			if got := len(matches[0].Text); got != wantLen {
+				t.Errorf("reported span is %d bytes, want %d (the widest any pattern can "+
+					"claim on a %d-char line) — got %q", got, wantLen, len(line), matches[0].Text)
+			}
+			if !strings.HasPrefix(line, matches[0].Text) {
+				t.Errorf("reported text %q is not a prefix of the MRZ line %q",
+					matches[0].Text, line)
+			}
+		})
+	}
+}
+
+// TestRepeatedMRZOnOneLineYieldsTwoFindings is the other half of the contract, and
+// the reason the dedup key has to be the byte SPAN rather than (type, line, text).
+//
+// The same MRZ value appearing twice on one line is two real leaks at two
+// offsets. A text-based key would collapse them and under-report an actual
+// double-disclosure.
+func TestRepeatedMRZOnOneLineYieldsTwoFindings(t *testing.T) {
+	line := buildMRZLine1(44)
+	content := "passport " + line + " and passport " + line + "\n"
+
+	matches := scan(t, content)
+	if len(matches) != 2 {
+		t.Fatalf("the same MRZ twice on one line produced %d findings, want 2 — these are "+
+			"two distinct disclosures at two offsets, not one claim seen twice. Folding them "+
+			"would under-report a real double-leak.", len(matches))
+	}
+}
+
+// TestDistinctMRZsAreBothReported guards the obvious regression: folding must be
+// per line and per span, never across documents.
+func TestDistinctMRZsAreBothReported(t *testing.T) {
+	gbr := buildMRZLine1(44)
+	usa := "P<USAJONES<<MARY<ELLEN" + strings.Repeat("<", 44-len("P<USAJONES<<MARY<ELLEN"))
+	content := "passport records icao machine readable zone\n" + gbr + "\n" + usa + "\n"
+
+	matches := scan(t, content)
+	if len(matches) != 2 {
+		t.Fatalf("two different MRZs produced %d findings, want 2", len(matches))
+	}
+}
+
+// TestKeepOutermostSpans unit-tests the arbitration directly, including the cases
+// the corpus above cannot reach.
+func TestKeepOutermostSpans(t *testing.T) {
+	mk := func(start, end int, conf float64, label string) spannedMatch {
+		return spannedMatch{
+			start: start,
+			end:   end,
+			match: detector.Match{
+				Text:       label,
+				Confidence: conf,
+				Metadata:   map[string]any{"country": label},
+			},
+		}
+	}
+	labels := func(in []spannedMatch) []string {
+		out := make([]string, 0, len(in))
+		for _, m := range in {
+			out = append(out, m.match.Text)
+		}
+		return out
+	}
+	eq := func(a, b []string) bool {
+		if len(a) != len(b) {
+			return false
+		}
+		for i := range a {
+			if a[i] != b[i] {
+				return false
+			}
+		}
+		return true
+	}
+
+	cases := []struct {
+		name string
+		in   []spannedMatch
+		want []string
+	}{
+		{"empty", nil, []string{}},
+		{"single", []spannedMatch{mk(0, 44, 80, "a")}, []string{"a"}},
+		{
+			// The 44-char case: identical spans, incumbent wins.
+			"identical spans keep the first",
+			[]spannedMatch{mk(0, 44, 80, "TD3"), mk(0, 44, 80, "MRZ")},
+			[]string{"TD3"},
+		},
+		{
+			// The 45-char case: the wider span wins even though it is second.
+			"nested span keeps the wider",
+			[]spannedMatch{mk(0, 44, 80, "TD3"), mk(0, 45, 80, "MRZ")},
+			[]string{"MRZ"},
+		},
+		{
+			"disjoint spans both survive",
+			[]spannedMatch{mk(0, 44, 80, "a"), mk(60, 104, 80, "b")},
+			[]string{"a", "b"},
+		},
+		{
+			"partial overlap is not containment, both survive",
+			[]spannedMatch{mk(0, 44, 80, "a"), mk(20, 70, 80, "b")},
+			[]string{"a", "b"},
+		},
+		{
+			"three nested spans collapse to the widest",
+			[]spannedMatch{mk(0, 44, 80, "inner"), mk(0, 45, 80, "mid"), mk(0, 46, 80, "outer")},
+			[]string{"outer"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := labels(keepOutermostSpans(tc.in))
+			if !eq(got, tc.want) {
+				t.Errorf("keepOutermostSpans = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFoldingNeverLowersConfidence pins the leak-safe direction: folding must not
+// demote a finding into a lower severity band than it would have had, because a
+// band change can drop it below a --confidence filter or flip an exit code.
+func TestFoldingNeverLowersConfidence(t *testing.T) {
+	// The narrower claim scores higher; the wider one survives and must inherit it.
+	in := []spannedMatch{
+		{start: 0, end: 44, match: detector.Match{Text: "inner", Confidence: 100}},
+		{start: 0, end: 45, match: detector.Match{Text: "outer", Confidence: 80}},
+	}
+	got := keepOutermostSpans(in)
+	if len(got) != 1 {
+		t.Fatalf("got %d survivors, want 1", len(got))
+	}
+	if got[0].match.Confidence != 100 {
+		t.Errorf("survivor confidence = %.0f, want 100 — folding must carry up the strongest "+
+			"confidence any folded claim assigned, so a merge can never lower severity",
+			got[0].match.Confidence)
+	}
+}

--- a/internal/validators/passport/order_test.go
+++ b/internal/validators/passport/order_test.go
@@ -37,13 +37,26 @@ func signature(t *testing.T, content string) string {
 	return strings.Join(parts, ",")
 }
 
-// TestPatternOrderIsFixed pins the emitted order for a span two patterns claim.
-// Before the fix the scan ranged v.patterns (a map), so this produced either
-// "MRZ_TD3,MRZ" or "MRZ,MRZ_TD3" at random.
+// TestPatternOrderIsFixed pins which pattern wins a span two patterns claim.
+//
+// This test has covered two successive defects on the same overlap. Originally
+// the scan ranged v.patterns (a map), so the emitted order was random —
+// "MRZ_TD3,MRZ" or "MRZ,MRZ_TD3" — and it pinned the order to make that
+// deterministic. It then asserted TWO findings, which was the deterministic form
+// of a second bug: one physical MRZ reported twice, differing only in the
+// "country" metadata (which is the pattern name, not an issuing state).
+//
+// keepOutermostSpans now folds claims that cover the same bytes, so the expected
+// signature is the single winner. patternOrder still decides WHICH one that is —
+// "MRZ_TD3" is listed first as the more specific pattern and is the incumbent on
+// an exact-span tie — so this remains a test of the fixed order, not just of the
+// dedup.
 func TestPatternOrderIsFixed(t *testing.T) {
 	got := signature(t, mrzContent())
-	if got != "MRZ_TD3,MRZ" {
-		t.Fatalf("pattern order = %q, want %q (patternOrder puts the more specific TD3 pattern first)", got, "MRZ_TD3,MRZ")
+	if got != "MRZ_TD3" {
+		t.Fatalf("pattern signature = %q, want %q — one MRZ is one document, and on an "+
+			"exact-span tie the first entry of patternOrder (the more specific TD3 pattern) "+
+			"must win", got, "MRZ_TD3")
 	}
 }
 

--- a/internal/validators/passport/validator.go
+++ b/internal/validators/passport/validator.go
@@ -343,6 +343,99 @@ func hasMRZStructure(s string) bool {
 	return fillers >= 5
 }
 
+// spannedMatch is an emitted finding that still remembers the byte span it
+// occupied in its line, so overlapping claims from different patterns can be
+// arbitrated before that information is discarded — detector.Match carries no
+// offset, so afterwards two patterns claiming one document are indistinguishable
+// from the same value genuinely appearing twice.
+type spannedMatch struct {
+	match detector.Match
+	start int
+	end   int
+}
+
+// keepOutermostSpans folds away claims contained within another claim on the same
+// line, so one physical document yields one finding.
+//
+// The MRZ patterns overlap by construction: MRZ is `P<[A-Z]{3}[A-Z0-9<]{38,40}`
+// and MRZ_TD3 is `P<[A-Z]{3}[A-Z0-9<]{39}`, so {39} is inside {38,40} and EVERY
+// MRZ_TD3 hit is also an MRZ hit. Each pattern runs independently, and the emit
+// loop appended every surviving hit, so a single ICAO 9303 TD3 line 1 produced two
+// PASSPORT findings. Two shapes, both reproduced:
+//
+//   - line 1 exactly 44 chars: both patterns return the IDENTICAL span, giving two
+//     findings with the same text differing only in metadata["country"]
+//     ("MRZ_TD3" vs "MRZ" — the pattern name, not an issuing state).
+//   - line 1 45+ chars: MRZ_TD3 returns [0:44] and MRZ returns [0:45], a strict
+//     PREFIX. Exact-span keying would miss this one, which is why containment is
+//     the test and not equality.
+//
+// The nested case is the more damaging of the two: --generate-suppressions wrote
+// two rules with two different match_text_hash values for one leak, and one of
+// them keyed a truncated 44-byte prefix that is not a complete token anywhere in
+// the file — a baseline entry that can never match the document it came from.
+//
+// Longest span wins, which is the honest choice here: the widest match is the one
+// that covers the whole token, so the reported Text is a complete MRZ line rather
+// than a truncation. Confidence is deliberately NOT the tiebreak — both MRZ arms
+// of CalculateConfidence score identically (same +20 valid-country-code boost,
+// both land at 80/100), so ranking on confidence would pick arbitrarily. On an
+// exact-span tie the incumbent survives, and patternOrder is a fixed slice
+// ("MRZ_TD3" before "MRZ", most specific first) rather than the map's random
+// order, so the winner is deterministic run to run.
+//
+// Confidence is carried up to the maximum of the folded claims. That keeps a merge
+// from ever demoting a finding into a lower severity band than it would have had —
+// the leak-safe direction, and the same rule the secrets validator's
+// mergeBySpanKeepStrongest applies.
+//
+// Surviving findings keep their original relative order, so byte order downstream
+// is unchanged. O(n^2) in claims per line, which is bounded and tiny: at most one
+// hit per pattern per position and only six patterns.
+func keepOutermostSpans(claims []spannedMatch) []spannedMatch {
+	if len(claims) < 2 {
+		return claims
+	}
+
+	keep := make([]spannedMatch, 0, len(claims))
+	for i, c := range claims {
+		contained := false
+		for j, other := range claims {
+			if i == j {
+				continue
+			}
+			// Strictly wider span that covers this one: this claim is redundant.
+			if other.start <= c.start && other.end >= c.end &&
+				(other.end-other.start) > (c.end-c.start) {
+				contained = true
+				break
+			}
+			// Identical span: the earlier claim (more specific pattern, per
+			// patternOrder) is the incumbent and survives.
+			if other.start == c.start && other.end == c.end && j < i {
+				contained = true
+				break
+			}
+		}
+		if contained {
+			continue
+		}
+		// Carry up the strongest confidence any folded claim assigned, so folding
+		// cannot lower the reported severity.
+		for j, other := range claims {
+			if i == j {
+				continue
+			}
+			if other.start >= c.start && other.end <= c.end &&
+				other.match.Confidence > c.match.Confidence {
+				c.match.Confidence = other.match.Confidence
+			}
+		}
+		keep = append(keep, c)
+	}
+	return keep
+}
+
 // maxMatchesPerLinePerPattern bounds how many regex hits we will fully process
 // for a single (line, pattern) pair. A single pathologically long line packed
 // with thousands of passport-shaped tokens would otherwise drive the validator
@@ -387,6 +480,11 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 		// (the match argument was never used in their bodies), so precompute.
 		lineIsTabular := v.isTabularDataLine(line)
 		lineIsForm := v.isInFormContextLine(lineLower)
+
+		// Collected per line, with byte spans retained, so overlapping claims can
+		// be arbitrated before the spans are lost (detector.Match has no offset
+		// field). See keepOutermostSpans.
+		var lineMatches []spannedMatch
 
 		// Check each pattern against the line, in the fixed order (see
 		// Validator.patternOrder) rather than the patterns map's random one.
@@ -477,23 +575,32 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 					continue
 				}
 
-				matches = append(matches, detector.Match{
-					Text:       match,
-					LineNumber: lineNum + 1, // 1-based line numbering
-					Type:       "PASSPORT",
-					Confidence: confidence,
-					Filename:   originalPath,
-					Validator:  "passport",
-					Context:    contextInfo,
-					Metadata: map[string]any{
-						"country":           country,
-						"validation_checks": checks,
-						"context_impact":    contextImpact,
-						"source":            "preprocessed_content",
-						"original_file":     originalPath,
+				lineMatches = append(lineMatches, spannedMatch{
+					start: loc[0],
+					end:   loc[1],
+					match: detector.Match{
+						Text:       match,
+						LineNumber: lineNum + 1, // 1-based line numbering
+						Type:       "PASSPORT",
+						Confidence: confidence,
+						Filename:   originalPath,
+						Validator:  "passport",
+						Context:    contextInfo,
+						Metadata: map[string]any{
+							"country":           country,
+							"validation_checks": checks,
+							"context_impact":    contextImpact,
+							"source":            "preprocessed_content",
+							"original_file":     originalPath,
+						},
 					},
 				})
 			}
+		}
+
+		// One document, one finding: fold away claims that cover the same bytes.
+		for _, sm := range keepOutermostSpans(lineMatches) {
+			matches = append(matches, sm.match)
 		}
 	}
 


### PR DESCRIPTION
## One passport, two findings

The two MRZ patterns overlap by construction:

```
MRZ     = \bP<[A-Z]{3}[A-Z0-9<]{38,40}   (43-45 chars total)
MRZ_TD3 = \bP<[A-Z]{3}[A-Z0-9<]{39}      (exactly 44)
```

`{39}` sits inside `{38,40}`, so **every MRZ_TD3 hit is also an MRZ hit**. Each pattern runs independently and the emit loop appended every surviving hit with nothing comparing spans — so one physical ICAO 9303 TD3 line 1 produced two `PASSPORT` findings, identical in text, differing only in `metadata["country"]`. That value is the *pattern name*, not an issuing state, and the text formatter prints it verbatim as `Country:`:

```
Type: PASSPORT   Country: MRZ_TD3
Type: PASSPORT   Country: MRZ        <- same span, same text
```

Two overlap shapes, which fail differently:

| line-1 width | MRZ_TD3 | MRZ | relationship |
|---|---|---|---|
| 44 | `[0:44]` | `[0:44]` | **identical** |
| 45+ | `[0:44]` | `[0:45]` | **strict prefix** |

An exact-span dedup key fixes the first and misses the second — which is why containment, not equality, is the test.

## The nested case is the damaging one

`--generate-suppressions` wrote **two rules for one leak** with two different `match_text_hash` values, and one keyed a truncated 44-byte prefix that **is not a complete token anywhere in the file** — a baseline entry that can never match the document it came from. After the fix: 1 rule, keyed to the full span, and it applies (findings 1 → 0, one `[SUPP]` line).

## The fix

Keep the byte span alongside each emitted match — `detector.Match` has no offset field, so afterwards two patterns claiming one document are indistinguishable from the same value genuinely appearing twice — then fold contained claims per line. Same shape as the secrets validator's `mergeBySpanKeepStrongest` from the earlier duplicate-emit fix.

Arbitration, and why each rule:

- **Longest span wins** → the reported `Text` is the complete token, not a truncation.
- **Confidence is not the tiebreak** → both MRZ arms of `CalculateConfidence` score identically (same +20 valid-country-code boost, both land at 80/100), so ranking on confidence would pick arbitrarily.
- **Exact-span ties keep the incumbent**, and `patternOrder` is a fixed slice (`MRZ_TD3` first, most specific), so the winner is deterministic run to run.
- **Confidence is carried up** to the strongest folded claim, so a fold can never demote a finding into a lower band — the leak-safe direction.

## Why the key must be the span, not (type, line, text)

The **same MRZ appearing twice on one line** is two real disclosures at two offsets and must stay two findings. On the pre-change code that case emitted **four** findings (2 leaks × 2 patterns); it now emits **2**. A text-based key would have collapsed it to 1 and under-reported an actual double-disclosure.

## Verification

- **Repo-wide: 29 PASSPORT findings → 24, zero rows added.** Every one of the 5 removals is a 2→1 fold at the same `(file, line, confidence)` with the finding retained — no detection loss.
- **Redaction**, all three strategies: zero cleartext MRZ, and byte-identical to pre-change for the two deterministic ones (synthetic differs by design). The MRZ is fully replaced with `[PASSPORT-REDACTED]`. `redactors.ResolveOverlaps` already collapsed the duplicate pair, which is why this was a report-integrity bug rather than a redaction leak.
- Behavioral tests **fail on the pre-change validator** (2 findings where 1 is wanted, 4 where 2 are wanted) and pass after.
- First-party suite `exit=0` (58 packages); `-race` clean; `gofmt`/`vet`/`build` clean. Golden unchanged — the corpus has **zero passport cases**, which is why this needed hand-built end-to-end proof (tracked separately).

## An existing test asserted the bug

`TestPatternOrderIsFixed` asserted `"MRZ_TD3,MRZ"` — the *deterministic form of the duplicate*. It was written for a **different** defect (map iteration order, fixed earlier) and its own comment flags this overlap. It now asserts the single winner, so it still tests that `patternOrder` decides *which* pattern survives. The file's other two tests (200-run stability, `patternOrder` covers every pattern) are unchanged and pass.

## Found while testing, filed separately

The MRZ quantifier tops out at **45 bytes**, so a line 1 of 46+ chars is never matched in full — same truncated-hash class, but a pre-existing regex ceiling, not a dedup artifact. The test asserts `min(len(line), 45)` and says why, so a future reader doesn't "fix" it by widening the dedup. Also missing TD2/TD1 widths (36/30).

Merges clean in order across the full 14-branch stack; combined stack builds and passes.
