### PR TITLE
test(ssn): cover labelled SSNs in prose, the class a proposed FP fix would delete

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build clean vet fmt run install-config install check-go-version
+.PHONY: build clean vet fmt run install-config install check-go-version pr-checklist
 
 # Default target
 all: check-go-version fmt vet build
@@ -44,6 +44,7 @@ help:
 	@echo "  test-git-commit    - Test real git commit blocking"
 	@echo "  test-cleanup       - Test cleanup functionality"
 	@echo "  container-test     - Test container health"
+	@echo "  pr-checklist       - Pre-PR audit: prints RAN/N-A/NEEDS-MANUAL per TEST_PLAN dimension"
 	@echo ""
 	@echo "🔧 Development:"
 	@echo "  clean              - Clean build artifacts"
@@ -222,6 +223,16 @@ vet:
 fmt:
 	@echo "Formatting..."
 	@go fmt ./...
+
+# Pre-PR self-audit: run every TEST_PLAN dimension and print an explicit
+# RAN / N-A / NEEDS-MANUAL line for each, so a skipped dimension is visible
+# instead of silently absent. Paste the output in the pull request.
+#
+# Not a CI gate — CI already runs the suite. The value is that it enumerates the
+# dimensions a reviewer cannot otherwise tell were considered, particularly the
+# redaction and suppression sinks.
+pr-checklist:
+	@./scripts/pr-checklist.sh $(BASE)
 
 # Run the application
 run: build

--- a/docs/testing/TEST_PLAN.md
+++ b/docs/testing/TEST_PLAN.md
@@ -218,6 +218,23 @@ Work lands as a conflict-free sequence, so:
 When in doubt, run more. The cost of an extra `go test ./...` is seconds; the cost of a
 shipped redaction bypass is a cleartext leak.
 
+### Run the checklist mechanically
+
+Reciting these dimensions is not the same as running them, and a dimension that is simply absent
+from a PR description is indistinguishable from one that was considered and dismissed. So enumerate
+them:
+
+```bash
+make pr-checklist              # vs origin/main
+scripts/pr-checklist.sh <ref>  # vs another base
+```
+
+It executes what it can and prints one line per dimension — `RAN`, `N/A because …`, or
+`NEEDS-MANUAL`. The sink dimensions (redaction, suppression) and the timing curve print
+NEEDS-MANUAL whenever production code changed, because those need a fixture that exercises *your*
+change and no script can invent one. Paste the output in the PR; leaving a NEEDS-MANUAL item unrun
+is how a cleartext leak ships.
+
 ---
 
 ## Security reporting

--- a/docs/testing/TEST_PLAN.md
+++ b/docs/testing/TEST_PLAN.md
@@ -218,7 +218,19 @@ Work lands as a conflict-free sequence, so:
 When in doubt, run more. The cost of an extra `go test ./...` is seconds; the cost of a
 shipped redaction bypass is a cleartext leak.
 
-### Run the checklist mechanically
+---
+
+## Security reporting
+
+A newly discovered vulnerability is reported to AWS/Amazon Security via the
+[vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/)
+**before** any public write-up — never as a public GitHub issue (`CONTRIBUTING.md`).
+A remediation for an *already-documented* threat-model item (e.g. a `THREAT_MODEL.md`
+row) is ordinary tracked work and ships as a normal PR.
+
+---
+
+## Run the checklist mechanically
 
 Reciting these dimensions is not the same as running them, and a dimension that is simply absent
 from a PR description is indistinguishable from one that was considered and dismissed. So enumerate
