### PR TITLE
fix(cloudresources): stop suppressing private GCP projects that merely start with a public prefix

### DIFF
--- a/internal/validators/cloudresources/cloudresources.go
+++ b/internal/validators/cloudresources/cloudresources.go
@@ -553,8 +553,61 @@ func (v *Validator) AnalyzeContext(match string, context detector.ContextInfo) f
 
 // publicProjectPrefixes are GCP project IDs published by Google (public datasets
 // / public artifact projects); a resource scoped to one of these is not a leak.
-var publicProjectPrefixes = []string{
-	"bigquery-public-data", "gcp-public-data", "google.com:", "public-data",
+//
+// Matching is EXACT on the project segment. A bare substring test over the whole
+// match suppressed ordinary private projects:
+//
+//	projects/public-database-prod/...     -> silently dropped ("public-data" prefix)
+//	projects/public-datastore-pii/...     -> silently dropped
+//	projects/bigquery-public-data-evilcorp/... -> silently dropped
+//	projects/gcp-public-data-internal-acme/... -> silently dropped
+//
+// The first two need no attacker at all — "public-database-prod" is an ordinary
+// project name — and a suppressed cloud resource is a finding the report never
+// shows, which is the same class of miss as a detection failure.
+//
+// Allowing a "-" extension is NOT the fix either: "gcp-public-data-landsat" is a
+// REAL Google public project (asserted in cloudresources_test.go) and
+// "gcp-public-data-internal-acme" is not, yet the two are indistinguishable in
+// FORM. So form cannot be the test — the real projects are enumerated instead.
+// The list is EXACT project IDs, not prefixes. Google's public projects are a
+// small, enumerable set, and matching them exactly is what makes the unknown case
+// fail SAFE: an ID this list has not heard of is reported, not silently dropped.
+// Adding a new Google public project is a one-line change; failing to report a
+// private one is a finding the user never sees.
+var publicProjectIDs = map[string]bool{
+	// BigQuery public datasets all live under this single project.
+	"bigquery-public-data": true,
+	// Google's public-artifact projects. These are individually published, so they
+	// are listed individually rather than matched as "gcp-public-data-*" — an
+	// attacker-chosen "gcp-public-data-internal-acme" is indistinguishable in FORM
+	// from a real one, so form cannot be the test.
+	"gcp-public-data-landsat":    true,
+	"gcp-public-data-sentinel-2": true,
+	"gcp-public-data-nexrad-l2":  true,
+	// Historical/short form seen in older docs and samples.
+	"public-data": true,
+}
+
+// publicProjectScopePrefix is the one case where a prefix IS the right test:
+// "google.com:<project>" is a Google-internal scoping form where the colon is
+// itself the segment boundary, so the part after it varies by design.
+const publicProjectScopePrefix = "google.com:"
+
+// projectSegmentIsPublic reports whether the GCP project segment beginning at the
+// start of seg is a public-by-design project.
+//
+// seg is the text immediately after "projects/", so it may be followed by "/" and
+// the rest of the resource path; only the segment up to the first "/" is the
+// project ID.
+func projectSegmentIsPublic(seg string) bool {
+	if i := strings.IndexByte(seg, '/'); i >= 0 {
+		seg = seg[:i]
+	}
+	if publicProjectIDs[seg] {
+		return true
+	}
+	return strings.HasPrefix(seg, publicProjectScopePrefix)
 }
 
 // isPublicResource reports whether a matched identifier is public-by-design and
@@ -571,9 +624,16 @@ func isPublicResource(match string) bool {
 			return true
 		}
 	}
