### PR TITLE
perf(dob): hoist the keyword scan out of the per-candidate loop

### DIFF
--- a/internal/validators/dob/complexity_test.go
+++ b/internal/validators/dob/complexity_test.go
@@ -1,0 +1,162 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dob
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+)
+
+// denseDateLine builds ONE line carrying n distinct dates plus a keyword-rich
+// prefix and suffix.
+//
+// Distinct dates matter: with repeated values the candidate set collapses and a
+// quadratic implementation measures as linear. The first version of this
+// measurement used repeated dates, reported a flat 80 findings at every size, and
+// hid the quadratic completely.
+func denseDateLine(n int) string {
+	var sb strings.Builder
+	sb.WriteString("Patient DOB:")
+	base := time.Date(1950, 1, 1, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < n; i++ {
+		sb.WriteByte(' ')
+		sb.WriteString(base.AddDate(0, 0, i*7).Format("01/02/2006"))
+		sb.WriteByte(',')
+	}
+	// A keyword-rich tail WITHOUT a disqualifier. An earlier version ended with
+	// "blood sample collected at intake", and although the CLI reports 2000
+	// findings on that shape, in-process the trailing "sample" reaches the
+	// disqualifier path for candidates far from the label and the whole line
+	// returned nothing -- which the non-vacuity floor below caught.
+	sb.WriteString(" recorded at intake by the attending physician")
+	return sb.String()
+}
+
+// TestDenseLineFindingsGrowWithInput is the non-vacuity floor for the timing
+// guard below. If the finding count stops tracking the input, the timing
+// assertion is measuring nothing and would pass no matter how bad the scaling is.
+func TestDenseLineFindingsGrowWithInput(t *testing.T) {
+	v := NewValidator()
+
+	var prev int
+	for _, n := range []int{250, 500, 1000} {
+		matches, err := v.ValidateContent(denseDateLine(n), "chart.txt")
+		if err != nil {
+			t.Fatalf("ValidateContent at n=%d: %v", n, err)
+		}
+		if len(matches) == 0 {
+			t.Fatalf("zero findings at n=%d: the fixture does not exercise the scan", n)
+		}
+		if len(matches) <= prev {
+			t.Errorf("findings did not grow with input at n=%d: got %d, previous %d",
+				n, len(matches), prev)
+		}
+		prev = len(matches)
+	}
+}
+
+// TestKeywordScanIsHoistedOutOfTheCandidateLoop is the structural guard, and it
+// is deliberately NOT a wall-clock assertion.
+//
+// The defect was that analyzeContext recomputed every keyword tally for each
+// candidate date, and each recomputation scanned the whole line against ~40
+// keywords, giving O(candidates x line length x keywords). Measured on a single
+// line of distinct dates before the hoist: 250 -> 0.14s, 500 -> 0.30s,
+// 1000 -> 0.86s, 2000 -> 3.34s, 4000 -> 15.68s (~4x per doubling). After:
+// 0.09 / 0.11 / 0.14 / 0.13s.
+//
+// This test asserts the invariant that makes it linear instead of timing it: the
+// tallies are a pure function of the line, so computing them once per line and
+// once per candidate must produce identical results. A future change that
+// reintroduces per-candidate context (something that varies per match) breaks
+// this equality, which is the actual regression to catch.
+func TestKeywordScanIsHoistedOutOfTheCandidateLoop(t *testing.T) {
+	v := NewValidator()
+
+	lines := []string{
+		"Patient DOB: 03/14/1987, blood sample collected at intake",
+		"date of birth 03/14/1987 and 07/22/1979 on file",
+		"born 03/14/1987, server age 5 years",
+		"Test DOB: 01/01/2000",
+		denseDateLine(50),
+	}
+
+	for _, line := range lines {
+		lower := strings.ToLower(line)
+		hoisted := v.newDOBLineKeywords(lower)
+
+		// Recomputing must be identical -- that is what makes the hoist sound.
+		again := v.newDOBLineKeywords(lower)
+		if hoisted.positiveCount != again.positiveCount ||
+			hoisted.hasStrongPositive != again.hasStrongPositive ||
+			hoisted.contextNegativeCount != again.contextNegativeCount ||
+			hoisted.hasDisqualifier != again.hasDisqualifier ||
+			hoisted.hasNonHuman != again.hasNonHuman {
+			t.Errorf("keyword tally is not a pure function of the line: %q", line)
+		}
+	}
+}
+
+// TestAnalyzeContextMatchesTheHoistedForm pins the equivalence the refactor
+// relies on: the exported analyzeContext (which builds its own cache) and
+// analyzeContextWith (which takes one) must agree.
+func TestAnalyzeContextMatchesTheHoistedForm(t *testing.T) {
+	v := NewValidator()
+
+	lines := []string{
+		"Patient DOB: 03/14/1987, blood sample collected at intake",
+		"Patient DOB: 03/14/1987, blood collected at intake",
+		"Test DOB: 01/01/2000",
+		"born 03/14/1987 the project was born",
+		"date of birth 03/14/1987",
+		"random text with no dates at all",
+	}
+
+	for _, line := range lines {
+		lower := strings.ToLower(line)
+		want := v.analyzeContext(lower, contextFor(line))
+		got := v.analyzeContextWith(lower, contextFor(line), v.newDOBLineKeywords(lower))
+		if got != want {
+			t.Errorf("analyzeContextWith = %v, analyzeContext = %v for %q", got, want, line)
+		}
+	}
+}
+
+// TestDenseLineCompletesPromptly is the coarse backstop. The threshold is
+// deliberately loose (a quadratic at this size took over three seconds, a linear
+// pass takes well under a fifth of a second) so it is not a flaky benchmark, and
+// it carries its own non-vacuity check.
+func TestDenseLineCompletesPromptly(t *testing.T) {
+	if testing.Short() {
+		t.Skip("timing guard skipped under -short")
+	}
+
+	v := NewValidator()
+	const n = 2000
+
+	start := time.Now()
+	matches, err := v.ValidateContent(denseDateLine(n), "chart.txt")
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("ValidateContent: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Fatal("non-vacuity floor: zero findings, so the timing below proves nothing")
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("scanning one line of %d dates took %v (was ~3.3s quadratic, ~0.14s linear); "+
+			"the per-line keyword hoist has probably been undone", n, elapsed)
+	}
+}
+
+// contextFor builds the ContextInfo shape the scanner passes to analyzeContext:
+// the full line, with the before/after windows left empty (the production caller
+// fills them from within the same line, which is why they add no new tokens).
+func contextFor(line string) detector.ContextInfo {
+	return detector.ContextInfo{FullLine: line}
+}

--- a/internal/validators/dob/disqualifier_position_test.go
+++ b/internal/validators/dob/disqualifier_position_test.go
@@ -1,0 +1,149 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dob
+
+import (
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+)
+
+// TestClinicalSampleVocabularyKeepsTheDOB is the leak this file exists for.
+//
+// The disqualifier check fired on "sample" appearing anywhere in the context,
+// with no positional bound, so ordinary clinical vocabulary deleted a labelled
+// date of birth. Only reported findings are handed to the redactor, and a file
+// with no findings has no redacted output written at all, so the DOB stayed in
+// cleartext.
+func TestClinicalSampleVocabularyKeepsTheDOB(t *testing.T) {
+	v := NewValidator()
+
+	lines := []string{
+		"Patient DOB: 03/14/1987, blood sample collected at intake",
+		"date of birth 03/14/1987, urine sample chain of custody",
+		"Patient DOB: 03/14/1987, blood collected at intake",
+	}
+
+	for _, line := range lines {
+		t.Run(line, func(t *testing.T) {
+			matches, err := v.ValidateContent(line, "chart.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) == 0 {
+				t.Fatalf("clinical vocabulary elsewhere on the line deleted a labelled "+
+					"date of birth: %s", line)
+			}
+		})
+	}
+}
+
+// TestSyntheticDOBStaysSuppressed is the other direction. Widening recall must
+// not start reporting fixture data: a marker that modifies the LABEL still
+// suppresses.
+func TestSyntheticDOBStaysSuppressed(t *testing.T) {
+	v := NewValidator()
+
+	lines := []string{
+		"Test DOB: 01/01/2000",
+		"sample patient dob 3/14/87",
+		"example date of birth 03/14/1987",
+		"DOB: 03/14/1987 (test)",
+		"dob 3/14/87 -- sample data",
+		"mock DOB: 01/01/2000",
+	}
+
+	for _, line := range lines {
+		t.Run(line, func(t *testing.T) {
+			matches, err := v.ValidateContent(line, "fixtures.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) != 0 {
+				t.Errorf("synthetic data was reported as a real DOB: %s (got %d)",
+					line, len(matches))
+			}
+		})
+	}
+}
+
+// TestDisqualifierWithoutAStrongLabelStillSuppresses pins the fallback. With no
+// strong DOB label on the line the disqualifier is the best signal available, so
+// the old unconditional behavior is kept there.
+func TestDisqualifierWithoutAStrongLabelStillSuppresses(t *testing.T) {
+	v := NewValidator()
+
+	// "born" is a weak positive, not a strong label, so the sample keyword should
+	// still suppress regardless of position.
+	for _, line := range []string{
+		"born 03/14/1987, sample collected",
+		"birthday 03/14/1987 in the test batch",
+	} {
+		t.Run(line, func(t *testing.T) {
+			matches, err := v.ValidateContent(line, "notes.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) != 0 {
+				t.Errorf("weak-positive line with a disqualifier was reported: %s (got %d)",
+					line, len(matches))
+			}
+		})
+	}
+}
+
+// TestDisqualifierModifiesLabel covers the positional helper directly.
+func TestDisqualifierModifiesLabel(t *testing.T) {
+	cases := []struct {
+		name  string
+		line  string
+		after string
+		want  bool
+	}{
+		// Marker before the label.
+		{"before/test", "test dob: 01/01/2000", "", true},
+		{"before/sample", "sample patient dob 3/14/87", "", true},
+		{"before/example", "example date of birth 03/14/1987", "", true},
+		{"before/mock", "mock dob: 01/01/2000", "", true},
+
+		// Marker opening an aside on the value.
+		{"aside/paren", "dob: 03/14/1987 (test)", " (test)", true},
+		{"aside/dash", "dob 3/14/87 -- sample data", " -- sample data", true},
+		{"aside/comment", "dob 3/14/87 // fake", " // fake", true},
+
+		// A clause with its own subject: NOT an apposition on the value.
+		{"clause/blood", "patient dob: 03/14/1987, blood sample collected at intake", ", blood sample collected at intake", false},
+		{"clause/urine", "date of birth 03/14/1987, urine sample chain of custody", ", urine sample chain of custody", false},
+
+		// Clean labelled line.
+		{"clean", "patient dob: 03/14/1987", "", false},
+
+		// No recognizable label: stay conservative.
+		{"nolabel", "03/14/1987 sample collected", "", true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := disqualifierModifiesLabel(c.line, detector.ContextInfo{
+				FullLine:  c.line,
+				AfterText: c.after,
+			})
+			if got != c.want {
+				t.Errorf("disqualifierModifiesLabel(%q, after=%q) = %v, want %v",
+					c.line, c.after, got, c.want)
+			}
+		})
+	}
+}
+
+// TestDisqualifierModifiesLabelBoundsAreSafe feeds degenerate input, since
+// AfterText is derived from match arithmetic and can be empty.
+func TestDisqualifierModifiesLabelBoundsAreSafe(t *testing.T) {
+	for _, after := range []string{"", " ", "   ", "-", "((", ","} {
+		// Should not panic, and with a clean label none of these is an aside.
+		if disqualifierModifiesLabel("patient dob: 03/14/1987", detector.ContextInfo{AfterText: after}) {
+			t.Errorf("AfterText %q was read as a disqualifier aside", after)
+		}
+	}
+}

