### PR TITLE
fix(config): make every documented option work, or stop shipping it

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -93,6 +93,29 @@ func loadConfiguration(configFile string) *config.Config {
 	return cfg
 }
 
+// warnUnknownConfigKeys reports config keys the schema does not recognize.
+//
+// Unknown keys are not an error — rejecting them would break any config written
+// against an older or newer version, including this project's own shipped
+// config.yaml before these keys were reconciled. But silence is worse: a typo'd
+// option name looks exactly like a working one, so the setting is never applied
+// and the user has no way to tell. This is the same courtesy the cloud_resources
+// validator already extends for its own sub-keys.
+//
+// The warnings go to w rather than straight to os.Stderr because stderr is not
+// always a human channel: in stdin redaction mode the findings document IS
+// stderr, and prose there breaks `2> findings.json`. Callers pass io.Discard when
+// shouldSuppressStdinProse says to stay quiet.
+func warnUnknownConfigKeys(w io.Writer, cfg *config.Config) {
+	if cfg == nil || w == nil {
+		return
+	}
+	for _, key := range cfg.UnknownKeys {
+		fmt.Fprintf(w,
+			"Warning: unknown config key %q — ignored (check for a typo)\n", key)
+	}
+}
+
 // configFlags holds command line flag values
 type configFlags struct {
 	outputFormat         string
@@ -112,6 +135,7 @@ type configFlags struct {
 	showSuppressed       bool
 	generateSuppressions bool
 	failOnIncomplete     bool
+	suppressionFile      string
 	// Redaction flags
 	enableRedaction    bool
 	redactionOutputDir string
@@ -144,6 +168,7 @@ type finalConfiguration struct {
 	showSuppressed       bool
 	generateSuppressions bool
 	failOnIncomplete     bool
+	suppressionFile      string
 	disableIPTypes       string
 }
 
@@ -352,10 +377,17 @@ func resolveConfiguration(cfg *config.Config, activeProfile *config.Profile, fla
 		final.quiet = flags.quiet
 	}
 
-	// Include suppressed findings in output
+	// Include suppressed findings in output. The dedicated `suppressions:` block
+	// is a peer of `defaults:`, so it is applied after it and before the profile.
+	//
+	// The two keys OR together: either can switch the behavior on, neither can
+	// switch it back off. Both default to false and both mean "turn this on", so
+	// there is no way to tell `suppressions.show_suppressed: false` apart from the
+	// key being absent — treating an explicit false as an override would make
+	// omitting the key silently disable defaults.show_suppressed.
 	final.showSuppressed = false // default fallback
 	if cfg != nil {
-		final.showSuppressed = cfg.Defaults.ShowSuppressed
+		final.showSuppressed = cfg.Defaults.ShowSuppressed || cfg.Suppressions.ShowSuppressed
 	}
 	if activeProfile != nil {
 		final.showSuppressed = activeProfile.ShowSuppressed
@@ -364,10 +396,11 @@ func resolveConfiguration(cfg *config.Config, activeProfile *config.Profile, fla
 		final.showSuppressed = flags.showSuppressed
 	}
 
-	// Auto-generate suppression rules for all findings
+	// Auto-generate suppression rules for all findings. Same OR semantics as
+	// show_suppressed above.
 	final.generateSuppressions = false // default fallback
 	if cfg != nil {
-		final.generateSuppressions = cfg.Defaults.GenerateSuppressions
+		final.generateSuppressions = cfg.Defaults.GenerateSuppressions || cfg.Suppressions.GenerateOnScan
 	}
 	if activeProfile != nil {
 		final.generateSuppressions = activeProfile.GenerateSuppressions
@@ -386,6 +419,16 @@ func resolveConfiguration(cfg *config.Config, activeProfile *config.Profile, fla
 	}
 	if isFlagSet("fail-on-incomplete") {
 		final.failOnIncomplete = flags.failOnIncomplete
+	}
+
+	// Suppression file: suppressions.file -> flag (flag wins). Empty means the
+	// suppression manager picks its own platform default.
+	final.suppressionFile = ""
+	if cfg != nil {
+		final.suppressionFile = cfg.Suppressions.File
+	}
+	if isFlagSet("suppression-file") && flags.suppressionFile != "" {
+		final.suppressionFile = flags.suppressionFile
 	}
 
 	// Disable IP types
@@ -1013,6 +1056,7 @@ func main() {
 		showSuppressed:       flags.showSuppressed,
 		generateSuppressions: flags.generateSuppressions,
 		failOnIncomplete:     flags.failOnIncomplete,
+		suppressionFile:      flags.suppressionFile,
 		disableIPTypes:       flags.disableIPTypes,
 	})
 
@@ -1352,8 +1396,9 @@ func main() {
 		}
 	}
 
-	// Initialize suppression manager
-	suppressionManager := suppressions.NewSuppressionManager(*suppressionFile)
+	// Initialize suppression manager. The path comes from resolveConfiguration so
+	// that suppressions.file in the config file is honored, not just the flag.
+	suppressionManager := suppressions.NewSuppressionManager(finalConfig.suppressionFile)
 	if mainDebugObs != nil {
 		mainDebugObs.LogDetail("main", "Suppression manager initialized")
 	}
@@ -1487,6 +1532,17 @@ func main() {
 	// stderr warning: the findings are still reported, but the sensitive values
 	// remain in cleartext at the original path with no shareable artifact.
 	var unredactedFiles []parallel.FileDiagnostic
+
+	// Report config keys the schema does not recognize. Gated only on pre-commit
+	// mode, NOT on quiet/non-interactive — the same rule as the
+	// incomplete-coverage warning below, and for the same reason: CI is exactly
+	// where a config that silently fails to apply is most dangerous, and CI is
+	// never interactive. --quiet documents suppressing *progress* output, which
+	// this is not. It writes to stderr, so scripts parsing results on stdout are
+	// unaffected, and it never changes the exit code.
+	if precommitConfig == nil {
+		warnUnknownConfigKeys(os.Stderr, cfg)
+	}
 
 	// Suppress progress messages in pre-commit mode or quiet mode
 	if !shouldSuppressProgressOutput(finalConfig, precommitConfig, isInteractive) {

--- a/cmd/stdin.go
+++ b/cmd/stdin.go
@@ -133,6 +133,7 @@ func runStdinScan(in stdinScanInputs) int {
 		showSuppressed:       in.flags.showSuppressed,
 		generateSuppressions: in.flags.generateSuppressions,
 		failOnIncomplete:     in.flags.failOnIncomplete,
+		suppressionFile:      in.flags.suppressionFile,
 		enableRedaction:      in.flags.enableRedaction,
 		redactionOutputDir:   "",
 		redactionStrategy:    in.flags.redactionStrategy,
@@ -164,7 +165,10 @@ func runStdinScan(in stdinScanInputs) int {
 	}
 
 	// Suppression manager mirrors file mode.
-	suppressionManager := suppressions.NewSuppressionManager(in.flags.suppressionFile)
+	// Use the resolved path, not the raw flag, so suppressions.file in the config
+	// file is honored here too. Reading the flag directly reintroduces exactly the
+	// defect this resolution chain exists to prevent.
+	suppressionManager := suppressions.NewSuppressionManager(finalCfg.suppressionFile)
 
 	// Parse checks list into a []string for ScanContent.
 	checks := parseChecksList(finalCfg.checksToRun)
@@ -241,6 +245,11 @@ func runStdinScan(in stdinScanInputs) int {
 	}
 
 	if !shouldSuppressStdinProse(finalCfg, precommitConfig, in.outputFile) {
+		// Unknown-key warnings are prose, so they ride the same gate: with
+		// --enable-redaction and no --output, stderr carries the findings
+		// document and anything else on it breaks `2> findings.json`.
+		warnUnknownConfigKeys(os.Stderr, cfg)
+
 		fmt.Fprintf(os.Stderr, "Scan complete: stdin scanned in %s\n", elapsed.Round(time.Millisecond))
 		// Mirror file-mode's suppression notice so users see the same
 		// signal regardless of input source.

--- a/cmd/suppressions_config_test.go
+++ b/cmd/suppressions_config_test.go
@@ -1,0 +1,128 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/config"
+)
+
+// The `suppressions:` block was documented in the shipped config.yaml but had no
+// struct field, so all three of its keys were discarded by the YAML decoder. Now
+// that they parse, they also have to reach the resolved configuration — parsing
+// into a field nothing reads is the same defect one layer up.
+//
+// No CLI flag is set in-test, so isFlagSet is false throughout and these cover
+// the config-file half of the precedence chain.
+
+func TestResolveConfiguration_SuppressionsBlock(t *testing.T) {
+	t.Run("suppressions.file reaches the resolved config", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Suppressions.File = "/tmp/probe-suppressions.yaml"
+
+		final := resolveConfiguration(cfg, nil, &configFlags{})
+		if final.suppressionFile != "/tmp/probe-suppressions.yaml" {
+			t.Errorf("suppressionFile = %q, want the configured path — the suppression "+
+				"manager is constructed from this value, so an unread key means the "+
+				"user's rules are never loaded", final.suppressionFile)
+		}
+	})
+
+	t.Run("suppressions.generate_on_scan enables generation", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Suppressions.GenerateOnScan = true
+
+		final := resolveConfiguration(cfg, nil, &configFlags{})
+		if !final.generateSuppressions {
+			t.Error("suppressions.generate_on_scan=true did not enable suppression generation")
+		}
+	})
+
+	t.Run("suppressions.show_suppressed enables display", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Suppressions.ShowSuppressed = true
+
+		final := resolveConfiguration(cfg, nil, &configFlags{})
+		if !final.showSuppressed {
+			t.Error("suppressions.show_suppressed=true did not enable suppressed display")
+		}
+	})
+
+	t.Run("defaults.* still works on its own", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Defaults.ShowSuppressed = true
+		cfg.Defaults.GenerateSuppressions = true
+
+		final := resolveConfiguration(cfg, nil, &configFlags{})
+		if !final.showSuppressed || !final.generateSuppressions {
+			t.Error("the pre-existing defaults.show_suppressed / defaults.generate_suppressions " +
+				"keys must keep working; the suppressions: block is an addition, not a " +
+				"replacement")
+		}
+	})
+
+	t.Run("a profile still overrides both", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Suppressions.ShowSuppressed = true
+		cfg.Suppressions.GenerateOnScan = true
+		prof := &config.Profile{ShowSuppressed: false, GenerateSuppressions: false}
+
+		final := resolveConfiguration(cfg, prof, &configFlags{})
+		if final.showSuppressed {
+			t.Error("an active profile must override suppressions.show_suppressed")
+		}
+		if final.generateSuppressions {
+			t.Error("an active profile must override suppressions.generate_on_scan")
+		}
+	})
+
+	t.Run("empty file leaves the platform default", func(t *testing.T) {
+		final := resolveConfiguration(&config.Config{}, nil, &configFlags{})
+		if final.suppressionFile != "" {
+			t.Errorf("suppressionFile = %q, want empty so the suppression manager picks "+
+				"its own platform-specific default", final.suppressionFile)
+		}
+	})
+}
+
+// TestWarnUnknownConfigKeys covers the helper's output and its nil-safety. The
+// config loader's failure path can hand back a nil config, and the writer is
+// io.Discard whenever stderr is a data channel rather than a human one.
+func TestWarnUnknownConfigKeys(t *testing.T) {
+	t.Run("nil inputs do not panic", func(t *testing.T) {
+		var buf bytes.Buffer
+		warnUnknownConfigKeys(&buf, nil)
+		warnUnknownConfigKeys(nil, &config.Config{UnknownKeys: []string{"x"}})
+		if buf.Len() != 0 {
+			t.Errorf("expected no output for a nil config, got %q", buf.String())
+		}
+	})
+
+	t.Run("one line per unknown key", func(t *testing.T) {
+		var buf bytes.Buffer
+		warnUnknownConfigKeys(&buf, &config.Config{
+			UnknownKeys: []string{"shwo_match", "nonsense_block"},
+		})
+		out := buf.String()
+		for _, want := range []string{"shwo_match", "nonsense_block"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("output %q does not mention %q", out, want)
+			}
+		}
+		if got := strings.Count(out, "\n"); got != 2 {
+			t.Errorf("expected 2 warning lines, got %d: %q", got, out)
+		}
+	})
+
+	t.Run("a clean config writes nothing", func(t *testing.T) {
+		var buf bytes.Buffer
+		warnUnknownConfigKeys(&buf, &config.Config{})
+		if buf.Len() != 0 {
+			t.Errorf("expected silence for a config with no unknown keys, got %q", buf.String())
+		}
+	})
+}

