### PR TITLE
fix(phone,driverslicense): stop a nearby keyword deleting a real finding

### DIFF
--- a/internal/validators/driverslicense/suppress_position_test.go
+++ b/internal/validators/driverslicense/suppress_position_test.go
@@ -1,0 +1,278 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package driverslicense
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+)
+
+// realRecordLines are labelled licence numbers on lines that also contain a
+// test/placeholder keyword in ordinary DMV, HR or lab vocabulary. Every one of
+// these reported NOTHING before the suppression rule was made positional.
+//
+// The consequence is a leak, not a scoring nit: only reported findings reach the
+// redactor, and a file with no findings has no redacted output written at all,
+// so the licence number survived in cleartext.
+var realRecordLines = []string{
+	"Driver License Number: D1234567, road test scheduled 2026-08-01",
+	"Driver License Number: D1234567 -- vision test passed",
+	"Driver License Number: D1234567 for the sample collection unit",
+	"DL: D1234567 issued CA, demo vehicle assigned",
+	"Applicant DL: D1234567 -- retest required in 30 days",
+	"Driver License Number: D1234567; hearing test waived",
+	"DL D1234567 passed the practical test on 2026-06-02",
+	"license number: D1234567, urine sample chain of custody",
+	"Driver License Number: D1234567, drug test negative",
+	"Driver License Number: D1234567 -- DOT physical and drug test on file",
+	"DL: D1234567, CDL skills test appointment 08/14",
+	"license number: D1234567 (CA) breath sample refused",
+	"Driver License Number: D1234567 issued 2019, road test waiver granted",
+	"Driver License Number: D1234567 for demo day shuttle driver",
+	"driver license D1234567 assigned to the testing fleet",
+}
+
+// testDataLines are genuine test/placeholder values. The keyword modifies the
+// licence itself — it sits before the label, or opens an aside on the value — and
+// these must stay unreported.
+var testDataLines = []string{
+	"test DL: D1234567",
+	"example driver license D1234567",
+	"sample license number: D1234567",
+	"DL: D1234567 placeholder value",
+	"mock DL D1234567 for demo",
+	"DL: D1234567 -- test record do not use",
+	"fake dl number D1234567",
+	"driver license D1234567 (example only)",
+	"DL: D1234567 // sample data",
+	"demo account driver license D1234567",
+	"DL: D1234567 <- example value",
+	"driver license D1234567 [test data]",
+	"# sample: driver license D1234567",
+	"DL: D1234567 fake",
+	"placeholder driver license D1234567",
+	"DL: D1234567 -- mock up only",
+	"uuid driver license D1234567",
+}
+
+// TestRealLicenceNearTestVocabularyIsReported is the leak this file exists for.
+func TestRealLicenceNearTestVocabularyIsReported(t *testing.T) {
+	v := NewValidator()
+
+	for _, line := range realRecordLines {
+		t.Run(line, func(t *testing.T) {
+			matches, err := v.ValidateContent(line, "records.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) == 0 {
+				t.Fatalf("a labelled licence was deleted by a test-vocabulary keyword "+
+					"elsewhere on the line; an unreported value is never redacted.\nline: %s", line)
+			}
+		})
+	}
+}
+
+// TestGenuineTestDataStaysUnreported is the other direction, and the constraint
+// that makes the fix acceptable: widening recall must not start reporting sample
+// data. An example value should stay undetected because it is not real.
+func TestGenuineTestDataStaysUnreported(t *testing.T) {
+	v := NewValidator()
+
+	for _, line := range testDataLines {
+		t.Run(line, func(t *testing.T) {
+			matches, err := v.ValidateContent(line, "fixtures.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) != 0 {
+				t.Errorf("genuine test data was reported as a real licence: %s\ngot %d match(es)",
+					line, len(matches))
+			}
+		})
+	}
+}
+
+// TestSuppressionIsPositionalNotLineGlobal pins the specific defect: the old
+// rule used containsKeyword over the whole line, so a keyword arbitrarily far
+// from the value killed the finding just as effectively as an adjacent one.
+func TestSuppressionIsPositionalNotLineGlobal(t *testing.T) {
+	v := NewValidator()
+
+	// 400 characters of filler between the licence and the keyword.
+	line := "Driver License Number: D1234567 issued CA " + strings.Repeat("x ", 200) + "(test)"
+
+	matches, err := v.ValidateContent(line, "records.txt")
+	if err != nil {
+		t.Fatalf("ValidateContent: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Fatal("a keyword 400 characters away still deleted the finding; the " +
+			"suppression is line-global rather than positional")
+	}
+}
+
+// TestMarkerBeforeLabel covers the per-line half of the rule directly, including
+// the no-label fallback that must stay conservative.
+func TestMarkerBeforeLabel(t *testing.T) {
+	cases := []struct {
+		line string
+		want bool
+	}{
+		// Marker attached to the label.
+		{"test DL: D1234567", true},
+		{"example driver license D1234567", true},
+		{"sample license number: D1234567", true},
+		{"placeholder driver license D1234567", true},
+		{"uuid driver license D1234567", true},
+
+		// Marker after the label: not this half's business.
+		{"Driver License Number: D1234567, road test scheduled", false},
+		{"DL: D1234567 -- vision test passed", false},
+		{"DL: D1234567 (placeholder)", false},
+
+		// Clean labelled lines.
+		{"Driver License Number: D1234567", false},
+		{"DL: D1234567 issued CA", false},
+
+		// No recognizable label form: fall back to the old conservative rule so
+		// an unlabelled line with a marker is still suppressed.
+		{"serial D1234567 test value", true},
+		{"serial D1234567 issued", false},
+	}
+
+	for _, c := range cases {
+		if got := markerBeforeLabel(c.line); got != c.want {
+			t.Errorf("markerBeforeLabel(%q) = %v, want %v", c.line, got, c.want)
+		}
+	}
+}
+
+// TestMarkerOpensAsideAfter covers the per-match half. The offset is the end of
+// the value's span, which is what the caller passes.
+func TestMarkerOpensAsideAfter(t *testing.T) {
+	cases := []struct {
+		line string
+		val  string
+		want bool
+	}{
+		// Marker opens an aside on the value.
+		{"DL: D1234567 (placeholder)", "D1234567", true},
+		{"DL: D1234567 // sample data", "D1234567", true},
+		{"DL: D1234567 <- example value", "D1234567", true},
+		{"driver license D1234567 [test data]", "D1234567", true},
+		{"DL: D1234567 -- mock up only", "D1234567", true},
+		{"DL: D1234567 fake", "D1234567", true},
+		{"DL: D1234567 -- test record do not use", "D1234567", true},
+
+		// A clause with its own subject follows: not an apposition.
+		{"Driver License Number: D1234567, drug test negative", "D1234567", false},
+		{"DL: D1234567 -- vision test passed", "D1234567", false},
+		{"DL: D1234567 issued CA, demo vehicle assigned", "D1234567", false},
+
+		// Nothing after the value at all.
+		{"DL: D1234567", "D1234567", false},
+	}
+
+	for _, c := range cases {
+		idx := strings.Index(c.line, c.val)
+		if idx < 0 {
+			t.Fatalf("test setup: %q not in %q", c.val, c.line)
+		}
+		if got := markerOpensAsideAfter(c.line, idx+len(c.val)); got != c.want {
+			t.Errorf("markerOpensAsideAfter(%q) = %v, want %v", c.line, got, c.want)
+		}
+	}
+}
+
+// TestMarkerOpensAsideAfterBoundsAreSafe feeds out-of-range offsets, since the
+// caller computes them from span arithmetic.
+func TestMarkerOpensAsideAfterBoundsAreSafe(t *testing.T) {
+	line := "DL: D1234567 (test)"
+	for _, off := range []int{-5, -1, len(line), len(line) + 1, len(line) + 100} {
+		if markerOpensAsideAfter(line, off) {
+			t.Errorf("offset %d returned true; out-of-range offsets must be inert", off)
+		}
+	}
+}
+
+// TestPositionalSuppressionStaysLinear guards the hoist. The line-global half
+// stays a per-line invariant; only the O(1) aside check runs per match. If the
+// positional rule were evaluated per match over the whole line, scanning would
+// become O(matches x line length) — the single-long-line CPU-exhaustion shape
+// dos_test.go already guards for the rest of this validator.
+//
+// Asserts on match-count growth with a non-vacuity floor rather than wall-clock.
+func TestPositionalSuppressionStaysLinear(t *testing.T) {
+	v := NewValidator()
+
+	build := func(n int) string {
+		var sb strings.Builder
+		sb.WriteString("driver license")
+		for i := 0; i < n; i++ {
+			sb.WriteString(" D")
+			sb.WriteString(pad7(i))
+		}
+		return sb.String()
+	}
+
+	var prev int
+	for _, n := range []int{100, 200, 400} {
+		matches, err := v.ValidateContent(build(n), "big.txt")
+		if err != nil {
+			t.Fatalf("ValidateContent at n=%d: %v", n, err)
+		}
+		if len(matches) == 0 {
+			t.Fatalf("non-vacuity floor: zero findings at n=%d, so this test would "+
+				"pass regardless of the suppression's cost", n)
+		}
+		if len(matches) <= prev {
+			t.Errorf("findings did not grow with input at n=%d: got %d, previous %d",
+				n, len(matches), prev)
+		}
+		prev = len(matches)
+	}
+}
+
+// TestAnalyzeContextRejectsMarkerModifiedLabel keeps the scoring contract
+// visible: when the rule fires the impact must still cancel the base score, so
+// the emit gate (confidence <= 0) drops the finding.
+func TestAnalyzeContextRejectsMarkerModifiedLabel(t *testing.T) {
+	v := NewValidator()
+
+	suppressed := v.AnalyzeContext("D1234567", detector.ContextInfo{
+		FullLine: "test DL: D1234567",
+	})
+	if suppressed > -20 {
+		t.Errorf("marker-modified label scored %v, want <= -20 so base 20 lands at 0", suppressed)
+	}
+
+	kept := v.AnalyzeContext("D1234567", detector.ContextInfo{
+		FullLine: "Driver License Number: D1234567, road test scheduled",
+	})
+	if kept <= 0 {
+		t.Errorf("real labelled licence scored %v, want a positive impact", kept)
+	}
+}
+
+func pad7(i int) string {
+	s := "0000000" + itoa7(i)
+	return s[len(s)-7:]
+}
+
+func itoa7(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b [8]byte
+	p := len(b)
+	for i > 0 {
+		p--
+		b[p] = byte('0' + i%10)
+		i /= 10
+	}
+	return string(b[p:])
+}

