### PR TITLE
fix: honor the config file in web mode, and stop calling an unreadable file 'unsupported'

### DIFF
--- a/cmd/fail_on_incomplete_config_test.go
+++ b/cmd/fail_on_incomplete_config_test.go
@@ -49,3 +49,27 @@ func TestResolveConfiguration_FailOnIncomplete(t *testing.T) {
 		}
 	})
 }
+
+// TestResolveIncompleteExitCode_CountsUnreadableFiles pins that a file which could
+// not be OPENED escalates the exit code the same way a cut-short scan does.
+//
+// The two are the same class of problem from the caller's point of view — findings
+// may be missing — and the unreadable case is the more severe of the pair: a
+// cut-short scan examined part of the file, an unreadable one was never examined at
+// all. Before this, an unreadable file left the exit code at 0 and printed "No
+// matches found", so CI treated a file the scanner never opened as clean.
+func TestResolveIncompleteExitCode_CountsUnreadableFiles(t *testing.T) {
+	// The production call site passes len(incompleteFiles)+len(unreadableFiles);
+	// this asserts the policy those counts feed.
+	if got := resolveIncompleteExitCode(0, true, 1); got != exitCodeIncompleteCoverage {
+		t.Errorf("one coverage gap with --fail-on-incomplete = %d, want %d",
+			got, exitCodeIncompleteCoverage)
+	}
+	if got := resolveIncompleteExitCode(0, false, 1); got != 0 {
+		t.Errorf("without --fail-on-incomplete the warning must stay advisory, got %d", got)
+	}
+	// A findings/error verdict is never downgraded to the coverage code.
+	if got := resolveIncompleteExitCode(1, true, 1); got != 1 {
+		t.Errorf("a non-zero base must not be replaced, got %d", got)
+	}
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -45,10 +45,11 @@ import (
 )
 
 // exitCodeIncompleteCoverage is returned when --fail-on-incomplete is set and at
-// least one file's validator coverage was cut short (timeout, cancellation, or a
-// per-validator budget). It is distinct from the other CLI exit codes — 0 (clean),
-// 1 (system/usage error), and 2 (no files to process) — so CI can tell degraded
-// coverage apart from a genuinely clean scan.
+// least one file was not fully scanned — either its validator coverage was cut short
+// (timeout, cancellation, or a per-validator budget) or the file could not be opened
+// at all (permissions, a dangling symlink, deletion mid-scan). It is distinct from
+// the other CLI exit codes — 0 (clean), 1 (system/usage error), and 2 (no files to
+// process) — so CI can tell degraded coverage apart from a genuinely clean scan.
 const exitCodeIncompleteCoverage = 3
 
 // resolveIncompleteExitCode applies the --fail-on-incomplete policy on top of a
@@ -716,6 +717,36 @@ func writeUnredactedFilesWarning(w io.Writer, unredactedFiles []parallel.FileDia
 	return true
 }
 
+// writeUnreadableFilesWarning emits a warning to w for every file that could not
+// be opened or stat'ed — a permission error, a dangling symlink, a file deleted
+// mid-scan. It returns true if a warning was written.
+//
+// This is the third member of the family alongside writeIncompleteCoverageWarning
+// and writeUnredactedFilesWarning, and it covers the earliest failure: the file was
+// never read at all. Before this existed, such a file was counted as an
+// "unsupported type", so scanning a directory of .txt files with one unreadable
+// member reported "1 files skipped (1 unsupported types)" — describing a supported
+// extension as an unrecognized format, and giving no hint that a file which may be
+// full of PII went unexamined. Scanning that file alone printed an empty result set
+// and exited 0: a clean bill of health for a file the tool never opened.
+//
+// Gated only on pre-commit mode, like its siblings — not on quiet or
+// non-interactive — because CI is exactly where an unnoticed unscanned file
+// matters. Goes to stderr (never stdout/JSON). It does not change the exit code by
+// itself, but these files are counted toward --fail-on-incomplete alongside
+// cut-short scans, so CI can opt into failing on them.
+func writeUnreadableFilesWarning(w io.Writer, unreadableFiles []string, totalFiles int) bool {
+	if len(unreadableFiles) == 0 {
+		return false
+	}
+	fmt.Fprintf(w, "WARNING: scan incomplete — %d of %d file(s) could not be opened, so they were not scanned at all; any sensitive data they contain was NOT detected:\n",
+		len(unreadableFiles), totalFiles)
+	for _, entry := range unreadableFiles {
+		fmt.Fprintf(w, "  %s\n", entry)
+	}
+	return true
+}
+
 // extractedFlags holds safely extracted flag values to avoid repeated nil checks
 type extractedFlags struct {
 	webMode              bool
@@ -871,7 +902,7 @@ func main() {
 	showSuppressed := flag.Bool("show-suppressed", false, "Include suppressed findings in output with suppression details (marked as [SUPP] in text format)")
 	quiet := flag.Bool("quiet", false, "Suppress progress output (useful for scripts and CI/CD)")
 	precommitMode := flag.Bool("pre-commit-mode", false, "Enable pre-commit optimizations (quiet mode, no colors, appropriate exit codes)")
-	failOnIncomplete := flag.Bool("fail-on-incomplete", false, "Exit non-zero (3) if any file's validator coverage was cut short (timeout, cancellation, or budget). Default off: incomplete coverage only warns on stderr.")
+	failOnIncomplete := flag.Bool("fail-on-incomplete", false, "Exit non-zero (3) if any file was not fully scanned — coverage cut short (timeout, cancellation, or budget) or the file could not be opened at all. Default off: both conditions only warn on stderr.")
 
 	// Redaction flags
 	enableRedaction := flag.Bool("enable-redaction", false, "Enable redaction of sensitive data found in documents")
@@ -1597,15 +1628,25 @@ func main() {
 	// Use parallel processing for all files (single or multiple)
 	parallelProcessor := parallel.NewParallelProcessor(observability.NewStandardObserver(observability.ObservabilityMetrics, os.Stderr))
 
-	// Filter supported files
+	// Filter supported files.
+	//
+	// Unreadable files are counted separately from unsupported ones. Collapsing the
+	// two made a permission-denied .txt report as "1 files skipped (1 unsupported
+	// types)" — a supported extension described as an unrecognized format — and gave
+	// the user no reason to look again at a file that was never scanned.
 	var supportedFiles []string
+	var unreadableFiles []string
 	for _, filePath := range filesToProcess {
-		canProcess, _ := fileRouter.CanProcessFile(filePath, finalConfig.enablePreprocessors)
+		canProcess, reason := fileRouter.CanProcessFile(filePath, finalConfig.enablePreprocessors)
 		if canProcess {
 			supportedFiles = append(supportedFiles, filePath)
-		} else {
-			skippedFiles++
+			continue
 		}
+		if strings.HasPrefix(reason, router.ReasonUnreadable) {
+			unreadableFiles = append(unreadableFiles, fmt.Sprintf("%s: %s", filePath, reason))
+			continue
+		}
+		skippedFiles++
 	}
 
 	// Handle preprocess-only mode - exit early after preprocessing
@@ -1722,6 +1763,7 @@ func main() {
 	// strict machine-readable output contract. Exit code is deliberately
 	// unchanged (default still 0) — this is an advisory warning.
 	if precommitConfig == nil {
+		writeUnreadableFilesWarning(os.Stderr, unreadableFiles, len(filesToProcess))
 		writeIncompleteCoverageWarning(os.Stderr, incompleteFiles, len(supportedFiles))
 		writeUnredactedFilesWarning(os.Stderr, unredactedFiles, len(supportedFiles))
 	}
@@ -1926,16 +1968,22 @@ func main() {
 	// Use pre-commit exit code logic if in pre-commit mode. --fail-on-incomplete
 	// (flag OR config/profile default) then escalates a clean result to the
 	// incomplete-coverage code without downgrading a findings/error verdict.
+	//
+	// A file that could not be OPENED counts as incomplete coverage too, and is the
+	// more severe case: a cut-short scan looked at part of the file, an unreadable
+	// one was never looked at. Both mean findings may be missing, so both feed the
+	// same opt-in escalation.
+	coverageGaps := len(incompleteFiles) + len(unreadableFiles)
 	if precommitConfig != nil {
 		exitCode := precommit.GetExitCode(hasFindings, hasErrors, highestConfidence, precommitConfig)
-		os.Exit(resolveIncompleteExitCode(exitCode, finalConfig.failOnIncomplete, len(incompleteFiles)))
+		os.Exit(resolveIncompleteExitCode(exitCode, finalConfig.failOnIncomplete, coverageGaps))
 	}
 
 	// Default behavior: exit 0 (findings are reported in output, not via exit code)
 	// unless --fail-on-incomplete escalates a cut-short scan to code 3. Distinct
 	// code lets CI tell "incomplete coverage" apart from clean (0), error (1), and
 	// no-files (2). Settable via --fail-on-incomplete or config fail_on_incomplete.
-	os.Exit(resolveIncompleteExitCode(0, finalConfig.failOnIncomplete, len(incompleteFiles)))
+	os.Exit(resolveIncompleteExitCode(0, finalConfig.failOnIncomplete, coverageGaps))
 }
 
 // parseConfidenceLevels delegates to core.ParseConfidenceLevels to avoid code duplication between CLI and web modes.

--- a/docs/PRE_COMMIT_INTEGRATION.md
+++ b/docs/PRE_COMMIT_INTEGRATION.md
@@ -114,10 +114,11 @@ When `--pre-commit-mode` is enabled, Ferret Scan automatically:
 - **Respects file filtering** - Only processes files passed by pre-commit's file filtering
 
 > **Tip — fail on incomplete coverage.** Add `--fail-on-incomplete` to make the
-> hook exit `3` when any file's validator coverage was cut short (a timeout,
-> cancellation, or per-validator budget), so a partially-scanned file blocks the
-> commit instead of passing silently. Without the flag, incomplete coverage only
-> prints a warning to stderr. It escalates an otherwise-clean pre-commit result to
+> hook exit `3` when any file was not fully scanned — either its validator coverage
+> was cut short (a timeout, cancellation, or per-validator budget) or the file could
+> not be opened at all (permissions, a dangling symlink) — so a partially-scanned or
+> unscanned file blocks the commit instead of passing silently. Without the flag,
+> both conditions only print a warning to stderr. It escalates an otherwise-clean pre-commit result to
 > `3` and never downgrades a findings-based non-zero exit.
 
 ## Environment Detection

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -236,7 +236,7 @@ Profiles now support all command-line options and include specialized configurat
 - `show_suppressed`: Include suppressed findings in output
 - `respect_gitignore`: Honor `.gitignore` files when scanning (opt-in; see [File Exclusion Patterns](#file-exclusion-patterns))
 - `generate_suppressions`: Auto-generate suppression rules
-- `fail_on_incomplete`: Exit with code `3` when a scan's validator coverage was cut short (timeout, cancellation, or a per-validator budget). Off by default; equivalent to the `--fail-on-incomplete` flag, which overrides this setting. See the README [Exit Codes](../README.md#exit-codes).
+- `fail_on_incomplete`: Exit with code `3` when any file was not fully scanned — either its validator coverage was cut short (timeout, cancellation, or a per-validator budget) or the file could not be opened at all (permissions, a dangling symlink, deletion mid-scan). Off by default; equivalent to the `--fail-on-incomplete` flag, which overrides this setting. See the README [Exit Codes](../README.md#exit-codes).
 
 ### CLI-Only Options (Not Configurable in YAML)
 
@@ -812,7 +812,7 @@ defaults:
   quiet: false
   show_suppressed: false
   generate_suppressions: false
-  fail_on_incomplete: false       # Exit code 3 if any file's coverage was cut short (timeout/budget)
+  fail_on_incomplete: false       # Exit code 3 if any file was cut short (timeout/budget) or could not be opened
   respect_gitignore: true         # Honor .gitignore, .git/info/exclude, global git excludes
 
   exclude_patterns:

--- a/internal/help/help.go
+++ b/internal/help/help.go
@@ -130,7 +130,7 @@ func (h *System) ShowGeneralHelp() {
 	fmt.Fprintln(w, "  --generate-suppressions\t\tGenerate suppression rules for all findings (disabled by default)")
 	fmt.Fprintln(w, "  --quiet\t\tSuppress progress output (useful for scripts and CI/CD)")
 	fmt.Fprintln(w, "  --pre-commit-mode\t\tEnable pre-commit optimizations (quiet mode, no colors, appropriate exit codes)")
-	fmt.Fprintln(w, "  --fail-on-incomplete\t\tExit non-zero (3) if any file's validator coverage was cut short (timeout, cancellation, or budget). Default off: incomplete coverage only warns on stderr.")
+	fmt.Fprintln(w, "  --fail-on-incomplete\t\tExit non-zero (3) if any file was not fully scanned -- coverage cut short (timeout, cancellation, or budget) or the file could not be opened at all. Default off: both conditions only warn on stderr.")
 	fmt.Fprintln(w, "  --disable-ip-types\t<types>\tComma-separated list of IP sub-types to skip: copyright,patent,trademark,trade_secret,internal_url")
 	fmt.Fprintln(w, "  --validator-budget\t<spec>\tPer-validator time budget as NAME=DURATION pairs; DURATION accepts any Go unit — ms, s, m, h (e.g. 'SSN=500ms,IP_ADDRESS=2m'). Use 'all=<dur>' for every validator, specific names override. Over-budget validators are stopped and the scan is marked incomplete. Default: none.")
 	fmt.Fprintln(w, "  --max-live-bytes\t<size>\tCap total extracted content held in memory across concurrently scanned files, e.g. '256MB' or '1GB' (units: B, KB, MB, GB; bare number = bytes). Bounds peak memory on constrained hosts so many large files cannot multiply memory. Default: no cap.")

--- a/internal/router/file_router.go
+++ b/internal/router/file_router.go
@@ -53,16 +53,34 @@ func (fr *FileRouter) InitializePreprocessors(config map[string]interface{}) {
 	fr.preprocessors = fr.registry.CreateAll(config)
 }
 
-// CanProcessFile determines if a file can be processed
+// ReasonUnreadable prefixes the reason returned when a file exists but cannot be
+// opened or stat'ed — a permission error, a broken symlink, a vanished file.
+//
+// It is deliberately distinct from "Unsupported file type". Those two are opposite
+// facts: an unsupported type is a file we looked at and chose not to scan, while an
+// unreadable file is one we never saw. Reporting the second as the first tells the
+// user their .txt is an unrecognized format and invites them to ignore it — when in
+// truth a file that may be full of PII went unscanned. Callers can test for this
+// prefix to separate "nothing to find here" from "we could not look".
+const ReasonUnreadable = "Unreadable"
+
+// CanProcessFile determines if a file can be processed. The second return value is
+// a human-readable reason; when it begins with ReasonUnreadable the file was not
+// examined at all, as opposed to examined and skipped.
 func (fr *FileRouter) CanProcessFile(filePath string, enablePreprocessors bool) (bool, string) {
 	ext := strings.ToLower(filepath.Ext(filePath))
 
-	// Check file size
+	// Check file size. A stat error here is the first sign the file cannot be read
+	// (permissions, a dangling symlink, a race with deletion). Previously it was
+	// swallowed by `err == nil` and execution fell through to the generic
+	// "Unsupported file type" at the bottom of this function.
 	cleanPath := filepath.Clean(filePath)
-	if info, err := os.Stat(cleanPath); err == nil {
-		if info.Size() > MaxFileSize {
-			return false, fmt.Sprintf("File too large (max: %dMB)", MaxFileSize/(1024*1024))
-		}
+	info, err := os.Stat(cleanPath)
+	if err != nil {
+		return false, fmt.Sprintf("%s: %v", ReasonUnreadable, err)
+	}
+	if info.Size() > MaxFileSize {
+		return false, fmt.Sprintf("File too large (max: %dMB)", MaxFileSize/(1024*1024))
 	}
 
 	// Binary documents require preprocessors
@@ -73,8 +91,15 @@ func (fr *FileRouter) CanProcessFile(filePath string, enablePreprocessors bool) 
 		return false, "Binary document (requires preprocessors)"
 	}
 
-	// Check if it's a text file
-	if isText, err := isTextFile(filePath); err == nil && isText {
+	// Check if it's a text file. Distinguish "read it, it is not text" from "could
+	// not read it": the old condition (err == nil && isText) collapsed both into
+	// the unsupported-type reason below, so a permission-denied .txt was reported
+	// as an unrecognized file format.
+	isText, err := isTextFile(filePath)
+	if err != nil {
+		return false, fmt.Sprintf("%s: %v", ReasonUnreadable, err)
+	}
+	if isText {
 		return true, "Text file"
 	}
 

--- a/internal/router/unreadable_reason_test.go
+++ b/internal/router/unreadable_reason_test.go
@@ -1,0 +1,118 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package router
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// CanProcessFile used to answer "no, unsupported file type" for a file it could not
+// open. Those are opposite facts: an unsupported type has been examined and
+// deliberately skipped, an unreadable file was never examined at all. Reporting the
+// second as the first told the user their .txt was an unrecognized format and
+// invited them to ignore it, while a file that may be full of PII went unscanned.
+
+// writeFile creates a file with the given mode and returns its path.
+func writeFile(t *testing.T, dir, name, content string, mode os.FileMode) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), mode); err != nil {
+		t.Fatalf("writing %s: %v", name, err)
+	}
+	return p
+}
+
+// TestUnreadableFileIsNotReportedAsUnsupported is the regression. A .txt is a
+// supported extension; if it cannot be read, the reason must say so.
+func TestUnreadableFileIsNotReportedAsUnsupported(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod 000 does not deny reads on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: mode bits do not deny reads")
+	}
+
+	dir := t.TempDir()
+	p := writeFile(t, dir, "secret.txt", "ssn 449-87-4100\n", 0o000)
+
+	fr := NewFileRouter(false)
+	ok, reason := fr.CanProcessFile(p, true)
+
+	if ok {
+		t.Fatalf("a mode-000 file was reported as processable (reason %q)", reason)
+	}
+	if !strings.HasPrefix(reason, ReasonUnreadable) {
+		t.Errorf("reason = %q, want it to start with %q.\nA supported extension that "+
+			"cannot be opened must not be described as an unsupported type: the user "+
+			"reads that as \"nothing to find here\" when in fact nothing was looked at.",
+			reason, ReasonUnreadable)
+	}
+	// Check the CLASSIFICATION, not a substring of the whole message: the reason
+	// embeds the file path, and a temp dir named after this test contains the word
+	// "Unsupported", so a naive Contains check fails on its own fixture.
+	if strings.HasPrefix(reason, "Unsupported") {
+		t.Errorf("reason = %q still claims the file type is unsupported", reason)
+	}
+}
+
+// TestMissingFileIsUnreadable covers the other way a file goes unexamined: it is
+// gone by the time the router looks (deleted mid-scan, or a dangling symlink).
+func TestMissingFileIsUnreadable(t *testing.T) {
+	fr := NewFileRouter(false)
+	ok, reason := fr.CanProcessFile(filepath.Join(t.TempDir(), "does-not-exist.txt"), true)
+
+	if ok {
+		t.Fatal("a nonexistent file was reported as processable")
+	}
+	if !strings.HasPrefix(reason, ReasonUnreadable) {
+		t.Errorf("reason = %q, want the %q prefix", reason, ReasonUnreadable)
+	}
+}
+
+// TestGenuinelyUnsupportedStillSaysUnsupported is the other half: the fix must not
+// relabel every rejection as unreadable. A readable file of an unknown binary type
+// is exactly what "Unsupported file type" is for, and pkg/scan exposes that string
+// through its public CanProcessFile, so the wording is a contract.
+func TestGenuinelyUnsupportedStillSaysUnsupported(t *testing.T) {
+	dir := t.TempDir()
+	// Readable, but binary content with an extension no preprocessor claims.
+	p := writeFile(t, dir, "blob.zzz", "\x00\x01\x02\x03binary\x00\xff", 0o644)
+
+	fr := NewFileRouter(false)
+	ok, reason := fr.CanProcessFile(p, true)
+
+	if ok {
+		t.Fatalf("an unknown binary type was reported as processable (reason %q)", reason)
+	}
+	if strings.HasPrefix(reason, ReasonUnreadable) {
+		t.Errorf("reason = %q claims the file is unreadable, but it is readable and "+
+			"simply an unsupported type — the two must stay distinguishable in both "+
+			"directions", reason)
+	}
+	if !strings.HasPrefix(reason, "Unsupported") {
+		t.Errorf("reason = %q, want it to start by saying the type is unsupported", reason)
+	}
+}
+
+// TestReadableTextFileIsStillAccepted is the non-vacuity floor: if the stat/read
+// error handling above were too aggressive it would reject everything, and the two
+// tests before this one would pass for the wrong reason.
+func TestReadableTextFileIsStillAccepted(t *testing.T) {
+	dir := t.TempDir()
+	p := writeFile(t, dir, "plain.txt", "ssn 449-87-4100\n", 0o644)
+
+	fr := NewFileRouter(false)
+	ok, reason := fr.CanProcessFile(p, true)
+
+	if !ok {
+		t.Fatalf("an ordinary readable .txt was rejected: %q", reason)
+	}
+	if reason != "Text file" {
+		t.Errorf("reason = %q, want %q", reason, "Text file")
+	}
+}

--- a/internal/web/config_precedence_test.go
+++ b/internal/web/config_precedence_test.go
@@ -1,0 +1,166 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package web
+
+import (
+	"bytes"
+	"encoding/json"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// handleScan used to fall straight through to the literal "all"/"all" when the
+// request omitted confidence/checks, so a config file was honored by the CLI and
+// silently ignored by the web UI. Scanning one file with `defaults: {checks: SSN}`
+// gave 1 finding on the command line and 3 in the browser.
+//
+// For a tool whose job is deciding what counts as sensitive, two answers from one
+// config is the defect: the operator believes they narrowed the scan and the UI
+// quietly widened it again. These tests pin the precedence
+// (request parameter > config file > built-in default) through the real HTTP
+// handler, because the bug lived in the handler, not in the scan engine.
+
+// fixtureWithThreeTypes writes a file that yields SSN, EMAIL and PHONE findings, so
+// a checks restriction is visible as a change in the reported types rather than
+// merely a change in count.
+func fixtureWithThreeTypes(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "mixed.txt")
+	body := "ssn 449-87-4100 mail a@corp.example.com phone 415-555-2671\n"
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("writing fixture: %v", err)
+	}
+	return p
+}
+
+// writeConfig writes a config file and returns its path.
+func writeConfig(t *testing.T, body string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "cfg.yaml")
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+	return p
+}
+
+// postScan drives ws.handleScan directly with a multipart upload and returns the
+// distinct finding types. query may be empty.
+func postScan(t *testing.T, ws *WebServer, filePath, query string) map[string]bool {
+	t.Helper()
+
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("reading fixture: %v", err)
+	}
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, err := mw.CreateFormFile("files", filepath.Base(filePath))
+	if err != nil {
+		t.Fatalf("multipart: %v", err)
+	}
+	if _, err := fw.Write(content); err != nil {
+		t.Fatalf("multipart write: %v", err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("multipart close: %v", err)
+	}
+
+	url := "/scan"
+	if query != "" {
+		url += "?" + query
+	}
+	req := httptest.NewRequest(http.MethodPost, url, &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	rec := httptest.NewRecorder()
+
+	ws.handleScan(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("handleScan returned %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Success bool `json:"success"`
+		Results []struct {
+			Type string `json:"type"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decoding response: %v\nbody: %s", err, rec.Body.String())
+	}
+
+	types := map[string]bool{}
+	for _, r := range resp.Results {
+		types[r.Type] = true
+	}
+	return types
+}
+
+// TestWebHonorsConfigChecks is the regression: with no request parameters, the
+// config file's checks must scope the scan exactly as it does on the CLI.
+func TestWebHonorsConfigChecks(t *testing.T) {
+	fixture := fixtureWithThreeTypes(t)
+
+	// Control: no config -> everything is reported.
+	wsAll := NewWebServerWithOptions("0", "127.0.0.1", "", "", nil)
+	all := postScan(t, wsAll, fixture, "")
+	if len(all) < 2 {
+		t.Fatalf("fixture is not discriminating: unrestricted scan found types %v; "+
+			"a checks restriction below could not be observed", all)
+	}
+
+	// Restricted by config only.
+	cfg := writeConfig(t, "defaults:\n  checks: SSN\n")
+	ws := NewWebServerWithOptions("0", "127.0.0.1", cfg, "", nil)
+	got := postScan(t, ws, fixture, "")
+
+	if !got["SSN"] {
+		t.Errorf("config restricted checks to SSN but no SSN was reported (types %v)", got)
+	}
+	for typ := range got {
+		if typ != "SSN" {
+			t.Errorf("type %q was reported despite `defaults: {checks: SSN}` in the config; "+
+				"web mode is ignoring the config file (types %v, unrestricted was %v)",
+				typ, got, all)
+		}
+	}
+}
+
+// TestWebRequestParamStillOverridesConfig guards the other direction. The fix must
+// not make the config authoritative over an explicit choice in the UI.
+func TestWebRequestParamStillOverridesConfig(t *testing.T) {
+	fixture := fixtureWithThreeTypes(t)
+	cfg := writeConfig(t, "defaults:\n  checks: SSN\n")
+	ws := NewWebServerWithOptions("0", "127.0.0.1", cfg, "", nil)
+
+	got := postScan(t, ws, fixture, "checks=SSN,EMAIL,PHONE")
+
+	if len(got) < 2 {
+		t.Errorf("an explicit checks parameter must win over the config file, but only "+
+			"%v was reported — the config is overriding the user's request", got)
+	}
+}
+
+// TestWebFallsBackToBuiltInDefault is the non-vacuity floor: with neither a request
+// parameter nor a config value, the handler must still scan everything. Without this
+// a fix that defaulted to "no checks" would satisfy the first test and break the UI.
+func TestWebFallsBackToBuiltInDefault(t *testing.T) {
+	fixture := fixtureWithThreeTypes(t)
+
+	// A config that says nothing about checks or confidence.
+	cfg := writeConfig(t, "defaults:\n  format: json\n")
+	ws := NewWebServerWithOptions("0", "127.0.0.1", cfg, "", nil)
+
+	got := postScan(t, ws, fixture, "")
+	if len(got) < 2 {
+		t.Errorf("with no checks in the request or the config, the scan should fall back "+
+			"to all checks, but only %v was reported", got)
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -447,19 +447,42 @@ func (ws *WebServer) handleScan(responseWriter http.ResponseWriter, request *htt
 		return
 	}
 
-	// Extract parameters (same as CLI flags)
+	// Extract parameters (same as CLI flags), falling back to the CONFIG FILE
+	// before the built-in default — the same precedence the CLI uses.
+	//
+	// These used to fall straight through to the literal "all"/"all", so a config
+	// with `defaults: {checks: SSN}` was honored by `ferret-scan --file x` and
+	// silently ignored by the web UI scanning the same file: 1 finding on the CLI,
+	// 3 in the browser. For a tool whose job is deciding what counts as sensitive,
+	// two answers from one config is the bug — the operator believes they narrowed
+	// the scan and the UI quietly widened it again.
+	cfg := ws.loadConfiguration(ws.configPath)
+
 	confidence := request.FormValue("confidence")
 	if confidence == "" {
-		confidence = "all" // CLI default: show all levels
+		confidence = "all" // built-in default: show all levels
+		if cfg != nil && cfg.Defaults.ConfidenceLevels != "" {
+			confidence = cfg.Defaults.ConfidenceLevels
+		}
 	}
 
 	checks := request.FormValue("checks")
 	if checks == "" {
-		checks = "all" // CLI default
+		checks = "all" // built-in default
+		if cfg != nil && cfg.Defaults.Checks != "" {
+			checks = cfg.Defaults.Checks
+		}
 	}
 
+	// An explicit "false" from the form still wins; absent means "use the config".
 	verbose := request.FormValue("verbose") == "true"
+	if request.FormValue("verbose") == "" && cfg != nil {
+		verbose = cfg.Defaults.Verbose
+	}
 	recursive := request.FormValue("recursive") == "true"
+	if request.FormValue("recursive") == "" && cfg != nil {
+		recursive = cfg.Defaults.Recursive
+	}
 	// Optional relative path from a folder drop (e.g. "myrepo/src/foo.go") —
 	// Go strips path components from multipart filename headers, so the
 	// front-end sends it as a parallel field.
@@ -630,13 +653,21 @@ func (ws *WebServer) runFullCLIScan(filePath, originalFilename, confidence, chec
 	// random temp path, but suppression hashes were created against the
 	// original upload filename. We rename below and then apply suppressions
 	// ourselves so the hashes match.
+	// Preprocessors default ON (the web UI's whole point is dropping documents in),
+	// but an explicit `enable_preprocessors: false` in the config is now honored
+	// rather than silently overridden.
+	enablePreprocessors := true
+	if cfg != nil {
+		enablePreprocessors = cfg.Defaults.EnablePreprocessors
+	}
+
 	scanConfig := core.ScanConfig{
 		FilePath:            filePath,
 		Checks:              checksSlice,
 		Debug:               false,
 		Verbose:             verbose,
 		Recursive:           recursive,
-		EnablePreprocessors: true,
+		EnablePreprocessors: enablePreprocessors,
 		EnableRedaction:     false,
 		Config:              cfg,
 		Profile:             nil,


### PR DESCRIPTION
Two independent defects found while deleting dead code in #234. Both share a shape: something the user configured or the tool detected was silently discarded, and in each case the visible symptom pointed the user *away* from the problem.

## 1. Web mode ignored four config options

`handleScan` fell through to the literal `"all"`/`"all"` whenever a request omitted `confidence` or `checks`, and `runFullCLIScan` hardcoded `EnablePreprocessors: true`. So the same config file was obeyed on the command line and ignored in the browser. Same config, same file:

```
ferret-scan --file mixed.txt      -> 1 finding  (SSN)
POST /scan  (web UI)              -> 3 findings (SSN, EMAIL, PHONE)
```

with `defaults: {checks: SSN}` in the config both times.

For a tool whose entire job is deciding what counts as sensitive, two answers from one configuration is the defect. Here the operator narrowed the scan on purpose and the UI quietly widened it again. The inverse direction is the dangerous one and is equally reachable: a config that narrows `confidence` to `high` is ignored, so a reviewer working in the browser sees a different picture from the CI job that gates the merge.

Precedence now matches the CLI — **request parameter > config file > built-in default**:

- `confidence` / `checks` fall back to `cfg.Defaults` before `"all"`
- `verbose` / `recursive` read the config when the form field is absent; an explicit value in the request still wins
- `EnablePreprocessors` still defaults on (dropping documents in is the point of the web UI) but an explicit `enable_preprocessors: false` is honored instead of overridden

This is the same defect class as the config-option audit in #233 — options that parse and then do nothing — and it was invisible there because it only manifests under `--web`. It surfaced while deleting `resolveWebConfiguration` in #234: that function was the only reader of these four values, and it had no callers, which is what proved the config was going nowhere.

## 2. A file we could not open was reported as an unsupported type

`CanProcessFile` swallowed two errors. `os.Stat` and `isTextFile` were both guarded by `err == nil`, so a permission error or a vanished file fell through to the generic `"Unsupported file type"` at the bottom of the function. A mode-000 `.txt` full of PII produced:

```
1 files skipped (1 unsupported types)
```

and for a single such file, `[]` with exit code 0 — indistinguishable from a clean scan.

Those two reasons are opposite facts. An unsupported type is a file we looked at and chose not to scan; an unreadable file is one we never saw. Reporting the second as the first tells the user their `.txt` is an unrecognized format and invites them to ignore it, while a file that may be full of PII went unscanned. And because only reported findings reach the redactor, "not scanned" also means "not redacted" — the cleartext stays.

The fix adds a `router.ReasonUnreadable` prefix rather than changing existing wording, since `pkg/scan` re-exports `CanProcessFile` and that string is a public contract. `"Unsupported file type"` still means exactly what it did. The scan loop now counts unreadable files separately and says so:

```
WARNING: scan incomplete — 1 of 3 file(s) could not be opened, so they were not
scanned at all; any sensitive data they contain was NOT detected:
  /path/to/no.txt: Unreadable: open /path/to/no.txt: permission denied
```

Unreadable files also now feed `--fail-on-incomplete`, which previously only counted files that failed *during* processing. A file that never got opened is the more complete coverage gap of the two, so it belongs in the same exit code (3). Verified: exit 0 without the flag, exit 3 with it. `--help`, `internal/help`, `docs/configuration.md` and `docs/PRE_COMMIT_INTEGRATION.md` were updated to describe the widened scope.

## Testing

Per `docs/testing/TEST_PLAN.md`. Both fixes were mutation-proven load-bearing — reverting each one makes its test fail with the diagnostic that describes the bug:

- reverting the web fallback: `type "PHONE" was reported despite \`defaults: {checks: SSN}\` in the config; web mode is ignoring the config file`
- reverting the router classification: `reason = "Unsupported file type", want it to start with "Unreadable"`

The web tests drive the real `http.Handler` through `httptest` with a multipart upload, because the bug lived in the handler and not in the scan engine. Each fix carries a non-vacuity floor: a config that says nothing about `checks` must still scan everything (a fix that defaulted to "no checks" would satisfy the regression test and break the UI), and an ordinary readable `.txt` must still be accepted (over-aggressive error handling would reject everything and make the other assertions pass for the wrong reason). The unreadable-file test skips on Windows and as root, where mode bits do not deny reads.

60 packages pass; `gofmt` and `vet` clean; build and vet on darwin, linux and windows; golden corpus 0 rewrites.