--- a/config.yaml
+++ b/config.yaml
@@ -43,9 +43,6 @@ preprocessors:
   # Text extraction from documents
   text_extraction:
     enabled: true # Enable text extraction preprocessor
-    types: # Types of text extraction to perform
-      - pdf # Extract text from PDF documents
-      - office # Extract text from Office documents (DOCX, XLSX, PPTX, ODT, ODS, ODP)
 
   # Metadata extraction (automatically enabled when preprocessors are enabled)
   # Supports multiple file types:
@@ -61,21 +58,16 @@ redaction:
   enabled: false # Enable redaction of sensitive data (can be overridden with --enable-redaction)
   output_dir: "./redacted" # Directory where redacted files will be stored
   strategy: "format_preserving" # Default redaction strategy: simple, format_preserving, or synthetic
-  audit_log_file: "" # Path to save redaction audit log file (JSON format for compliance)
-  memory_scrub: true # Enable secure memory scrubbing after processing sensitive data
-  audit_trail: true # Enable audit trail generation for redaction operations
+  audit_log_file: "" # Path to save redaction audit log file (JSON format for compliance).
+  # `index_file` is an accepted alias for the same setting.
 
-  # Strategy-specific configurations
-  strategies:
-    simple:
-      replacement: "[REDACTED]" # Text to replace sensitive data with
-
-    format_preserving:
-      preserve_length: true # Maintain original text length
-      preserve_format: true # Maintain original text format (e.g., XXX-XX-XXXX for SSN)
-
-    synthetic:
-      secure: true # Use cryptographically secure synthetic data generation
+  # Each strategy's behavior is fixed and needs no configuration:
+  #   simple            per-type placeholders, e.g. [SSN-REDACTED]. The marker
+  #                     names the type deliberately, so it is not configurable.
+  #   format_preserving masks the value but keeps its length and separators,
+  #                     e.g. ***-**-4100.
+  #   synthetic         substitutes a realistic fake value, generated with
+  #                     crypto/rand.
 
 # Validator-specific configurations
 validators:

--- a/docs/WINDOWS_INSTALLATION.md
+++ b/docs/WINDOWS_INSTALLATION.md
@@ -181,8 +181,6 @@ defaults:
 
 platform:
   windows:
-    use_appdata: true
-    long_path_support: false
     temp_dir: "%TEMP%\ferret-scan"
     config_dir: "%APPDATA%\ferret-scan"
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -863,17 +863,7 @@ redaction:
   enabled: false
   output_dir: ./redacted
   strategy: format_preserving
-  audit_log_file: ""
-  memory_scrub: true
-  audit_trail: true
-  strategies:
-    simple:
-      replacement: "[REDACTED]"
-    format_preserving:
-      preserve_length: true
-      preserve_format: true
-    synthetic:
-      secure: true
+  audit_log_file: "" # alias: index_file
 
 # Profiles — use with: ferret-scan --profile <name> --file <target>
 profiles:
@@ -940,20 +930,18 @@ redaction:
   output_dir: "./redacted"          # Where redacted copies are written
   strategy: "format_preserving"     # simple | format_preserving | synthetic
   audit_log_file: ""                # Optional path for JSON compliance log
-  memory_scrub: true                # Scrub sensitive data from memory after processing
-  audit_trail: true                 # Write audit trail alongside redacted files
-
-  strategies:
-    simple:
-      replacement: "[REDACTED]"     # Placeholder text for simple strategy
-
-    format_preserving:
-      preserve_length: true         # Keep original character count
-      preserve_format: true         # Keep separators (dashes, dots, @, etc.)
-
-    synthetic:
-      secure: true                  # Use crypto/rand for generation
+                                    # (alias: index_file; --redaction-audit-log wins)
 ```
+
+Each strategy's behaviour is fixed and takes no options:
+
+- `simple` writes a per-type placeholder such as `[SSN-REDACTED]`. The marker
+  names the type on purpose, so it is not configurable — a single replacement
+  string for every type would discard that information.
+- `format_preserving` masks the value while keeping its length and separators,
+  e.g. `***-**-4100`.
+- `synthetic` substitutes a realistic fake value, always generated with
+  `crypto/rand`.
 
 ### Strategy Behaviour
 

--- a/docs/development/WINDOWS_DEVELOPMENT.md
+++ b/docs/development/WINDOWS_DEVELOPMENT.md
@@ -361,7 +361,7 @@ defaults:
   checks: "all"
 platform:
   windows:
-    use_appdata: true
+    temp_dir: "%TEMP%\ferret-scan"
 "@ | Out-File "testdata\windows_config.yaml" -Encoding UTF8
 ```
 

--- a/docs/user-guides/README-Redaction.md
+++ b/docs/user-guides/README-Redaction.md
@@ -126,20 +126,12 @@ redaction:
   output_dir: "./redacted"          # Where to write redacted files
   strategy: "format_preserving"     # simple | format_preserving | synthetic
   audit_log_file: ""                # Path for JSON audit log (optional)