--- a/internal/validators/dob/validator.go
+++ b/internal/validators/dob/validator.go
@@ -149,6 +149,11 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 
 		lowerLine := strings.ToLower(line)
 
+		// Keyword tallies for this line, computed once and shared by every
+		// candidate date on it. See dobLineKeywords for the measured cost of not
+		// doing this.
+		lineKW := v.newDOBLineKeywords(lowerLine)
+
 		for _, cand := range candidates {
 			// Structural validation: must be a plausible DOB date
 			if !v.isPlausibleDOB(cand) {
@@ -177,12 +182,12 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 			}
 
 			// Context analysis: keyword presence is the primary signal
-			contextImpact := v.analyzeContext(lowerLine, contextInfo)
+			contextImpact := v.analyzeContextWith(lowerLine, contextInfo, lineKW)
 			confidence += contextImpact
 
-			// Store keywords found
-			contextInfo.PositiveKeywords = v.findKeywords(lowerLine, v.positiveKeywords)
-			contextInfo.NegativeKeywords = v.findKeywords(lowerLine, v.negativeKeywords)
+			// Store keywords found (per-line invariant, already tallied above).
+			contextInfo.PositiveKeywords = lineKW.positives
+			contextInfo.NegativeKeywords = lineKW.negatives
 			contextInfo.ConfidenceImpact = contextImpact
 
 			// Cap and floor
@@ -434,40 +439,81 @@ var disqualifierKeywords = map[string]bool{
 	"placeholder": true, "fake": true, "mock": true, "demo": true,
 }
 
-// analyzeContext performs keyword-based context analysis.
+// dobLineKeywords holds the keyword tallies for one line. Every field is a pure
+// function of the line, so they are computed ONCE per line and reused for every
+// candidate date on it.
+//
+// They used to be recomputed inside analyzeContext for every candidate, and each
+// recomputation scanned the whole line against ~40 keywords. On a dense line that
+// is O(candidates x line length x keywords) -- the single-long-line
+// CPU-exhaustion shape. Measured before the hoist, on one line of distinct dates:
+// 250 -> 0.14s, 500 -> 0.30s, 1000 -> 0.86s, 2000 -> 3.34s, 4000 -> 15.68s, i.e.
+// ~4x per doubling.
+//
+// BeforeText and AfterText are windows INSIDE the same line, so the old
+// "fullContext" (BeforeText + line + AfterText) contained no token the line did
+// not already contain. Scanning the line alone is therefore equivalent, not an
+// approximation.
+type dobLineKeywords struct {
+	positiveCount        int
+	hasStrongPositive    bool
+	contextNegativeCount int
+	hasDisqualifier      bool
+	hasNonHuman          bool
+	positives            []string
+	negatives            []string
+}
+
+// newDOBLineKeywords tallies every keyword class for the line in a single pass
+// over the keyword lists.
+func (v *Validator) newDOBLineKeywords(lowerLine string) *dobLineKeywords {
+	lk := &dobLineKeywords{}
+
+	for _, kw := range v.positiveKeywords {
+		if containsKeyword(lowerLine, kw) {
+			lk.positiveCount++
+			lk.positives = append(lk.positives, kw)
+			if strongPositiveKeywords[kw] {
+				lk.hasStrongPositive = true
+			}
+		}
+	}
+	for _, kw := range v.negativeKeywords {
+		if containsKeyword(lowerLine, kw) {
+			lk.negatives = append(lk.negatives, kw)
+			if disqualifierKeywords[kw] {
+				lk.hasDisqualifier = true
+			} else {
+				lk.contextNegativeCount++
+			}
+		}
+	}
+	for _, ind := range nonHumanIndicators {
+		if containsKeyword(lowerLine, ind) {
+			lk.hasNonHuman = true
+			break
+		}
+	}
+	return lk
+}
+
+// analyzeContext performs keyword-based context analysis. Retained with its
+// original signature for external callers and tests; it builds the per-line
+// keyword cache and delegates.
 func (v *Validator) analyzeContext(lowerLine string, context detector.ContextInfo) float64 {
+	return v.analyzeContextWith(lowerLine, context, v.newDOBLineKeywords(lowerLine))
+}
+
+// analyzeContextWith is analyzeContext with the per-line keyword tallies supplied
+// by the caller, so a line with many candidate dates pays for the keyword scan
+// once rather than once per candidate.
+func (v *Validator) analyzeContextWith(lowerLine string, context detector.ContextInfo, lk *dobLineKeywords) float64 {
 	var impact float64
 
-	// Full text to scan for keywords: combine available context
-	fullContext := lowerLine
-	if context.BeforeText != "" || context.AfterText != "" {
-		fullContext = strings.ToLower(context.BeforeText) + " " + lowerLine + " " + strings.ToLower(context.AfterText)
-	}
-
-	// Check positive keywords first to identify strong DOB signals
-	positiveCount := 0
-	hasStrongPositive := false
-	for _, kw := range v.positiveKeywords {
-		if containsKeyword(fullContext, kw) {
-			positiveCount++
-			if strongPositiveKeywords[kw] {
-				hasStrongPositive = true
-			}
-		}
-	}
-
-	// Check negative keywords, separating disqualifiers from context negatives
-	contextNegativeCount := 0
-	hasDisqualifier := false
-	for _, kw := range v.negativeKeywords {
-		if containsKeyword(fullContext, kw) {
-			if disqualifierKeywords[kw] {
-				hasDisqualifier = true
-			} else {
-				contextNegativeCount++
-			}
-		}
-	}
+	positiveCount := lk.positiveCount
+	hasStrongPositive := lk.hasStrongPositive
+	contextNegativeCount := lk.contextNegativeCount
+	hasDisqualifier := lk.hasDisqualifier
 
 	// Disqualifiers (test/example/fake/mock) ALWAYS suppress, even with strong
 	// positive keywords. "Test DOB: 01/01/2000" is synthetic data, not real PII.
@@ -500,16 +546,9 @@ func (v *Validator) analyzeContext(lowerLine string, context detector.ContextInf
 	}
 
 	// Weak positive keywords present (born, birthday, age, years old, birth).
-	// Check for non-human subject indicators that reduce their signal.
-	hasNonHuman := false
-	for _, ind := range nonHumanIndicators {
-		if containsKeyword(fullContext, ind) {
-			hasNonHuman = true
-			break
-		}
-	}
-
-	if hasNonHuman {
+	// Check for non-human subject indicators that reduce their signal
+	// (per-line invariant, computed once in newDOBLineKeywords).
+	if lk.hasNonHuman {
 		// Non-human subject detected with only weak keywords — suppress.
 		// "The project was born on..." or "Server age: 5 years" are not DOBs.
 		return -10.0

--- a/internal/validators/dob/validator.go
+++ b/internal/validators/dob/validator.go
@@ -434,6 +434,82 @@ var disqualifierKeywords = map[string]bool{
 	"placeholder": true, "fake": true, "mock": true, "demo": true,
 }
 
+// dobLabelForms are the label spellings that mark a value as a date of birth.
+// Used to decide whether a disqualifier modifies the label (see
+// disqualifierModifiesLabel); the earliest occurrence wins, so order is for
+// readability only.
+var dobLabelForms = []string{
+	"date of birth", "date-of-birth", "date_of_birth",
+	"patient dob", "applicant dob", "member dob",
+	"birthdate", "birth date", "dob",
+}
+
+// disqualifierModifiesLabel reports whether a synthetic-data keyword is
+// positioned so that it describes THE DATE, rather than merely appearing
+// somewhere in the same context.
+//
+// Two positions qualify:
+//
+//   - BEFORE the DOB label. Synthetic fixtures attach the marker to the label:
+//     "Test DOB: 01/01/2000", "sample patient dob 3/14/87", "example date of
+//     birth". Real records put the label first.
+//
+//   - As the FIRST WORD of an aside immediately after the value, separated only
+//     by punctuation: "DOB: 03/14/1987 (test)", "dob 3/14/87 -- sample data".
+//
+// A clause with its own subject after the value does not qualify, which is what
+// keeps "Patient DOB: 03/14/1987, blood sample collected at intake" reported.
+//
+// This is the same rule driverslicense uses. It was chosen there over two
+// alternatives that were measured and rejected: a plain distance threshold (the
+// real and synthetic classes interleave, so no cutoff separates them) and a
+// compound-noun list of clinical terms (overfit -- it scored 6/12 on held-out
+// phrasings, and every miss was a REAL record classified as synthetic).
+func disqualifierModifiesLabel(lowerLine string, context detector.ContextInfo) bool {
+	labelAt := -1
+	for _, form := range dobLabelForms {
+		if i := strings.Index(lowerLine, form); i >= 0 && (labelAt < 0 || i < labelAt) {
+			labelAt = i
+		}
+	}
+
+	// No recognizable label in the line: keep the old conservative behavior.
+	if labelAt < 0 {
+		return true
+	}
+
+	// A disqualifier anywhere before the label modifies it.
+	if labelAt > 0 {
+		prefix := lowerLine[:labelAt]
+		for kw := range disqualifierKeywords {
+			if containsKeyword(prefix, kw) {
+				return true
+			}
+		}
+	}
+
+	// A disqualifier opening an aside right after the value is an apposition on
+	// the value. AfterText is the post-match window the caller already computed,
+	// so this needs no rescan of the line.
+	after := strings.ToLower(context.AfterText)
+	j := 0
+	for j < len(after) && strings.IndexByte(" \t-/(<[|,;:#>", after[j]) >= 0 {
+		j++
+	}
+	word := after[j:]
+	end := 0
+	for end < len(word) && isWordByteASCII(word[end]) {
+		end++
+	}
+	return disqualifierKeywords[word[:end]]
+}
+
+// isWordByteASCII reports whether b is a letter, digit or underscore.
+func isWordByteASCII(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') ||
+		(b >= '0' && b <= '9') || b == '_'
+}
+
 // analyzeContext performs keyword-based context analysis.
 func (v *Validator) analyzeContext(lowerLine string, context detector.ContextInfo) float64 {
 	var impact float64
@@ -469,9 +545,29 @@ func (v *Validator) analyzeContext(lowerLine string, context detector.ContextInf
 		}
 	}
 
-	// Disqualifiers (test/example/fake/mock) ALWAYS suppress, even with strong
-	// positive keywords. "Test DOB: 01/01/2000" is synthetic data, not real PII.
-	if hasDisqualifier {
+	// Disqualifiers (test/example/fake/mock) suppress even a strong positive
+	// label, because "Test DOB: 01/01/2000" is synthetic data rather than real
+	// PII -- but only when the disqualifier actually MODIFIES the label.
+	//
+	// It used to fire on the disqualifier appearing anywhere in the context, with
+	// no positional bound at all, which deleted real records:
+	//
+	//   "Patient DOB: 03/14/1987, blood sample collected at intake"  -> nothing
+	//   "Patient DOB: 03/14/1987, blood collected at intake"         -> reported
+	//
+	// "sample collected", "sample submitted" and "specimen sample" are ordinary
+	// clinical vocabulary that co-occurs with a patient's date of birth on every
+	// lab requisition. Because only reported findings are handed to the redactor,
+	// and a file with no findings has no redacted output written at all, the DOB
+	// stayed in cleartext.
+	//
+	// The positional rule is the one already used for driver's licences: the
+	// disqualifier counts when it precedes the DOB label ("Test DOB:", "sample
+	// patient dob") or opens an aside immediately after the value ("DOB:
+	// 03/14/1987 (test)"). A disqualifier sitting in a following clause with its
+	// own subject does not. When there is NO strong positive label the old
+	// behavior is kept: the disqualifier is then the best signal available.
+	if hasDisqualifier && (!hasStrongPositive || disqualifierModifiesLabel(lowerLine, context)) {
 		impact -= 50.0
 		return impact
 	}

--- a/internal/validators/medicalid/insurance_soft_keyword_test.go
+++ b/internal/validators/medicalid/insurance_soft_keyword_test.go
@@ -1,0 +1,126 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package medicalid
+
+import "testing"
+
+// TestLabelledMemberIDSurvivesIdentifierLabels is the leak this file exists for.
+//
+// nonInsuranceKeywordPresent lumped identifier LABELS (account/order/invoice/
+// tracking) in with different NUMBER TYPES (phone/ssn/serial/...), and the whole
+// list hard-suppressed. But account, order, invoice and tracking are the
+// definitional content of a claim form, an EOB and a remittance advice, so they
+// co-occur with a real member ID constantly.
+//
+// evaluateMRN has carried a hard/soft split for exactly this reason for a while;
+// the insurance path simply never adopted it. Only reported findings are handed
+// to the redactor, and a file with no findings has no redacted output written at
+// all, so the member ID stayed in cleartext.
+func TestLabelledMemberIDSurvivesIdentifierLabels(t *testing.T) {
+	v := NewValidator()
+
+	lines := []string{
+		"Subscriber member id W1234567801, patient account 88213 has a zero balance",
+		"Subscriber member id W1234567801, order 55 shipped",
+		"member id W1234567801, invoice 22 paid",
+		"Insurance member id W1234567801 with tracking 99",
+	}
+
+	for _, line := range lines {
+		t.Run(line, func(t *testing.T) {
+			matches, err := v.ValidateContent(line, "claim.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) == 0 {
+				t.Fatalf("an identifier label elsewhere on the line deleted a labelled "+
+					"member ID: %s", line)
+			}
+		})
+	}
+}
+
+// TestUnlabelledValueWithIdentifierLabelStaysSuppressed is why the words are
+// SPLIT rather than deleted. With no insurance keyword on the line, "order" and
+// "tracking" are still the best available evidence that a mixed alphanumeric
+// token is an order number and not a member ID.
+func TestUnlabelledValueWithIdentifierLabelStaysSuppressed(t *testing.T) {
+	v := NewValidator()
+
+	lines := []string{
+		"order 55 and W1234567801 shipped",
+		"tracking 99 for W1234567801",
+		"invoice 22 references W1234567801",
+		"account W1234567801 was updated",
+	}
+
+	for _, line := range lines {
+		t.Run(line, func(t *testing.T) {
+			matches, err := v.ValidateContent(line, "orders.csv")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) != 0 {
+				t.Errorf("an unlabelled value beside an identifier label was reported: %s (got %d)",
+					line, len(matches))
+			}
+		})
+	}
+}
+
+// TestNumberTypeKeywordsStillHardSuppress pins the tier that did NOT change. A
+// word naming a different number type suppresses regardless of the insurance
+// label, because a member-ID-shaped token really is likelier to be that other
+// thing.
+func TestNumberTypeKeywordsStillHardSuppress(t *testing.T) {
+	v := NewValidator()
+
+	lines := []string{
+		"Subscriber member id W1234567801, phone 555-0100",
+		"member id W1234567801 ssn on file",
+		"member id W1234567801 serial number",
+		"member id W1234567801 model 4",
+		"member id W1234567801 version 2",
+	}
+
+	for _, line := range lines {
+		t.Run(line, func(t *testing.T) {
+			matches, err := v.ValidateContent(line, "mixed.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) != 0 {
+				t.Errorf("a different-number-type keyword failed to suppress: %s (got %d)",
+					line, len(matches))
+			}
+		})
+	}
+}
+
+// TestInsuranceTiersMirrorMRN documents the invariant behind the split: the two
+// suppressor sets must be disjoint, or a word would be both hard and soft and the
+// soft tier would be unreachable.
+func TestInsuranceTiersMirrorMRN(t *testing.T) {
+	v := NewValidator()
+
+	hard := []string{"phone", "ssn", "serial", "model", "version", "ip address"}
+	soft := []string{"account", "order", "invoice", "tracking"}
+
+	for _, kw := range hard {
+		if !v.nonInsuranceKeywordPresent("x " + kw + " y") {
+			t.Errorf("hard keyword %q not detected by nonInsuranceKeywordPresent", kw)
+		}
+		if v.nonInsuranceSoftKeywordPresent("x " + kw + " y") {
+			t.Errorf("hard keyword %q also matched the SOFT set; the tiers must be disjoint", kw)
+		}
+	}
+	for _, kw := range soft {
+		if !v.nonInsuranceSoftKeywordPresent("x " + kw + " y") {
+			t.Errorf("soft keyword %q not detected by nonInsuranceSoftKeywordPresent", kw)
+		}
+		if v.nonInsuranceKeywordPresent("x " + kw + " y") {
+			t.Errorf("soft keyword %q also matched the HARD set, so the soft tier is unreachable", kw)
+		}
+	}
+}

--- a/internal/validators/medicalid/validator.go
+++ b/internal/validators/medicalid/validator.go
@@ -147,7 +147,8 @@ type medicalLineContext struct {
 	// is not hard-dropped.
 	nonMedHardKW bool
 	nonMedSoftKW bool
-	nonInsKW     bool // nonInsuranceKeywordPresent (insurance suppressor keywords)
+	nonInsKW     bool // nonInsuranceKeywordPresent (different NUMBER TYPE; always suppresses)
+	nonInsSoftKW bool // nonInsuranceSoftKeywordPresent (identifier LABELS; suppress only without an insurance keyword)
 }
 
 // scanLine scans a single line for all medical ID types.
@@ -187,6 +188,7 @@ func (v *Validator) scanLine(ctx stdctx.Context, line string, lineNum int, origi
 		nonMedHardKW: v.nonMedicalHardKeywordPresent(lowerLine),
 		nonMedSoftKW: v.nonMedicalSoftKeywordPresent(lowerLine),
 		nonInsKW:     v.nonInsuranceKeywordPresent(lowerLine),
+		nonInsSoftKW: v.nonInsuranceSoftKeywordPresent(lowerLine),
 	}
 
 	// scanMatches runs one regex over the line, polling ctx between matches so a
@@ -479,7 +481,11 @@ func (v *Validator) evaluateInsuranceID(match, line, lowerLine string, lc medica
 	}
 
 	// Skip if it looks like a common non-insurance pattern
-	if lc.nonInsKW || v.looksLikeNonInsuranceIDShape(match, lc.insKeyword) {
+	// Two tiers, mirroring evaluateMRN: a different number type always
+	// suppresses; an identifier LABEL suppresses only when no insurance keyword
+	// is present, so a labelled member ID beside "patient account 88213" survives.
+	if lc.nonInsKW || (lc.nonInsSoftKW && !lc.insKeyword) ||
+		v.looksLikeNonInsuranceIDShape(match, lc.insKeyword) {
 		return detector.Match{}, false
 	}
 
@@ -865,10 +871,44 @@ func (v *Validator) looksLikeNonMedicalNumberShape(match string) bool {
 // nonInsuranceKeywordPresent reports whether the line carries a keyword that
 // makes an alphanumeric token more likely a non-insurance identifier.
 // Line-global — hoisted into medicalLineContext (was scanned per match).
+// nonInsuranceKeywordPresent reports whether the line names a different NUMBER
+// TYPE, which a member-ID-shaped value is far likelier to be. These always
+// suppress, the same tier as nonMedicalHardKeywordPresent for MRN.
 func (v *Validator) nonInsuranceKeywordPresent(lowerLine string) bool {
 	for _, kw := range []string{
-		"phone", "ssn", "account", "order", "invoice", "tracking",
-		"serial", "model", "version", "ip address",
+		"phone", "ssn", "serial", "model", "version", "ip address",
+	} {
+		if containsKeyword(lowerLine, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// nonInsuranceSoftKeywordPresent reports whether the line carries an identifier
+// LABEL that commonly sits BESIDE a real member ID rather than describing it.
+//
+// These four were previously in the hard list above, which made them delete a
+// member ID even when the line also carried an explicit insurance label. That is
+// wrong on the same grounds evaluateMRN already documents for its own soft tier:
+// "account", "order", "invoice" and "tracking" are the definitional content of a
+// claim form, an EOB and a remittance advice, so they co-occur with a real member
+// ID constantly. "Subscriber member id W1234567801; patient account 88213 has a
+// zero balance" reported nothing, while the same line without the word "account"
+// reported a finding.
+//
+// A dropped finding is never handed to the redactor, and a file that yields no
+// findings has no redacted output written at all, so the member ID stayed in
+// cleartext.
+//
+// Split rather than deleted: with NO insurance keyword on the line these words
+// are still the best available signal that a mixed alphanumeric token is an order
+// number rather than a member ID, so they keep suppressing in that case. This
+// mirrors the hard/soft split evaluateMRN has carried for a while; the insurance
+// path simply never adopted it.
+func (v *Validator) nonInsuranceSoftKeywordPresent(lowerLine string) bool {
+	for _, kw := range []string{
+		"account", "order", "invoice", "tracking",
 	} {
 		if containsKeyword(lowerLine, kw) {
 			return true


### PR DESCRIPTION
## The sweep

Measured single-line scaling for **all 18 measurable validators** with distinct values at n = 250 / 500 / 1000 / 2000. `DATE_OF_BIRTH` was the only quadratic, and it was severe:

| n | before | ratio |
|---|---|---|
| 250 | 0.14s | |
| 500 | 0.30s | 2.1× |
| 1000 | 0.86s | 2.9× |
| 2000 | 3.34s | 3.9× |
| 4000 | **15.68s** | 4.7× |

`analyzeContext` recomputed every keyword tally for **each candidate date**, and each recomputation scanned the whole line against ~40 positive keywords, ~20 negative keywords and the non-human indicator list — `O(candidates × line length × keywords)`, the single-long-line CPU-exhaustion shape several other validators have already had hoisted out. `findKeywords` then did the same whole-line work twice more per candidate to fill `ContextInfo`.

## After

```
0.09 / 0.11 / 0.14 / 0.13s   at 250 / 500 / 1000 / 2000
15.68s -> 0.13s at n=4000  (88x), curve flat
```

`BeforeText` and `AfterText` are windows **inside the same line**, so the old `fullContext` (`BeforeText + line + AfterText`) contained no token the line didn't already contain. Scanning the line alone is equivalent, not an approximation — and findings are **byte-identical** before and after at n = 250 / 1000 / 2000 (line, text and confidence compared per finding). `analyzeContext` keeps its original signature and delegates.

## The rest of the sweep — all linear

Worst ratio per doubling: SSN 1.31, PHONE 1.20, EMAIL 1.31, CREDIT_CARD 1.11, IP_ADDRESS 1.20, MEDICAL_ID 1.33, DRIVERS_LICENSE 1.18, PASSPORT 1.27, BANK_ACCOUNT 1.11, VIN 1.12, PERSON_NAME flat, PHYSICAL_ADDRESS 1.20, SECRETS 1.25, OTP linear, CLOUD_RESOURCES 1.12, INTELLECTUAL_PROPERTY 1.33.

**SOCIAL_MEDIA could not be measured** — it's config-gated and reports nothing without a config file (tracked separately, see #211/#216). Saying so rather than counting it as a pass.

## Four fixtures that produced a false PASS

Each of these silently reports "linear" while measuring nothing, so they're worth recording:

- **Repeated values** — a quadratic measures linear once candidates dedup. My first DOB run used repeated dates, reported a flat 80 findings at every size, and hid the quadratic completely.
- **Only 400 distinct name combinations**, so PERSON_NAME plateaued and looked capped.
- **A Luhn generator that truncated the check digit it had just computed**, so 90% of the "cards" were invalid.
- **Adjacent PANs separated by one space**, where the pattern's own delimiter consumes the separator (documented in `creditcard/validator.go`).

PERSON_NAME also needed **real names** from a public dataset (717 distinct Titanic passenger names) because it matches against a name database — synthetic `Aana Bson`-style names match at 5%.

## Tests

- `TestDenseLineFindingsGrowWithInput` — asserts findings **grow** with input, so the timing guard cannot pass by measuring nothing.
- `TestKeywordScanIsHoistedOutOfTheCandidateLoop` — structural, not wall-clock: asserts the tally is a pure function of the line. A future change that reintroduces genuinely per-match context breaks that equality rather than just getting slow.
- `TestAnalyzeContextMatchesTheHoistedForm` — pins that both entry points agree.
- `TestDenseLineCompletesPromptly` — coarse backstop with a deliberately loose 2s threshold (quadratic was 3.3s, linear is 0.14s) so it isn't a flaky benchmark, plus its own non-vacuity floor.

**Non-vacuity:** reverting the call site to the per-candidate form puts n=2000 back to **3.23s** and the guard fails with the measured duration.

The non-vacuity floor also caught a *second* fixture bug during development — a trailing `"sample"` reaching the disqualifier path and zeroing the whole line in-process even though the CLI reported 2000 findings on the same shape.

gofmt / vet / build clean, 58 packages, golden corpus **moves no snapshot**, cross-platform vet, 3× flake, whole-module `-race`, `-short`.