### PR TITLE
fix(address): stop street-name heuristics deleting real addresses

### DIFF
--- a/internal/validators/address/stopword_veto_test.go
+++ b/internal/validators/address/stopword_veto_test.go
@@ -1,0 +1,248 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package address
+
+import "testing"
+
+// realAddressesWithCollidingStreetNames are real US street names that collide
+// with the monthNames or unlikelyStreetWords sets, written as complete addresses.
+// Every one of these reported NOTHING before the heuristics were gated on
+// independent address evidence.
+//
+// The consequence is a leak, not a scoring nit: only reported findings are handed
+// to the redactor, and a file that yields no findings has no redacted output
+// written at all, so the whole address survived in cleartext.
+var realAddressesWithCollidingStreetNames = []string{
+	// monthNames collisions -- May, March, August, June are all real US streets.
+	"Mailing address: 1420 May Street, Springfield IL 62704",
+	"Residence: 77 August Lane, Boise ID 83702",
+	"Employee home address 15 June Court, Tulsa OK 74103",
+	"Billing address: 12 January Road, Peoria IL 61602",
+	"1420 May Street, Springfield IL 62704",
+
+	// unlikelyStreetWords collisions -- articles are ordinary in planned
+	// developments and coastal towns.
+	"Mailing address: 88 The Meadows Drive, Springfield IL 62704",
+	"Ship to 300 The Oaks Boulevard, Cary NC 27511",
+
+	// The abbreviation-plus-unit form, where the space after "Dr."/"St." is
+	// omitted. Previously read as a file extension.
+	"Home address 4821 Maple Dr.Suite 200, Springfield IL 62704",
+	"Mailing address: 1 Oak St.Apt 4, Reno NV 89501",
+}
+
+// nonAddressesThatMustStaySuppressed is what the heuristics exist for. Widening
+// recall must not start reporting these.
+var nonAddressesThatMustStaySuppressed = []string{
+	// The shape the unlikelyStreetWords set was written to catch: a count, a
+	// preposition, then something that looks like a street.
+	"100 connections on Main Loop",
+	"3 processes on Server Way",
+	"12 entries in the Event Circle",
+	"8 sessions on Test Drive",
+	"6 connections on the Main Way",
+	"Retry 3 requests in the Batch Circle",
+
+	// Month/day words in ordinary prose.
+	"Meeting on Monday Street",
+	"Due 15 January Road",
+	"Scheduled 4 events on Friday Street",
+
+	// Code references: the file-extension check must still fire.
+	"Home address 4821 Maple Dr.go handler",
+	"Home address 100 North Dr.py script",
+	"Mailing address: 5 Elm St.java build",
+
+	// Adversarial: log lines that happen to contain a bare STATE ZIP token. The
+	// city/state/ZIP evidence pattern requires the ", City ST ZIP" tail precisely
+	// so these do not get rescued.
+	"Error IL 62704 returned by 3 processes on Server Way",
+	"Job CA 90210 failed after 5 items in the Queue Lane",
+}
+
+// TestRealStreetNamesAreReported is the leak this file exists for.
+func TestRealStreetNamesAreReported(t *testing.T) {
+	v := NewValidator()
+
+	for _, line := range realAddressesWithCollidingStreetNames {
+		t.Run(line, func(t *testing.T) {
+			matches, err := v.ValidateContent(line, "hr-export.csv")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) == 0 {
+				t.Fatalf("a real address was deleted because its street name collides "+
+					"with a stopword or month name: %s", line)
+			}
+		})
+	}
+}
+
+// TestNonAddressesStaySuppressed is the precision half, and the reason the fix
+// gates the heuristics rather than deleting them.
+func TestNonAddressesStaySuppressed(t *testing.T) {
+	v := NewValidator()
+
+	for _, line := range nonAddressesThatMustStaySuppressed {
+		t.Run(line, func(t *testing.T) {
+			matches, err := v.ValidateContent(line, "app.log")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) != 0 {
+				t.Errorf("a non-address was reported: %s (got %d)", line, len(matches))
+			}
+		})
+	}
+}
+
+// TestControlPairs is what makes the two tests above non-circular: for each
+// leaking street name, the identical line with a neutral name must ALREADY
+// report. If the control did not report either, the fixture shape would be wrong
+// and the "leak" would be an artifact of the sentence rather than the word.
+func TestControlPairs(t *testing.T) {
+	v := NewValidator()
+
+	pairs := []struct{ colliding, control string }{
+		{
+			"Mailing address: 1420 May Street, Springfield IL 62704",
+			"Mailing address: 1420 Oak Street, Springfield IL 62704",
+		},
+		{
+			"Mailing address: 88 The Meadows Drive, Springfield IL 62704",
+			"Mailing address: 88 Meadows Drive, Springfield IL 62704",
+		},
+		{
+			"Home address 4821 Maple Dr.Suite 200, Springfield IL 62704",
+			"Home address 4821 Maple Dr Suite 200, Springfield IL 62704",
+		},
+	}
+
+	for _, p := range pairs {
+		t.Run(p.control, func(t *testing.T) {
+			control, err := v.ValidateContent(p.control, "hr-export.csv")
+			if err != nil {
+				t.Fatalf("ValidateContent(control): %v", err)
+			}
+			if len(control) == 0 {
+				t.Fatalf("the CONTROL line reports nothing, so the paired case proves "+
+					"nothing about the colliding word: %s", p.control)
+			}
+
+			colliding, err := v.ValidateContent(p.colliding, "hr-export.csv")
+			if err != nil {
+				t.Fatalf("ValidateContent(colliding): %v", err)
+			}
+			if len(colliding) == 0 {
+				t.Errorf("colliding form dropped while the control reports: %s", p.colliding)
+			}
+		})
+	}
+}
+
+// TestHasAddressEvidence pins the arbitration signal directly. It has to be
+// independent of the street name's own words, which is exactly what lets it
+// overrule name-based heuristics.
+func TestHasAddressEvidence(t *testing.T) {
+	cases := []struct {
+		line string
+		want bool
+	}{
+		// Explicit labels.
+		{"Mailing address: 1420 May Street", true},
+		{"Home address 4821 Maple Dr", true},
+		{"Billing address: 12 January Road", true},
+		{"Residence: 77 August Lane, Boise ID 83702", true},
+		{"address: 1 Oak St", true},
+
+		// City/state/ZIP tail.
+		{"1420 May Street, Springfield IL 62704", true},
+		{"300 The Oaks Boulevard, Cary NC 27511", true},
+		{"9 Isle of Wight Road, Norfolk VA 23510-1234", true},
+		{"1 Main St, New York NY 10020", true},
+
+		// Neither: ordinary prose and log lines.
+		{"100 connections on Main Loop", false},
+		{"Meeting on Monday Street", false},
+		{"Due 15 January Road", false},
+		{"5 items in the Records Court", false},
+
+		// A bare STATE ZIP with no ", City" prefix must NOT count, or log text
+		// gets the rescue.
+		{"Error IL 62704 returned by 3 processes on Server Way", false},
+		{"Job CA 90210 failed after 5 items in the Queue Lane", false},
+
+		// Degenerate.
+		{"", false},
+	}
+
+	for _, c := range cases {
+		ctx := &streetFPContext{line: c.line}
+		if got := ctx.hasAddressEvidence(); got != c.want {
+			t.Errorf("hasAddressEvidence(%q) = %v, want %v", c.line, got, c.want)
+		}
+	}
+}
+
+// TestHasAddressEvidenceIsMemoized guards the per-line hoist. isFalsePositive
+// runs once per match and these are whole-line regexes, so evaluating them per
+// match would put O(matches x line length) work back into the hot path -- the
+// single-long-line shape streetFPContext exists to remove.
+func TestHasAddressEvidenceIsMemoized(t *testing.T) {
+	ctx := &streetFPContext{line: "Mailing address: 1420 May Street"}
+
+	if ctx.addrEvidenceDone {
+		t.Fatal("evidence must be computed lazily, not at construction")
+	}
+	first := ctx.hasAddressEvidence()
+	if !ctx.addrEvidenceDone {
+		t.Error("the memo flag was not set after the first call")
+	}
+
+	// Poison the cached value: a second call must return the CACHED result, not
+	// recompute from the line.
+	ctx.addrEvidence = !first
+	if got := ctx.hasAddressEvidence(); got == first {
+		t.Error("hasAddressEvidence recomputed instead of returning the memoized value")
+	}
+}
+
+// TestIsSourceFileExtension pins the extension check. Requiring a real extension
+// (rather than "any letter") is what distinguishes a code reference from an
+// address whose space was omitted.
+func TestIsSourceFileExtension(t *testing.T) {
+	cases := []struct {
+		rest string
+		want bool
+	}{
+		// Real code references.
+		{"go handler", true},
+		{"py script", true},
+		{"java build", true},
+		{"ts", true},
+		{"cpp:42", true},
+
+		// Address continuations, not extensions.
+		{"Suite 200", false},
+		{"Apt 4", false},
+		{"Unit 12", false},
+		{"Ste 900", false},
+		{"Floor 3", false},
+
+		// The token must END at a non-word byte: "gopher" is not ".go".
+		{"gopher Lane", false},
+		{"pythonic Way", false},
+
+		// Degenerate.
+		{"", false},
+		{" go", false},
+		{".go", false},
+	}
+
+	for _, c := range cases {
+		if got := isSourceFileExtension(c.rest); got != c.want {
+			t.Errorf("isSourceFileExtension(%q) = %v, want %v", c.rest, got, c.want)
+		}
+	}
+}