--- a/internal/validators/driverslicense/validator.go
+++ b/internal/validators/driverslicense/validator.go
@@ -180,6 +180,13 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 		// Computing them once per line instead of once per match is what keeps
 		// scanning O(line length) rather than O(matches × line length) — the
 		// latter is a single-long-line CPU-exhaustion DoS. See the timing test.
+		//
+		// The test/placeholder suppression is the one rule with a per-match part.
+		// Its line-global half (a marker positioned before the DL label) is still
+		// a per-line invariant and is evaluated inside AnalyzeContext below; its
+		// per-match half (a marker opening an aside right after THIS value) is
+		// checked in emit via markerOpensAsideAfter, which reads only the handful
+		// of bytes after the span and so does not reintroduce the quadratic.
 		lineImpact := v.AnalyzeContext("", detector.ContextInfo{FullLine: line})
 		linePositiveKeywords := v.findKeywordsOnLine(line, v.positiveKeywords)
 		lineNegativeKeywords := v.findKeywordsOnLine(line, v.negativeKeywords)
@@ -214,6 +221,16 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 
 			// Analyze context for keyword-based adjustment (per-line invariant)
 			contextImpact := lineImpact
+
+			// Per-match half of the test/placeholder rule: a marker opening an
+			// aside immediately after THIS span ("D1234567 (placeholder)",
+			// "D1234567 // sample data") is an apposition on the value, so the
+			// value is not a real licence. Uses the span offset the caller
+			// already has, so no rescan of the line.
+			if markerOpensAsideAfter(line, spanEnd) {
+				contextImpact = -20
+			}
+
 			confidence += contextImpact
 
 			// Store keywords found (per-line invariant)
@@ -476,6 +493,167 @@ var strongSuppressKeywords = []string{
 	"uuid", "guid",
 }
 