-  memory_scrub: true                # Scrub sensitive data from memory after processing
-  audit_trail: true                 # Generate audit trail
-
-  strategies:
-    simple:
-      replacement: "[REDACTED]"     # Custom placeholder text
-
-    format_preserving:
-      preserve_length: true
-      preserve_format: true
-
-    synthetic:
-      secure: true                  # Use cryptographically secure random generation
+                                    # (alias: index_file)
 ```
+
+The strategies themselves take no options: `simple` writes per-type markers like
+`[SSN-REDACTED]`, `format_preserving` keeps the value's length and separators, and
+`synthetic` generates a realistic replacement with `crypto/rand`.
 
 ## Audit Log
 

--- a/docs/user-guides/README-Windows-Usage.md
+++ b/docs/user-guides/README-Windows-Usage.md
@@ -277,8 +277,6 @@ defaults:
 
 platform:
   windows:
-    use_appdata: true
-    long_path_support: false
     temp_dir: "%TEMP%\\ferret-scan"
     config_dir: "%APPDATA%\\ferret-scan"
 

--- a/examples/ferret-windows.yaml
+++ b/examples/ferret-windows.yaml
@@ -110,13 +110,8 @@ defaults:
 # ─────────────────────────────────────────────────────────────────────────────
 platform:
   windows:
-    use_appdata: true           # Store config in %APPDATA%\ferret-scan\
-    system_wide_install: false  # Per-user install (set true for enterprise GPO deployment)
-    create_shortcuts: false
-    add_to_path: false
     config_dir: ""              # Leave empty to use default (%APPDATA%\ferret-scan)
     temp_dir: ""                # Leave empty to use %TEMP%
-    long_path_support: false    # Enable for repos with paths >260 chars
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Preprocessors
@@ -124,9 +119,6 @@ platform:
 preprocessors:
   text_extraction:
     enabled: true
-    types:
-      - pdf
-      - office
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Redaction (Windows paths)
@@ -135,18 +127,12 @@ redaction:
   enabled: false
   output_dir: "%USERPROFILE%\\Documents\\ferret-redacted"
   strategy: format_preserving
-  audit_log_file: "%LOCALAPPDATA%\\ferret-scan\\audit.log"
-  memory_scrub: true
-  audit_trail: true
+  audit_log_file: "%LOCALAPPDATA%\\ferret-scan\\audit.log"  # alias: index_file
 
-  strategies:
-    simple:
-      replacement: "[REDACTED]"
-    format_preserving:
-      preserve_length: true
-      preserve_format: true
-    synthetic:
-      secure: true
+  # Each strategy's behavior is fixed and takes no options:
+  #   simple            per-type markers, e.g. [SSN-REDACTED]
+  #   format_preserving keeps length and separators, e.g. ***-**-4100
+  #   synthetic         a realistic fake value, generated with crypto/rand
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Validators
@@ -229,8 +215,7 @@ profiles:
     description: "Default CLI scan — human-readable text output"
     platform:
       windows:
-        use_appdata: true
-        long_path_support: true
+        temp_dir: "%TEMP%\\ferret-scan"
 
   # ── Web ──────────────────────────────────────────────────────────────────
   web:
@@ -261,7 +246,6 @@ profiles:
     description: "CI/CD pipeline — quiet, machine-readable output (change format to junit/sarif as needed)"
     platform:
       windows:
-        use_appdata: false
         temp_dir: "%TEMP%\\ferret-scan"
 
   # ── Pre-commit ───────────────────────────────────────────────────────────

--- a/examples/ferret.yaml
+++ b/examples/ferret.yaml
@@ -119,9 +119,6 @@ defaults:
 preprocessors:
   text_extraction:
     enabled: true
-    types:
-      - pdf
-      - office
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Redaction configurations (activated with --enable-redaction or profile)
@@ -130,18 +127,12 @@ redaction:
   enabled: false
   output_dir: ./redacted
   strategy: format_preserving   # Options: simple, format_preserving, synthetic
-  audit_log_file: ""
-  memory_scrub: true
-  audit_trail: true
+  audit_log_file: ""            # JSON compliance log (alias: index_file)
 
-  strategies:
-    simple:
-      replacement: "[REDACTED]"
-    format_preserving:
-      preserve_length: true
-      preserve_format: true
-    synthetic:
-      secure: true
+  # Each strategy's behavior is fixed and takes no options:
+  #   simple            per-type markers, e.g. [SSN-REDACTED]
+  #   format_preserving keeps length and separators, e.g. ***-**-4100
+  #   synthetic         a realistic fake value, generated with crypto/rand
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Validator configurations

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,11 +4,14 @@
 package config
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strings"
 
 	"github.com/awslabs/ferret-scan/v2/internal/paths"
 
@@ -42,38 +45,40 @@ type Config struct {
 	// Preprocessor configurations
 	Preprocessors struct {
 		TextExtraction struct {
-			Enabled bool     `yaml:"enabled"`
-			Types   []string `yaml:"types"`
+			Enabled bool `yaml:"enabled"`
 		} `yaml:"text_extraction"`
 	} `yaml:"preprocessors"`
 
 	// Redaction configurations
 	Redaction struct {
-		Enabled     bool   `yaml:"enabled"`
-		OutputDir   string `yaml:"output_dir"`
-		Strategy    string `yaml:"strategy"`
-		IndexFile   string `yaml:"index_file"`
-		MemoryScrub bool   `yaml:"memory_scrub"`
-		AuditTrail  bool   `yaml:"audit_trail"`
-		Strategies  struct {
-			Simple struct {
-				Replacement string `yaml:"replacement"`
-			} `yaml:"simple"`
-			FormatPreserving struct {
-				PreserveLength bool `yaml:"preserve_length"`
-				PreserveFormat bool `yaml:"preserve_format"`
-			} `yaml:"format_preserving"`
-			Synthetic struct {
-				Secure bool `yaml:"secure"`
-			} `yaml:"synthetic"`
-		} `yaml:"strategies"`
+		Enabled   bool   `yaml:"enabled"`
+		OutputDir string `yaml:"output_dir"`
+		Strategy  string `yaml:"strategy"`
+		// IndexFile is the JSON redaction log. `audit_log_file` is the name the
+		// shipped config, the docs and the --redaction-audit-log flag all use,
+		// so it is accepted as an alias; see resolveAuditLogAlias.
+		IndexFile    string `yaml:"index_file"`
+		AuditLogFile string `yaml:"audit_log_file"`
 	} `yaml:"redaction"`
+
+	// Suppression configurations. These are the config-file equivalents of
+	// --suppression-file, --generate-suppressions and --show-suppressed.
+	Suppressions struct {
+		File           string `yaml:"file"`
+		GenerateOnScan bool   `yaml:"generate_on_scan"`
+		ShowSuppressed bool   `yaml:"show_suppressed"`
+	} `yaml:"suppressions"`
 
 	// Platform-specific configurations
 	Platform *PlatformConfig `yaml:"platform,omitempty"`
 
 	// Profiles for different scanning scenarios
 	Profiles map[string]Profile `yaml:"profiles"`
+
+	// UnknownKeys lists config keys the schema does not recognize. Populated by
+	// LoadConfig so callers can warn; a typo'd option is otherwise invisible.
+	// Not itself a config key.
+	UnknownKeys []string `yaml:"-"`
 }
 
 // PlatformConfig holds platform-specific configuration settings
@@ -84,22 +89,36 @@ type PlatformConfig struct {
 	Unix *UnixConfig `yaml:"unix,omitempty"`
 }
 
-// WindowsConfig holds Windows-specific configuration settings
+// WindowsConfig holds Windows-specific configuration settings.
+//
+// This block once also carried use_appdata, system_wide_install,
+// create_shortcuts, add_to_path and long_path_support. Those describe an
+// installer, not a scanner: nothing in this repo (including the install-system
+// scripts) ever read them, so they were validated and then ignored. They are
+// gone; the directory overrides below are the two that have a meaning here.
 type WindowsConfig struct {
-	UseAppData        bool   `yaml:"use_appdata"`         // Use APPDATA directory for configuration
-	SystemWideInstall bool   `yaml:"system_wide_install"` // Install system-wide vs user-specific
-	CreateShortcuts   bool   `yaml:"create_shortcuts"`    // Create desktop/start menu shortcuts
-	AddToPath         bool   `yaml:"add_to_path"`         // Add to PATH environment variable
-	ConfigDir         string `yaml:"config_dir"`          // Override default config directory
-	TempDir           string `yaml:"temp_dir"`            // Override default temp directory
-	LongPathSupport   bool   `yaml:"long_path_support"`   // Enable long path support (>260 chars)
-}
-
-// UnixConfig holds Unix-specific configuration settings
-type UnixConfig struct {
-	UseXDG    bool   `yaml:"use_xdg"`    // Use XDG Base Directory specification
 	ConfigDir string `yaml:"config_dir"` // Override default config directory
 	TempDir   string `yaml:"temp_dir"`   // Override default temp directory
+}
+
+// UnixConfig holds Unix-specific configuration settings. See WindowsConfig for
+// why use_xdg is no longer here.
+type UnixConfig struct {
+	ConfigDir string `yaml:"config_dir"` // Override default config directory
+	TempDir   string `yaml:"temp_dir"`   // Override default temp directory
+}
+
+// ProfileRedaction holds a profile's redaction settings. It is a named type
+// rather than an anonymous struct so that constructing a default profile does
+// not require restating every field and tag verbatim at each site.
+type ProfileRedaction struct {
+	Enabled   bool   `yaml:"enabled"`
+	OutputDir string `yaml:"output_dir"`
+	Strategy  string `yaml:"strategy"`
+	// IndexFile / AuditLogFile are the same slot under two names; see
+	// resolveAuditLogAlias.
+	IndexFile    string `yaml:"index_file"`
+	AuditLogFile string `yaml:"audit_log_file"`
 }
 
 // Profile represents a scanning profile with specific settings
@@ -122,12 +141,7 @@ type Profile struct {
 	Description          string                            `yaml:"description"`
 	Validators           map[string]map[string]interface{} `yaml:"validators"`
 	// Redaction settings for this profile
-	Redaction struct {
-		Enabled   bool   `yaml:"enabled"`
-		OutputDir string `yaml:"output_dir"`
-		Strategy  string `yaml:"strategy"`
-		IndexFile string `yaml:"index_file"`
-	} `yaml:"redaction"`
+	Redaction ProfileRedaction `yaml:"redaction"`
 	// Platform-specific settings for this profile
 	Platform *PlatformConfig `yaml:"platform,omitempty"`
 }
@@ -152,19 +166,17 @@ func LoadConfig(configPath string) (*Config, error) {
 
 	// Set default preprocessor values
 	config.Preprocessors.TextExtraction.Enabled = true
-	config.Preprocessors.TextExtraction.Types = []string{"pdf", "office"}
 
 	// Set default redaction values with platform-aware paths
 	config.Redaction.Enabled = false
 	config.Redaction.OutputDir = normalizePlatformPath("./redacted")
 	config.Redaction.Strategy = "format_preserving"
 	config.Redaction.IndexFile = ""
-	config.Redaction.MemoryScrub = true
-	config.Redaction.AuditTrail = true
-	config.Redaction.Strategies.Simple.Replacement = "[HIDDEN]"
-	config.Redaction.Strategies.FormatPreserving.PreserveLength = true
-	config.Redaction.Strategies.FormatPreserving.PreserveFormat = true
-	config.Redaction.Strategies.Synthetic.Secure = true
+
+	// Set default suppression values
+	config.Suppressions.File = ""
+	config.Suppressions.GenerateOnScan = false
+	config.Suppressions.ShowSuppressed = false
 
 	// Set platform-specific defaults
 	config.Platform = getDefaultPlatformConfig()
@@ -181,12 +193,7 @@ func LoadConfig(configPath string) (*Config, error) {
 		EnablePreprocessors: true,
 		Description:         "Optimized for pre-commit hooks with concise output and essential checks",
 		Validators:          make(map[string]map[string]interface{}),
-		Redaction: struct {
-			Enabled   bool   `yaml:"enabled"`
-			OutputDir string `yaml:"output_dir"`
-			Strategy  string `yaml:"strategy"`
-			IndexFile string `yaml:"index_file"`
-		}{
+		Redaction: ProfileRedaction{
 			Enabled:   false,
 			OutputDir: normalizePlatformPath("./redacted"),
 			Strategy:  "format_preserving",
@@ -238,15 +245,107 @@ func LoadConfig(configPath string) (*Config, error) {
 	// See backfillProfileBools for the list of fields this handles.
 	backfillProfileBools(yamlTree, config)
 
+	// Fold `audit_log_file` into the slot that actually drives the redaction log.
+	resolveAuditLogAlias(config)
+
 	// Apply platform-specific defaults and path normalization
 	ApplyPlatformDefaults(config)
+
+	// Collect (but do not fail on) keys the schema does not recognize, so a
+	// typo'd option is visible instead of silently ignored.
+	config.UnknownKeys = collectUnknownKeys(data)
 
 	// Validate the configuration
 	if err := ValidateConfig(config); err != nil {
 		return nil, fmt.Errorf("configuration validation failed: %w", err)
 	}
 
+	// Publish the platform block's temp directory so paths.GetTempDir honors it.
+	// Without this the whole `platform:` block was validated and then ignored.
+	//
+	// This runs AFTER validation, and only on success: the override is
+	// process-wide, so publishing it earlier would let a config that is about to
+	// be rejected — for a bad path, possibly that very temp_dir — leave the
+	// process pointing at a directory no accepted config ever named.
+	paths.SetTempDirOverride(platformTempDirOverride(config))
+
 	return config, nil
+}
+
+// resolveAuditLogAlias folds redaction.audit_log_file into redaction.index_file.
+//
+// These are one feature with two names: the struct field has always been
+// `index_file`, while the shipped config.yaml, every doc that mentions it, and
+// the --redaction-audit-log flag all call it `audit_log_file`. The mismatch dates
+// to the initial commit, so setting the documented name wrote to a field nothing
+// read and produced no log and no error.
+//
+// index_file wins when both are set, because it is the name the loader has always
+// honored — a user who set both is most likely mid-migration.
+func resolveAuditLogAlias(config *Config) {
+	if config.Redaction.IndexFile == "" {
+		config.Redaction.IndexFile = config.Redaction.AuditLogFile
+	}
+	for name, profile := range config.Profiles {
+		if profile.Redaction.IndexFile == "" && profile.Redaction.AuditLogFile != "" {
+			profile.Redaction.IndexFile = profile.Redaction.AuditLogFile
+			config.Profiles[name] = profile
+		}
+	}
+}
+
+// collectUnknownKeys reports config keys the schema does not recognize.
+//
+// The authoritative decode above is deliberately lenient: erroring on an unknown
+// key would be a breaking change, and would reject this project's own shipped
+// config.yaml. So this makes a second, strict pass purely to collect the key
+// names and throws its result away. Callers surface these as warnings.
+//
+// Returns paths like "redaction.typo" in file order.
+func collectUnknownKeys(data []byte) []string {
+	var throwaway Config
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+
+	err := dec.Decode(&throwaway)
+	if err == nil {
+		return nil
+	}
+	typeErr := &yaml.TypeError{}
+	if !errors.As(err, &typeErr) {
+		// A malformed document, not an unknown key. The lenient decode above
+		// already succeeded, so there is nothing to report.
+		return nil
+	}
+
+	var keys []string
+	for _, msg := range typeErr.Errors {
+		if name, ok := unknownFieldName(msg); ok {
+			keys = append(keys, name)
+		}
+	}
+	return keys
+}
+
+// unknownFieldName pulls the key name out of a yaml.v3 "field X not found"
+// message. Anything else (a type mismatch, say) is not an unknown key and is
+// reported as such so the caller can ignore it.
+func unknownFieldName(msg string) (string, bool) {
+	const marker = "field "
+	i := strings.Index(msg, marker)
+	if i < 0 {
+		return "", false
+	}
+	rest := msg[i+len(marker):]
+	j := strings.Index(rest, " not found in type")
+	if j < 0 {
+		return "", false
+	}
+	name := strings.TrimSpace(rest[:j])
+	if name == "" {
+		return "", false
+	}
+	return name, true
 }
 
 // FindConfigFile looks for a configuration file in standard locations using platform-aware paths
@@ -440,12 +539,7 @@ func (c *Config) GetPrecommitProfile() *Profile {
 		EnablePreprocessors: true,
 		Description:         "Optimized for pre-commit hooks with concise output and essential checks",
 		Validators:          make(map[string]map[string]interface{}),
-		Redaction: struct {
-			Enabled   bool   `yaml:"enabled"`
-			OutputDir string `yaml:"output_dir"`
-			Strategy  string `yaml:"strategy"`
-			IndexFile string `yaml:"index_file"`
-		}{
+		Redaction: ProfileRedaction{
 			Enabled:   false,
 			OutputDir: normalizePlatformPath("./redacted"),
 			Strategy:  "format_preserving",
@@ -614,22 +708,19 @@ func normalizePlatformPath(path string) string {
 	return paths.NormalizePath(path)
 }
 
-// getDefaultPlatformConfig returns default platform-specific configuration
+// getDefaultPlatformConfig returns default platform-specific configuration.
+//
+// Both directory overrides default to empty, which means "use the platform's own
+// location" (see paths.GetConfigDir / paths.GetTempDir). The struct is still
+// populated for the current OS so that a config file setting only one of the two
+// keys merges into a non-nil block.
 func getDefaultPlatformConfig() *PlatformConfig {
 	platformConfig := &PlatformConfig{}
 
 	if runtime.GOOS == "windows" {
-		platformConfig.Windows = &WindowsConfig{
-			UseAppData:        true,  // Use APPDATA by default on Windows
-			SystemWideInstall: false, // User-specific install by default
-			CreateShortcuts:   false, // Don't create shortcuts by default
-			AddToPath:         false, // Don't modify PATH by default
-			LongPathSupport:   false, // Disabled by default for compatibility
-		}
+		platformConfig.Windows = &WindowsConfig{}
 	} else {
-		platformConfig.Unix = &UnixConfig{
-			UseXDG: true, // Use XDG Base Directory specification by default
-		}
+		platformConfig.Unix = &UnixConfig{}
 	}
 
 	return platformConfig
@@ -763,18 +854,30 @@ func GetEffectiveConfigDir(config *Config) string {
 
 // GetEffectiveTempDir returns the effective temporary directory based on platform and config
 func GetEffectiveTempDir(config *Config) string {
-	// Check for platform-specific override
-	if config.Platform != nil {
-		if runtime.GOOS == "windows" && config.Platform.Windows != nil && config.Platform.Windows.TempDir != "" {
-			return normalizePlatformPath(config.Platform.Windows.TempDir)
-		}
-		if runtime.GOOS != "windows" && config.Platform.Unix != nil && config.Platform.Unix.TempDir != "" {
-			return normalizePlatformPath(config.Platform.Unix.TempDir)
-		}
+	if dir := platformTempDirOverride(config); dir != "" {
+		return dir
 	}
 
 	// Fall back to default platform-aware temp directory
 	return paths.GetTempDir()
+}
+
+// platformTempDirOverride returns the config file's temp directory for the
+// current OS, or "" when the platform block does not set one.
+func platformTempDirOverride(config *Config) string {
+	if config == nil || config.Platform == nil {
+		return ""
+	}
+	if runtime.GOOS == "windows" {
+		if config.Platform.Windows != nil && config.Platform.Windows.TempDir != "" {
+			return normalizePlatformPath(config.Platform.Windows.TempDir)
+		}
+		return ""
+	}
+	if config.Platform.Unix != nil && config.Platform.Unix.TempDir != "" {
+		return normalizePlatformPath(config.Platform.Unix.TempDir)
+	}
+	return ""
 }
 
 // ApplyPlatformDefaults applies platform-specific defaults to paths in the configuration

--- a/internal/config/dead_options_test.go
+++ b/internal/config/dead_options_test.go
@@ -1,0 +1,307 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/paths"
+)
+
+// This file covers the config keys an audit found to be parsed and then ignored.
+// A key that unmarshals into a field nothing reads is indistinguishable, from the
+// user's side, from a key that works: there is no error and no effect. These
+// tests assert the effect.
+
+// writeConfig writes a config file into a temp dir and returns its path.
+func writeConfig(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cfg.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+	return path
+}
+
+// TestAuditLogFileIsHonored covers the one dead key that silently discarded a
+// path the user asked for.
+//
+// The struct field has always been `index_file`, but the shipped config.yaml,
+// every doc that mentions it, and the --redaction-audit-log flag all call it
+// `audit_log_file`. Setting the documented name wrote to a field nothing read,
+// so no log was produced and no error was reported.
+func TestAuditLogFileIsHonored(t *testing.T) {
+	t.Run("alias fills an empty index_file", func(t *testing.T) {
+		cfg, err := LoadConfig(writeConfig(t, `
+redaction:
+  audit_log_file: "/tmp/ferret-audit.json"
+`))
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		if cfg.Redaction.IndexFile != "/tmp/ferret-audit.json" {
+			t.Errorf("audit_log_file did not reach IndexFile: got %q — the redaction log "+
+				"is driven by IndexFile, so an unread alias means no log file is written",
+				cfg.Redaction.IndexFile)
+		}
+	})
+
+	t.Run("index_file wins when both are set", func(t *testing.T) {
+		cfg, err := LoadConfig(writeConfig(t, `
+redaction:
+  index_file: "/tmp/from-index.json"
+  audit_log_file: "/tmp/from-alias.json"
+`))
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		if cfg.Redaction.IndexFile != "/tmp/from-index.json" {
+			t.Errorf("IndexFile = %q, want the explicit index_file value: it is the name "+
+				"the loader has always honored, so it must not be clobbered by the alias",
+				cfg.Redaction.IndexFile)
+		}
+	})
+
+	t.Run("alias works inside a profile", func(t *testing.T) {
+		cfg, err := LoadConfig(writeConfig(t, `
+profiles:
+  audited:
+    description: probe
+    redaction:
+      audit_log_file: "/tmp/profile-audit.json"
+`))
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		got := cfg.Profiles["audited"].Redaction.IndexFile
+		if got != "/tmp/profile-audit.json" {
+			t.Errorf("profile audit_log_file did not reach IndexFile: got %q", got)
+		}
+	})
+}
+
+// TestSuppressionsBlockIsParsed covers a block the shipped config.yaml has always
+// documented while Config had no field for it at all, so all three keys were
+// silently discarded.
+func TestSuppressionsBlockIsParsed(t *testing.T) {
+	cfg, err := LoadConfig(writeConfig(t, `
+suppressions:
+  file: ".my-suppressions.yaml"
+  generate_on_scan: true
+  show_suppressed: true
+`))
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	if cfg.Suppressions.File != ".my-suppressions.yaml" {
+		t.Errorf("suppressions.file = %q, want %q", cfg.Suppressions.File, ".my-suppressions.yaml")
+	}
+	if !cfg.Suppressions.GenerateOnScan {
+		t.Error("suppressions.generate_on_scan did not survive parsing")
+	}
+	if !cfg.Suppressions.ShowSuppressed {
+		t.Error("suppressions.show_suppressed did not survive parsing")
+	}
+}
+
+// TestUnknownKeysAreReported is the typo guard. yaml.Unmarshal is deliberately
+// lenient — erroring on an unknown key would reject configs written for another
+// version, including this project's own shipped config.yaml before this change.
+// But silence means a misspelled option looks exactly like a working one.
+func TestUnknownKeysAreReported(t *testing.T) {
+	cfg, err := LoadConfig(writeConfig(t, `
+defaults:
+  shwo_match: true
+redaction:
+  enabledd: true
+nonsense_block:
+  x: 1
+`))
+	if err != nil {
+		t.Fatalf("LoadConfig must not fail on unknown keys, only report them: %v", err)
+	}
+
+	joined := strings.Join(cfg.UnknownKeys, ",")
+	for _, want := range []string{"shwo_match", "enabledd", "nonsense_block"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("unknown key %q was not reported (got %v) — an unreported typo is "+
+				"applied to nothing and looks like a working setting", want, cfg.UnknownKeys)
+		}
+	}
+}
+
+// TestValidConfigReportsNoUnknownKeys is the other half: a warning that fires on
+// correct input would train users to ignore it.
+func TestValidConfigReportsNoUnknownKeys(t *testing.T) {
+	cfg, err := LoadConfig(writeConfig(t, `
+defaults:
+  format: json
+  show_match: true
+  confidence_levels: high
+redaction:
+  enabled: true
+  output_dir: "./redacted"
+  strategy: simple
+  index_file: "./idx.json"
+  audit_log_file: ""
+suppressions:
+  file: ".s.yaml"
+  generate_on_scan: false
+  show_suppressed: false
+validators:
+  intellectual_property:
+    internal_urls:
+      - "internal\\.example\\.invalid"
+profiles:
+  quick:
+    description: probe
+    format: text
+    redaction:
+      enabled: false
+`))
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if len(cfg.UnknownKeys) != 0 {
+		t.Errorf("a fully valid config reported unknown keys %v — false warnings teach "+
+			"users to ignore real ones", cfg.UnknownKeys)
+	}
+}
+
+// TestShippedConfigsHaveNoUnknownKeys pins the invariant that every config we
+// ship validates against our own schema. None of them did: `audit_log_file` and
+// the whole `suppressions:` block had no struct fields, so the project's own
+// examples documented settings that did nothing.
+//
+// examples/ferret.yaml matters most: `make install` copies it to the user's
+// config directory, so an unknown key there means a warning on every scan for
+// every installed user. Covering only the repo-root config.yaml would have
+// missed that.
+func TestShippedConfigsHaveNoUnknownKeys(t *testing.T) {
+	// Paths are relative to internal/config.
+	for _, rel := range []string{
+		filepath.Join("..", "..", "config.yaml"),
+		filepath.Join("..", "..", "examples", "ferret.yaml"),
+		filepath.Join("..", "..", "examples", "ferret-windows.yaml"),
+	} {
+		t.Run(filepath.Base(filepath.Dir(rel))+"/"+filepath.Base(rel), func(t *testing.T) {
+			if _, err := os.Stat(rel); err != nil {
+				t.Skipf("%s not found: %v", rel, err)
+			}
+
+			cfg, err := LoadConfig(rel)
+			if err != nil {
+				t.Fatalf("%s must load: %v", rel, err)
+			}
+			if len(cfg.UnknownKeys) != 0 {
+				t.Errorf("%s contains keys the schema does not recognize: %v\n"+
+					"Either wire the key up or drop it from the file — shipping a "+
+					"documented no-op is how these went unnoticed.", rel, cfg.UnknownKeys)
+			}
+		})
+	}
+}
+
+// TestPlatformTempDirIsApplied covers the `platform:` block, which was validated
+// (a bad path was rejected) and then never applied: GetEffectiveTempDir and
+// GetEffectiveConfigDir had zero callers, so a good path was ignored.
+func TestPlatformTempDirIsApplied(t *testing.T) {
+	// Restore the process-wide override so this test cannot leak into others.
+	t.Cleanup(func() { paths.SetTempDirOverride("") })
+
+	want := filepath.Join(t.TempDir(), "ferret-temp")
+	body := "platform:\n  unix:\n    temp_dir: " + quoteYAML(want) + "\n"
+	if runtime.GOOS == "windows" {
+		body = "platform:\n  windows:\n    temp_dir: " + quoteYAML(want) + "\n"
+	}
+
+	cfg, err := LoadConfig(writeConfig(t, body))
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	if got := GetEffectiveTempDir(cfg); got != want {
+		t.Errorf("GetEffectiveTempDir() = %q, want %q", got, want)
+	}
+	// The real assertion: the override must reach the package everything else
+	// calls. GetEffectiveTempDir returning the right value while paths.GetTempDir
+	// ignores it is exactly the state this test exists to prevent.
+	if got := paths.GetTempDir(); got != want {
+		t.Errorf("paths.GetTempDir() = %q, want %q — loading a config with a "+
+			"platform temp_dir must change the directory the rest of the program uses",
+			got, want)
+	}
+}
+
+// TestRejectedConfigDoesNotPublishTempDir covers the ordering hazard created by
+// making the temp dir a process-wide override: a config that fails validation must
+// not leave the process pointing at a directory no accepted config ever named.
+// Publishing before ValidateConfig would do exactly that — including when the
+// rejected key IS the temp dir.
+func TestRejectedConfigDoesNotPublishTempDir(t *testing.T) {
+	t.Cleanup(func() { paths.SetTempDirOverride("") })
+
+	paths.SetTempDirOverride("")
+	before := paths.GetTempDir()
+
+	// An embedded NUL makes ValidateConfig reject the path — and the rejected key
+	// is the temp dir itself, which is the case that matters: publishing before
+	// validation would point the process at a path the validator just refused.
+	leak := filepath.Join(t.TempDir(), "should-not-leak")
+	osKey := "unix"
+	if runtime.GOOS == "windows" {
+		osKey = "windows"
+	}
+	body := "platform:\n  " + osKey + ":\n    temp_dir: \"" + leak + "\\0bad\"\n"
+
+	if _, err := LoadConfig(writeConfig(t, body)); err == nil {
+		t.Fatal("expected the invalid temp_dir path to be rejected")
+	}
+
+	if got := paths.GetTempDir(); got != before {
+		t.Errorf("paths.GetTempDir() = %q after a REJECTED config, want the previous "+
+			"value %q — a config that was refused must not mutate process state", got, before)
+	}
+}
+
+// TestPlatformTempDirAbsentLeavesDefault makes sure the override is not applied
+// unconditionally, which would silently redirect every scan's temp files.
+func TestPlatformTempDirAbsentLeavesDefault(t *testing.T) {
+	t.Cleanup(func() { paths.SetTempDirOverride("") })
+
+	// Seed a stale override so a no-op loader would be caught.
+	paths.SetTempDirOverride(filepath.Join(t.TempDir(), "stale"))
+
+	cfg, err := LoadConfig(writeConfig(t, "defaults:\n  format: json\n"))
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("nil config")
+	}
+
+	if got, def := paths.GetTempDir(), osTempDir(); got != def {
+		t.Errorf("paths.GetTempDir() = %q after loading a config with no platform "+
+			"temp_dir, want the platform default %q — a config that says nothing "+
+			"must not redirect temp files", got, def)
+	}
+}
+
+// osTempDir is the platform default, read without the config override.
+func osTempDir() string {
+	paths.SetTempDirOverride("")
+	return paths.GetTempDir()
+}
+
+// quoteYAML renders s as a single-quoted YAML scalar, so Windows backslashes are
+// not read as escapes.
+func quoteYAML(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}

--- a/internal/config/dead_options_test.go
+++ b/internal/config/dead_options_test.go
@@ -37,6 +37,16 @@ func writeConfig(t *testing.T, body string) string {
 // `audit_log_file`. Setting the documented name wrote to a field nothing read,
 // so no log was produced and no error was reported.
 func TestAuditLogFileIsHonored(t *testing.T) {
+	// LoadConfig runs ApplyPlatformDefaults, which normalizes IndexFile — on
+	// Windows "/tmp/x.json" comes back as "\tmp\x.json". Compare on the
+	// normalized form so these assertions test the ALIAS rather than the
+	// separator convention of whichever OS runs the suite.
+	//
+	// filepath.Clean, not FromSlash: it is what both platform normalizers
+	// actually call, so the expectation cannot drift from the implementation on
+	// inputs where the two differ (".", "..", repeated separators).
+	norm := filepath.Clean
+
 	t.Run("alias fills an empty index_file", func(t *testing.T) {
 		cfg, err := LoadConfig(writeConfig(t, `
 redaction:
@@ -45,7 +55,7 @@ redaction:
 		if err != nil {
 			t.Fatalf("LoadConfig: %v", err)
 		}
-		if cfg.Redaction.IndexFile != "/tmp/ferret-audit.json" {
+		if cfg.Redaction.IndexFile != norm("/tmp/ferret-audit.json") {
 			t.Errorf("audit_log_file did not reach IndexFile: got %q — the redaction log "+
 				"is driven by IndexFile, so an unread alias means no log file is written",
 				cfg.Redaction.IndexFile)
@@ -61,7 +71,7 @@ redaction:
 		if err != nil {
 			t.Fatalf("LoadConfig: %v", err)
 		}
-		if cfg.Redaction.IndexFile != "/tmp/from-index.json" {
+		if cfg.Redaction.IndexFile != norm("/tmp/from-index.json") {
 			t.Errorf("IndexFile = %q, want the explicit index_file value: it is the name "+
 				"the loader has always honored, so it must not be clobbered by the alias",
 				cfg.Redaction.IndexFile)
@@ -80,7 +90,7 @@ profiles:
 			t.Fatalf("LoadConfig: %v", err)
 		}
 		got := cfg.Profiles["audited"].Redaction.IndexFile
-		if got != "/tmp/profile-audit.json" {
+		if got != norm("/tmp/profile-audit.json") {
 			t.Errorf("profile audit_log_file did not reach IndexFile: got %q", got)
 		}
 	})

--- a/internal/core/factory.go
+++ b/internal/core/factory.go
@@ -85,24 +85,35 @@ func BuildValidatorSet(enabledChecks map[string]bool, cfg *config.Config, profil
 
 	// Apply global config-level validator settings
 	if cfg != nil {
-		if v, ok := result["CLOUD_RESOURCES"].(*cloudresources.Validator); ok {
-			v.Configure(cfg)
-		}
-		if v, ok := result["INTELLECTUAL_PROPERTY"].(*intellectualproperty.Validator); ok {
-			v.Configure(cfg)
-		}
-		if v, ok := result["SOCIAL_MEDIA"].(*socialmedia.Validator); ok {
-			v.Configure(cfg)
-		}
+		configureConfigurableValidators(result, cfg)
 	}
 
-	// Apply profile-level overrides
+	// Apply profile-level overrides. This must cover the SAME validators as the
+	// global pass: it previously reached only INTELLECTUAL_PROPERTY, so a profile
+	// that configured cloud_resources or social_media was silently ignored while
+	// the identical block at the top level worked.
+	//
+	// Each Configure returns early when its own section is absent, so passing a
+	// profile-only config overrides just the sections the profile actually sets
+	// and leaves the global settings for the others in place.
 	if profile != nil && profile.Validators != nil {
-		profileCfg := &config.Config{Validators: profile.Validators}
-		if v, ok := result["INTELLECTUAL_PROPERTY"].(*intellectualproperty.Validator); ok {
-			v.Configure(profileCfg)
-		}
+		configureConfigurableValidators(result, &config.Config{Validators: profile.Validators})
 	}
 
 	return result
+}
+
+// configureConfigurableValidators hands cfg to every validator that reads the
+// `validators:` config block. Keeping this in one place is what stops the
+// global and profile passes from drifting apart again.
+func configureConfigurableValidators(result map[string]detector.Validator, cfg *config.Config) {
+	if v, ok := result["CLOUD_RESOURCES"].(*cloudresources.Validator); ok {
+		v.Configure(cfg)
+	}
+	if v, ok := result["INTELLECTUAL_PROPERTY"].(*intellectualproperty.Validator); ok {
+		v.Configure(cfg)
+	}
+	if v, ok := result["SOCIAL_MEDIA"].(*socialmedia.Validator); ok {
+		v.Configure(cfg)
+	}
 }

--- a/internal/core/factory_profile_config_test.go
+++ b/internal/core/factory_profile_config_test.go
@@ -1,0 +1,162 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package core
+
+import (
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/config"
+)
+
+// Three validators read the `validators:` config block: CLOUD_RESOURCES,
+// INTELLECTUAL_PROPERTY and SOCIAL_MEDIA. BuildValidatorSet applied the global
+// block to all three but the profile-level block to INTELLECTUAL_PROPERTY only,
+// so the identical YAML worked at the top level and did nothing inside a profile.
+//
+// These tests drive the validators through BuildValidatorSet, because the bug was
+// in the wiring rather than in any validator.
+
+// profileWith returns a profile carrying just the given validators block.
+func profileWith(validators map[string]map[string]interface{}) *config.Profile {
+	return &config.Profile{
+		Description: "test",
+		Validators:  validators,
+	}
+}
+
+// TestProfileValidatorConfigReachesCloudResources is the regression: a custom
+// pattern set in a profile was dropped, so a resource the user asked to detect
+// was not reported — and an unreported finding is never handed to the redactor.
+func TestProfileValidatorConfigReachesCloudResources(t *testing.T) {
+	const marker = "ZZQQ-9911-CUSTOM"
+	validators := map[string]map[string]interface{}{
+		"cloud_resources": {
+			// custom_patterns is a list of plain regex strings.
+			"custom_patterns": []interface{}{`ZZQQ-[0-9]{4}-CUSTOM`},
+		},
+	}
+
+	set := BuildValidatorSet(
+		map[string]bool{"CLOUD_RESOURCES": true},
+		&config.Config{},
+		profileWith(validators),
+	)
+
+	v, ok := set["CLOUD_RESOURCES"]
+	if !ok {
+		t.Fatal("CLOUD_RESOURCES validator was not built")
+	}
+
+	matches, err := v.ValidateContent("resource marker "+marker+" here", "probe.txt")
+	if err != nil {
+		t.Fatalf("ValidateContent: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Error("a custom_patterns entry set in a PROFILE produced no findings; the " +
+			"identical block at the top level works, so the profile's validator " +
+			"config was dropped")
+	}
+}
+
+// TestProfileValidatorConfigReachesSocialMedia covers the second dropped
+// validator. SOCIAL_MEDIA is config-gated — with no platform_patterns it returns
+// immediately — so a profile-only block being ignored leaves it entirely inert.
+func TestProfileValidatorConfigReachesSocialMedia(t *testing.T) {
+	validators := map[string]map[string]interface{}{
+		"social_media": {
+			// Each platform takes a LIST of patterns, not a scalar.
+			"platform_patterns": map[string]any{
+				"twitter": []any{`https://twitter\.com/[A-Za-z0-9_]+`},
+			},
+		},
+	}
+
+	set := BuildValidatorSet(
+		map[string]bool{"SOCIAL_MEDIA": true},
+		&config.Config{},
+		profileWith(validators),
+	)
+
+	v, ok := set["SOCIAL_MEDIA"]
+	if !ok {
+		t.Fatal("SOCIAL_MEDIA validator was not built")
+	}
+
+	matches, err := v.ValidateContent("profile https://twitter.com/probeuser1 here", "probe.txt")
+	if err != nil {
+		t.Fatalf("ValidateContent: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Error("platform_patterns set in a PROFILE produced no findings; this validator " +
+			"is config-gated, so dropping the profile block leaves it permanently inert")
+	}
+}
+
+// TestProfileValidatorConfigReachesIntellectualProperty pins the one validator
+// that already worked, so the refactor that generalized the profile pass cannot
+// regress it.
+func TestProfileValidatorConfigReachesIntellectualProperty(t *testing.T) {
+	validators := map[string]map[string]interface{}{
+		"intellectual_property": {
+			"internal_urls": []interface{}{`internal\.example\.invalid`},
+		},
+	}
+
+	set := BuildValidatorSet(
+		map[string]bool{"INTELLECTUAL_PROPERTY": true},
+		&config.Config{},
+		profileWith(validators),
+	)
+
+	v, ok := set["INTELLECTUAL_PROPERTY"]
+	if !ok {
+		t.Fatal("INTELLECTUAL_PROPERTY validator was not built")
+	}
+
+	matches, err := v.ValidateContent("see https://wiki.internal.example.invalid/page", "probe.txt")
+	if err != nil {
+		t.Fatalf("ValidateContent: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Error("internal_urls set in a profile produced no findings — this path already " +
+			"worked before the profile pass was generalized")
+	}
+}
+
+// TestGlobalValidatorConfigStillApplies guards the other direction: the profile
+// pass must not clobber global settings for sections the profile does not mention.
+// Each Configure returns early on a missing section, which is what makes the
+// second pass safe.
+func TestGlobalValidatorConfigStillApplies(t *testing.T) {
+	global := &config.Config{
+		Validators: map[string]map[string]interface{}{
+			"cloud_resources": {
+				"custom_patterns": []interface{}{`ZZQQ-[0-9]{4}-CUSTOM`},
+			},
+		},
+	}
+	// The profile configures a DIFFERENT validator, so cloud_resources must keep
+	// the global pattern.
+	profile := profileWith(map[string]map[string]interface{}{
+		"intellectual_property": {
+			"internal_urls": []interface{}{`internal\.example\.invalid`},
+		},
+	})
+
+	set := BuildValidatorSet(
+		map[string]bool{"CLOUD_RESOURCES": true, "INTELLECTUAL_PROPERTY": true},
+		global,
+		profile,
+	)
+
+	matches, err := set["CLOUD_RESOURCES"].ValidateContent("marker ZZQQ-9911-CUSTOM here", "probe.txt")
+	if err != nil {
+		t.Fatalf("ValidateContent: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Error("a global cloud_resources pattern was lost once a profile configured " +
+			"some other validator; the profile pass must override only the sections " +
+			"the profile actually sets")
+	}
+}

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -6,9 +6,44 @@ package paths
 import (
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/awslabs/ferret-scan/v2/internal/platform"
 )
+
+// tempDirOverride is the platform-specific temp directory from the config file's
+// `platform:` block, if one was set.
+//
+// It is package state rather than a parameter because internal/config imports
+// this package, so this package cannot import internal/config to read the value
+// directly. The loader pushes it in with SetTempDirOverride once the config is
+// parsed. This mirrors the FERRET_CONFIG_DIR environment override below: a
+// process-wide setting, read from everywhere.
+//
+// The mutex is load-bearing, not defensive. Config loading is not confined to
+// startup: the web server falls back to a per-request LoadConfigOrDefault, and
+// pkg/scan calls it on every exported entry point, so a caller scanning from
+// several goroutines writes this while other goroutines read it.
+var (
+	tempDirMu       sync.RWMutex
+	tempDirOverride string
+)
+
+// SetTempDirOverride records the config file's platform-specific temp directory.
+// An empty value clears the override. Called by the config loader; the config's
+// `platform:` block was previously validated and then ignored.
+func SetTempDirOverride(dir string) {
+	tempDirMu.Lock()
+	defer tempDirMu.Unlock()
+	tempDirOverride = dir
+}
+
+// tempDirOverrideValue reads the override under the lock.
+func tempDirOverrideValue() string {
+	tempDirMu.RLock()
+	defer tempDirMu.RUnlock()
+	return tempDirOverride
+}
 
 // GetConfigDir returns the ferret-scan configuration directory
 // Uses platform-specific logic for Windows APPDATA directories and Unix home directories
@@ -33,8 +68,12 @@ func GetSuppressionsFile() string {
 	return filepath.Join(GetConfigDir(), "suppressions.yaml")
 }
 
-// GetTempDir returns the platform-appropriate temporary directory
+// GetTempDir returns the temporary directory, preferring the config file's
+// platform-specific override when one is set.
 func GetTempDir() string {
+	if dir := tempDirOverrideValue(); dir != "" {
+		return dir
+	}
 	p := platform.GetPlatform()
 	return p.GetTempDir()
 }

--- a/internal/paths/tempdir_override_race_test.go
+++ b/internal/paths/tempdir_override_race_test.go
@@ -1,0 +1,80 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package paths
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestTempDirOverrideConcurrentAccess exercises SetTempDirOverride against
+// GetTempDir from many goroutines, so `go test -race` can see the access pattern.
+//
+// This test exists because the override is process-wide package state and config
+// loading is NOT confined to startup: internal/web falls back to a per-request
+// LoadConfigOrDefault, and every pkg/scan entry point loads a config. A library
+// caller scanning from several goroutines therefore writes this while others read
+// it. Without the mutex this test fails under -race; the rest of the suite does
+// not, because nothing else touches the override concurrently.
+func TestTempDirOverrideConcurrentAccess(t *testing.T) {
+	t.Cleanup(func() { SetTempDirOverride("") })
+
+	const goroutines = 16
+	const iterations = 200
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 2)
+
+	for i := 0; i < goroutines; i++ {
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				// Alternate between setting and clearing, so readers see both.
+				if j%2 == 0 {
+					SetTempDirOverride("/tmp/ferret-probe")
+				} else {
+					SetTempDirOverride("")
+				}
+			}
+		}(i)
+
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				// The value is racing by design; only that it is read safely
+				// (and non-empty) matters here.
+				if got := GetTempDir(); got == "" {
+					t.Error("GetTempDir returned an empty path")
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestSetTempDirOverrideRoundTrip pins the basic contract the config loader
+// depends on: a set value is returned, and an empty value restores the platform
+// default rather than yielding an empty path.
+func TestSetTempDirOverrideRoundTrip(t *testing.T) {
+	t.Cleanup(func() { SetTempDirOverride("") })
+
+	SetTempDirOverride("")
+	platformDefault := GetTempDir()
+	if platformDefault == "" {
+		t.Fatal("the platform default temp dir is empty")
+	}
+
+	SetTempDirOverride("/tmp/ferret-override")
+	if got := GetTempDir(); got != "/tmp/ferret-override" {
+		t.Errorf("GetTempDir() = %q, want the override", got)
+	}
+
+	SetTempDirOverride("")
+	if got := GetTempDir(); got != platformDefault {
+		t.Errorf("GetTempDir() = %q after clearing the override, want the platform "+
+			"default %q — clearing must not leave an empty path", got, platformDefault)
+	}
+}

--- a/tests/integration/config_unknown_keys_test.go
+++ b/tests/integration/config_unknown_keys_test.go
@@ -1,0 +1,240 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/tests/helpers"
+)
+
+// A config file with a misspelled option used to be indistinguishable from a
+// working one: yaml.Unmarshal ignores unknown keys, so the setting was silently
+// never applied. These tests pin where the resulting warning is and is not
+// allowed to appear, because stderr is a human channel in some invocation shapes
+// and a machine-readable data channel in others.
+
+const unknownKeyConfig = `defaults:
+  format: json
+  shwo_match: true
+bogus_block:
+  x: 1
+`
+
+// writeUnknownKeyConfig writes a config carrying two unknown keys plus a scan
+// target, and returns their paths.
+func writeUnknownKeyConfig(t *testing.T) (cfgPath, targetPath string) {
+	t.Helper()
+	dir := t.TempDir()
+
+	cfgPath = filepath.Join(dir, "cfg.yaml")
+	if err := os.WriteFile(cfgPath, []byte(unknownKeyConfig), 0o600); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+
+	targetPath = filepath.Join(dir, "target.txt")
+	if err := os.WriteFile(targetPath, []byte("ssn 449-87-4100\n"), 0o600); err != nil {
+		t.Fatalf("writing target: %v", err)
+	}
+	return cfgPath, targetPath
+}
+
+// TestUnknownConfigKeysWarnInCI is the important case. CI is never interactive,
+// and it is exactly where a config that silently fails to apply does the most
+// damage — the scan looks configured and is not. So this warning deliberately
+// does NOT ride the progress-output gate, which treats non-interactive as quiet.
+func TestUnknownConfigKeysWarnInCI(t *testing.T) {
+	helpers.SetupTestMode()
+	defer helpers.CleanupTestMode()
+
+	bin := stdinBinary(t)
+	cfgPath, targetPath := writeUnknownKeyConfig(t)
+
+	cmd := exec.Command(bin, "--file", targetPath, "--config", cfgPath, "--format", "json")
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("scan failed: %v\nstderr=%s", err, stderr.String())
+	}
+
+	for _, key := range []string{"shwo_match", "bogus_block"} {
+		if !strings.Contains(stderr.String(), key) {
+			t.Errorf("stderr does not warn about unknown key %q; a misspelled option "+
+				"that is silently ignored looks exactly like one that works\nstderr=%s",
+				key, stderr.String())
+		}
+	}
+
+	// The warning must never contaminate the results document.
+	if strings.Contains(stdout.String(), "unknown config key") {
+		t.Errorf("the warning leaked onto stdout, which carries the results document:\n%s",
+			stdout.String())
+	}
+	var doc struct {
+		Results []map[string]any `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(stdout.String())), &doc); err != nil {
+		t.Errorf("stdout is no longer parseable JSON: %v\n%s", err, stdout.String())
+	}
+}
+
+// TestUnknownConfigKeysSilentInStdinRedaction guards the shape where stderr is
+// the findings document rather than a human channel: with --stdin
+// --enable-redaction and no --output, redacted bytes go to stdout and the
+// findings JSON goes to stderr, so any prose there breaks `2> findings.json`.
+func TestUnknownConfigKeysSilentInStdinRedaction(t *testing.T) {
+	helpers.SetupTestMode()
+	defer helpers.CleanupTestMode()
+
+	bin := stdinBinary(t)
+	cfgPath, _ := writeUnknownKeyConfig(t)
+
+	_, stderr, code := runStdinSeparateStreams(t, bin,
+		"ssn 449-87-4100\n",
+		"--stdin", "--config", cfgPath, "--enable-redaction",
+		"--redaction-strategy", "simple", "--confidence", "all", "--format", "json")
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d. stderr=%s", code, stderr)
+	}
+
+	trimmed := strings.TrimSpace(stderr)
+	if !strings.HasPrefix(trimmed, "{") && !strings.HasPrefix(trimmed, "[") {
+		t.Fatalf("stderr must stay a parseable document in streaming-redaction mode, "+
+			"got prose first: %q", trimmed[:min(len(trimmed), 120)])
+	}
+	if strings.Contains(trimmed, "unknown config key") {
+		t.Error("the unknown-key warning was written to stderr while stderr carries " +
+			"the findings document; it must be suppressed in this mode")
+	}
+}
+
+// TestUnknownConfigKeysSilentInPrecommit pins the one mode that is allowed to
+// stay quiet: pre-commit output is deliberately minimal, and the same exemption
+// applies to the incomplete-coverage warning.
+func TestUnknownConfigKeysSilentInPrecommit(t *testing.T) {
+	helpers.SetupTestMode()
+	defer helpers.CleanupTestMode()
+
+	bin := stdinBinary(t)
+	cfgPath, targetPath := writeUnknownKeyConfig(t)
+
+	cmd := exec.Command(bin, "--file", targetPath, "--config", cfgPath, "--pre-commit-mode")
+	cmd.Env = append(os.Environ(), "PRE_COMMIT=1")
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	// Exit code is irrelevant here: pre-commit mode returns non-zero on findings.
+	_ = cmd.Run()
+
+	if strings.Contains(stderr.String(), "unknown config key") {
+		t.Errorf("pre-commit mode must not emit the unknown-key warning:\n%s", stderr.String())
+	}
+}
+
+// TestStdinHonorsSuppressionsFile covers the config-file path to the suppression
+// file in stdin mode. cmd/stdin.go built its suppression manager straight from
+// the flag, ignoring the value resolveConfiguration had just computed two lines
+// earlier — the same read-the-flag-not-the-config defect this change exists to
+// remove, in the one mode that was missed.
+func TestStdinHonorsSuppressionsFile(t *testing.T) {
+	helpers.SetupTestMode()
+	defer helpers.CleanupTestMode()
+
+	bin := stdinBinary(t)
+	dir := t.TempDir()
+
+	supPath := filepath.Join(dir, "generated-suppressions.yaml")
+	cfgPath := filepath.Join(dir, "cfg.yaml")
+	cfg := "defaults:\n  format: json\nsuppressions:\n  file: " +
+		strconv.Quote(supPath) + "\n  generate_on_scan: true\n"
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+
+	_, stderr, code := runStdinSeparateStreams(t, bin,
+		"ssn 449-87-4100\n",
+		"--stdin", "--config", cfgPath, "--confidence", "all", "--format", "json")
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d. stderr=%s", code, stderr)
+	}
+
+	if _, err := os.Stat(supPath); err != nil {
+		t.Errorf("suppressions.file + generate_on_scan produced no file at %s in stdin "+
+			"mode: %v\nstderr=%s", supPath, err, stderr)
+	}
+}
+
+// TestValidConfigWarnsAboutNothing is the false-positive guard: a warning that
+// fires on a correct config trains users to ignore it.
+func TestValidConfigWarnsAboutNothing(t *testing.T) {
+	helpers.SetupTestMode()
+	defer helpers.CleanupTestMode()
+
+	bin := stdinBinary(t)
+	dir := t.TempDir()
+
+	cfgPath := filepath.Join(dir, "cfg.yaml")
+	valid := "defaults:\n  format: json\n  show_match: true\n"
+	if err := os.WriteFile(cfgPath, []byte(valid), 0o600); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+	targetPath := filepath.Join(dir, "target.txt")
+	if err := os.WriteFile(targetPath, []byte("ssn 449-87-4100\n"), 0o600); err != nil {
+		t.Fatalf("writing target: %v", err)
+	}
+
+	cmd := exec.Command(bin, "--file", targetPath, "--config", cfgPath, "--format", "json")
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("scan failed: %v\nstderr=%s", err, stderr.String())
+	}
+
+	if strings.Contains(stderr.String(), "unknown config key") {
+		t.Errorf("a fully valid config produced an unknown-key warning:\n%s", stderr.String())
+	}
+}
+
+// TestShippedConfigWarnsAboutNothing pins that the config we ship validates
+// against our own schema. It did not: `audit_log_file` and the whole
+// `suppressions:` block had no struct fields, so the project's own example
+// documented settings that did nothing.
+func TestShippedConfigWarnsAboutNothing(t *testing.T) {
+	helpers.SetupTestMode()
+	defer helpers.CleanupTestMode()
+
+	shipped, err := filepath.Abs(filepath.Join("..", "..", "config.yaml"))
+	if err != nil {
+		t.Fatalf("resolving shipped config: %v", err)
+	}
+	if _, err := os.Stat(shipped); err != nil {
+		t.Skipf("shipped config.yaml not found: %v", err)
+	}
+
+	bin := stdinBinary(t)
+	dir := t.TempDir()
+	targetPath := filepath.Join(dir, "target.txt")
+	if err := os.WriteFile(targetPath, []byte("ssn 449-87-4100\n"), 0o600); err != nil {
+		t.Fatalf("writing target: %v", err)
+	}
+
+	cmd := exec.Command(bin, "--file", targetPath, "--config", shipped, "--format", "json")
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("scanning with the shipped config failed: %v\nstderr=%s", err, stderr.String())
+	}
+
+	if strings.Contains(stderr.String(), "unknown config key") {
+		t.Errorf("the shipped config.yaml contains keys our own schema rejects:\n%s\n"+
+			"Either wire the key up or drop it from the example — shipping a "+
+			"documented no-op is how these went unnoticed.", stderr.String())
+	}
+}

--- a/tests/integration/windows_release_comprehensive_test.go
+++ b/tests/integration/windows_release_comprehensive_test.go
@@ -349,8 +349,6 @@ defaults:
 
 platform:
   windows:
-    use_appdata: true
-    long_path_support: false
     temp_dir: "%TEMP%\\ferret-scan"
 
 profiles:

--- a/tests/integration/windows_release_validation_test.go
+++ b/tests/integration/windows_release_validation_test.go
@@ -408,8 +408,6 @@ defaults:
 # Platform-specific settings
 platform:
   windows:
-    use_appdata: true
-    long_path_support: true
     temp_dir: "C:\\Windows\\Temp\\ferret-scan"
 `
 


### PR DESCRIPTION
## What

An audit of all 64 config keys found **ten that were parsed and then ignored**. A key that unmarshals into a field nothing reads is indistinguishable from one that works: no error, no effect, and the setting is simply never applied. Two were in the config we ship to users, and one silently discarded a file path the user asked for.

Each option was either **wired up** or **removed** — and removal means gone from the code, all three shipped configs, and the six docs that documented it.

## Wired up

| Option | Was | Now |
|---|---|---|
| `redaction.audit_log_file` | wrote to a field nothing read → no log, no error | feeds the redaction log |
| `suppressions:` (3 keys) | no struct field at all → dropped by the decoder | parsed and honored |
| `platform.{windows,unix}.temp_dir` | validated, then ignored | reaches `paths.GetTempDir` |
| profile-level `validators:` | only reached `INTELLECTUAL_PROPERTY` | also `CLOUD_RESOURCES`, `SOCIAL_MEDIA` |

Details worth review:

- **`audit_log_file`** — the struct field has always been `index_file`, while the shipped config, every doc, and the `--redaction-audit-log` flag all call it `audit_log_file`. The mismatch dates to the initial commit. It is now an alias; `index_file` wins if both are set.
- **`suppressions:`** — `cmd/stdin.go` also built its suppression manager straight from the flag, ignoring the value `resolveConfiguration` had computed two lines earlier. `defaults.*` and `suppressions.*` OR together: either can enable, neither can disable, because both default to false and an explicit `false` is indistinguishable from an absent key.
- **`platform:`** — `GetEffectiveTempDir`/`GetEffectiveConfigDir` had **zero callers**, so a bad path was *rejected* while a good one was *ignored*. The override is published only after validation, so a refused config cannot leave the process pointing at a directory it named.
- **profile `validators:`** — identical YAML worked at the top level and did nothing in a profile. `SOCIAL_MEDIA` is config-gated, so for it the drop left the validator inert. Each `Configure` returns early on a missing section, so the profile pass overrides only what the profile sets.

## Removed

- `redaction.strategies.*` — each strategy's behavior is fixed. `simple`'s per-type marker is deliberate (a single replacement string would discard the type), `format_preserving` already preserves length *and* format, and `synthetic` already uses `crypto/rand` unconditionally.
- `redaction.memory_scrub` / `audit_trail` — no implementation exists anywhere; the working equivalent is the redaction log.
- `preprocessors.text_extraction.types` — its values (`pdf`, `office`) never matched any registered preprocessor name (`pdf_metadata`, `office_metadata`).
- 6 platform keys (`use_appdata`, `system_wide_install`, `create_shortcuts`, `add_to_path`, `long_path_support`, `use_xdg`) — installer concerns no installer, including our own scripts, ever read.

## Unknown keys now warn

A typo'd option used to pass in silence. It is a **warning, not an error**, on purpose: erroring would reject configs written for another version — including this project's own `config.yaml`, which strict decoding refused at exactly the two keys above.

Gated only on pre-commit mode, **not** on quiet/non-interactive — the same rule as the incomplete-coverage warning, because CI is where a config that silently fails to apply does the most damage and CI is never interactive. Goes to stderr, never changes the exit code, and is suppressed in stdin redaction mode where stderr carries the findings document.

`examples/ferret.yaml` matters most here: `make install` copies it to the user's config directory, so an unknown key there would mean a warning on every scan for every installed user.

## Verification

- Detection and redaction output are **byte-identical** on the same input; golden corpus unchanged.
- **Every fix proven load-bearing** by reverting it and confirming the matching test fails — including the ordering fix (a rejected NUL-containing path became the process temp dir) and the `stdin` suppression path.
- `paths.SetTempDirOverride` is mutex-guarded because config loading is **not** confined to startup: the web server has a per-request fallback and `pkg/scan` loads on every entry point. Without the lock the new concurrency test fails under `-race`.
- Full suite, `go vet`, `gofmt`, `-race` on all changed packages, and the golden corpus all pass.

## Test plan

Per `docs/testing/TEST_PLAN.md`:

- [x] Regression — full suite green; golden corpus unchanged
- [x] Behavior neutrality — redaction output byte-identical for all 3 strategies
- [x] Non-vacuity — each fix reverted individually, matching test fails
- [x] Redaction — all 3 strategies exercised; audit log written
- [x] Suppression — generate + show + file path, in file *and* stdin mode
- [x] All outputs — stdout stays parseable JSON in every mode
- [x] Determinism / race — `-race` on the 4 changed packages, plus a new concurrency test
- [x] Cross-platform — platform block tested per-OS; YAML paths single-quoted so Windows backslashes are not escapes
- [x] Dead code — 10 dead options removed, no new dead code

🤖 Generated with [Claude Code](https://claude.com/claude-code)