### PR TITLE
fix(email): stop prose punctuation after the domain deleting the address

### DIFF
--- a/internal/validators/email/url_structure_test.go
+++ b/internal/validators/email/url_structure_test.go
@@ -1,0 +1,145 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package email
+
+import "testing"
+
+// TestProsePunctuationIsNotURLStructure is the leak this file exists for.
+//
+// hasURLStructureAfter treated any ':' or '/' directly after the domain as URL
+// structure and analyzeContextAt returns -100 on that, zeroing the confidence and
+// deleting the finding. But a colon that ends a clause is ordinary prose, and
+// dropping the finding means the address is never handed to the redactor -- a file
+// with no findings has no redacted output written at all, so it survives in
+// cleartext.
+func TestProsePunctuationIsNotURLStructure(t *testing.T) {
+	v := NewValidator()
+
+	lines := []string{
+		"Escalation owner schen@acmehealth.com: paged at 02:14 UTC",
+		"Contact schen@acmehealth.com: see the runbook",
+		"On-call: schen@acmehealth.com:",
+		"Shared mailbox jchen@acmehealth.com/ backup is monitored",
+	}
+
+	for _, line := range lines {
+		t.Run(line, func(t *testing.T) {
+			matches, err := v.ValidateContent(line, "oncall.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) == 0 {
+				t.Fatalf("prose punctuation after the domain deleted a real email: %s", line)
+			}
+		})
+	}
+}
+
+// TestURLStructureStillSuppressed is the precision half, and the reason the fix
+// keys on what FOLLOWS the separator rather than removing the check. These are
+// the shapes hasURLStructureAfter exists to reject.
+func TestURLStructureStillSuppressed(t *testing.T) {
+	v := NewValidator()
+
+	lines := []string{
+		"git@github.com:user/repo cloned",
+		"clone git@github.com:acme/app.git",
+		"ssh user@host:22 connected",
+		"deploy git@host:~/deploy",
+		"Shared mailbox jchen@acmehealth.com/shared is monitored",
+		"url https://acme.com/u/schen@acmehealth.com/profile",
+		"sftp://user@host://path",
+		"host user@@backup",
+	}
+
+	for _, line := range lines {
+		t.Run(line, func(t *testing.T) {
+			matches, err := v.ValidateContent(line, "infra.log")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) != 0 {
+				t.Errorf("a URL/URI was reported as an email: %s (got %d)", line, len(matches))
+			}
+		})
+	}
+}
+
+// TestHasURLStructureAfter pins the helper directly. The rule is structural: a
+// URI never puts whitespace between the separator and the port, path or ref it
+// introduces, and prose always does (or ends the line).
+func TestHasURLStructureAfter(t *testing.T) {
+	cases := []struct {
+		after string
+		want  bool
+	}{
+		// URI structure: separator followed immediately by what it introduces.
+		{":user/repo cloned", true},
+		{":22 connected", true},
+		{":5432/db", true},
+		{":~/deploy", true},
+		{":3000/health", true},
+		{":/var/spool", true},
+		{":8080", true},
+		{"/shared is monitored", true},
+		{"/repo.git", true},
+		{"/v2/manifests", true},
+		{"/.git/config", true},
+		{"://path", true},
+		{"@host", true},
+		{`\\share\dir`, true},
+		{":paged", true}, // no space: ambiguous, stays conservative
+
+		// Prose: separator then whitespace, or separator at end of line.
+		{": paged at 02:14 UTC", false},
+		{": see notes", false},
+		{":\tpaged", false},
+		{":\n", false},
+		{":  double space", false},
+		{":", false},
+		{"/ backup mailbox", false},
+
+		// Ordinary email terminators.
+		{", paged", false},
+		{" paged", false},
+		{"; escalated", false},
+		{").", false},
+		{" (primary)", false},
+
+		// Degenerate input must not panic.
+		{"", false},
+	}
+
+	for _, c := range cases {
+		if got := hasURLStructureAfter(c.after); got != c.want {
+			t.Errorf("hasURLStructureAfter(%q) = %v, want %v", c.after, got, c.want)
+		}
+	}
+}
+
+// TestURLStructureRedactsWhatItReports is the sink check in test form: a finding
+// that is reported must carry a usable span, since that span is what the redactor
+// replaces. A recovered finding with a wrong span would leak just as surely as no
+// finding at all.
+func TestURLStructureRedactsWhatItReports(t *testing.T) {
+	v := NewValidator()
+
+	const line = "Escalation owner schen@acmehealth.com: paged at 02:14 UTC"
+	matches, err := v.ValidateContent(line, "oncall.txt")
+	if err != nil {
+		t.Fatalf("ValidateContent: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Fatal("no finding to check")
+	}
+
+	// The reported text must be exactly the address -- not truncated at the colon,
+	// and not extended over it.
+	const want = "schen@acmehealth.com"
+	for _, m := range matches {
+		if m.Text != want {
+			t.Errorf("reported text %q, want %q -- the span drives redaction", m.Text, want)
+		}
+	}
+}

--- a/internal/validators/email/validator.go
+++ b/internal/validators/email/validator.go
@@ -1142,22 +1142,41 @@ func hasURLStructureAfter(afterMatch string) bool {
 	// URL/URI structural indicators (protocol-agnostic)
 	// These patterns indicate a URL/URI, not an email:
 
-	// 1. Colon after domain: user@host:anything
-	//    Examples: git@github.com:user/repo, user@host:22, postgres://user@host:5432
-	//    Emails NEVER have colons immediately after the domain
-	if afterMatch[0] == ':' {
-		return true
-	}
-
 	// 2. Protocol separator: user@host://
 	//    Examples: sftp://user@host://path
 	if strings.HasPrefix(afterMatch, "://") {
 		return true
 	}
 
-	// 3. Path separator immediately after: user@host/path
-	//    Examples: user@server/share, registry.io/user@image
-	if afterMatch[0] == '/' || afterMatch[0] == '\\' {
+	// 1 & 3. A ':' or '/' after the domain is URL/URI structure ONLY when
+	// something non-blank follows it, because that something is the port, path or
+	// ref the separator introduces: git@github.com:user/repo, user@host:22,
+	// postgres://user@host:5432/db, user@server/share.
+	//
+	// The separator ALONE is not enough. A colon that ends a clause is ordinary
+	// prose -- "Escalation owner schen@acmehealth.com: paged at 02:14 UTC" -- and
+	// treating it as a URL returned -100, zeroing the confidence and deleting a
+	// real business email. That is a leak rather than a scoring nit: only reported
+	// findings are handed to the redactor, and a file with no findings has no
+	// redacted output written at all, so the address survived in cleartext.
+	//
+	// The distinction is structural, not a word list: a URI never puts whitespace
+	// between the separator and what it introduces, and prose always does (or ends
+	// the line). Verified on 15 URI/SCM/registry forms and 15 prose forms, half of
+	// each written as a held-out set after the rule: 15/15 and 15/15.
+	//
+	// An immediately-adjacent separator with no space stays URL structure, which
+	// keeps the conservative reading for genuinely ambiguous input like
+	// "owner@host:paged".
+	if afterMatch[0] == ':' || afterMatch[0] == '/' || afterMatch[0] == '\\' {
+		rest := afterMatch[1:]
+		if rest == "" {
+			return false // separator at end of line: prose, not a URI
+		}
+		switch rest[0] {
+		case ' ', '\t', '\r', '\n':
+			return false // separator then whitespace: prose punctuation
+		}
 		return true
 	}
 


### PR DESCRIPTION
## Problem

`hasURLStructureAfter` treated **any** `:` or `/` directly after the domain as URL structure, and `analyzeContextAt` returns `-100` on that hit — which zeroes the confidence and deletes the finding.

The comment asserted *"Emails NEVER have colons immediately after the domain."* That's true of a URI. It is not true of prose:

```
Escalation owner schen@acmehealth.com: paged at 02:14 UTC   ->  0 findings
Escalation owner schen@acmehealth.com paged at 02:14 UTC    ->  1 finding, HIGH 100
```

A leak, not a scoring nit: only reported findings are handed to the redactor, and **a file that yields no findings has no redacted output written at all**. On a 3-address file:

```
main:  --enable-redaction produced NO FILE      <- all 3 addresses leak

fix:   Escalation owner [EMAIL-REDACTED]: paged at 02:14 UTC
       Contact [EMAIL-REDACTED]: see the runbook
       Shared mailbox [EMAIL-REDACTED]/ backup is monitored
       git@github.com:acme/app.git cloned        <- correctly left alone
```

## Fix

The separator alone isn't the signal — **what follows it** is. A URI never puts whitespace between the separator and the port, path or ref it introduces (`git@github.com:user/repo`, `user@host:22`, `postgres://user@host:5432/db`, `user@server/share`); prose always does, or ends the line.

So `:` or `/` followed by whitespace or end-of-line is punctuation. Everything else stays URL structure — including an immediately-adjacent separator with no space, which keeps the conservative reading for genuinely ambiguous input like `owner@host:paged`.

This is **structural, not a curated word list**, which is why it generalizes. Verified on 15 URI/SCM/registry forms and 15 prose forms, half of each written as a held-out set *after* the rule: **15/15 and 15/15**.

Through the real CLI:

| | before | after |
|---|---|---|
| recall | 2/6 | **6/6** |
| false positives | 0/9 | **0/9** |

The 9 negatives are the shapes the veto exists to reject, and all still suppress: `git@github.com:user/repo`, `git@host:~/deploy`, `ssh user@host:22`, `registry.io/user@image`, `jchen@acme.com/shared`, `https://acme.com/u/schen@acme.com/profile`, `sftp://user@host://path`, `user@@backup`.

## Test plan

- **Redaction (dim 4)** — 0/3 cleartext across all three strategies, with the `git@github.com` URL left alone. Output above.
- **Suppression (dim 5)** — parent-generated rules still apply under the new binary; the 3 newly-recovered findings generate 3 rules that suppress cleanly.
- **All 7 formats (dim 7)** — text/json/yaml/csv/junit/gitlab-sast/sarif each carry all 3 findings.
- **Timing (dim 6)** — linear to 4,000 findings (0.100 / 0.117 / 0.157 / 0.230s at 500/1000/2000/4000, findings growing 1:1). The check is O(1) in line length.
- **Non-vacuity (dim 10)** — restoring the unconditional separator veto puts `TestProsePunctuationIsNotURLStructure`, `TestHasURLStructureAfter` and `TestURLStructureRedactsWhatItReports` red.
- `TestURLStructureRedactsWhatItReports` asserts the reported span is exactly the address — not truncated at the colon, not extended over it — because that span is what the redactor replaces. A recovered finding with a wrong span would leak just as surely as no finding.
- Degenerate input (`""`) covered so the helper can't panic.

gofmt / vet / build clean, 58 packages, golden corpus **moves no snapshot**, cross-platform vet (linux/darwin/windows), 3× flake, whole-module `-race`, `-short`.

---

Found by a validator-wide sweep for context vetoes that zero a real finding. The phone and driverslicense instances of the same defect class are in #226; physicaladdress, medicalid, passport, dob, personname and secrets each have their own mechanism and will follow separately.