-	// Public GCP datasets / projects.
-	for _, p := range publicProjectPrefixes {
-		if strings.Contains(match, "projects/"+p) {
+	// Public GCP datasets / projects. Each "projects/" occurrence is checked, and
+	// only the project SEGMENT is compared — a substring test over the whole match
+	// let a broad prefix swallow unrelated private projects.
+	for rest := match; ; {
+		i := strings.Index(rest, "projects/")
+		if i < 0 {
+			break
+		}
+		rest = rest[i+len("projects/"):]
+		if projectSegmentIsPublic(rest) {
 			return true
 		}
 	}

--- a/internal/validators/cloudresources/public_prefix_test.go
+++ b/internal/validators/cloudresources/public_prefix_test.go
@@ -1,0 +1,176 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudresources
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPrivateProjectsAreNotSuppressed is the leak gate.
+//
+// The public-project allowlist used to be tested with
+// strings.Contains(match, "projects/"+prefix), with no segment boundary. Because
+// the list carried the broad bare entry "public-data", any project whose ID merely
+// STARTED with it was silently dropped — and a suppressed cloud resource is a
+// finding the report never shows, which is the same class of miss as a detection
+// failure.
+//
+// The first two cases need no attacker at all: "public-database-prod" and
+// "public-datastore-pii" are ordinary project names.
+func TestPrivateProjectsAreNotSuppressed(t *testing.T) {
+	cases := []struct {
+		name string
+		id   string
+	}{
+		{"ordinary name extending public-data", "public-database-prod"},
+		{"ordinary name extending public-data (2)", "public-datastore-pii"},
+		{"attacker extends bigquery-public-data", "bigquery-public-data-evilcorp"},
+		{"attacker extends gcp-public-data", "gcp-public-data-internal-acme"},
+		{"unrelated private project", "acme-prod-internal"},
+		{"public-data as a mid-word substring", "not-public-database"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resource := "projects/" + tc.id + "/zones/us-central1-a/instances/customer-db"
+			if isPublicResource(resource) {
+				t.Errorf("isPublicResource(%q) = true — this is a PRIVATE project, and "+
+					"suppressing it means the resource never appears in the report. The "+
+					"allowlist must match the project segment exactly, not as a prefix of it.",
+					resource)
+			}
+		})
+	}
+}
+
+// TestPublicProjectsStaySuppressed is the other direction: the allowlist must keep
+// doing its job, or every IaC file full of public dataset references becomes noise.
+//
+// gcp-public-data-landsat is the load-bearing case. It is a REAL Google public
+// project whose ID extends "gcp-public-data", so a blanket segment-boundary rule
+// would have broken it — which is why the list enumerates real project IDs rather
+// than matching a shape.
+func TestPublicProjectsStaySuppressed(t *testing.T) {
+	cases := []string{
+		"bigquery-public-data",
+		"gcp-public-data-landsat",
+		"gcp-public-data-sentinel-2",
+		"gcp-public-data-nexrad-l2",
+		"public-data",
+		"google.com:my-project",
+	}
+
+	for _, id := range cases {
+		t.Run(id, func(t *testing.T) {
+			resource := "projects/" + id + "/zones/us/instances/x"
+			if !isPublicResource(resource) {
+				t.Errorf("isPublicResource(%q) = false — this is a public-by-design Google "+
+					"project and must stay suppressed, or IaC files become pure noise", resource)
+			}
+		})
+	}
+}
+
+// TestProjectSegmentBoundary pins the segment logic directly, including the shapes
+// the resource-level test cannot express.
+func TestProjectSegmentBoundary(t *testing.T) {
+	cases := []struct {
+		seg  string
+		want bool
+	}{
+		// Exact IDs.
+		{"bigquery-public-data", true},
+		{"bigquery-public-data/datasets/samples", true},
+		{"public-data", true},
+		{"public-data/datasets/x", true},
+		// Extensions of an exact ID are somebody else's project.
+		{"bigquery-public-data-evilcorp", false},
+		{"public-database-prod", false},
+		{"public-datax", false},
+		// Enumerated real extensions.
+		{"gcp-public-data-landsat", true},
+		{"gcp-public-data-landsat/zones/us/instances/x", true},
+		// Not enumerated: fails safe.
+		{"gcp-public-data", false},
+		{"gcp-public-data-internal-acme", false},
+		// The colon form is prefix-matched by design.
+		{"google.com:anything-here", true},
+		{"google.com:anything/zones/us", true},
+		{"googlexcom:notreally", false},
+		// Degenerate.
+		{"", false},
+		{"/", false},
+	}
+
+	for _, tc := range cases {
+		if got := projectSegmentIsPublic(tc.seg); got != tc.want {
+			t.Errorf("projectSegmentIsPublic(%q) = %v, want %v", tc.seg, got, tc.want)
+		}
+	}
+}
+
+// TestPublicAllowlistFailsSafeOnUnknown states the design rule as a test, so a
+// future change back to prefix matching has to argue with it.
+//
+// An ID the allowlist has not heard of must be REPORTED. Adding a newly published
+// Google project is a one-line change; failing to report a private one is a finding
+// the user never sees.
+func TestPublicAllowlistFailsSafeOnUnknown(t *testing.T) {
+	unknown := []string{
+		"gcp-public-data-somethingnew", // plausibly real, but not enumerated
+		"bigquery-public-data-v2",      // plausibly real, but not enumerated
+		"public-data-archive",          // plausibly real, but not enumerated
+	}
+	for _, id := range unknown {
+		if projectSegmentIsPublic(id) {
+			t.Errorf("projectSegmentIsPublic(%q) = true, but this ID is not in the "+
+				"allowlist — unknown projects must fail SAFE (reported), not be suppressed "+
+				"on the strength of resembling a public one", id)
+		}
+	}
+}
+
+// TestAWSManagedPolicyArmIsBuiltinUnreachable documents a measured fact that is
+// easy to misread from the code alone: isPublicResource's AWS managed-policy arms
+// return true for these ARNs, but NO built-in pattern matches them, so on a default
+// configuration the arm is never consulted.
+//
+// Pattern 1 requires a 12-digit account slot (a managed policy has the literal
+// "aws" there) and pattern 2 requires "s3:::". The arm therefore contributes zero
+// recall on built-in patterns and exists for custom-pattern users, who CAN reach it.
+//
+// This is asserted rather than deleted for two reasons: deleting it would regress
+// those users, and pinning the reachability means a future pattern change that
+// makes managed-policy ARNs matchable will fail here and prompt a deliberate
+// decision about whether suppressing them is still wanted.
+func TestAWSManagedPolicyArmIsBuiltinUnreachable(t *testing.T) {
+	arns := []string{
+		"arn:aws:iam::aws:policy/AdministratorAccess",
+		"arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM",
+		"arn:aws-us-gov:iam::aws:policy/AdministratorAccess",
+		"arn:aws-cn:iam::aws:policy/AdministratorAccess",
+	}
+
+	patterns := compileCloudResourcePatterns()
+	for _, arn := range arns {
+		// The allowlist says "public".
+		if !isPublicResource(arn) {
+			t.Errorf("isPublicResource(%q) = false, want true (AWS-managed policy)", arn)
+		}
+		// But nothing matches it, so the allowlist is never reached.
+		for i, p := range patterns {
+			if m := p.FindString(arn); m != "" {
+				t.Errorf("built-in pattern %d now matches %q as %q — the managed-policy "+
+					"suppression arm just became reachable on a default config. Decide "+
+					"deliberately whether these should be suppressed before updating this test.",
+					i, arn, m)
+			}
+		}
+		if strings.Contains(arn, "iam::aws:") && !strings.Contains(arn, ":::") {
+			continue // shape sanity: these are managed-policy ARNs, as intended
+		}
+		t.Errorf("test fixture %q is not a managed-policy ARN", arn)
+	}
+}


### PR DESCRIPTION
## Ordinary private projects were silently dropped

`isPublicResource` tested the public-project allowlist with

```go
strings.Contains(match, "projects/"+prefix)
```

with **no segment boundary**. The list carried the broad bare entry `"public-data"`, so any project whose ID merely *started* with a listed prefix was suppressed. A suppressed cloud resource never appears in the report at all — the user is told the file is clean.

All four confirmed dropped, each with a `public-by-design` log line:

| resource | why it's wrong |
|---|---|
| `projects/public-database-prod/…` | **ordinary project name** — no attacker needed |
| `projects/public-datastore-pii/…` | **ordinary project name** — no attacker needed |
| `projects/bigquery-public-data-evilcorp/…` | attacker extension |
| `projects/gcp-public-data-internal-acme/…` | attacker extension |

The first two are the sharp ones: `public-database-prod` is a name anyone might pick, and it inherits suppression from the unrelated `public-data` entry.

## Why a segment boundary is *not* the fix

Worth reading before changing this back. `gcp-public-data-landsat` is a **real** Google public project (asserted in `cloudresources_test.go:242`) whose ID legitimately extends its prefix, while `gcp-public-data-internal-acme` is not — and **the two are indistinguishable in form**. Allowing a `-` extension keeps the hole open; denying it breaks a shipped test case that is correct.

So form cannot be the test. The allowlist now enumerates **exact project IDs** and compares the project **segment** (the text after `projects/` up to the next `/`), not a substring of the whole match. `google.com:` stays a prefix test because the colon is itself the boundary and the part after it varies by design.

That makes the unknown case **fail safe**: an ID the list hasn't heard of is *reported*. Adding a newly published Google project is a one-line change; failing to report a private one is a finding the user never sees. `TestPublicAllowlistFailsSafeOnUnknown` states that rule as a test, so a future change back to prefix matching has to argue with it.

## Also pins a measured fact about the AWS arm

`isPublicResource`'s AWS managed-policy arms return `true` for `arn:aws:iam::aws:policy/…` — but **no built-in pattern matches those ARNs**. Pattern 1 requires a 12-digit account slot (a managed policy has the literal `aws` there) and pattern 2 requires `s3:::`.

Verified against every compiled built-in pattern: **zero matches** for all four managed-policy forms (commercial, GovCloud, China, service-role), and the CLI logs **no** `public-by-design` line for them — the allowlist is never consulted. On a default configuration that arm has zero recall value.

It's **asserted rather than deleted**, deliberately: `custom_patterns` users *can* reach it, so deleting would regress them. Pinning the reachability means a future pattern change that makes managed-policy ARNs matchable fails `TestAWSManagedPolicyArmIsBuiltinUnreachable` and forces a deliberate decision about whether suppressing them is still wanted.

## Verification

- Behavioral gate: **4/4 private projects wrongly suppressed → 0/4**, with **0/4 public projects losing suppression** in *both* directions — so the allowlist still does its job and IaC files don't become noise.
- First-party suite `exit=0` (58 packages); `-race` clean; `gofmt`/`vet`/`build` clean; `UPDATE_GOLDEN=1` → **zero golden diff**.
- Pre-existing `cloudresources` tests, including the `gcp-public-data-landsat` case, pass unchanged.
- Merges clean in order across the full 15-branch stack.

## Scope

This is the GCP suppression leak only. The other logged `cloudresources`-adjacent items — the `LogWriter` no-payload chokepoint and the `factory.go` profile-override asymmetry — are separate and land on their own.