@@ -234,13 +246,3 @@ It executes what it can and prints one line per dimension — `RAN`, `N/A becaus
 NEEDS-MANUAL whenever production code changed, because those need a fixture that exercises *your*
 change and no script can invent one. Paste the output in the PR; leaving a NEEDS-MANUAL item unrun
 is how a cleartext leak ships.
-
----
-
-## Security reporting
-
-A newly discovered vulnerability is reported to AWS/Amazon Security via the
-[vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/)
-**before** any public write-up — never as a public GitHub issue (`CONTRIBUTING.md`).
-A remediation for an *already-documented* threat-model item (e.g. a `THREAT_MODEL.md`
-row) is ordinary tracked work and ships as a normal PR.

--- a/internal/validators/ssn/prose_boundary_test.go
+++ b/internal/validators/ssn/prose_boundary_test.go
@@ -1,0 +1,202 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ssn
+
+import (
+	stdctx "context"
+	"strings"
+	"testing"
+)
+
+// TestLabelledSSNInProseIsDetected closes a coverage gap that let a proposed
+// false-positive fix look safe when it was a cleartext leak.
+//
+// A large false-positive class exists in tabular data: any 9-digit value in a
+// >=3-field delimited line scores HIGH (2161 high-confidence hits on a public
+// World Bank population CSV, which contains no PII at all). A tempting one-line
+// fix is a "decimal guard" that rejects a digit run adjacent to a "." on a word
+// boundary, on the theory that 1.130075728 is a fraction rather than an SSN.
+//
+// That guard silently deletes every case below, because \b ends BEFORE a
+// sentence-terminal period: "the SSN is 130075728." looks identical to a decimal
+// fraction under a boundary test. These are the HIGHEST-confidence shapes the
+// validator has — an explicit label next to the value — and the guard runs before
+// isValidSSN, so it removes them outright rather than re-banding them. Measured on
+// the shipped validator: all four score 95-100; under the guard, all four vanish
+// and the redaction pipeline writes no output file, leaving the value in
+// cleartext.
+//
+// Neither the ssn package suite nor the golden corpus contained a single
+// sentence-terminal SSN, so both PASSED under the broken guard. A regression gate
+// cannot prove anything about a class it does not contain. This test is that
+// class.
+func TestLabelledSSNInProseIsDetected(t *testing.T) {
+	v := NewValidator()
+
+	cases := []struct {
+		name string
+		line string
+		want string
+	}{
+		{"sentence terminal, no separators", "Employee record: the SSN is 130075728.", "130075728"},
+		{"sentence terminal, hyphenated", "Employee SSN: 130-07-5728.", "130-07-5728"},
+		{"sentence terminal, spaced", "Social Security Number: 130 07 5728.", "130 07 5728"},
+		{"key=value terminated", "ssn=130075728.", "130075728"},
+		{"comma terminated", "The SSN is 130075728, on file since 2019.", "130075728"},
+		{"parenthesised", "Employee SSN (130-07-5728) verified.", "130-07-5728"},
+		{"semicolon terminated", "ssn: 130075728; verified", "130075728"},
+		{"quoted in prose", `The employee's SSN is "130075728".`, "130075728"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			matches, err := v.ValidateContentCtx(stdctx.Background(), tc.line, "/test/hr.txt")
+			if err != nil {
+				t.Fatalf("ValidateContentCtx: %v", err)
+			}
+			if len(matches) == 0 {
+				t.Fatalf("no findings — an explicitly LABELLED SSN in prose is the "+
+					"highest-confidence shape this validator has, and dropping it is a "+
+					"cleartext leak (an unreported value is never redacted). A value-shape "+
+					"guard that treats a trailing '.' as a decimal point causes exactly "+
+					"this.\n  line: %q", tc.line)
+			}
+			var found bool
+			var got []string
+			for _, m := range matches {
+				got = append(got, m.Text)
+				if m.Text == tc.want {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("findings %v do not include %q\n  line: %q", got, tc.want, tc.line)
+			}
+		})
+	}
+}
+
+// TestLabelledProseSSNKeepsHighConfidence pins the BAND, not just the presence.
+//
+// Presence alone is not enough: a fix that demoted these from HIGH to LOW would
+// hide them under `--confidence high,medium` and change pre-commit exit codes,
+// which is a quieter version of the same leak. An explicit "SSN"/"social security
+// number" label adjacent to a structurally valid value should reach MEDIUM at
+// minimum.
+func TestLabelledProseSSNKeepsHighConfidence(t *testing.T) {
+	v := NewValidator()
+
+	lines := []string{
+		"Employee record: the SSN is 130075728.",
+		"Employee SSN: 130-07-5728.",
+		"Social Security Number: 130 07 5728.",
+	}
+
+	const floor = 60.0 // MEDIUM band boundary
+	for _, line := range lines {
+		matches, err := v.ValidateContentCtx(stdctx.Background(), line, "/test/hr.txt")
+		if err != nil {
+			t.Fatalf("ValidateContentCtx(%q): %v", line, err)
+		}
+		if len(matches) == 0 {
+			t.Fatalf("no findings for %q (see TestLabelledSSNInProseIsDetected)", line)
+		}
+		var best float64
+		for _, m := range matches {
+			if m.Confidence > best {
+				best = m.Confidence
+			}
+		}
+		if best < floor {
+			t.Errorf("best confidence %.1f < %.0f for %q — an explicit label next to a valid "+
+				"SSN must stay in the MEDIUM band or above, or it disappears under "+
+				"--confidence high,medium and stops failing pre-commit", best, floor, line)
+		}
+	}
+}
+
+// TestDecimalFractionsAreNotSSNs is the other half of the contract, and the reason
+// the rejected guard was attractive in the first place: a digit run that is
+// genuinely part of a decimal number should not be reported.
+//
+// Recorded as the CURRENT behavior rather than an aspiration. Any future
+// false-positive work in this area has to keep TestLabelledSSNInProseIsDetected
+// green while improving these — that pairing is the whole point. Cases that the
+// validator reports today are marked, so the file states the real starting line
+// instead of a wished-for one.
+func TestDecimalFractionsAreNotSSNs(t *testing.T) {
+	v := NewValidator()
+
+	cases := []struct {
+		name string
+		line string
+	}{
+		{"leading decimal", "ratio 1.130075728 computed"},
+		{"trailing decimal", "value 130075728.44 recorded"},
+		{"version-like", "build 1.130075728.2"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			matches, err := v.ValidateContentCtx(stdctx.Background(), tc.line, "/test/metrics.txt")
+			if err != nil {
+				t.Fatalf("ValidateContentCtx: %v", err)
+			}
+			// Not asserted as zero: this documents today's behavior so a future
+			// precision fix has a measured starting point. What IS asserted is that
+			// nothing here reaches the HIGH band, since an unlabelled digit run
+			// inside a decimal has no business being high-confidence.
+			for _, m := range matches {
+				if m.Confidence >= 90 {
+					t.Errorf("reported %q at confidence %.1f (HIGH) on a line with no SSN "+
+						"label and a decimal context: %q", m.Text, m.Confidence, tc.line)
+				}
+			}
+			if len(matches) > 0 {
+				var got []string
+				for _, m := range matches {
+					got = append(got, m.Text)
+				}
+				t.Logf("current behavior: reports %v (below HIGH) — a precision fix here must "+
+					"not regress TestLabelledSSNInProseIsDetected", got)
+			}
+		})
+	}
+}
+
+// TestProseAndTabularSSNsCoexist guards the specific blind spot that made the
+// broken fix look safe: a recall corpus consisting only of delimited rows cannot
+// detect a prose regression, and vice versa. Both shapes in one document.
+func TestProseAndTabularSSNsCoexist(t *testing.T) {
+	v := NewValidator()
+
+	content := strings.Join([]string{
+		"name,dept,ssn",
+		"Jane Smith,Payroll,130-07-5728",
+		"",
+		"Note: the employee above confirmed her SSN is 130075728.",
+	}, "\n")
+
+	matches, err := v.ValidateContentCtx(stdctx.Background(), content, "/test/mixed.txt")
+	if err != nil {
+		t.Fatalf("ValidateContentCtx: %v", err)
+	}
+
+	var tabular, prose bool
+	for _, m := range matches {
+		switch m.LineNumber {
+		case 2:
+			tabular = true
+		case 4:
+			prose = true
+		}
+	}
+	if !tabular {
+		t.Error("the delimited row (line 2) produced no finding")
+	}
+	if !prose {
+		t.Error("the prose sentence (line 4) produced no finding — this is the shape a " +
+			"columnar-only recall corpus cannot see")
+	}
+}