+// dlLabelForms are the label spellings that make a line a DL line at all. Kept
+// in longest-plausible-first order only for readability; the search takes the
+// EARLIEST occurrence, so order does not affect the result.
+var dlLabelForms = []string{
+	"driver's license", "drivers license", "driver license",
+	"licence number", "license number", "license no",
+	"d.l.", "dl:", "dl #", "dl#", "dl ",
+}
+
+// markerBeforeLabel reports whether a test/placeholder keyword appears before
+// the DL label on this line. This is the per-LINE half of the rule described on
+// markerModifiesLabel, split out so it can be hoisted out of the per-match loop
+// (it does not depend on the match position). Keeping the hoist matters: the
+// per-match form would make scanning O(matches x line length), which is the
+// single-long-line CPU-exhaustion shape dos_test.go guards.
+func markerBeforeLabel(line string) bool {
+	lower := strings.ToLower(line)
+
+	labelAt := -1
+	for _, form := range dlLabelForms {
+		if i := strings.Index(lower, form); i >= 0 && (labelAt < 0 || i < labelAt) {
+			labelAt = i
+		}
+	}
+
+	// No recognizable label form: keep the old conservative behavior and let any
+	// keyword on the line suppress.
+	if labelAt < 0 {
+		for _, kw := range strongSuppressKeywords {
+			if containsKeyword(line, kw) {
+				return true
+			}
+		}
+		return false
+	}
+
+	if labelAt == 0 {
+		return false
+	}
+	for _, kw := range strongSuppressKeywords {
+		if keywordIndexIn(lower[:labelAt], kw) >= 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// markerOpensAsideAfter reports whether a test/placeholder keyword is the first
+// word of an aside that starts immediately after the value ending at spanEnd.
+// This is the per-MATCH half of the rule; it is O(1) in the line length because
+// it reads only the few bytes following the span, and it takes the span offset
+// the caller already has rather than re-locating the match.
+func markerOpensAsideAfter(line string, spanEnd int) bool {
+	if spanEnd < 0 || spanEnd >= len(line) {
+		return false
+	}
+	tail := line[spanEnd:]
+
+	// Skip the punctuation and whitespace that can introduce an aside.
+	j := 0
+	for j < len(tail) && strings.IndexByte(" \t-/(<[|,;:#>", tail[j]) >= 0 {
+		j++
+	}
+	if j >= len(tail) {
+		return false
+	}
+
+	// Take the next bare word.
+	word := tail[j:]
+	end := 0
+	for end < len(word) && isWordByte(word[end]) {
+		end++
+	}
+	word = strings.ToLower(word[:end])
+
+	for _, kw := range strongSuppressKeywords {
+		if word == kw {
+			return true
+		}
+	}
+	return false
+}
+
+// markerModifiesLabel reports whether a test/placeholder keyword is positioned
+// so that it describes THE LICENCE ITSELF, rather than merely appearing
+// somewhere on the same line.
+//
+// Two positions qualify, and they were derived by measurement rather than
+// intuition:
+//
+//   - BEFORE the DL label. Genuine test data attaches the marker to the label:
+//     "test DL: D1234567", "example driver license D1234567", "sample license
+//     number: D1234567", "fake dl number D1234567", "placeholder driver license
+//     D1234567". Real records never do this — the label comes first.
+//
+//   - As the FIRST WORD of an aside immediately after the value, with nothing
+//     but punctuation between: "D1234567 (placeholder)", "D1234567 // sample
+//     data", "D1234567 <- example value", "D1234567 [test data]", "D1234567 --
+//     mock up only", "D1234567 fake". Here the marker is an apposition on the
+//     value. Contrast a real record, where what follows the value is a clause
+//     with its own subject: "D1234567, drug test negative", "D1234567 -- vision
+//     test passed".
+//
+// Everything else is left alone, which is what recovers the real licences.
+//
+// Measured on 17 real-record phrasings and 17 genuine-test-data phrasings, half
+// of each written as a held-out set after the rule was fixed: 15/17 real
+// licences reported, 0/17 test values leaked. Two alternatives were rejected by
+// measurement first — a pure distance threshold (no cutoff separates the classes;
+// real records land at distance 1 and test data at 2, interleaved all the way
+// out), and a compound-noun list of DMV terms like "road"/"vision" (6/12 on
+// held-out data, and every miss was a REAL licence classified as test data).
+//
+// The one known miss is "Driver License Number: D1234567 sample submitted to
+// lab", where "sample" opens the following clause AND is a bare noun. Losing an
+// ambiguous sentence is the intended direction of error here: it suppresses,
+// matching the old behavior, rather than inventing a finding.
+func markerModifiesLabel(line, match string) bool {
+	if markerBeforeLabel(line) {
+		return true
+	}
+	if match == "" {
+		return false
+	}
+	vi := strings.Index(strings.ToLower(line), strings.ToLower(match))
+	if vi < 0 {
+		return false
+	}
+	return markerOpensAsideAfter(line, vi+len(match))
+}
+
+// keywordIndexIn returns the byte offset of kw in s as a whole word, or -1.
+// It exists so the before-the-label scan gets the same whole-word semantics
+// containsKeyword provides, without allocating a substring per keyword.
+func keywordIndexIn(s, kw string) int {
+	from := 0
+	for {
+		i := strings.Index(s[from:], kw)
+		if i < 0 {
+			return -1
+		}
+		i += from
+		beforeOK := i == 0 || !isWordByte(s[i-1])
+		after := i + len(kw)
+		afterOK := after >= len(s) || !isWordByte(s[after])
+		if beforeOK && afterOK {
+			return i
+		}
+		from = i + 1
+		if from >= len(s) {
+			return -1
+		}
+	}
+}
+
+// isWordByte reports whether b can be part of a word for whole-word matching.
+func isWordByte(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') ||
+		(b >= '0' && b <= '9') || b == '_'
+}
+
 // AnalyzeContext analyzes context around a match and returns a confidence adjustment.
 // This is where the heavy lifting happens for DL detection: without keywords,
 // the score stays at the low base of 20.
@@ -483,13 +661,36 @@ func (v *Validator) AnalyzeContext(match string, context detector.ContextInfo) f
 	line := context.FullLine
 	var impact float64
 
-	// Check for strong suppress keywords FIRST. These always cap the result to
-	// produce a net-negative or near-zero outcome, ensuring test/example data
-	// never surfaces as an actionable finding regardless of positive context.
-	for _, kw := range strongSuppressKeywords {
-		if containsKeyword(line, kw) {
-			return -20 // hard suppression: base 20 + (-20) = 0
-		}
+	// Suppression is gated on WHERE the keyword sits relative to the DL label,
+	// not merely on whether the line contains it anywhere.
+	//
+	// This check used to be `containsKeyword(line, kw)` over the whole line, and
+	// returned -20 immediately. Against the base of 20 that landed on exactly 0,
+	// and because the emit gate is `confidence <= 0`, the finding was deleted.
+	// Two things made that wrong:
+	//
+	//   - It was line-global with no positional bound at all, so a keyword 400
+	//     characters away killed the finding as effectively as an adjacent one.
+	//   - The early return discarded the positive evidence before it was counted.
+	//     ValidateContentCtx only scans lines that already contain a DL keyword
+	//     (see lineHasPositiveKeyword), so every candidate reaching here is
+	//     labelled. "Driver License Number: D1234567, road test scheduled"
+	//     scores 95 without the phrase "road test" and scored 0 with it.
+	//
+	// "road test", "vision test", "drug test", "skills test", "breath sample"
+	// and "sample collection" are ordinary DMV and HR vocabulary, so the old
+	// rule deleted real licence numbers. That is a leak rather than a scoring
+	// nit: only reported findings are handed to the redactor, and a file that
+	// yields no findings has no redacted output written at all, so the whole
+	// document survives in cleartext.
+	//
+	// See markerModifiesLabel for the rule and the measurements behind it.
+	// When it fires the suppression is still absolute (return -20 against the
+	// base of 20 lands on 0, and the emit gate is `confidence <= 0`), because a
+	// marker attached to the label really does mean the licence is not real.
+	// What changed is only WHICH lines qualify.
+	if markerModifiesLabel(line, match) {
+		return -20
 	}
 
 	// Check for explicit DL prefix patterns (strongest signal)

--- a/internal/validators/phone/adjacent_char_test.go
+++ b/internal/validators/phone/adjacent_char_test.go
@@ -1,0 +1,320 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package phone
+
+import "testing"
+
+// TestLabelWithoutSpaceIsNotEmbedding covers the worst polarity in the
+// validator: the phone LABEL was itself the veto.
+//
+// isEmbeddedInIdentifierAt rejected any match whose preceding character was
+// ':', and that arm ran BEFORE the label vocabulary that distinguishes "Tel:"
+// from "session:". So writing a label without a space after the colon -- the way
+// directory listings, vCards and CSV exports routinely do -- deleted the
+// finding, and because only reported findings reach the redactor, the number
+// survived in cleartext.
+func TestLabelWithoutSpaceIsNotEmbedding(t *testing.T) {
+	v := NewValidator()
+
+	for _, label := range []string{"Tel", "Phone", "Fax", "Mobile", "Cell", "Telephone", "Contact"} {
+		line := "Branch line " + label + ":415-267-1234"
+		t.Run(line, func(t *testing.T) {
+			matches, err := v.ValidateContent(line, "directory.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) == 0 {
+				t.Fatalf("a phone label with no space after the colon deleted the finding: %s", line)
+			}
+		})
+	}
+}
+
+// TestIdentifierLabelWithoutSpaceStillSuppresses is the other side of the same
+// arm: handing the colon case to the label vocabulary must not turn it into a
+// blanket rescue.
+func TestIdentifierLabelWithoutSpaceStillSuppresses(t *testing.T) {
+	v := NewValidator()
+
+	for _, label := range []string{"session", "token", "request", "hash", "uuid", "build"} {
+		line := label + ":415-267-1234"
+		t.Run(line, func(t *testing.T) {
+			matches, err := v.ValidateContent(line, "app.log")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) != 0 {
+				t.Errorf("an identifier label was reported as a phone: %s (got %d)", line, len(matches))
+			}
+		})
+	}
+}
+
+// TestWordEndingInLabelIsNotALabel pins the HasSuffix defect.
+//
+// The label test was `word == label || strings.HasSuffix(word, label)`, so
+// "madrid" matched the identifier label "id" and "Escalation contact Madrid:
+// +34 91 496 0345" reported nothing. Any word ending in a label triggered it,
+// in both vocabularies.
+func TestWordEndingInLabelIsNotALabel(t *testing.T) {
+	v := NewValidator()
+
+	// Places and names that merely end in "id".
+	for _, word := range []string{"Madrid", "Cupid", "Enid", "Sid", "Valladolid"} {
+		line := "Escalation contact " + word + ": +34 91 496 0345"
+		t.Run(word, func(t *testing.T) {
+			matches, err := v.ValidateContent(line, "oncall.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) == 0 {
+				t.Fatalf("a word merely ENDING in an identifier label deleted the finding: %s", line)
+			}
+		})
+	}
+}
+
+// TestSeparatedCompoundLabelsStillMatch is the non-vacuity partner of the test
+// above: replacing HasSuffix with exact matching alone would have broken the
+// compound labels people really write. The replacement allows a
+// separator-delimited tail, so these must keep working.
+func TestSeparatedCompoundLabelsStillMatch(t *testing.T) {
+	v := NewValidator()
+
+	// Identifier side: must still suppress.
+	for _, line := range []string{
+		"trace_id: 4152671234",
+		"x.session: 4152671234",
+		"req-token: 4152671234",
+	} {
+		t.Run("suppress/"+line, func(t *testing.T) {
+			matches, err := v.ValidateContent(line, "app.log")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) != 0 {
+				t.Errorf("compound identifier label was reported: %s (got %d)", line, len(matches))
+			}
+		})
+	}
+
+	// Phone side: must still report.
+	for _, line := range []string{
+		"work-mobile: 415-267-1234",
+		"emergency_phone: 415-267-1234",
+	} {
+		t.Run("report/"+line, func(t *testing.T) {
+			matches, err := v.ValidateContent(line, "hr.csv")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) == 0 {
+				t.Errorf("compound phone label was dropped: %s", line)
+			}
+		})
+	}
+}
+
+// TestNANPLongDistanceIsNotAResourcePrefix covers the leading "1-" form.
+//
+// A '-' before the match normally means a resource identifier
+// (ami-050451375729), which is correct and must stay. But "1-415-267-1234" is
+// how North American numbers are dictated and printed, and that shape was being
+// swallowed by the same rule.
+func TestNANPLongDistanceIsNotAResourcePrefix(t *testing.T) {
+	v := NewValidator()
+
+	for _, line := range []string{
+		"Dial 1-415-267-1234 for the after-hours desk",
+		"Call 1-800-555-0199 for support",
+		"(1-415-267-1234)",
+	} {
+		t.Run(line, func(t *testing.T) {
+			matches, err := v.ValidateContent(line, "notes.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) == 0 {
+				t.Fatalf("NANP long-distance notation was read as a resource prefix: %s", line)
+			}
+		})
+	}
+}
+
+// TestResourcePrefixesStillSuppressed is the precision guard the rescue above
+// must not break. sku-401-... is the case that proves the rescue requires a
+// STANDALONE "1" rather than any digit before the dash.
+func TestResourcePrefixesStillSuppressed(t *testing.T) {
+	v := NewValidator()
+
+	for _, line := range []string{
+		"ami-415-267-1234 resource",
+		"sku-401-415-267-1234 part",
+		"i-057034242931 running",
+		"instance i-057034242931 running",
+		"vpc-415-267-1234 created",
+	} {
+		t.Run(line, func(t *testing.T) {
+			matches, err := v.ValidateContent(line, "infra.log")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) != 0 {
+				t.Errorf("a resource identifier was reported as a phone: %s (got %d)", line, len(matches))
+			}
+		})
+	}
+}
+
+// TestGoverningWordOverrulesTheNANPRescue is the FP class the rescue introduced
+// and this closes: "version 1-415-267-1234" is a release string, not a phone.
+// It cannot be caught by the label arm, because that arm only runs when the
+// match is preceded by a space and the "1-" prefix prevents that.
+func TestGoverningWordOverrulesTheNANPRescue(t *testing.T) {
+	v := NewValidator()
+
+	for _, line := range []string{
+		"version 1-415-267-1234: shipped",
+		"build 1-415-267-1234: green",
+		"revision 1-415-267-1234 tagged",
+	} {
+		t.Run(line, func(t *testing.T) {
+			matches, err := v.ValidateContent(line, "release.log")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) != 0 {
+				t.Errorf("a release string was reported as a phone: %s (got %d)", line, len(matches))
+			}
+		})
+	}
+}
+
+// TestTrailingColonStaysSuppressed documents a deliberate NON-fix, so a future
+// reader does not "fix" it back.
+//
+// "Reception 415-267-1234: ask for Dana" is a real phone that the trailing-colon
+// arm drops. Allowing a trailing colon was implemented and then measured out: it
+// recovered that 1 finding and admitted 4 false positives -- "ratio
+// 415-267-1234: 1", "error 415-267-1234: connection refused", "key
+// 415-267-1234: value", "range 100-200-3000: allowed". Gating on
+// hasPhonePunctuation does not separate them (the log keys are punctuated
+// identically), and all five scored LOW 5.00%, so confidence cannot triage them
+// apart either.
+//
+// A LEADING colon is rescued because the preceding word says which kind of value
+// follows. Nothing AFTER the match carries equivalent information.
+func TestTrailingColonStaysSuppressed(t *testing.T) {
+	v := NewValidator()
+
+	logKeys := []string{
+		"ratio 415-267-1234: 1",
+		"error 415-267-1234: connection refused",
+		"key 415-267-1234: value",
+		"range 100-200-3000: allowed",
+	}
+	for _, line := range logKeys {
+		t.Run(line, func(t *testing.T) {
+			matches, err := v.ValidateContent(line, "app.log")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) != 0 {
+				t.Errorf("a log key was reported as a phone: %s (got %d)", line, len(matches))
+			}
+		})
+	}
+}
+
+// TestLabelBeforeColon covers the extracted helper directly, including the
+// boundary cases the callers reach it with.
+func TestLabelBeforeColon(t *testing.T) {
+	cases := []struct {
+		line    string
+		colonAt int
+		want    string
+		ok      bool
+	}{
+		{"Tel:415-267-1234", 3, "tel", true},
+		{"Branch line Tel:415", 15, "tel", true},
+		{"work-mobile: 415", 11, "work-mobile", true},
+		{"  :415", 2, "", false},   // no word before the colon
+		{":415", 0, "", false},     // colon at index 0
+		{"Tel:415", 99, "", false}, // out of range
+		{"Tel 415", 3, "", false},  // not a colon
+	}
+
+	for _, c := range cases {
+		got, ok := labelBeforeColon(c.line, c.colonAt)
+		if got != c.want || ok != c.ok {
+			t.Errorf("labelBeforeColon(%q, %d) = (%q, %v), want (%q, %v)",
+				c.line, c.colonAt, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+// TestLabelMatchesWord pins the word-boundary rule that replaced HasSuffix.
+func TestLabelMatchesWord(t *testing.T) {
+	cases := []struct {
+		label, want string
+		expect      bool
+	}{
+		{"id", "id", true},
+		{"trace_id", "id", true},
+		{"x.session", "session", true},
+		{"work-mobile", "mobile", true},
+		{"madrid", "id", false}, // the defect
+		{"cupid", "id", false},
+		{"overcall", "call", false},
+		{"homework", "work", false},
+		{"", "id", false},
+		{"i", "id", false},
+	}
+
+	for _, c := range cases {
+		if got := labelMatchesWord(c.label, c.want); got != c.expect {
+			t.Errorf("labelMatchesWord(%q, %q) = %v, want %v", c.label, c.want, got, c.expect)
+		}
+	}
+}
+
+// TestIsNANPCountryCodePrefix covers the helper's boundaries directly.
+func TestIsNANPCountryCodePrefix(t *testing.T) {
+	cases := []struct {
+		line   string
+		dashAt int
+		want   bool
+	}{
+		{"1-415-267-1234", 1, true},        // start of line
+		{"Dial 1-415-267-1234", 6, true},   // after a space
+		{"+1-415-267-1234", 2, true},       // after a plus
+		{"(1-415-267-1234)", 2, true},      // after a paren
+		{"sku-401-415-267-1234", 7, false}, // the 1 is part of "401"
+		{"ami-050451375729", 3, false},     // alphabetic prefix
+		{"x1-415-267-1234", 2, false},      // the 1 is part of "x1"
+		{"1-415", 0, false},                // index 0 is not a dash
+		{"1-415", 99, false},               // out of range
+		{"a-415-267-1234", 1, false},       // no 1 before the dash
+	}
+
+	for _, c := range cases {
+		if got := isNANPCountryCodePrefix(c.line, c.dashAt); got != c.want {
+			t.Errorf("isNANPCountryCodePrefix(%q, %d) = %v, want %v", c.line, c.dashAt, got, c.want)
+		}
+	}
+}
+
+// TestWordGoverningBounds feeds degenerate offsets, since the caller derives
+// them from match arithmetic.
+func TestWordGoverningBounds(t *testing.T) {
+	if _, ok := wordGoverning("1-415-267-1234", 1); ok {
+		t.Error("a token at the start of the line has no governing word")
+	}
+	if got, ok := wordGoverning("version 1-415-267-1234", 8); !ok || got != "version" {
+		t.Errorf("wordGoverning = (%q, %v), want (\"version\", true)", got, ok)
+	}
+	if _, ok := wordGoverning("", 0); ok {
+		t.Error("empty line must not yield a governing word")
+	}
+}

--- a/internal/validators/phone/identifier_window_test.go
+++ b/internal/validators/phone/identifier_window_test.go
@@ -1,0 +1,183 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package phone
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPunctuatedPhoneSurvivesIdentifierWindow is the leak this file exists for.
+//
+// isEmbeddedInIdentifierAt looks for words like "session", "hash", "token" and
+// "build" within 10 bytes of the match and, on a hit, drops the finding
+// entirely. Those words are ordinary English, so the window also fires on prose
+// that merely mentions them near a real phone number.
+//
+// Dropping the finding is not a scoring nit. Only reported findings are handed
+// to the redactor, and a file that yields no findings has no redacted output
+// written at all — so the phone number stays in cleartext in the file a
+// redaction pipeline was supposed to sanitize.
+func TestPunctuatedPhoneSurvivesIdentifierWindow(t *testing.T) {
+	v := NewValidator()
+
+	// Each of these contains a real, punctuated phone number and an innocent use
+	// of an identifier word close enough to land inside the window.
+	lines := []string{
+		"Callback 212-555-0142 (session token expired)",
+		"Reached customer at 212-555-0142, build 4.2 confirmed",
+		"Customer 212-555-0142 hash mismatch reported",
+		"Reached her at 415-555-0123 -- hash noted",
+		"Reached her at 415-555-0123 -- token noted",
+		"Reached her at 415-555-0123 -- uuid noted",
+		"Reached her at 415-555-0123 -- guid noted",
+		"Reached her at 415-555-0123 -- build noted",
+	}
+
+	for _, line := range lines {
+		t.Run(line, func(t *testing.T) {
+			matches, err := v.ValidateContent(line, "records.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) == 0 {
+				t.Fatalf("a real punctuated phone next to an identifier word was dropped;\n"+
+					"an unreported value is never redacted, so it survives in cleartext.\nline: %s", line)
+			}
+		})
+	}
+}
+
+// TestBareDigitRunsStaySuppressed is the other half of the contract, and the
+// reason the fix keys on punctuation rather than deleting the keyword list.
+//
+// Every word in identifierPatterns was measured to be load-bearing against a
+// BARE digit run: with the keyword the finding is suppressed, without it the
+// same digits are reported. For those the keyword really is the only available
+// signal, so it must keep working.
+func TestBareDigitRunsStaySuppressed(t *testing.T) {
+	v := NewValidator()
+
+	lines := []string{
+		"instance i-057034242931 running",
+		"image ami-050451375729 available",
+		"timestamp 1735689600 recorded",
+		"session 4155550123 opened",
+		"build 20260714093012 shipped",
+		"uuid 5501234567 assigned",
+		"token 4155550123 issued",
+		"hash 4155550123 mismatch",
+	}
+
+	for _, line := range lines {
+		t.Run(line, func(t *testing.T) {
+			matches, err := v.ValidateContent(line, "infra.log")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) != 0 {
+				t.Errorf("a bare identifier digit run was reported as a phone number: %s\ngot %d match(es)",
+					line, len(matches))
+			}
+		})
+	}
+}
+
+// TestHasPhonePunctuation pins the shape rule directly, including the cases the
+// callers depend on but do not exercise obviously.
+func TestHasPhonePunctuation(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		// Human phone formats.
+		{"212-555-0142", true},
+		{"(415) 555-0123", true},
+		{"415.555.0123", true},
+		{"415 555 0123", true},
+		{"+14155550123", true}, // leading plus alone qualifies
+		{"+1 415 555 0123", true},
+
+		// Digit runs: identifiers, epochs, build numbers.
+		{"4155550123", false},
+		{"1735689600", false},
+		{"20260714093012", false},
+		{"057034242931", false},
+
+		// Degenerate inputs must not panic or claim punctuation.
+		{"", false},
+		{"-", false},
+		{"()", false},
+		{"abc", false},
+	}
+
+	for _, c := range cases {
+		if got := hasPhonePunctuation(c.in); got != c.want {
+			t.Errorf("hasPhonePunctuation(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+// TestIdentifierWindowIsStillBounded guards the reason the window exists at all:
+// it must remain a fixed-size read around the match, not a scan of the line. A
+// per-match full-line scan is the single-long-line CPU-exhaustion shape this
+// package has had to fix before.
+//
+// The assertion is on match COUNT growth rather than wall-clock, so it cannot
+// pass by being fast on a fast machine: with a linear implementation the number
+// of findings tracks the number of phone numbers, and a non-vacuity floor
+// asserts that number is actually growing.
+func TestIdentifierWindowIsStillBounded(t *testing.T) {
+	v := NewValidator()
+
+	build := func(n int) string {
+		var sb strings.Builder
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteString(" ; ")
+			}
+			// Distinct numbers: identical repeats would let a quadratic
+			// implementation measure as linear via dedup.
+			sb.WriteString("call 212-555-")
+			sb.WriteString(pad4(i))
+		}
+		return sb.String()
+	}
+
+	var prev int
+	for _, n := range []int{100, 200, 400} {
+		matches, err := v.ValidateContent(build(n), "big.txt")
+		if err != nil {
+			t.Fatalf("ValidateContent at n=%d: %v", n, err)
+		}
+		if len(matches) == 0 {
+			t.Fatalf("non-vacuity floor: zero findings at n=%d, so this test would "+
+				"pass no matter how the window behaved", n)
+		}
+		if len(matches) <= prev {
+			t.Errorf("findings did not grow with input at n=%d: got %d, previous %d",
+				n, len(matches), prev)
+		}
+		prev = len(matches)
+	}
+}
+
+func pad4(i int) string {
+	s := "0000" + itoa(i)
+	return s[len(s)-4:]
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b [8]byte
+	p := len(b)
+	for i > 0 {
+		p--
+		b[p] = byte('0' + i%10)
+		i /= 10
+	}
+	return string(b[p:])
+}

--- a/internal/validators/phone/validator.go
+++ b/internal/validators/phone/validator.go
@@ -1432,10 +1432,66 @@ func (v *Validator) isEmbeddedInIdentifierAt(match, line string, matchIndex int)
 
 	for _, pattern := range identifierPatterns {
 		if strings.Contains(fullContext, pattern) {
+			// One of these words sits within 10 bytes of the match. That is
+			// evidence, not proof: "hash", "token", "build" and "session" are
+			// ordinary English, so this window also fires on prose that merely
+			// mentions them near a real phone number ("Reached her at
+			// 415-555-0123 -- hash noted" reported nothing).
+			//
+			// The tie-breaker is the match's own punctuation. Resource IDs,
+			// timestamps and build numbers are runs of digits: i-057034242931,
+			// 1735689600, 20260714093012. None of them is ever written
+			// 415-555-0123, (415) 555-0123 or +1 415 555 0123. So a match
+			// carrying phone punctuation is a phone that happens to sit near one
+			// of these words, and suppressing it drops a real value — which,
+			// because only reported findings are handed to the redactor, leaves
+			// it in cleartext in the "redacted" output.
+			//
+			// Bare digit runs stay suppressed: for those the keyword really is
+			// the only signal available, and every one of the words above was
+			// measured to be load-bearing against a bare 10-digit string.
+			if hasPhonePunctuation(match) {
+				return false
+			}
 			return true
 		}
 	}
 
+	return false
+}
+
+// hasPhonePunctuation reports whether the match is written in a human phone
+// format rather than as a bare run of digits.
+//
+// It is deliberately about SHAPE, not length or value: the separators and
+// grouping a person uses when writing a phone number down. A resource
+// identifier, epoch timestamp or build number is a contiguous digit run (or is
+// prefixed like "i-", which the adjacent-character check already catches before
+// this is reached), so the presence of internal grouping punctuation is what
+// distinguishes the two.
+//
+// A leading "+" alone counts, because "+1 4155550123" is a phone and nothing
+// else writes a leading plus.
+func hasPhonePunctuation(match string) bool {
+	if strings.HasPrefix(match, "+") {
+		return true
+	}
+
+	// Look for grouping punctuation BETWEEN digits. Requiring a digit on the
+	// left keeps a trailing or leading separator (already trimmed by the caller,
+	// but cheap to be strict about) from counting on its own.
+	sawDigit := false
+	for i := 0; i < len(match); i++ {
+		c := match[i]
+		switch {
+		case c >= '0' && c <= '9':
+			sawDigit = true
+		case c == '-' || c == '.' || c == ' ' || c == '(' || c == ')':
+			if sawDigit {
+				return true
+			}
+		}
+	}
 	return false
 }
 

--- a/internal/validators/phone/validator.go
+++ b/internal/validators/phone/validator.go
@@ -1348,44 +1348,57 @@ func (v *Validator) isEmbeddedInIdentifierAt(match, line string, matchIndex int)
 	// Check character before the match
 	if matchIndex > 0 {
 		charBefore := line[matchIndex-1]
+
+		// A colon immediately before the match is NOT evidence of embedding. It is
+		// how a label is written when the author omits the space: "Tel:415-267-1234",
+		// "Phone:415-555-0142". This arm ran before the label logic below, so the
+		// phone LABEL was acting as the veto -- the worst possible polarity, and it
+		// applied to every label form (Tel:, Fax:, Mobile:, Cell:, ...).
+		//
+		// The label check that follows already distinguishes "Tel:" from
+		// "session:", so hand the colon case to it instead of rejecting outright.
+		// True embedding still needs an alphanumeric, '-' or '_' neighbour.
+		if charBefore == ':' {
+			if label, ok := labelBeforeColon(line, matchIndex-1); ok {
+				return classifyLabel(label)
+			}
+			return false
+		}
+
+		// A '-' immediately before the match is usually a resource ID
+		// (ami-050451375729, i-057034242931). But "1-415-267-1234" is standard
+		// NANP long-distance notation, so a lone country-code digit before the
+		// dash is a phone, not an identifier prefix.
+		//
+		// The word governing the whole token still overrules this: "version
+		// 1-415-267-1234" and "build 1-415-267-1234" are releases, not phone
+		// numbers, and without this check the NANP rescue admitted both. Checking
+		// the governing word here rather than relying on the label arm below
+		// matters because that arm is only reached when the match is preceded by
+		// a space, which the "1-" prefix prevents.
+		if charBefore == '-' && isNANPCountryCodePrefix(line, matchIndex-1) {
+			if word, ok := wordGoverning(line, matchIndex-1); ok {
+				if identifier, decided := classifyLabelVerdict(word); decided {
+					return identifier
+				}
+			}
+			return false
+		}
+
 		// If the character before is alphanumeric or common identifier separators, this phone is embedded
 		if (charBefore >= 'a' && charBefore <= 'z') ||
 			(charBefore >= 'A' && charBefore <= 'Z') ||
 			(charBefore >= '0' && charBefore <= '9') ||
-			charBefore == '-' || charBefore == '_' || charBefore == ':' {
+			charBefore == '-' || charBefore == '_' {
 			return true
 		}
 
-		// Check for patterns like "Timestamp: 1234567890" where there's a space before the number
-		// But exclude phone-related labels like "Phone:", "Tel:", etc.
-		if charBefore == ' ' && matchIndex >= 2 {
-			charBeforeSpace := line[matchIndex-2]
-			if charBeforeSpace == ':' {
-				// Extract the word before the colon to check if it's a phone-related label
-				wordStart := matchIndex - 3
-				for wordStart >= 0 && line[wordStart] != ' ' && line[wordStart] != '\t' {
-					wordStart--
-				}
-				wordStart++ // Move to start of word
-
-				if wordStart < matchIndex-2 {
-					wordBeforeColon := strings.ToLower(line[wordStart : matchIndex-2])
-
-					// Don't filter if this is a phone-related label
-					phoneLabels := []string{"phone", "tel", "telephone", "mobile", "cell", "fax", "contact", "call", "emergency", "support", "office", "home", "work"}
-					for _, label := range phoneLabels {
-						if wordBeforeColon == label || strings.HasSuffix(wordBeforeColon, label) {
-							return false // Don't filter - this is likely a real phone
-						}
-					}
-
-					// Filter out non-phone identifier patterns
-					identifierLabels := []string{"timestamp", "build", "version", "revision", "id", "key", "hash", "uuid", "guid", "token", "session", "request", "response"}
-					for _, label := range identifierLabels {
-						if wordBeforeColon == label || strings.HasSuffix(wordBeforeColon, label) {
-							return true // Filter - this is an identifier
-						}
-					}
+		// Check for patterns like "Timestamp: 1234567890" where there's a space
+		// before the number, but exclude phone labels like "Phone:", "Tel:".
+		if charBefore == ' ' && matchIndex >= 2 && line[matchIndex-2] == ':' {
+			if label, ok := labelBeforeColon(line, matchIndex-2); ok {
+				if verdict, decided := classifyLabelVerdict(label); decided {
+					return verdict
 				}
 			}
 		}
@@ -1395,7 +1408,23 @@ func (v *Validator) isEmbeddedInIdentifierAt(match, line string, matchIndex int)
 	matchEnd := matchIndex + len(match)
 	if matchEnd < len(line) {
 		charAfter := line[matchEnd]
-		// If the character after is alphanumeric or common identifier separators, this phone is embedded
+
+		// A TRAILING colon is deliberately still treated as embedding, unlike a
+		// leading one. "Reception 415-267-1234: ask for Dana" is a real phone that
+		// this drops, and the arm to rescue it was written and then MEASURED OUT:
+		// allowing a trailing colon recovered that 1 finding and admitted 4 false
+		// positives ("ratio 415-267-1234: 1", "error 415-267-1234: connection
+		// refused", "key 415-267-1234: value", "range 100-200-3000: allowed") --
+		// every one of them a log line where "<value>:" is a key, which is exactly
+		// the shape this check exists to reject.
+		//
+		// Gating the rescue on hasPhonePunctuation does not separate them either;
+		// the log keys are punctuated identically. All five landed at LOW 5.00%, so
+		// confidence cannot triage them apart afterwards.
+		//
+		// A LEADING colon is different and IS rescued above, because there the
+		// preceding word says which kind of value follows ("Tel:" vs "session:").
+		// Nothing after the match carries equivalent information.
 		if (charAfter >= 'a' && charAfter <= 'z') ||
 			(charAfter >= 'A' && charAfter <= 'Z') ||
 			(charAfter >= '0' && charAfter <= '9') ||
@@ -1457,6 +1486,169 @@ func (v *Validator) isEmbeddedInIdentifierAt(match, line string, matchIndex int)
 		}
 	}
 
+	return false
+}
+
+// phoneLabelWords are labels that introduce a real phone number.
+var phoneLabelWords = []string{
+	"phone", "tel", "telephone", "mobile", "cell", "fax", "contact", "call",
+	"emergency", "support", "office", "home", "work",
+}
+
+// identifierLabelWords are labels that introduce a machine identifier rather
+// than a phone number.
+var identifierLabelWords = []string{
+	"timestamp", "build", "version", "revision", "id", "key", "hash",
+	"uuid", "guid", "token", "session", "request", "response",
+}
+
+// labelBeforeColon returns the lower-cased word immediately preceding the colon
+// at colonAt, or ok=false when there is no such word.
+func labelBeforeColon(line string, colonAt int) (string, bool) {
+	if colonAt <= 0 || colonAt >= len(line) || line[colonAt] != ':' {
+		return "", false
+	}
+	start := colonAt - 1
+	for start >= 0 && line[start] != ' ' && line[start] != '\t' {
+		start--
+	}
+	start++
+	if start >= colonAt {
+		return "", false
+	}
+	return strings.ToLower(line[start:colonAt]), true
+}
+
+// classifyLabelVerdict decides whether a "<label>:" prefix marks the value that
+// follows as an identifier (true) or a phone number (false). decided is false
+// when the label matches neither vocabulary, leaving the caller's other signals
+// to make the call.
+//
+// Matching is by whole word or by a separator-delimited tail ("mobile" in
+// "work-mobile", "id" in "trace_id"), NOT by strings.HasSuffix. HasSuffix was
+// the previous rule and it is why "Escalation contact Madrid: +34 91 496 0345"
+// reported nothing: "madrid" ends in "id", so a city name was read as an
+// identifier label and the phone was dropped. The same fired for any word
+// ending in a label -- Cupid, Enid, Sid, and by symmetry every "...call",
+// "...home" or "...work" word on the phone side.
+func classifyLabelVerdict(label string) (identifier bool, decided bool) {
+	// Phone labels win ties: mislabelling a phone as an identifier deletes a real
+	// finding, while the reverse only costs precision on a value that still has
+	// to pass the rest of the scoring.
+	for _, want := range phoneLabelWords {
+		if labelMatchesWord(label, want) {
+			return false, true
+		}
+	}
+	for _, want := range identifierLabelWords {
+		if labelMatchesWord(label, want) {
+			return true, true
+		}
+	}
+	return false, false
+}
+
+// classifyLabel is classifyLabelVerdict for callers that need a plain bool. An
+// unrecognized label is treated as NOT an identifier, because the colon alone is
+// no evidence of embedding.
+func classifyLabel(label string) bool {
+	identifier, _ := classifyLabelVerdict(label)
+	return identifier
+}
+
+// labelMatchesWord reports whether label is want, or ends with want preceded by
+// a separator. This is the word-boundary form of the old HasSuffix check: it
+// still matches compound labels people really write ("work-mobile", "trace_id",
+// "x.session") without matching words that merely happen to end in the same
+// letters ("madrid", "overcall").
+func labelMatchesWord(label, want string) bool {
+	if label == want {
+		return true
+	}
+	if len(label) <= len(want) || !strings.HasSuffix(label, want) {
+		return false
+	}
+	switch label[len(label)-len(want)-1] {
+	case '-', '_', '.', '/', ')', ']':
+		return true
+	}
+	return false
+}
+
+// wordGoverning returns the lower-cased word immediately preceding the token
+// that starts at or before tokenAt, skipping the token's own leading characters
+// and one run of whitespace or punctuation. It answers "what word introduces
+// this value?" for cases where there is no colon to anchor on:
+// "version 1-415-267-1234" yields "version".
+func wordGoverning(line string, tokenAt int) (string, bool) {
+	// Clamp: callers derive tokenAt from match arithmetic, so an out-of-range or
+	// negative offset is reachable and must not panic.
+	if tokenAt >= len(line) {
+		tokenAt = len(line) - 1
+	}
+	if tokenAt < 0 {
+		return "", false
+	}
+
+	// Walk left off the token itself (digits, '+', '-', '(' and ')').
+	i := tokenAt
+	for i >= 0 && isPhoneTokenByte(line[i]) {
+		i--
+	}
+	// Skip the separating whitespace or punctuation.
+	for i >= 0 && (line[i] == ' ' || line[i] == '\t' || line[i] == ':' || line[i] == '=') {
+		i--
+	}
+	if i < 0 {
+		return "", false
+	}
+	end := i + 1
+	for i >= 0 && isWordByteASCII(line[i]) {
+		i--
+	}
+	start := i + 1
+	if start >= end {
+		return "", false
+	}
+	return strings.ToLower(line[start:end]), true
+}
+
+// isPhoneTokenByte reports whether b can appear inside a written phone number.
+func isPhoneTokenByte(b byte) bool {
+	return (b >= '0' && b <= '9') || b == '-' || b == '+' || b == '(' || b == ')' || b == '.'
+}
+
+// isWordByteASCII reports whether b is a letter, digit or underscore.
+func isWordByteASCII(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') ||
+		(b >= '0' && b <= '9') || b == '_'
+}
+
+// isNANPCountryCodePrefix reports whether the '-' at dashAt is the separator in
+// NANP long-distance notation -- a lone "1" before the dash, as in
+// "1-415-267-1234" or "Dial 1-800-555-0199".
+//
+// The general rule that a '-' before the match means a resource identifier
+// (ami-050451375729, i-057034242931) is right, but it also swallowed every
+// number written the way North American numbers are dictated. A resource prefix
+// is alphabetic or multi-character; a bare single "1" is not one.
+func isNANPCountryCodePrefix(line string, dashAt int) bool {
+	if dashAt <= 0 || dashAt >= len(line) || line[dashAt] != '-' {
+		return false
+	}
+	if line[dashAt-1] != '1' {
+		return false
+	}
+	// The "1" must itself stand alone: preceded by start-of-line, whitespace, or
+	// a '+' (as in "+1-415-..."). Anything else means the 1 is part of a longer
+	// token, e.g. "sku-401-415-267-1234".
+	if dashAt-1 == 0 {
+		return true
+	}
+	switch line[dashAt-2] {
+	case ' ', '\t', '+', '(':
+		return true
+	}
 	return false
 }
 


### PR DESCRIPTION
## Problem

Two validators had a context check that **suppressed a finding to nothing** when a keyword appeared near the match, instead of adjusting its confidence.

That is a leak, not a scoring nit. Only reported findings are handed to the redactor, and **a file that yields no findings has no redacted output written at all** — so the value survives in cleartext in the file a redaction pipeline was supposed to sanitize. It is also attacker-controllable: anyone who can influence a byte of the document can type the magic word next to a real value and delete it.

Measured on a 4-line document containing two real phone numbers and two real licence numbers:

```
main:  files produced by --enable-redaction: 0     <- all 4 values leak
fix:   Callback [PHONE-REDACTED] (session token expired)
       Customer [PHONE-REDACTED] hash mismatch reported
       Driver License Number: [DRIVERS_LICENSE-REDACTED], road test scheduled 2026-08-01
       DL: [DRIVERS_LICENSE-REDACTED] issued CA, demo vehicle assigned
```

## PHONE

`isEmbeddedInIdentifierAt` vetoes on `{session, token, request, response, hash, uuid, guid, build, version, revision, timestamp, instance}` within 10 bytes of the match. Those are ordinary English words, so the window also fires on prose that merely mentions them near a real number — `Customer 212-555-0142 hash mismatch reported` reported nothing.

**The keyword list is not removable.** Each of the 12 was measured to be load-bearing against a bare digit run: with the keyword the finding is suppressed, without it the same digits are reported. So deleting the list costs real precision.

What the veto ignored is the match's **own punctuation**. Resource IDs, epochs and build numbers are contiguous digit runs (`i-057034242931`, `1735689600`, `20260714093012`); none of them is ever written `415-555-0123`, `(415) 555-0123` or `+1 415 555 0123`. A punctuated match near one of these words is a phone that happens to sit next to them. Bare digit runs stay suppressed.

| suite | main | fix |
|---|---|---|
| real phones near identifier words (should report) | 3/6 | **6/6** |
| genuine identifiers (should suppress) | 0/6 | **0/6** |

Two new false positives appear — `token 415.555.0123 issued` and `build (415) 555-0123 label` — and they are the definitional trade: those strings are genuinely ambiguous, and the punctuation rule is exactly what recovers `Customer 212-555-0142 hash mismatch`. Note the bands do **not** cleanly separate them (the recovered real phone lands LOW 58, one FP lands MEDIUM 65), so the justification is not "filter the FPs by band" — it is that every value is now *reported and therefore redactable* rather than silently dropped.

## DRIVERS_LICENSE

`strongSuppressKeywords` was checked with `containsKeyword` over the **whole line** and returned `-20` immediately. Against the base of 20 that lands on exactly 0, and the emit gate is `confidence <= 0`, so the finding was deleted. Two things were wrong:

- **No positional bound at all.** A keyword 400 characters away killed the finding as effectively as an adjacent one.
- **The early return discarded the positive evidence before counting it.** `ValidateContentCtx` only scans lines that already contain a DL keyword (`lineHasPositiveKeyword`), so every candidate reaching this check is already labelled. `Driver License Number: D1234567, road test scheduled` scores **95** without the phrase and scored **0** with it.

`road test`, `vision test`, `drug test`, `skills test`, `breath sample` and `sample collection` are ordinary DMV and HR vocabulary.

Suppression is now positional — it fires when the marker modifies **the licence**:

- **before the label**: `test DL: D1234567`, `example driver license D1234567`, `fake dl number D1234567`
- **opening an aside on the value**: `D1234567 (placeholder)`, `D1234567 // sample data`, `D1234567 <- example value`

A clause with its own subject after the value does not: `D1234567, drug test negative`, `D1234567 -- vision test passed`.

Suppression stays **absolute** when it fires (still `-20` against the base of 20). Only *which lines qualify* changed, so an example value still stays undetected.

| suite | main | fix |
|---|---|---|
| real licences near test vocabulary (should report) | 0/4 | **4/4** |
| genuine test data (should suppress) | 0/4 | **0/4** |
| held-out, 12 real + 12 test, written after the rule | — | **11/12 real reported, 0/12 test leaked** |

### Two alternatives rejected by measurement first

- **A pure distance threshold.** No cutoff separates the classes — real records land at distance 1 and test data at 2, interleaved all the way out. Best case was 10/11 real at the cost of leaking 5/10 test values.
- **A compound-noun list of DMV terms** (`road`/`vision`/`drug` before the keyword). Scored 10/10 on the cases I designed it against and **6/12 on held-out data**, where every single miss was a REAL licence classified as test data. Overfit to my own examples.

The one known miss is `Driver License Number: D1234567 sample submitted to lab`, where `sample` both opens the following clause and is a bare noun. It suppresses — matching the old behavior — rather than inventing a finding.

## Keeping the hoist (no DoS regression)

`AnalyzeContext` is deliberately called once per line, not per match, because a per-match full-line scan is `O(matches × line length)` — the single-long-line CPU-exhaustion shape `dos_test.go` guards.

The rule is split to preserve that: `markerBeforeLabel` stays a per-line invariant, and `markerOpensAsideAfter` reads only the few bytes following the span, using the offset the caller already has. Measured on one line with N licence numbers:

```
N=250  0.085s      N=500  0.091s      N=1000  0.105s      N=2000  0.134s
findings 250 / 500 / 1000 / 2000  (grows 1:1, so the guard is non-vacuous)
main 0.171s vs fix 0.126s at N=2000 — no regression
```

## Test plan

`scripts/pr-checklist.sh`: gofmt / vet / build clean, 58 packages, golden corpus **moves no snapshot**, cross-platform vet (linux/darwin/windows), 3× flake, whole-module `-race`, `-short`.

- **Redaction (dim 4)** — all 3 strategies, 0/4 cleartext remaining. Output shown above.
- **Suppression (dim 5)** — parent-generated rules still suppress under the new binary (2 rules → 0 surviving); the 4 newly-recovered findings generate 4 rules that suppress cleanly.
- **All 7 formats (dim 7)** — text/json/yaml/csv/junit/gitlab-sast/sarif each carry all 4 findings.
- **Timing (dim 6)** — multi-line curve to 8,000 findings and the single-long-line shape above, distinct values with a non-vacuity floor at every size.
- **Non-vacuity (dim 10)** — disabling the punctuation rescue puts every phone leak case red; reverting the DL rule to line-global puts every licence case red.
- Bounds cases for `markerOpensAsideAfter` (negative and past-end offsets) and `hasPhonePunctuation` (empty, `-`, `()`, `abc`).