--- a/internal/validators/address/validator.go
+++ b/internal/validators/address/validator.go
@@ -136,6 +136,25 @@ var (
 	reMathExpr      = regexp.MustCompile(`\b\d+\s*[+\-*/=<>]+\s*\d+\b`)
 	reAllDigitsLine = regexp.MustCompile(`^\s*\d+\s*$`)
 
+	// Independent evidence that a line is an address, established WITHOUT looking
+	// at the street name's own words. Either an explicit address label, or the
+	// ", City ST ZIP" tail that ends a written US address.
+	//
+	// This is what lets the month/stopword heuristics below be overruled: those
+	// heuristics inspect the street NAME, so on their own they cannot tell "1420
+	// May Street" (a real street in several US cities) from "Due 15 January Road".
+	// A label or a city/state/ZIP tail is orthogonal to the name, so it can
+	// arbitrate between them.
+	//
+	// reCityStateZIP deliberately requires the comma and a capitalized city
+	// before the state and ZIP. A bare "IL 62704" occurs in ordinary log text
+	// ("Error IL 62704 returned by 3 processes on Server Way") and matching it
+	// would hand the rescue to lines that are not addresses at all.
+	reAddressLabel = regexp.MustCompile(
+		`(?i)\b(?:mailing|home|business|billing|shipping|street|physical|postal|residence|work)\s+address\b|(?i)\baddress\s*:`)
+	reCityStateZIP = regexp.MustCompile(
+		`,\s*[A-Z][A-Za-z.'-]*(?:\s+[A-Z][A-Za-z.'-]*)*\s+[A-Z]{2}\s+\d{5}(?:-\d{4})?\b`)
+
 	// Month names and day names that should not be street names by themselves.
 	monthNames = map[string]bool{
 		"january": true, "february": true, "march": true, "april": true,
@@ -778,6 +797,26 @@ type streetFPContext struct {
 	verLocs  [][]int
 	codeLocs [][]int
 	mathLocs [][]int
+
+	// addrEvidence is whether the line carries independent evidence that it is an
+	// address (see reAddressLabel / reCityStateZIP). It is a per-LINE property, so
+	// it is computed lazily at most once and reused for every match on the line --
+	// evaluating it per match would put two whole-line regex scans back inside the
+	// per-match path, which is the O(matches x line length) shape this type exists
+	// to remove.
+	addrEvidence     bool
+	addrEvidenceDone bool
+}
+
+// hasAddressEvidence reports whether this line looks like an address for reasons
+// independent of the street name's own words: an explicit address label, or the
+// ", City ST ZIP" tail. Memoized per line.
+func (c *streetFPContext) hasAddressEvidence() bool {
+	if !c.addrEvidenceDone {
+		c.addrEvidence = reAddressLabel.MatchString(c.line) || reCityStateZIP.MatchString(c.line)
+		c.addrEvidenceDone = true
+	}
+	return c.addrEvidence
 }
 
 func (v *Validator) newStreetFPContext(line string) *streetFPContext {
@@ -869,18 +908,23 @@ func (c *streetFPContext) isFalsePositive(match string, matchStart int) bool {
 
 	// Check if the trailing dot of the match is actually part of a file extension
 	// e.g., "100 North Dr.go" — the "Dr." is part of "Dr.go"
+	//
+	// The word after the dot must actually BE a source-file extension. Testing
+	// only "is it alphabetic" also swallowed the abbreviation-plus-unit form that
+	// real addresses use when the space is omitted: "4821 Maple Dr.Suite 200" and
+	// "1 Oak St.Apt 4" reported nothing, while the same lines with a space
+	// reported a finding. That is a leak, not a scoring nit -- an unreported
+	// address is never handed to the redactor, and a file with no findings has no
+	// redacted output written at all.
 	matchEnd := matchStart + len(match)
 	if matchEnd < len(line) && line[matchEnd-1] == '.' {
-		// The match ended with a dot; check if it continues with alpha chars (file extension)
-		rest := line[matchEnd:]
-		if len(rest) > 0 && rest[0] >= 'a' && rest[0] <= 'z' || (len(rest) > 0 && rest[0] >= 'A' && rest[0] <= 'Z') {
+		if isSourceFileExtension(line[matchEnd:]) {
 			return true
 		}
 	}
 	// Also check: match without dot but next char after match is a dot then alpha
 	if matchEnd < len(line) && line[matchEnd] == '.' {
-		rest := line[matchEnd+1:]
-		if len(rest) > 0 && ((rest[0] >= 'a' && rest[0] <= 'z') || (rest[0] >= 'A' && rest[0] <= 'Z')) {
+		if isSourceFileExtension(line[matchEnd+1:]) {
 			return true
 		}
 	}
@@ -895,10 +939,18 @@ func (c *streetFPContext) isFalsePositive(match string, matchStart int) bool {
 			return true // Single-character street names are suspicious
 		}
 
-		// Reject if the street name is a month/day name (e.g., "12 January Dr")
+		// Reject if the street name is a month/day name (e.g., "12 January Dr"),
+		// UNLESS the line carries independent address evidence.
+		//
+		// May Street, March Street, August Avenue and June Court are all real US
+		// streets, so this heuristic deleted real addresses: "Mailing address: 1420
+		// May Street, Springfield IL 62704" reported nothing while the identical
+		// line with "Oak" reported a finding. Because only reported findings are
+		// handed to the redactor -- and a file with no findings has no redacted
+		// output written at all -- the whole address stayed in cleartext.
 		nameWords := strings.Fields(streetName)
 		if len(nameWords) == 1 {
-			if monthNames[strings.ToLower(nameWords[0])] {
+			if monthNames[strings.ToLower(nameWords[0])] && !c.hasAddressEvidence() {
 				return true
 			}
 		}
@@ -918,17 +970,66 @@ func (c *streetFPContext) isFalsePositive(match string, matchStart int) bool {
 			}
 		}
 		// If the name part has unlikely words and the overall structure looks like
-		// "N things preposition Name Suffix", reject it.
+		// "N things preposition Name Suffix", reject it -- UNLESS the line carries
+		// independent address evidence.
+		//
+		// The exemption matters because articles are ordinary in real street names:
+		// "The Meadows Drive", "The Oaks Boulevard", "Isle of Wight Road", "Avenue
+		// of the Americas". Those all begin (or contain) a word in
+		// unlikelyStreetWords, so "Mailing address: 88 The Meadows Drive,
+		// Springfield IL 62704" reported nothing while "88 Meadows Drive" reported
+		// a finding.
+		//
+		// "100 connections on Main Loop" has neither a label nor a city/state/ZIP
+		// tail, so it stays suppressed and the heuristic keeps doing its job.
 		if hasUnlikely && hasRealName && len(nameWords) >= 2 {
 			// Check if the first word of the street name is an unlikely word
 			// Pattern: "100 connections on Main Loop" — "connections" is first, unlikely
-			if unlikelyStreetWords[strings.ToLower(nameWords[0])] {
+			if unlikelyStreetWords[strings.ToLower(nameWords[0])] && !c.hasAddressEvidence() {
 				return true
 			}
 		}
 	}
 
 	return false
+}
+
+// sourceFileExtensions are the extensions that make "<StreetType>.<word>" a code
+// reference rather than an address. Kept in sync with reCodeLineRef, which does
+// the same job for the whole-line form ("42 handler.go").
+var sourceFileExtensions = map[string]bool{
+	"go": true, "py": true, "js": true, "ts": true, "java": true, "rb": true,
+	"rs": true, "c": true, "cpp": true, "h": true, "cs": true, "swift": true,
+	"kt": true, "php": true, "scala": true, "m": true, "mm": true,
+}
+
+// isSourceFileExtension reports whether rest BEGINS with a source-file extension
+// as a complete token, i.e. the text after a dot really is an extension and not
+// the next word of an address.
+//
+// "Dr.go handler"    -> "go"    -> true  (a code reference)
+// "Dr.Suite 200"     -> "suite" -> false (an address with the space omitted)
+// "St.Apt 4"         -> "apt"   -> false
+//
+// The token must END at a non-word byte, so "Dr.gopher Lane" is not read as ".go".
+func isSourceFileExtension(rest string) bool {
+	if rest == "" {
+		return false
+	}
+	end := 0
+	for end < len(rest) && isWordByteASCII(rest[end]) {
+		end++
+	}
+	if end == 0 {
+		return false
+	}
+	return sourceFileExtensions[strings.ToLower(rest[:end])]
+}
+
+// isWordByteASCII reports whether b is a letter, digit or underscore.
+func isWordByteASCII(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') ||
+		(b >= '0' && b <= '9') || b == '_'
 }
 
 // getAdjacentLines returns concatenated text from lines adjacent to lineNum.


### PR DESCRIPTION
## Problem

Three name-inspecting heuristics in `streetFPContext.isFalsePositive` suppress the finding **entirely**, and each deletes real addresses:

| # | heuristic | deletes |
|---|---|---|
| 1 | `monthNames` rejects a single-word month/day street name | `1420 May Street` — **May St is a real Chicago street** |
| 2 | `unlikelyStreetWords` rejects a name whose first word is an article | `88 The Meadows Drive`, `300 The Oaks Boulevard`, `Isle of Wight Road` |
| 3 | file-extension check treats `<StreetType>.<letters>` as a code ref | `4821 Maple Dr.Suite 200`, `1 Oak St.Apt 4` |

Leaks rather than scoring nits: only reported findings are handed to the redactor, and **a file that yields no findings has no redacted output written at all**.

```
main:  --enable-redaction on a 3-address file produced NO FILE   <- all 3 leak

fix:   Mailing address: [US_STREET_ADDRESS-REDACTED], Springfield IL 62704
       Mailing address: [US_STREET_ADDRESS-REDACTED], Springfield IL 62704
       Home address [US_STREET_ADDRESS-REDACTED]Suite 200, Springfield IL 62704
       100 connections on Main Loop        <- correctly untouched
```

## Fix

Heuristics 1 and 2 are **gated on independent address evidence** — an explicit address label, or the `, City ST ZIP` tail — rather than removed. That signal is orthogonal to the street name's own words, which is exactly what lets it arbitrate: the heuristics inspect the *name*, so on their own they cannot tell `1420 May Street, Springfield IL 62704` from `Due 15 January Road`.

`reCityStateZIP` deliberately requires the comma and a capitalized city. A bare `IL 62704` occurs in ordinary log text — `Error IL 62704 returned by 3 processes on Server Way` — and matching it would hand the rescue to lines that aren't addresses. Both adversarial log lines are in the test set.

Heuristic 3 requires the word after the dot to actually **be** a source-file extension, reusing the vocabulary `reCodeLineRef` already uses for the whole-line form. `Dr.go` / `Dr.py` / `St.java` still suppress, and `Dr.gopher Lane` isn't read as `.go` because the token must end at a non-word byte.

## Measured against real data, not invented fixtures

**1,994 distinct real Chicago street names** from the city's open-data street list ([`i6bp-fvbx`](https://data.cityofchicago.org/resource/i6bp-fvbx.csv)), rendered as complete addresses:

```
main 1782 findings  ->  fix 1783
per-line diff: +1 recovered ("1420 May St"), 0 regressed
```

That's the honest scale — **surgical, not a recall widening**. Only 4 of 2,582 real Chicago streets collide with these word sets at all, which is what makes this cheap to fix and also confirms the collision is real rather than hypothetical.

Curated matrix:

| | before | after |
|---|---|---|
| recall | 2/9 | **9/9** |
| false positives | 0/11 | **0/11** |

The 11 negatives are the shapes the heuristics exist for: `100 connections on Main Loop`, `3 processes on Server Way`, `12 entries in the Event Circle`, `Meeting on Monday Street`, `Due 15 January Road`, the three code-reference forms, and the two state+ZIP log lines.

## Performance

`hasAddressEvidence` is **memoized per line**. `isFalsePositive` runs once per match and these are whole-line regexes, so evaluating them per match would put `O(matches × line length)` back into the hot path — the single-long-line shape `streetFPContext` exists to remove. `TestHasAddressEvidenceIsMemoized` poisons the cached value to prove the second call returns the memo rather than recomputing.

Long-line timing stays linear: 500/1000/2000 spans at 0.099 / 0.109 / 0.141s, findings growing 1:1.

## Test plan

- **Redaction (dim 4)** — 0/3 cleartext across all three strategies, non-address line untouched. Output above.
- **Suppression (dim 5)** — parent-generated rules still apply under the new binary; the 3 newly-recovered findings generate 3 rules that suppress cleanly.
- **All 7 formats (dim 7)** — each carries all 3 findings.
- **Timing (dim 6)** — above, with a non-vacuity floor at every size.
- **Non-vacuity (dim 10)** — each of the three gates reverted in turn; each put exactly its own cases red.
- **`TestControlPairs`** makes the recall test non-circular: for every colliding street name, the identical line with a neutral name must *already* report. If the control didn't report either, the fixture shape would be wrong and the "leak" an artifact of the sentence rather than the word.

gofmt / vet / build clean, 58 packages, golden corpus **moves no snapshot**, cross-platform vet, 3× flake, whole-module `-race`, `-short`.

---

Part of a validator-wide sweep for context vetoes that zero a real finding. Phone and driverslicense are in #226, email in #227; medicalid, passport, dob, personname and secrets each have their own mechanism and will follow separately.