--- a/scripts/pr-checklist.sh
+++ b/scripts/pr-checklist.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+#
+# pr-checklist.sh — run the TEST_PLAN dimensions and print an explicit
+# RAN / N-A line for every one of them.
+#
+# Why this exists: the dimensions were already written down in
+# docs/testing/TEST_PLAN.md and were still being skipped, because "run the
+# tests" collapses in practice to `go test ./...` and stops there. A reviewer
+# cannot tell the difference between "redaction was verified" and "redaction was
+# not considered" unless the run SAYS so. This script makes the omission
+# visible: every dimension prints a line, and the ones it cannot decide for you
+# print NEEDS-MANUAL rather than nothing.
+#
+# It is deliberately not wired into CI as a gate. CI already runs the suite, and
+# `make test-ci` already does the race + uncached pass this script also performs.
+# What neither of those does is ENUMERATE — they tell you the suite is green, not
+# which dimensions were considered. The sink dimensions in particular (redaction,
+# suppression) cannot be covered by a generic suite run at all, because they need
+# a fixture that exercises the specific change. Run this, paste the output in the
+# PR.
+#
+# Usage:
+#   scripts/pr-checklist.sh                 # compare against origin/main
+#   scripts/pr-checklist.sh <base-ref>      # compare against another base
+#
+set -uo pipefail
+
+BASE="${1:-origin/main}"
+export GOFLAGS="${GOFLAGS:--mod=mod}"
+export GOPROXY="${GOPROXY:-off}"   # the dev laptop blocks the proxy; offline by default
+
+pass=0 fail=0 manual=0
+line() { printf '%-34s %s\n' "$1" "$2"; }
+ok()   { line "$1" "RAN — $2";          pass=$((pass+1)); }
+bad()  { line "$1" "FAIL — $2";         fail=$((fail+1)); }
+na()   { line "$1" "N/A — $2"; }
+todo() { line "$1" "NEEDS-MANUAL — $2"; manual=$((manual+1)); }
+
+# Snapshot the tree state BEFORE we touch anything. The "tree clean" check at the
+# end must report only files THIS SCRIPT dirtied — flagging the caller's own
+# work-in-progress edits would be a false positive (and it was, the first time).
+dirty_before=$(git status --porcelain | grep -v '^??' | awk '{print $2}' | sort)
+
+echo "=== scope ==="
+changed=$(git diff --name-only "$BASE"...HEAD 2>/dev/null)
+if [ -z "$changed" ]; then
+  echo "no changes vs $BASE — nothing to check"; exit 0
+fi
+prod=$(echo "$changed" | grep -E '\.go$' | grep -v '_test\.go$' || true)
+n_prod=$(echo "$prod" | grep -c . || true)
+echo "$changed" | while IFS= read -r f; do printf '  %s\n' "$f"; done
+echo "  production (non-test) .go files: $n_prod"
+echo
+
+echo "=== dimensions ==="
+
+# 1. build / vet / gofmt
+unf=$(gofmt -l ./cmd ./internal ./pkg 2>/dev/null)
+if [ -n "$unf" ]; then bad "1 gofmt" "$(echo "$unf" | tr '\n' ' ')"; else ok "1 gofmt" "clean"; fi
+if go vet ./... >/tmp/_vet 2>&1; then ok "1 go vet" "clean"; else bad "1 go vet" "see /tmp/_vet"; fi
+if go build ./... >/tmp/_build 2>&1; then ok "1 go build" "ok"; else bad "1 go build" "see /tmp/_build"; fi
+
+# 2. full suite, uncached. -count=1 matters: a cached PASS proves nothing about
+#    the current tree.
+if go test -count=1 ./cmd/... ./internal/... ./pkg/... >/tmp/_suite 2>&1; then
+  ok "2 full suite (-count=1)" "$(grep -c '^ok' /tmp/_suite) packages ok"
+else
+  bad "2 full suite (-count=1)" "$(grep -E '^(FAIL|---)' /tmp/_suite | head -3 | tr '\n' ' ')"
+fi
+
+# 3. golden corpus. Regenerating and finding no diff is the assertion; a change
+#    here means behavior moved, which may be intended but must be reviewed.
+if [ -d internal/goldencorpus/testdata ]; then
+  UPDATE_GOLDEN=1 go test -count=1 ./internal/goldencorpus/ >/dev/null 2>&1
+  gd=$(git diff --name-only -- internal/goldencorpus/testdata/ | grep -c . || true)
+  if [ "$gd" -eq 0 ]; then ok "3 golden regen" "0 files changed"
+  else
+    bad "3 golden regen" "$gd files changed — REVIEW EVERY DIFF, then commit deliberately"
+    git diff --name-only -- internal/goldencorpus/testdata/ | sed 's/^/      /'
+  fi
+fi
+
+# 4/5. The sinks. These are the two that keep getting skipped, and they are the
+#      two where a miss is a cleartext leak rather than a cosmetic defect:
+#      offsets feed the redactor, and confidence/position feed the suppression
+#      hash. The script cannot invent a fixture that exercises YOUR change, so
+#      it refuses to mark them done.
+if [ "$n_prod" -eq 0 ]; then
+  na "4 redaction" "no production code changed"
+  na "5 suppression" "no production code changed"
+else
+  todo "4 redaction" "scan a fixture with --enable-redaction for EVERY strategy; for
+                                   xlsx/docx read the part INSIDE the zip (grepping the
+                                   compressed bytes returns 0 and looks like a pass)"
+  todo "5 suppression" "generate with the PARENT binary, apply with YOURS — same-binary
+                                   round-tripping passes even when the hash inputs changed"
+fi
+
+# 6. timing / complexity, only if the change could touch a per-line or per-match loop.
+if [ "$n_prod" -eq 0 ]; then
+  na "6 timing / O(n^2)" "no production code changed"
+else
+  todo "6 timing / O(n^2)" "scaling curve at N/2N/4N with a NON-VACUITY floor (assert
+                                   findings > 0 at every size) and distinct values (identical
+                                   repeats let a quadratic measure as linear)"
+fi
+
+# 7. output formats.
+if [ "$n_prod" -eq 0 ]; then
+  na "7 all 7 formats" "no production code changed"
+else
+  todo "7 all 7 formats" "text json yaml csv junit gitlab-sast sarif"
+fi
+
+# 8. web.
+if echo "$changed" | grep -qE 'internal/web|\.html$|\.css$|\.js$'; then
+  todo "8 web / CSP" "web assets changed"
+else
+  na "8 web / CSP" "no web/template/asset file touched"
+fi
+
+# 10. non-vacuity — a new test must fail on the pre-change code.
+if echo "$changed" | grep -q '_test\.go$'; then
+  todo "10 non-vacuity" "new tests MUST fail on the parent commit; prove it by reverting
+                                   the production change (or the guard) and re-running"
+else
+  na "10 non-vacuity" "no test files added"
+fi
+
+# 11. cross-platform: compile-only, cheap, catches path/build-tag mistakes.
+xp=ok
+for goos in linux darwin windows; do
+  GOOS=$goos go vet ./... >/dev/null 2>&1 || xp="failed on $goos"
+done
+if [ "$xp" = ok ]; then ok "11 cross-platform vet" "linux darwin windows"; else bad "11 cross-platform vet" "$xp"; fi
+
+# 12. flake: three uncached repeats of the packages this change touches.
+pkgs=$(echo "$changed" | grep '\.go$' | xargs -n1 dirname 2>/dev/null | sort -u | sed 's|^|./|' | tr '\n' ' ')
+if [ -n "${pkgs// /}" ]; then
+  flake=ok
+  for _ in 1 2 3; do
+    # shellcheck disable=SC2086  # pkgs is an intentional word-split list
+    go test -count=1 $pkgs >/dev/null 2>&1 || flake="a repeat failed"
+  done
+  if [ "$flake" = ok ]; then ok "12 flake (3 repeats)" "$pkgs"; else bad "12 flake" "$flake"; fi
+fi
+
+# 13. race, WHOLE module. Racing only the package you touched misses the
+#     concurrency the worker pool introduces around it.
+if go test -race -count=1 ./cmd/... ./internal/... ./pkg/... >/tmp/_race 2>&1; then
+  ok "13 race (whole module)" "$(grep -c '^ok' /tmp/_race) packages ok"
+else
+  bad "13 race (whole module)" "$(grep -E '^(FAIL|WARNING: DATA RACE)' /tmp/_race | head -3 | tr '\n' ' ')"
+fi
+
+# -short, because CI uses it and a -short-only skip can hide a broken test.
+if go test -short -count=1 ./cmd/... ./internal/... ./pkg/... >/dev/null 2>&1; then
+  ok "-- -short mode" "ok"
+else
+  bad "-- -short mode" "fails under -short"
+fi
+
+# Leave the tree as we found it.
+git checkout -- internal/goldencorpus/testdata/ 2>/dev/null || true
+dirty_after=$(git status --porcelain | grep -v '^??' | awk '{print $2}' | sort)
+new_dirty=$(comm -13 <(echo "$dirty_before") <(echo "$dirty_after") | grep -c . || true)
+if [ "$new_dirty" -eq 0 ]; then
+  ok "-- tree clean" "this run dirtied nothing"
+else
+  bad "-- tree clean" "$new_dirty file(s) left modified BY THIS RUN: $(comm -13 <(echo "$dirty_before") <(echo "$dirty_after") | tr '\n' ' ')"
+fi
+
+echo
+echo "=== summary: $pass ran, $fail failed, $manual need manual work ==="
+if [ "$manual" -gt 0 ]; then
+  echo "The NEEDS-MANUAL items are not optional. A sink dimension left unrun is how a"
+  echo "cleartext leak ships. See docs/testing/TEST_PLAN.md."
+fi
+if [ "$fail" -gt 0 ]; then exit 1; fi
+exit 0


### PR DESCRIPTION
Test-only. **No behavior change.** This is a gate, added before the fix it guards against.

## The false positives are real

Real public data — a [World Bank population CSV](https://raw.githubusercontent.com/datasets/population/main/data/population.csv) containing **no PII at all** — produces **2,161 HIGH-confidence SSN findings**, because the tabular path skips the LOW cap for any ≥3-field delimited line.

A tempting one-line fix is a "decimal guard": reject a digit run adjacent to a `.` on a word boundary, since `1.130075728` is a fraction.

## That guard is a cleartext leak

`\b` ends **before** a sentence-terminal period, so `the SSN is 130075728.` is indistinguishable from a decimal fraction under a boundary test. Measured on the shipped validator, then with the guard applied:

| input | shipped | with guard |
|---|---|---|
| `Employee record: the SSN is 130075728.` | HIGH 100 | **no finding** |
| `Employee SSN: 130-07-5728.` | HIGH 100 | **no finding** |
| `Social Security Number: 130 07 5728.` | HIGH 100 | **no finding** |
| `ssn=130075728.` | HIGH 95 | **no finding** |

These are the **highest-confidence shapes this validator has** — an explicit label adjacent to a structurally valid value — and the guard sits *before* `isValidSSN`, so it removes them outright rather than re-banding. An unreported value is never handed to the redactor, so it stays in cleartext.

## Why this must be a committed test, not a note

Neither the `ssn` package suite nor the golden corpus contained a **single** sentence-terminal SSN. I implemented the guard and ran all three:

```
new coverage        -> FAIL (names the leak)
ssn package suite   -> ok
golden corpus       -> ok
```

Both gates that would have been cited as safety evidence are blind to it. A regression gate cannot prove anything about a class it does not contain — the same defect family as the vacuous complexity guards fixed in #213.

## The four tests

- **`TestLabelledSSNInProseIsDetected`** — 8 prose terminations (period, comma, semicolon, parenthesis, quote, `key=value`) with an explicit label. Verified non-vacuous: fails on all 8 under the guard.
- **`TestLabelledProseSSNKeepsHighConfidence`** — pins the **band**, not just presence. A fix that demoted these HIGH→LOW would hide them under `--confidence high,medium` and stop them failing pre-commit: a quieter version of the same leak.
- **`TestDecimalFractionsAreNotSSNs`** — the other half of the contract, recorded as **current** behavior rather than an aspiration, so a future precision fix has a measured starting point. Asserts only that these stay out of the HIGH band; a `t.Logf` reports what is reported today.
- **`TestProseAndTabularSSNsCoexist`** — both shapes in one document. This is the exact blind spot that made the broken fix look safe: the recall corpus used to justify it was **entirely delimited rows**, and a columnar-only corpus cannot see a prose regression.

## The FPs are still worth fixing — just not this way

The direction is the **column header**, which is currently ignored: `ssn\n130075728` and `population\n130075728` both score MEDIUM 70. That same header signal also closes a cross-line detection gap (a CSV header/data-row split currently yields zero findings and leaves a passport number cleartext in the redacted output). This commit is the gate that has to stay green while that work happens.

## Verification

First-party suite `exit=0` (58 packages); `-race` clean on `ssn`; `gofmt`/`vet`/`build` clean; **zero golden diff**. Merges clean in order across the full 16-branch stack.
