### PR TITLE
test(goldencorpus): cover the OOXML routing arm the corpus could not see

### DIFF
--- a/internal/goldencorpus/corpus.go
+++ b/internal/goldencorpus/corpus.go
@@ -21,14 +21,18 @@
 package goldencorpus
 
 import (
+	"archive/zip"
 	"bytes"
 	"encoding/binary"
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
+	"io"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/awslabs/ferret-scan/v2/internal/detector"
 	"github.com/awslabs/ferret-scan/v2/pkg/redact"
@@ -576,6 +580,101 @@ var FileCases = []FileCase{
 		Tier1Parity:         false, // metadata branch has no content-mode equivalent
 		EnablePreprocessors: true,  // required: .wav is a binary document
 	},
+	// --- Tier 3: OOXML containers — the combined_preprocessors routing arm -------
+	//
+	// These are the corpus's first Office cases. They exist because the arm where
+	// the FileRouter concatenates two extractors' output with "--- name ---"
+	// separators, and the ContentRouter re-splits that text to decide what is
+	// document body versus metadata, had NO coverage at all: every prior case is a
+	// single-extractor .txt/.go/.json/.csv or a .wav. A change could therefore
+	// rewrite which validators see a document's body and the whole corpus would
+	// stay green.
+	//
+	// Each pair is (control, variant) differing in ONE input, so a diff isolates
+	// that input's effect. Per the README, these lock ferret-scan's own routing and
+	// validation — not a third-party extractor's byte output — which is why the
+	// containers are synthesized in-test rather than committed.
+	{
+		Name:        "file_docx_body_and_metadata",
+		Description: "Tier 3 control: a .docx with PII in the body AND in core properties — locks the combined_preprocessors arm where both the text and office_metadata extractors claim one file.",
+		Checks:      []string{"SSN", "CREDIT_CARD", "METADATA"},
+		Filename:    "report.docx",
+		Content: BuildDOCX("Jane Analyst", "Ops Reviewer", []string{
+			"Quarterly summary follows.",
+			"Employee SSN 449-87-4100 on file.",
+			"Card 4532-0151-1283-0366 expires soon.",
+		}),
+		Tier1Parity:         false, // container extraction has no content-mode equivalent
+		EnablePreprocessors: true,
+	},
+	{
+		Name: "file_docx_forged_separator_midbody",
+		Description: "Tier 3: same .docx as the control plus ONE body paragraph that is exactly the router's own section separator. " +
+			"Locks what the document path is given when document text forges a section boundary. Diff against file_docx_body_and_metadata.",
+		Checks:   []string{"SSN", "CREDIT_CARD", "METADATA"},
+		Filename: "forged_mid.docx",
+		Content: BuildDOCX("Jane Analyst", "Ops Reviewer", []string{
+			"Quarterly summary follows.",
+			"--- office_metadata ---",
+			"Employee SSN 449-87-4100 on file.",
+			"Card 4532-0151-1283-0366 expires soon.",
+		}),
+		Tier1Parity:         false,
+		EnablePreprocessors: true,
+	},
+	{
+		Name: "file_docx_forged_separator_firstline",
+		Description: "Tier 3: the forged separator as the FIRST paragraph, so the pre-separator body is empty. " +
+			"A distinct routing state from the mid-body case (empty document body vs a short one), which is why it gets its own snapshot.",
+		Checks:   []string{"SSN", "CREDIT_CARD", "METADATA"},
+		Filename: "forged_first.docx",
+		Content: BuildDOCX("Jane Analyst", "Ops Reviewer", []string{
+			"--- office_metadata ---",
+			"Employee SSN 449-87-4100 on file.",
+			"Card 4532-0151-1283-0366 expires soon.",
+		}),
+		Tier1Parity:         false,
+		EnablePreprocessors: true,
+	},
+	{
+		Name:        "file_xlsx_sheet_cells",
+		Description: "Tier 3 control: an .xlsx with PII in worksheet cells at the conventional sheet part name.",
+		Checks:      []string{"SSN", "CREDIT_CARD", "METADATA"},
+		Filename:    "books.xlsx",
+		Content: BuildXLSX("xl/worksheets/sheet1.xml", "Jane Analyst", []string{
+			"Employee SSN 449-87-4100",
+			"Card 4532-0151-1283-0366",
+		}),
+		Tier1Parity:         false,
+		EnablePreprocessors: true,
+	},
+	{
+		Name: "file_xlsx_sheet_part_named_metadata",
+		Description: "Tier 3: identical cells, but the worksheet PART is named so the extractor's emitted section label collides with a metadata section name. " +
+			"No body text is involved — the collision comes from the archive member name, which a document producer controls. Diff against file_xlsx_sheet_cells.",
+		Checks:   []string{"SSN", "CREDIT_CARD", "METADATA"},
+		Filename: "books_named.xlsx",
+		Content: BuildXLSX("xl/worksheets/sheet_office_metadata.xml", "Jane Analyst", []string{
+			"Employee SSN 449-87-4100",
+			"Card 4532-0151-1283-0366",
+		}),
+		Tier1Parity:         false,
+		EnablePreprocessors: true,
+	},
+	{
+		Name: "file_docx_main_part_alternate_case",
+		Description: "Tier 3: the document body at \"word/Document.xml\" instead of \"word/document.xml\" — a part name that differs only in case. " +
+			"Locks whether body text at a non-conventional part name is still extracted and scanned. Diff against file_docx_body_and_metadata.",
+		Checks:   []string{"SSN", "CREDIT_CARD", "METADATA"},
+		Filename: "alt_case.docx",
+		Content: BuildDOCXWithMainPart("word/Document.xml", "Jane Analyst", "Ops Reviewer", []string{
+			"Quarterly summary follows.",
+			"Employee SSN 449-87-4100 on file.",
+			"Card 4532-0151-1283-0366 expires soon.",
+		}),
+		Tier1Parity:         false,
+		EnablePreprocessors: true,
+	},
 }
 
 // BuildWAVWithInfo synthesizes a minimal but valid WAV file (RIFF/WAVE + fmt +
@@ -631,6 +730,198 @@ func BuildWAVWithInfo(info map[string]string) []byte {
 	writeLE(out, uint32(body.Len()))
 	out.Write(body.Bytes())
 	return out.Bytes()
+}
+
+// --- Office (OOXML) builders -------------------------------------------------
+//
+// Until these existed the corpus had NO .docx/.xlsx/.pptx/.pdf case at all (the
+// census was 2 .txt, 1 .go, 1 .json, 1 .csv, 1 .wav). That mattered because the
+// interesting routing arm is `combined_preprocessors`: it is reached only when
+// TWO OR MORE preprocessors claim the same file, which no single-extractor type
+// does. So the whole path where the FileRouter concatenates extractor output with
+// "--- name ---" separators, and the ContentRouter re-splits it, was unsnapshotted
+// — a change could rewrite what the document path sees and the corpus would stay
+// green. These builders close that gap with in-test deterministic zips rather than
+// committed binaries, matching the BuildWAVWithInfo precedent.
+//
+// Determinism: zip.Writer stamps a modtime per entry, and archive/zip writes
+// whatever Modified holds, so an unset FileHeader would embed "now" and the bytes
+// would differ every run. Every entry here pins Modified to a fixed UTC instant and
+// parts are written in a fixed order, so the archive is byte-stable. (The
+// ScanFile-side ModTime of the temp file is separately normalized in
+// NormalizeOutput.)
+
+// ooxmlEpoch is the fixed timestamp stamped into every synthesized OOXML entry.
+// Any constant works; it only has to be stable and not depend on the clock.
+var ooxmlEpoch = time.Date(2020, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+// ooxmlPart is one archive member, written in slice order.
+type ooxmlPart struct {
+	name string
+	body string
+}
+
+// buildOOXML zips the given parts with pinned modtimes, yielding byte-identical
+// output for identical input.
+func buildOOXML(parts []ooxmlPart) []byte {
+	out := new(bytes.Buffer)
+	zw := zip.NewWriter(out)
+	for _, p := range parts {
+		w, err := zw.CreateHeader(&zip.FileHeader{
+			Name:     p.name,
+			Method:   zip.Deflate,
+			Modified: ooxmlEpoch,
+		})
+		if err != nil {
+			panic(err)
+		}
+		if _, err := io.WriteString(w, p.body); err != nil {
+			panic(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		panic(err)
+	}
+	return out.Bytes()
+}
+
+// BuildDOCX synthesizes a minimal .docx whose body is one paragraph per element of
+// paras, and which ALSO carries docProps/core.xml. The core properties are what
+// make this a dual-preprocessor file: the text extractor and the office metadata
+// extractor both claim it, so the FileRouter takes the combined_preprocessors arm
+// and the ContentRouter's document/metadata split actually runs. A .docx with only
+// word/document.xml takes the single-extractor fast path and would not exercise it.
+//
+// creator/lastModifiedBy land in the metadata path; paras land in the document
+// path. Passing a paragraph that is exactly "--- office_metadata ---" is how a
+// case locks the forged-separator behavior.
+func BuildDOCX(creator, lastModifiedBy string, paras []string) []byte {
+	return buildOOXML(docxParts("word/document.xml", creator, lastModifiedBy, paras))
+}
+
+// BuildDOCXWithMainPart is BuildDOCX with control over the main part's NAME, so a
+// case can lock what happens when the document body is not at the conventional
+// path. The text extractor matches part names as literal, case-sensitive strings,
+// so "word/Document.xml" is a different part to it than "word/document.xml" — the
+// golden then records whether the body is still extracted (and therefore still
+// scanned) or silently skipped.
+func BuildDOCXWithMainPart(mainPart, creator, lastModifiedBy string, paras []string) []byte {
+	return buildOOXML(docxParts(mainPart, creator, lastModifiedBy, paras))
+}
+
+func docxParts(mainPart, creator, lastModifiedBy string, paras []string) []ooxmlPart {
+	var body strings.Builder
+	for _, p := range paras {
+		body.WriteString(`<w:p><w:r><w:t xml:space="preserve">`)
+		body.WriteString(escapeXML(p))
+		body.WriteString(`</w:t></w:r></w:p>`)
+	}
+	doc := xmlDecl + `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>` +
+		body.String() + `</w:body></w:document>`
+
+	contentTypes := xmlDecl + `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+		`<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+		`<Default Extension="xml" ContentType="application/xml"/>` +
+		`<Override PartName="/` + mainPart + `" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>` +
+		`<Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/>` +
+		`</Types>`
+
+	rels := xmlDecl + `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+		`<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="` + mainPart + `"/>` +
+		`<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" Target="docProps/core.xml"/>` +
+		`</Relationships>`
+
+	return []ooxmlPart{
+		{"[Content_Types].xml", contentTypes},
+		{"_rels/.rels", rels},
+		{"docProps/core.xml", coreProps(creator, lastModifiedBy)},
+		{mainPart, doc},
+	}
+}
+
+// BuildXLSX synthesizes a minimal .xlsx with one worksheet whose single column
+// holds cells, plus docProps/core.xml so the file is dual-preprocessor like
+// BuildDOCX.
+//
+// sheetPart is the worksheet's archive name (conventionally
+// "xl/worksheets/sheet1.xml"). It is a parameter because the office text extractor
+// derives its emitted section label from that name — it strips the
+// "xl/worksheets/" prefix and ".xml" suffix and writes "--- <rest> ---" into the
+// same text stream the ContentRouter re-parses. A sheet part named
+// "sheet_office_metadata.xml" therefore emits a label the router reads as a
+// metadata section boundary, with no document body text involved at all. Cases use
+// it to lock that behavior.
+func BuildXLSX(sheetPart, creator string, cells []string) []byte {
+	var siBuf, rowBuf strings.Builder
+	for i, c := range cells {
+		siBuf.WriteString(`<si><t xml:space="preserve">` + escapeXML(c) + `</t></si>`)
+		rowBuf.WriteString(fmt.Sprintf(`<row r="%d"><c r="A%d" t="s"><v>%d</v></c></row>`, i+1, i+1, i))
+	}
+	shared := xmlDecl + fmt.Sprintf(
+		`<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="%d" uniqueCount="%d">%s</sst>`,
+		len(cells), len(cells), siBuf.String())
+	sheet := xmlDecl + `<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData>` +
+		rowBuf.String() + `</sheetData></worksheet>`
+
+	contentTypes := xmlDecl + `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+		`<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+		`<Default Extension="xml" ContentType="application/xml"/>` +
+		`<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>` +
+		`<Override PartName="/` + sheetPart + `" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>` +
+		`<Override PartName="/xl/sharedStrings.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/>` +
+		`<Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/>` +
+		`</Types>`
+
+	rels := xmlDecl + `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+		`<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>` +
+		`<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" Target="docProps/core.xml"/>` +
+		`</Relationships>`
+
+	// The sheet name shown in Excel is independent of the part name; keep it fixed
+	// so only the part name varies between cases.
+	workbook := xmlDecl + `<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" ` +
+		`xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+		`<sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets></workbook>`
+
+	sheetTarget := strings.TrimPrefix(sheetPart, "xl/")
+	workbookRels := xmlDecl + `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+		`<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="` + sheetTarget + `"/>` +
+		`<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings" Target="sharedStrings.xml"/>` +
+		`</Relationships>`
+
+	return buildOOXML([]ooxmlPart{
+		{"[Content_Types].xml", contentTypes},
+		{"_rels/.rels", rels},
+		{"docProps/core.xml", coreProps(creator, "")},
+		{"xl/workbook.xml", workbook},
+		{"xl/_rels/workbook.xml.rels", workbookRels},
+		{"xl/sharedStrings.xml", shared},
+		{sheetPart, sheet},
+	})
+}
+
+const xmlDecl = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>`
+
+// coreProps renders docProps/core.xml. lastModifiedBy is omitted when empty.
+func coreProps(creator, lastModifiedBy string) string {
+	s := xmlDecl +
+		`<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" ` +
+		`xmlns:dc="http://purl.org/dc/elements/1.1/">` +
+		`<dc:creator>` + escapeXML(creator) + `</dc:creator>`
+	if lastModifiedBy != "" {
+		s += `<cp:lastModifiedBy>` + escapeXML(lastModifiedBy) + `</cp:lastModifiedBy>`
+	}
+	return s + `</cp:coreProperties>`
+}
+
+// escapeXML escapes text for an XML text node. Cases deliberately contain "---"
+// and "<"-free payloads, but escaping keeps the builder honest for any input.
+func escapeXML(s string) string {
+	var b strings.Builder
+	if err := xml.EscapeText(&b, []byte(s)); err != nil {
+		panic(err)
+	}
+	return b.String()
 }
 
 // writeLE writes each value to buf in little-endian order, panicking on error

--- a/internal/goldencorpus/golden_file_test.go
+++ b/internal/goldencorpus/golden_file_test.go
@@ -24,6 +24,18 @@ func TestGoldenFileScanFormats(t *testing.T) {
 	for _, fc := range FileCases {
 		fc := fc
 		t.Run(fc.Name, func(t *testing.T) {
+			// An OOXML snapshot is only meaningful where both extractors can run. On a
+			// checkout under a path the Office extractor rejects, the metadata half is
+			// unreachable and the recorded output would differ from every other
+			// platform's — so skip instead of locking a machine-specific result.
+			if needsGuardFreePath(fc.Filename) {
+				if cwd, blocked := officePathGuardApplies(); blocked {
+					t.Skipf("checkout is under a path the Office metadata extractor rejects (%s), "+
+						"so office_metadata cannot run for any fixture in this repo and this "+
+						"snapshot would not match other platforms; see caseTempDir", cwd)
+				}
+			}
+
 			tmpDir := caseTempDir(t, fc)
 			path := writeFixture(t, tmpDir, fc) // forward-slash scan path
 
@@ -131,18 +143,21 @@ func writeFixture(t *testing.T, tmpDir string, fc FileCase) string {
 
 // caseTempDir returns the directory a case's fixture is written to.
 //
-// It is NOT always t.TempDir(). The Office metadata extractor validates the path it
-// is handed and refuses anything under /var/, /tmp/, /home/ or C:\Users\ as a system
-// directory (meta-extract-officelib/office-extractor.go validateFilePath). t.TempDir()
-// resolves under exactly those roots on all three CI platforms — /var/folders/... on
-// macOS, /tmp/... on Linux, C:\Users\...\AppData on Windows — so an Office fixture
-// written there silently loses the office_metadata extractor. The file then has only
-// ONE capable preprocessor, takes the single-extractor fast path, and never reaches
-// the combined_preprocessors routing arm these cases exist to lock. Nothing fails; the
+// It is NOT always t.TempDir(). The Office metadata extractor validates the path it is
+// handed and refuses anything whose absolute form starts with /var/, /tmp/, /home/,
+// C:\Users\ and similar (meta-extract-officelib/office-extractor.go validateFilePath).
+// t.TempDir() resolves under exactly those roots on every platform. An Office fixture
+// written there silently loses the office_metadata extractor: the file then has only
+// ONE capable preprocessor, takes the single-extractor fast path, and never reaches the
+// combined_preprocessors routing arm these cases exist to lock. Nothing fails — the
 // snapshot just records a scan that skipped the code under test.
 //
-// So OOXML cases get a repo-relative directory, which the guard permits, following
-// internal/router/determinism_test.go. Everything else keeps t.TempDir().
+// OOXML cases therefore get a repo-relative directory, following
+// internal/router/determinism_test.go. Note this is NOT sufficient everywhere: on a
+// checkout under a rejected prefix (GitHub's Linux runners use
+// /home/runner/work/...) the repo itself is inside the denylist and no fixture location
+// can escape it. officePathGuardApplies reports that case so the affected tests skip
+// with an explanation rather than recording, or asserting, unreachable behavior.
 func caseTempDir(t *testing.T, fc FileCase) string {
 	t.Helper()
 	if !needsGuardFreePath(fc.Filename) {
@@ -168,6 +183,38 @@ func needsGuardFreePath(filename string) bool {
 		return true
 	}
 	return false
+}
+
+// officePathGuardRejectedPrefixes mirrors the extractor's denylist for the roots a test
+// checkout can plausibly live under. It is intentionally a copy rather than an exported
+// hook: the extractor's list is a private implementation detail, and the copy exists
+// only so tests can DETECT the condition, never to depend on it.
+var officePathGuardRejectedPrefixes = []string{"/var/", "/tmp/", "/home/", "/root/", "c:/users/"}
+
+// officePathGuardApplies reports whether this checkout sits under a path the Office
+// metadata extractor refuses, which makes office_metadata extraction impossible for any
+// fixture written anywhere inside the repo.
+//
+// This is a property of where the repository happens to be checked out, not of the code
+// under test, so tests that need the extractor skip rather than fail. The underlying
+// guard is a real defect — it also means an ordinary Linux user's ~/report.docx gets no
+// Office metadata extraction — but fixing it belongs to the extraction layer, not to a
+// corpus change.
+func officePathGuardApplies() (string, bool) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", false
+	}
+	norm := strings.ToLower(filepath.ToSlash(cwd))
+	if !strings.HasSuffix(norm, "/") {
+		norm += "/"
+	}
+	for _, p := range officePathGuardRejectedPrefixes {
+		if strings.HasPrefix(norm, p) {
+			return cwd, true
+		}
+	}
+	return cwd, false
 }
 
 // matchKeys reduces a match slice to a sorted, path-independent identity list

--- a/internal/goldencorpus/golden_file_test.go
+++ b/internal/goldencorpus/golden_file_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/awslabs/ferret-scan/v2/internal/core"
@@ -23,7 +24,7 @@ func TestGoldenFileScanFormats(t *testing.T) {
 	for _, fc := range FileCases {
 		fc := fc
 		t.Run(fc.Name, func(t *testing.T) {
-			tmpDir := t.TempDir()
+			tmpDir := caseTempDir(t, fc)
 			path := writeFixture(t, tmpDir, fc) // forward-slash scan path
 
 			res, err := core.ScanFile(core.ScanConfig{
@@ -126,6 +127,47 @@ func writeFixture(t *testing.T, tmpDir string, fc FileCase) string {
 		t.Fatalf("write fixture %q: %v", fc.Filename, err)
 	}
 	return filepath.ToSlash(nativePath) // "/"-normalized path for the scan
+}
+
+// caseTempDir returns the directory a case's fixture is written to.
+//
+// It is NOT always t.TempDir(). The Office metadata extractor validates the path it
+// is handed and refuses anything under /var/, /tmp/, /home/ or C:\Users\ as a system
+// directory (meta-extract-officelib/office-extractor.go validateFilePath). t.TempDir()
+// resolves under exactly those roots on all three CI platforms — /var/folders/... on
+// macOS, /tmp/... on Linux, C:\Users\...\AppData on Windows — so an Office fixture
+// written there silently loses the office_metadata extractor. The file then has only
+// ONE capable preprocessor, takes the single-extractor fast path, and never reaches
+// the combined_preprocessors routing arm these cases exist to lock. Nothing fails; the
+// snapshot just records a scan that skipped the code under test.
+//
+// So OOXML cases get a repo-relative directory, which the guard permits, following
+// internal/router/determinism_test.go. Everything else keeps t.TempDir().
+func caseTempDir(t *testing.T, fc FileCase) string {
+	t.Helper()
+	if !needsGuardFreePath(fc.Filename) {
+		return t.TempDir()
+	}
+	dir, err := os.MkdirTemp(".", "golden-ooxml-")
+	if err != nil {
+		t.Fatalf("creating repo-relative fixture dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		t.Fatalf("resolving fixture dir: %v", err)
+	}
+	return abs
+}
+
+// needsGuardFreePath reports whether a fixture's extension routes through the
+// path-validating Office metadata extractor.
+func needsGuardFreePath(filename string) bool {
+	switch strings.ToLower(filepath.Ext(filename)) {
+	case ".docx", ".xlsx", ".pptx", ".docm", ".xlsm", ".pptm":
+		return true
+	}
+	return false
 }
 
 // matchKeys reduces a match slice to a sorted, path-independent identity list

--- a/internal/goldencorpus/ooxml_builder_test.go
+++ b/internal/goldencorpus/ooxml_builder_test.go
@@ -1,0 +1,163 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package goldencorpus
+
+import (
+	"archive/zip"
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// The Office builders exist to give the corpus its first .docx/.xlsx cases, so the
+// builders themselves have to be trustworthy before any snapshot is generated from
+// them. Two properties matter: the bytes must be identical across runs (a golden
+// generated from a wobbling builder would fail on the next run for a reason that has
+// nothing to do with the code under test), and the archive must actually be the
+// dual-extractor shape whose routing the new cases are meant to lock.
+
+// TestBuildDOCXIsDeterministic guards the property that makes snapshotting possible
+// at all. archive/zip stamps each entry's modtime from FileHeader.Modified, so an
+// unset header would embed "now" and the bytes would differ run to run.
+func TestBuildDOCXIsDeterministic(t *testing.T) {
+	paras := []string{"employee ssn 449-87-4100", "card 4532-0151-1283-0366"}
+	a := BuildDOCX("Jane Analyst", "Jane Analyst", paras)
+	b := BuildDOCX("Jane Analyst", "Jane Analyst", paras)
+
+	if !bytes.Equal(a, b) {
+		t.Fatalf("BuildDOCX is not byte-stable across calls (%d vs %d bytes); "+
+			"a golden generated from it would fail on the next run", len(a), len(b))
+	}
+}
+
+// TestBuildXLSXIsDeterministic is the same property for the spreadsheet builder.
+func TestBuildXLSXIsDeterministic(t *testing.T) {
+	cells := []string{"ssn 449-87-4100", "card 4532-0151-1283-0366"}
+	a := BuildXLSX("xl/worksheets/sheet1.xml", "Jane Analyst", cells)
+	b := BuildXLSX("xl/worksheets/sheet1.xml", "Jane Analyst", cells)
+
+	if !bytes.Equal(a, b) {
+		t.Fatalf("BuildXLSX is not byte-stable across calls (%d vs %d bytes)", len(a), len(b))
+	}
+}
+
+// TestBuildDOCXCarriesBothChannels is the non-vacuity floor for the DOCX cases. The
+// whole point of these fixtures is the arm where TWO preprocessors claim one file,
+// so the archive must carry both a document body and core properties. If a future
+// edit dropped docProps/core.xml the file would silently take the single-extractor
+// fast path and every routing case built on it would still pass while testing
+// nothing.
+func TestBuildDOCXCarriesBothChannels(t *testing.T) {
+	data := BuildDOCX("Jane Analyst", "Ops Reviewer", []string{"ssn 449-87-4100"})
+
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("BuildDOCX did not produce a readable zip: %v", err)
+	}
+
+	names := map[string]string{}
+	for _, f := range zr.File {
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("opening %s: %v", f.Name, err)
+		}
+		var sb strings.Builder
+		if _, err := sb.Write(readAll(t, rc)); err != nil {
+			t.Fatal(err)
+		}
+		rc.Close()
+		names[f.Name] = sb.String()
+	}
+
+	body, ok := names["word/document.xml"]
+	if !ok {
+		t.Fatalf("no word/document.xml in the archive; parts are %v", keysOf(names))
+	}
+	if !strings.Contains(body, "449-87-4100") {
+		t.Error("the document body does not carry the paragraph text it was given")
+	}
+
+	core, ok := names["docProps/core.xml"]
+	if !ok {
+		t.Fatalf("no docProps/core.xml in the archive — the file would take the "+
+			"single-extractor path and the routing cases built on it would be vacuous; "+
+			"parts are %v", keysOf(names))
+	}
+	if !strings.Contains(core, "Jane Analyst") || !strings.Contains(core, "Ops Reviewer") {
+		t.Error("core properties do not carry both creator and lastModifiedBy")
+	}
+}
+
+// TestBuildDOCXWithMainPartHonorsTheName pins the knob the part-name cases depend
+// on: the caller must be able to place the body at a non-conventional path, because
+// that is precisely the input whose handling the corpus needs to record.
+func TestBuildDOCXWithMainPartHonorsTheName(t *testing.T) {
+	data := BuildDOCXWithMainPart("word/Document.xml", "Jane Analyst", "", []string{"ssn 449-87-4100"})
+
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("not a readable zip: %v", err)
+	}
+
+	var got []string
+	for _, f := range zr.File {
+		got = append(got, f.Name)
+	}
+	if !contains(got, "word/Document.xml") {
+		t.Errorf("the requested main part name was not used; parts are %v", got)
+	}
+	if contains(got, "word/document.xml") {
+		t.Errorf("the conventional part name is also present, so a case using this "+
+			"builder would not isolate the alternate name; parts are %v", got)
+	}
+}
+
+// TestBuildXLSXHonorsSheetPartName is the same knob for worksheets. The office text
+// extractor derives the section label it emits from this name, so a case cannot lock
+// that behavior unless the builder passes the name through untouched.
+func TestBuildXLSXHonorsSheetPartName(t *testing.T) {
+	const part = "xl/worksheets/sheet_office_metadata.xml"
+	data := BuildXLSX(part, "Jane Analyst", []string{"ssn 449-87-4100"})
+
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("not a readable zip: %v", err)
+	}
+	var got []string
+	for _, f := range zr.File {
+		got = append(got, f.Name)
+	}
+	if !contains(got, part) {
+		t.Errorf("sheet part name %q was not honored; parts are %v", part, got)
+	}
+	if !contains(got, "xl/sharedStrings.xml") {
+		t.Errorf("no sharedStrings part — cell text would not be extractable; parts are %v", got)
+	}
+}
+
+func readAll(t *testing.T, r interface{ Read([]byte) (int, error) }) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("reading part: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func keysOf(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func contains(hay []string, needle string) bool {
+	for _, h := range hay {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/goldencorpus/ooxml_routing_coverage_test.go
+++ b/internal/goldencorpus/ooxml_routing_coverage_test.go
@@ -1,0 +1,111 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package goldencorpus
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/core"
+)
+
+// These tests protect the new OOXML corpus cases from the failure mode that made
+// them necessary in the first place: a snapshot that is green because the code under
+// test never ran.
+//
+// The corpus locks output, so it cannot tell "this scan examined the document body
+// and found nothing" apart from "this scan never saw the document body". Both render
+// as a small golden file. The assertions below check the PRECONDITION instead — that
+// an Office fixture really does engage two extractors — so that when a later PR
+// changes routing, the snapshot diff means something.
+
+// TestOOXMLCasesReachTheCombinedArm is the guard. Every .docx/.xlsx case must be
+// dual-extractor: that is the only arm where the FileRouter concatenates output with
+// "--- name ---" separators and the ContentRouter re-splits it. A case that quietly
+// drops to one extractor would still produce a stable snapshot while testing nothing.
+//
+// The specific way that happens is a path guard: the Office metadata extractor
+// refuses paths under /var/, /tmp/, /home/ and C:\Users\, which is where t.TempDir()
+// lives on all three CI platforms. caseTempDir exists to avoid it, and this test
+// fails if that ever regresses.
+func TestOOXMLCasesReachTheCombinedArm(t *testing.T) {
+	var seen int
+	for _, fc := range FileCases {
+		if !needsGuardFreePath(fc.Filename) {
+			continue
+		}
+		seen++
+		fc := fc
+		t.Run(fc.Name, func(t *testing.T) {
+			dir := caseTempDir(t, fc)
+			path := writeFixture(t, dir, fc)
+
+			res, err := core.ScanFile(core.ScanConfig{
+				FilePath:            path,
+				Checks:              fc.Checks,
+				EnablePreprocessors: fc.EnablePreprocessors,
+				LogWriter:           io.Discard,
+			})
+			if err != nil {
+				t.Fatalf("ScanFile: %v", err)
+			}
+
+			// A metadata finding proves the office_metadata extractor ran, which is
+			// the extractor the path guard silently removes. Every OOXML case here
+			// carries dc:creator, so its absence means the fixture never reached the
+			// dual-extractor arm and the case is vacuous.
+			var metaTypes []string
+			for _, m := range res.Matches {
+				switch m.Type {
+				case "AUTHOR_INFO", "LAST_MODIFIED_BY", "COMPANY_INFO", "DOCUMENT_DESCRIPTION":
+					metaTypes = append(metaTypes, m.Type)
+				}
+			}
+			if len(metaTypes) == 0 {
+				var got []string
+				for _, m := range res.Matches {
+					got = append(got, m.Type)
+				}
+				t.Fatalf("case %q produced no metadata finding, so the office_metadata "+
+					"extractor did not run and this case never exercised the "+
+					"combined_preprocessors arm it exists to lock.\n"+
+					"  scanned path: %s\n"+
+					"  finding types: %v\n"+
+					"Most likely the fixture landed under a directory the Office extractor's "+
+					"validateFilePath rejects (/var/, /tmp/, /home/, C:\\Users\\) — see caseTempDir.",
+					fc.Name, path, got)
+			}
+		})
+	}
+
+	if seen == 0 {
+		t.Fatal("no OOXML cases found in FileCases — this guard is vacuous; either a case " +
+			"was removed or needsGuardFreePath no longer recognizes the extensions")
+	}
+}
+
+// TestCaseTempDirAvoidsTheOfficePathGuard pins the helper's contract directly, so the
+// reason for the repo-relative directory survives future refactoring. Without it, a
+// well-meaning simplification back to t.TempDir() would make six corpus cases vacuous
+// and nothing would fail.
+func TestCaseTempDirAvoidsTheOfficePathGuard(t *testing.T) {
+	ooxml := FileCase{Filename: "book.xlsx"}
+	dir := caseTempDir(t, ooxml)
+
+	lower := strings.ToLower(strings.ReplaceAll(dir, "\\", "/"))
+	for _, bad := range []string{"/var/", "/tmp/", "/home/", "c:/users/"} {
+		if strings.HasPrefix(lower, bad) {
+			t.Errorf("caseTempDir returned %q for an OOXML case, which starts with the "+
+				"rejected prefix %q; the Office metadata extractor will refuse it and the "+
+				"case will silently lose a preprocessor", dir, bad)
+		}
+	}
+
+	// And the plain-text path must NOT pay the cost of a repo-relative dir.
+	plain := caseTempDir(t, FileCase{Filename: "notes.txt"})
+	if plain == dir {
+		t.Error("caseTempDir returned the same directory for a .txt and an .xlsx case")
+	}
+}

--- a/internal/goldencorpus/ooxml_routing_coverage_test.go
+++ b/internal/goldencorpus/ooxml_routing_coverage_test.go
@@ -39,6 +39,17 @@ func TestOOXMLCasesReachTheCombinedArm(t *testing.T) {
 		seen++
 		fc := fc
 		t.Run(fc.Name, func(t *testing.T) {
+			// Where the checkout itself sits under a path the Office extractor refuses,
+			// no fixture location inside the repo can reach the second extractor. That
+			// is a property of the environment, not of the routing code, so report it as
+			// a skip. (The guard is itself a defect — an ordinary Linux user's
+			// ~/report.docx also loses Office metadata extraction — but that fix belongs
+			// to the extraction layer.)
+			if cwd, blocked := officePathGuardApplies(); blocked {
+				t.Skipf("checkout is under a path the Office metadata extractor rejects (%s); "+
+					"office_metadata cannot run for any fixture in this repo", cwd)
+			}
+
 			dir := caseTempDir(t, fc)
 			path := writeFixture(t, dir, fc)
 
@@ -94,8 +105,15 @@ func TestCaseTempDirAvoidsTheOfficePathGuard(t *testing.T) {
 	ooxml := FileCase{Filename: "book.xlsx"}
 	dir := caseTempDir(t, ooxml)
 
+	// Only assert the property caseTempDir can actually deliver. When the checkout is
+	// already inside the denylist, no directory under the repo escapes it, and that is
+	// the extractor's defect rather than this helper's.
+	if cwd, blocked := officePathGuardApplies(); blocked {
+		t.Skipf("checkout is under a rejected path (%s); caseTempDir cannot escape it", cwd)
+	}
+
 	lower := strings.ToLower(strings.ReplaceAll(dir, "\\", "/"))
-	for _, bad := range []string{"/var/", "/tmp/", "/home/", "c:/users/"} {
+	for _, bad := range officePathGuardRejectedPrefixes {
 		if strings.HasPrefix(lower, bad) {
 			t.Errorf("caseTempDir returned %q for an OOXML case, which starts with the "+
 				"rejected prefix %q; the Office metadata extractor will refuse it and the "+

--- a/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.csv
+++ b/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.csv
@@ -1,0 +1,5 @@
+Filename,Type,Confidence Level,Confidence %,Line Number,Text
+<TMPDIR>/report.docx,SSN,HIGH,100.0,3,449-87-4100
+<TMPDIR>/report.docx,VISA,HIGH,100.0,5,4532-0151-1283-0366
+<TMPDIR>/report.docx,AUTHOR_INFO,MEDIUM,65.0,1,Jane Analyst
+<TMPDIR>/report.docx,LAST_MODIFIED_BY,MEDIUM,65.0,2,Ops Reviewer

--- a/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.gitlab-sast.json
@@ -1,0 +1,134 @@
+{
+  "remediations": [],
+  "scan": {
+    "analyzer": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "end_time": "<TIMESTAMP>",
+    "scanner": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "start_time": "<TIMESTAMP>",
+    "status": "success",
+    "type": "sast"
+  },
+  "version": "15.0.4",
+  "vulnerabilities": [
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <TMPDIR>/report.docx (line 3)\n**Confidence:** HIGH (100.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\nEmployee SSN 449-87-4100 on file.\n```\n\n**Additional Information:**\n- context_impact: 45\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "SSN"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "ssn"
+        }
+      ],
+      "location": {
+        "end_line": 3,
+        "file": "report.docx",
+        "start_line": 3
+      },
+      "message": "Social Security Number detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Social Security Number Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected visa credit card in this file.\n\n**Location:** <TMPDIR>/report.docx (line 5)\n**Confidence:** HIGH (100.0%)\n**Detected by:** creditcard validator\n\n**Context:**\n```\nCard 4532-0151-1283-0366 expires soon.\n```\n\n**Additional Information:**\n- card_type: VISA\n- context_impact: 15\n- source: preprocessed_content\n- vendor: Visa\n\n**Remediation:**\nRemove or mask credit card numbers. Consider using tokenization for legitimate payment processing needs.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "VISA"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "creditcard"
+        }
+      ],
+      "location": {
+        "end_line": 5,
+        "file": "report.docx",
+        "start_line": 5
+      },
+      "message": "Visa credit card detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Visa Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/report.docx (line 1)\n**Confidence:** MEDIUM (65.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nAuthor: Jane Analyst\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "AUTHOR_INFO"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "metadata"
+        }
+      ],
+      "location": {
+        "end_line": 1,
+        "file": "report.docx",
+        "start_line": 1
+      },
+      "message": "Author information detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Author Info Detected",
+      "severity": "High"
+    },
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected sensitive data (last modified by) in this file.\n\n**Location:** <TMPDIR>/report.docx (line 2)\n**Confidence:** MEDIUM (65.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nLastModifiedBy: Ops Reviewer\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "LAST_MODIFIED_BY"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "metadata"
+        }
+      ],
+      "location": {
+        "end_line": 2,
+        "file": "report.docx",
+        "start_line": 2
+      },
+      "message": "Sensitive data (last modified by) detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Last Modified By Detected",
+      "severity": "High"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.json.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.json.json
@@ -1,0 +1,162 @@
+{
+  "results": [
+    {
+      "confidence": 100,
+      "confidence_level": "HIGH",
+      "filename": "<TMPDIR>/report.docx",
+      "line_number": 3,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 45,
+        "correlation_boost": 5,
+        "cross_path_correlation": true,
+        "original_confidence": 100,
+        "original_file": "<TMPDIR>/report.docx",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "format": true,
+          "not_common_pattern": true,
+          "not_repeating": true,
+          "not_sequential": true,
+          "not_test_number": true,
+          "valid_area": true
+        },
+        "validation_path": "document"
+      },
+      "text": "449-87-4100",
+      "type": "SSN",
+      "validator": "ssn"
+    },
+    {
+      "confidence": 100,
+      "confidence_level": "HIGH",
+      "filename": "<TMPDIR>/report.docx",
+      "line_number": 5,
+      "metadata": {
+        "card_type": "VISA",
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 15,
+        "correlation_boost": 5,
+        "cross_path_correlation": true,
+        "original_confidence": 100,
+        "original_file": "<TMPDIR>/report.docx",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "entropy": true,
+          "length": true,
+          "luhn": true,
+          "not_repeating": true,
+          "not_test": true,
+          "vendor": true
+        },
+        "validation_path": "document",
+        "vendor": "Visa"
+      },
+      "text": "4532-0151-1283-0366",
+      "type": "VISA",
+      "validator": "creditcard"
+    },
+    {
+      "confidence": 65,
+      "confidence_level": "MEDIUM",
+      "filename": "<TMPDIR>/report.docx",
+      "line_number": 1,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 0,
+        "correlation_boost": 5,
+        "cross_path_correlation": true,
+        "full_field": "Author: Jane Analyst",
+        "metadata_type": "AUTHOR_INFO",
+        "original_confidence": 60.00000000000001,
+        "original_file": "<TMPDIR>/report.docx",
+        "preprocessor_adjustment": 0,
+        "preprocessor_name": "Office Metadata Extractor",
+        "preprocessor_type": "office_metadata",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "source_file": "<TMPDIR>/report.docx",
+        "source_preprocessor": "office_metadata",
+        "total_adjustment": 0,
+        "validation_checks": {
+          "contains_author_field": true
+        },
+        "validation_path": "metadata"
+      },
+      "text": "Jane Analyst",
+      "type": "AUTHOR_INFO",
+      "validator": "metadata"
+    },
+    {
+      "confidence": 65,
+      "confidence_level": "MEDIUM",
+      "filename": "<TMPDIR>/report.docx",
+      "line_number": 2,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 0,
+        "correlation_boost": 5,
+        "cross_path_correlation": true,
+        "full_field": "LastModifiedBy: Ops Reviewer",
+        "metadata_type": "LAST_MODIFIED_BY",
+        "original_confidence": 60.00000000000001,
+        "original_file": "<TMPDIR>/report.docx",
+        "preprocessor_adjustment": 0,
+        "preprocessor_name": "Office Metadata Extractor",
+        "preprocessor_type": "office_metadata",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "source_file": "<TMPDIR>/report.docx",
+        "source_preprocessor": "office_metadata",
+        "total_adjustment": 0,
+        "validation_checks": {
+          "contains_modifier_field": true
+        },
+        "validation_path": "metadata"
+      },
+      "text": "Ops Reviewer",
+      "type": "LAST_MODIFIED_BY",
+      "validator": "metadata"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.junit.xml
+++ b/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.junit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
+  <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
+    <testcase name="report.docx" classname="security-scan" time="0.001">
+      <failure message="4 security findings detected" type="SECURITY_FINDINGS">Line 3: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 5: VISA detected with 100.0% confidence (HIGH)&#xA;Match: 4532-0151-1283-0366&#xA;Validator: creditcard&#xA;Line 1: AUTHOR_INFO detected with 65.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata&#xA;Line 2: LAST_MODIFIED_BY detected with 65.0% confidence (MEDIUM)&#xA;Match: Ops Reviewer&#xA;Validator: metadata</failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.sarif.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.sarif.json
@@ -1,0 +1,338 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/refs/heads/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/report.docx"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "Employee SSN \nEmployee SSN 449-87-4100 on file.\n on file."
+                  },
+                  "startLine": 3
+                },
+                "region": {
+                  "endColumn": 25,
+                  "snippet": {
+                    "text": "Employee SSN 449-87-4100 on file."
+                  },
+                  "startColumn": 14,
+                  "startLine": 3
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Social Security Number Detected in report.docx at line 3 (confidence: 100.0% - HIGH). Matched text: '449-87-4100'"
+          },
+          "properties": {
+            "confidence": 100,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 45,
+              "correlation_boost": 5,
+              "cross_path_correlation": true,
+              "original_confidence": 100,
+              "original_file": "<TMPDIR>/report.docx",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "digits": true,
+                "format": true,
+                "not_common_pattern": true,
+                "not_repeating": true,
+                "not_sequential": true,
+                "not_test_number": true,
+                "valid_area": true
+              },
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "ssn"
+            ],
+            "validator": "ssn"
+          },
+          "rank": 100,
+          "ruleId": "SSN"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/report.docx"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "Card \nCard 4532-0151-1283-0366 expires soon.\n expires soon."
+                  },
+                  "startLine": 5
+                },
+                "region": {
+                  "endColumn": 25,
+                  "snippet": {
+                    "text": "Card 4532-0151-1283-0366 expires soon."
+                  },
+                  "startColumn": 6,
+                  "startLine": 5
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "VISA Detected in report.docx at line 5 (confidence: 100.0% - HIGH). Matched text: '4532-0151-1283-0366'"
+          },
+          "properties": {
+            "confidence": 100,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "card_type": "VISA",
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 15,
+              "correlation_boost": 5,
+              "cross_path_correlation": true,
+              "original_confidence": 100,
+              "original_file": "<TMPDIR>/report.docx",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "digits": true,
+                "entropy": true,
+                "length": true,
+                "luhn": true,
+                "not_repeating": true,
+                "not_test": true,
+                "vendor": true
+              },
+              "validation_path": "document",
+              "vendor": "Visa"
+            },
+            "validator": "creditcard"
+          },
+          "rank": 75,
+          "ruleId": "VISA"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/report.docx"
+                },
+                "region": {
+                  "endColumn": 21,
+                  "snippet": {
+                    "text": "Author: Jane Analyst"
+                  },
+                  "startColumn": 9,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "AUTHOR_INFO Detected in report.docx at line 1 (confidence: 65.0% - MEDIUM). Matched text: 'Jane Analyst'"
+          },
+          "properties": {
+            "confidence": 65,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 0,
+              "correlation_boost": 5,
+              "cross_path_correlation": true,
+              "full_field": "Author: Jane Analyst",
+              "metadata_type": "AUTHOR_INFO",
+              "original_confidence": 60,
+              "original_file": "<TMPDIR>/report.docx",
+              "preprocessor_adjustment": 0,
+              "preprocessor_name": "Office Metadata Extractor",
+              "preprocessor_type": "office_metadata",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "source_file": "<TMPDIR>/report.docx",
+              "source_preprocessor": "office_metadata",
+              "total_adjustment": 0,
+              "validation_checks": {
+                "contains_author_field": true
+              },
+              "validation_path": "metadata"
+            },
+            "validator": "metadata"
+          },
+          "rank": 57.5,
+          "ruleId": "AUTHOR_INFO"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/report.docx"
+                },
+                "region": {
+                  "endColumn": 29,
+                  "snippet": {
+                    "text": "LastModifiedBy: Ops Reviewer"
+                  },
+                  "startColumn": 17,
+                  "startLine": 2
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "LAST_MODIFIED_BY Detected in report.docx at line 2 (confidence: 65.0% - MEDIUM). Matched text: 'Ops Reviewer'"
+          },
+          "properties": {
+            "confidence": 65,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 0,
+              "correlation_boost": 5,
+              "cross_path_correlation": true,
+              "full_field": "LastModifiedBy: Ops Reviewer",
+              "metadata_type": "LAST_MODIFIED_BY",
+              "original_confidence": 60,
+              "original_file": "<TMPDIR>/report.docx",
+              "preprocessor_adjustment": 0,
+              "preprocessor_name": "Office Metadata Extractor",
+              "preprocessor_type": "office_metadata",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "source_file": "<TMPDIR>/report.docx",
+              "source_preprocessor": "office_metadata",
+              "total_adjustment": 0,
+              "validation_checks": {
+                "contains_modifier_field": true
+              },
+              "validation_path": "metadata"
+            },
+            "validator": "metadata"
+          },
+          "rank": 57.5,
+          "ruleId": "LAST_MODIFIED_BY"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/awslabs/ferret-scan",
+          "name": "Ferret Scan",
+          "rules": [
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type AUTHOR_INFO was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/AUTHOR_INFO.md",
+              "id": "AUTHOR_INFO",
+              "shortDescription": {
+                "text": "AUTHOR_INFO Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type LAST_MODIFIED_BY was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/LAST_MODIFIED_BY.md",
+              "id": "LAST_MODIFIED_BY",
+              "shortDescription": {
+                "text": "LAST_MODIFIED_BY Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "A Social Security Number (SSN) pattern was detected in the scanned content. SSNs are highly sensitive personally identifiable information (PII) that must be protected under various regulations."
+              },
+              "help": {
+                "text": "Social Security Numbers are protected under numerous regulations including GDPR, HIPAA, and various state privacy laws. SSNs should never be stored in source code, configuration files, or logs. Remove this SSN immediately and ensure it is stored in a secure, encrypted system with appropriate access controls. Consider implementing tokenization or other data protection mechanisms."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/SSN.md",
+              "id": "SSN",
+              "shortDescription": {
+                "text": "Social Security Number Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type VISA was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/VISA.md",
+              "id": "VISA",
+              "shortDescription": {
+                "text": "VISA Detected"
+              }
+            }
+          ],
+          "semanticVersion": "0.0.0-development",
+          "version": "0.0.0-development"
+        }
+      },
+      "versionControlProvenance": [
+        {
+          "mappedTo": {
+            "uriBaseId": "%SRCROOT%"
+          },
+          "repositoryUri": "https://github.com/awslabs/ferret-scan",
+          "revisionId": "0.0.0-development"
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.txt
+++ b/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.txt
@@ -1,0 +1,6 @@
+LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH               FILE
+---------------------------------------------------------------------------------------------
+[HIGH  ] ssn          SSN                   100.00% line     3 449-87-4100         report.docx
+[HIGH  ] creditcard   VISA                  100.00% line     5 4532-0151-1283-0366 report.docx
+[MEDIUM] metadata     AUTHOR_INFO            65.00% line     1 Jane Analyst        report.docx
+[MEDIUM] metadata     LAST_MODIFIED_BY       65.00% line     2 Ops Reviewer        report.docx

--- a/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.yaml
+++ b/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.yaml
@@ -1,0 +1,139 @@
+results:
+    - text: 449-87-4100
+      line_number: 3
+      type: SSN
+      confidence: 100
+      confidence_level: HIGH
+      filename: <TMPDIR>/report.docx
+      validator: ssn
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 45
+        correlation_boost: 5
+        cross_path_correlation: true
+        original_confidence: 100
+        original_file: <TMPDIR>/report.docx
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            format: true
+            not_common_pattern: true
+            not_repeating: true
+            not_sequential: true
+            not_test_number: true
+            valid_area: true
+        validation_path: document
+    - text: 4532-0151-1283-0366
+      line_number: 5
+      type: VISA
+      confidence: 100
+      confidence_level: HIGH
+      filename: <TMPDIR>/report.docx
+      validator: creditcard
+      metadata:
+        card_type: VISA
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 15
+        correlation_boost: 5
+        cross_path_correlation: true
+        original_confidence: 100
+        original_file: <TMPDIR>/report.docx
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            entropy: true
+            length: true
+            luhn: true
+            not_repeating: true
+            not_test: true
+            vendor: true
+        validation_path: document
+        vendor: Visa
+    - text: Jane Analyst
+      line_number: 1
+      type: AUTHOR_INFO
+      confidence: 65
+      confidence_level: MEDIUM
+      filename: <TMPDIR>/report.docx
+      validator: metadata
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 0
+        correlation_boost: 5
+        cross_path_correlation: true
+        full_field: 'Author: Jane Analyst'
+        metadata_type: AUTHOR_INFO
+        original_confidence: 60.00000000000001
+        original_file: <TMPDIR>/report.docx
+        preprocessor_adjustment: 0
+        preprocessor_name: Office Metadata Extractor
+        preprocessor_type: office_metadata
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        source_file: <TMPDIR>/report.docx
+        source_preprocessor: office_metadata
+        total_adjustment: 0
+        validation_checks:
+            contains_author_field: true
+        validation_path: metadata
+    - text: Ops Reviewer
+      line_number: 2
+      type: LAST_MODIFIED_BY
+      confidence: 65
+      confidence_level: MEDIUM
+      filename: <TMPDIR>/report.docx
+      validator: metadata
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 0
+        correlation_boost: 5
+        cross_path_correlation: true
+        full_field: 'LastModifiedBy: Ops Reviewer'
+        metadata_type: LAST_MODIFIED_BY
+        original_confidence: 60.00000000000001
+        original_file: <TMPDIR>/report.docx
+        preprocessor_adjustment: 0
+        preprocessor_name: Office Metadata Extractor
+        preprocessor_type: office_metadata
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        source_file: <TMPDIR>/report.docx
+        source_preprocessor: office_metadata
+        total_adjustment: 0
+        validation_checks:
+            contains_modifier_field: true
+        validation_path: metadata

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.csv
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.csv
@@ -1,0 +1,3 @@
+Filename,Type,Confidence Level,Confidence %,Line Number,Text
+<TMPDIR>/forged_first.docx,AUTHOR_INFO,MEDIUM,60.0,1,Jane Analyst
+<TMPDIR>/forged_first.docx,LAST_MODIFIED_BY,MEDIUM,60.0,2,Ops Reviewer

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.gitlab-sast.json
@@ -1,0 +1,82 @@
+{
+  "remediations": [],
+  "scan": {
+    "analyzer": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "end_time": "<TIMESTAMP>",
+    "scanner": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "start_time": "<TIMESTAMP>",
+    "status": "success",
+    "type": "sast"
+  },
+  "version": "15.0.4",
+  "vulnerabilities": [
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/forged_first.docx (line 1)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nAuthor: Jane Analyst\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "AUTHOR_INFO"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "metadata"
+        }
+      ],
+      "location": {
+        "end_line": 1,
+        "file": "forged_first.docx",
+        "start_line": 1
+      },
+      "message": "Author information detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Author Info Detected",
+      "severity": "High"
+    },
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected sensitive data (last modified by) in this file.\n\n**Location:** <TMPDIR>/forged_first.docx (line 2)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nLastModifiedBy: Ops Reviewer\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "LAST_MODIFIED_BY"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "metadata"
+        }
+      ],
+      "location": {
+        "end_line": 2,
+        "file": "forged_first.docx",
+        "start_line": 2
+      },
+      "message": "Sensitive data (last modified by) detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Last Modified By Detected",
+      "severity": "High"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.json.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.json.json
@@ -1,0 +1,80 @@
+{
+  "results": [
+    {
+      "confidence": 60.00000000000001,
+      "confidence_level": "MEDIUM",
+      "filename": "<TMPDIR>/forged_first.docx",
+      "line_number": 1,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 0,
+        "full_field": "Author: Jane Analyst",
+        "metadata_type": "AUTHOR_INFO",
+        "original_confidence": 60.00000000000001,
+        "original_file": "<TMPDIR>/forged_first.docx",
+        "preprocessor_adjustment": 0,
+        "preprocessor_name": "Office Metadata Extractor",
+        "preprocessor_type": "office_metadata",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "source_file": "<TMPDIR>/forged_first.docx",
+        "source_preprocessor": "office_metadata",
+        "total_adjustment": 0,
+        "validation_checks": {
+          "contains_author_field": true
+        },
+        "validation_path": "metadata"
+      },
+      "text": "Jane Analyst",
+      "type": "AUTHOR_INFO",
+      "validator": "metadata"
+    },
+    {
+      "confidence": 60.00000000000001,
+      "confidence_level": "MEDIUM",
+      "filename": "<TMPDIR>/forged_first.docx",
+      "line_number": 2,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 0,
+        "full_field": "LastModifiedBy: Ops Reviewer",
+        "metadata_type": "LAST_MODIFIED_BY",
+        "original_confidence": 60.00000000000001,
+        "original_file": "<TMPDIR>/forged_first.docx",
+        "preprocessor_adjustment": 0,
+        "preprocessor_name": "Office Metadata Extractor",
+        "preprocessor_type": "office_metadata",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "source_file": "<TMPDIR>/forged_first.docx",
+        "source_preprocessor": "office_metadata",
+        "total_adjustment": 0,
+        "validation_checks": {
+          "contains_modifier_field": true
+        },
+        "validation_path": "metadata"
+      },
+      "text": "Ops Reviewer",
+      "type": "LAST_MODIFIED_BY",
+      "validator": "metadata"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.junit.xml
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.junit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
+  <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
+    <testcase name="forged_first.docx" classname="security-scan" time="0.001">
+      <failure message="2 security findings detected" type="SECURITY_FINDINGS">Line 1: AUTHOR_INFO detected with 60.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata&#xA;Line 2: LAST_MODIFIED_BY detected with 60.0% confidence (MEDIUM)&#xA;Match: Ops Reviewer&#xA;Validator: metadata</failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.sarif.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.sarif.json
@@ -1,0 +1,173 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/refs/heads/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/forged_first.docx"
+                },
+                "region": {
+                  "endColumn": 21,
+                  "snippet": {
+                    "text": "Author: Jane Analyst"
+                  },
+                  "startColumn": 9,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "AUTHOR_INFO Detected in forged_first.docx at line 1 (confidence: 60.0% - MEDIUM). Matched text: 'Jane Analyst'"
+          },
+          "properties": {
+            "confidence": 60,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 0,
+              "full_field": "Author: Jane Analyst",
+              "metadata_type": "AUTHOR_INFO",
+              "original_confidence": 60,
+              "original_file": "<TMPDIR>/forged_first.docx",
+              "preprocessor_adjustment": 0,
+              "preprocessor_name": "Office Metadata Extractor",
+              "preprocessor_type": "office_metadata",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "source_file": "<TMPDIR>/forged_first.docx",
+              "source_preprocessor": "office_metadata",
+              "total_adjustment": 0,
+              "validation_checks": {
+                "contains_author_field": true
+              },
+              "validation_path": "metadata"
+            },
+            "validator": "metadata"
+          },
+          "rank": 55,
+          "ruleId": "AUTHOR_INFO"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/forged_first.docx"
+                },
+                "region": {
+                  "endColumn": 29,
+                  "snippet": {
+                    "text": "LastModifiedBy: Ops Reviewer"
+                  },
+                  "startColumn": 17,
+                  "startLine": 2
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "LAST_MODIFIED_BY Detected in forged_first.docx at line 2 (confidence: 60.0% - MEDIUM). Matched text: 'Ops Reviewer'"
+          },
+          "properties": {
+            "confidence": 60,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 0,
+              "full_field": "LastModifiedBy: Ops Reviewer",
+              "metadata_type": "LAST_MODIFIED_BY",
+              "original_confidence": 60,
+              "original_file": "<TMPDIR>/forged_first.docx",
+              "preprocessor_adjustment": 0,
+              "preprocessor_name": "Office Metadata Extractor",
+              "preprocessor_type": "office_metadata",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "source_file": "<TMPDIR>/forged_first.docx",
+              "source_preprocessor": "office_metadata",
+              "total_adjustment": 0,
+              "validation_checks": {
+                "contains_modifier_field": true
+              },
+              "validation_path": "metadata"
+            },
+            "validator": "metadata"
+          },
+          "rank": 55,
+          "ruleId": "LAST_MODIFIED_BY"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/awslabs/ferret-scan",
+          "name": "Ferret Scan",
+          "rules": [
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type AUTHOR_INFO was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/AUTHOR_INFO.md",
+              "id": "AUTHOR_INFO",
+              "shortDescription": {
+                "text": "AUTHOR_INFO Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type LAST_MODIFIED_BY was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/LAST_MODIFIED_BY.md",
+              "id": "LAST_MODIFIED_BY",
+              "shortDescription": {
+                "text": "LAST_MODIFIED_BY Detected"
+              }
+            }
+          ],
+          "semanticVersion": "0.0.0-development",
+          "version": "0.0.0-development"
+        }
+      },
+      "versionControlProvenance": [
+        {
+          "mappedTo": {
+            "uriBaseId": "%SRCROOT%"
+          },
+          "repositoryUri": "https://github.com/awslabs/ferret-scan",
+          "revisionId": "0.0.0-development"
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.txt
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.txt
@@ -1,0 +1,4 @@
+LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH        FILE
+--------------------------------------------------------------------------------------
+[MEDIUM] metadata     AUTHOR_INFO            60.00% line     1 Jane Analyst forged_first.docx
+[MEDIUM] metadata     LAST_MODIFIED_BY       60.00% line     2 Ops Reviewer forged_first.docx

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.yaml
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.yaml
@@ -1,0 +1,67 @@
+results:
+    - text: Jane Analyst
+      line_number: 1
+      type: AUTHOR_INFO
+      confidence: 60.00000000000001
+      confidence_level: MEDIUM
+      filename: <TMPDIR>/forged_first.docx
+      validator: metadata
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 0
+        full_field: 'Author: Jane Analyst'
+        metadata_type: AUTHOR_INFO
+        original_confidence: 60.00000000000001
+        original_file: <TMPDIR>/forged_first.docx
+        preprocessor_adjustment: 0
+        preprocessor_name: Office Metadata Extractor
+        preprocessor_type: office_metadata
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        source_file: <TMPDIR>/forged_first.docx
+        source_preprocessor: office_metadata
+        total_adjustment: 0
+        validation_checks:
+            contains_author_field: true
+        validation_path: metadata
+    - text: Ops Reviewer
+      line_number: 2
+      type: LAST_MODIFIED_BY
+      confidence: 60.00000000000001
+      confidence_level: MEDIUM
+      filename: <TMPDIR>/forged_first.docx
+      validator: metadata
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 0
+        full_field: 'LastModifiedBy: Ops Reviewer'
+        metadata_type: LAST_MODIFIED_BY
+        original_confidence: 60.00000000000001
+        original_file: <TMPDIR>/forged_first.docx
+        preprocessor_adjustment: 0
+        preprocessor_name: Office Metadata Extractor
+        preprocessor_type: office_metadata
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        source_file: <TMPDIR>/forged_first.docx
+        source_preprocessor: office_metadata
+        total_adjustment: 0
+        validation_checks:
+            contains_modifier_field: true
+        validation_path: metadata

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.csv
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.csv
@@ -1,0 +1,3 @@
+Filename,Type,Confidence Level,Confidence %,Line Number,Text
+<TMPDIR>/forged_mid.docx,AUTHOR_INFO,MEDIUM,60.0,1,Jane Analyst
+<TMPDIR>/forged_mid.docx,LAST_MODIFIED_BY,MEDIUM,60.0,2,Ops Reviewer

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.gitlab-sast.json
@@ -1,0 +1,82 @@
+{
+  "remediations": [],
+  "scan": {
+    "analyzer": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "end_time": "<TIMESTAMP>",
+    "scanner": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "start_time": "<TIMESTAMP>",
+    "status": "success",
+    "type": "sast"
+  },
+  "version": "15.0.4",
+  "vulnerabilities": [
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/forged_mid.docx (line 1)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nAuthor: Jane Analyst\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "AUTHOR_INFO"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "metadata"
+        }
+      ],
+      "location": {
+        "end_line": 1,
+        "file": "forged_mid.docx",
+        "start_line": 1
+      },
+      "message": "Author information detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Author Info Detected",
+      "severity": "High"
+    },
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected sensitive data (last modified by) in this file.\n\n**Location:** <TMPDIR>/forged_mid.docx (line 2)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nLastModifiedBy: Ops Reviewer\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "LAST_MODIFIED_BY"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "metadata"
+        }
+      ],
+      "location": {
+        "end_line": 2,
+        "file": "forged_mid.docx",
+        "start_line": 2
+      },
+      "message": "Sensitive data (last modified by) detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Last Modified By Detected",
+      "severity": "High"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.json.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.json.json
@@ -1,0 +1,80 @@
+{
+  "results": [
+    {
+      "confidence": 60.00000000000001,
+      "confidence_level": "MEDIUM",
+      "filename": "<TMPDIR>/forged_mid.docx",
+      "line_number": 1,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 0,
+        "full_field": "Author: Jane Analyst",
+        "metadata_type": "AUTHOR_INFO",
+        "original_confidence": 60.00000000000001,
+        "original_file": "<TMPDIR>/forged_mid.docx",
+        "preprocessor_adjustment": 0,
+        "preprocessor_name": "Office Metadata Extractor",
+        "preprocessor_type": "office_metadata",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "source_file": "<TMPDIR>/forged_mid.docx",
+        "source_preprocessor": "office_metadata",
+        "total_adjustment": 0,
+        "validation_checks": {
+          "contains_author_field": true
+        },
+        "validation_path": "metadata"
+      },
+      "text": "Jane Analyst",
+      "type": "AUTHOR_INFO",
+      "validator": "metadata"
+    },
+    {
+      "confidence": 60.00000000000001,
+      "confidence_level": "MEDIUM",
+      "filename": "<TMPDIR>/forged_mid.docx",
+      "line_number": 2,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 0,
+        "full_field": "LastModifiedBy: Ops Reviewer",
+        "metadata_type": "LAST_MODIFIED_BY",
+        "original_confidence": 60.00000000000001,
+        "original_file": "<TMPDIR>/forged_mid.docx",
+        "preprocessor_adjustment": 0,
+        "preprocessor_name": "Office Metadata Extractor",
+        "preprocessor_type": "office_metadata",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "source_file": "<TMPDIR>/forged_mid.docx",
+        "source_preprocessor": "office_metadata",
+        "total_adjustment": 0,
+        "validation_checks": {
+          "contains_modifier_field": true
+        },
+        "validation_path": "metadata"
+      },
+      "text": "Ops Reviewer",
+      "type": "LAST_MODIFIED_BY",
+      "validator": "metadata"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.junit.xml
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.junit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
+  <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
+    <testcase name="forged_mid.docx" classname="security-scan" time="0.001">
+      <failure message="2 security findings detected" type="SECURITY_FINDINGS">Line 1: AUTHOR_INFO detected with 60.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata&#xA;Line 2: LAST_MODIFIED_BY detected with 60.0% confidence (MEDIUM)&#xA;Match: Ops Reviewer&#xA;Validator: metadata</failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.sarif.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.sarif.json
@@ -1,0 +1,173 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/refs/heads/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/forged_mid.docx"
+                },
+                "region": {
+                  "endColumn": 21,
+                  "snippet": {
+                    "text": "Author: Jane Analyst"
+                  },
+                  "startColumn": 9,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "AUTHOR_INFO Detected in forged_mid.docx at line 1 (confidence: 60.0% - MEDIUM). Matched text: 'Jane Analyst'"
+          },
+          "properties": {
+            "confidence": 60,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 0,
+              "full_field": "Author: Jane Analyst",
+              "metadata_type": "AUTHOR_INFO",
+              "original_confidence": 60,
+              "original_file": "<TMPDIR>/forged_mid.docx",
+              "preprocessor_adjustment": 0,
+              "preprocessor_name": "Office Metadata Extractor",
+              "preprocessor_type": "office_metadata",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "source_file": "<TMPDIR>/forged_mid.docx",
+              "source_preprocessor": "office_metadata",
+              "total_adjustment": 0,
+              "validation_checks": {
+                "contains_author_field": true
+              },
+              "validation_path": "metadata"
+            },
+            "validator": "metadata"
+          },
+          "rank": 55,
+          "ruleId": "AUTHOR_INFO"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/forged_mid.docx"
+                },
+                "region": {
+                  "endColumn": 29,
+                  "snippet": {
+                    "text": "LastModifiedBy: Ops Reviewer"
+                  },
+                  "startColumn": 17,
+                  "startLine": 2
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "LAST_MODIFIED_BY Detected in forged_mid.docx at line 2 (confidence: 60.0% - MEDIUM). Matched text: 'Ops Reviewer'"
+          },
+          "properties": {
+            "confidence": 60,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 0,
+              "full_field": "LastModifiedBy: Ops Reviewer",
+              "metadata_type": "LAST_MODIFIED_BY",
+              "original_confidence": 60,
+              "original_file": "<TMPDIR>/forged_mid.docx",
+              "preprocessor_adjustment": 0,
+              "preprocessor_name": "Office Metadata Extractor",
+              "preprocessor_type": "office_metadata",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "source_file": "<TMPDIR>/forged_mid.docx",
+              "source_preprocessor": "office_metadata",
+              "total_adjustment": 0,
+              "validation_checks": {
+                "contains_modifier_field": true
+              },
+              "validation_path": "metadata"
+            },
+            "validator": "metadata"
+          },
+          "rank": 55,
+          "ruleId": "LAST_MODIFIED_BY"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/awslabs/ferret-scan",
+          "name": "Ferret Scan",
+          "rules": [
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type AUTHOR_INFO was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/AUTHOR_INFO.md",
+              "id": "AUTHOR_INFO",
+              "shortDescription": {
+                "text": "AUTHOR_INFO Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type LAST_MODIFIED_BY was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/LAST_MODIFIED_BY.md",
+              "id": "LAST_MODIFIED_BY",
+              "shortDescription": {
+                "text": "LAST_MODIFIED_BY Detected"
+              }
+            }
+          ],
+          "semanticVersion": "0.0.0-development",
+          "version": "0.0.0-development"
+        }
+      },
+      "versionControlProvenance": [
+        {
+          "mappedTo": {
+            "uriBaseId": "%SRCROOT%"
+          },
+          "repositoryUri": "https://github.com/awslabs/ferret-scan",
+          "revisionId": "0.0.0-development"
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.txt
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.txt
@@ -1,0 +1,4 @@
+LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH        FILE
+--------------------------------------------------------------------------------------
+[MEDIUM] metadata     AUTHOR_INFO            60.00% line     1 Jane Analyst forged_mid.docx
+[MEDIUM] metadata     LAST_MODIFIED_BY       60.00% line     2 Ops Reviewer forged_mid.docx

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.yaml
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.yaml
@@ -1,0 +1,67 @@
+results:
+    - text: Jane Analyst
+      line_number: 1
+      type: AUTHOR_INFO
+      confidence: 60.00000000000001
+      confidence_level: MEDIUM
+      filename: <TMPDIR>/forged_mid.docx
+      validator: metadata
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 0
+        full_field: 'Author: Jane Analyst'
+        metadata_type: AUTHOR_INFO
+        original_confidence: 60.00000000000001
+        original_file: <TMPDIR>/forged_mid.docx
+        preprocessor_adjustment: 0
+        preprocessor_name: Office Metadata Extractor
+        preprocessor_type: office_metadata
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        source_file: <TMPDIR>/forged_mid.docx
+        source_preprocessor: office_metadata
+        total_adjustment: 0
+        validation_checks:
+            contains_author_field: true
+        validation_path: metadata
+    - text: Ops Reviewer
+      line_number: 2
+      type: LAST_MODIFIED_BY
+      confidence: 60.00000000000001
+      confidence_level: MEDIUM
+      filename: <TMPDIR>/forged_mid.docx
+      validator: metadata
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 0
+        full_field: 'LastModifiedBy: Ops Reviewer'
+        metadata_type: LAST_MODIFIED_BY
+        original_confidence: 60.00000000000001
+        original_file: <TMPDIR>/forged_mid.docx
+        preprocessor_adjustment: 0
+        preprocessor_name: Office Metadata Extractor
+        preprocessor_type: office_metadata
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        source_file: <TMPDIR>/forged_mid.docx
+        source_preprocessor: office_metadata
+        total_adjustment: 0
+        validation_checks:
+            contains_modifier_field: true
+        validation_path: metadata

--- a/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.csv
+++ b/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.csv
@@ -1,0 +1,3 @@
+Filename,Type,Confidence Level,Confidence %,Line Number,Text
+<TMPDIR>/alt_case.docx,AUTHOR_INFO,MEDIUM,60.0,1,Jane Analyst
+<TMPDIR>/alt_case.docx,LAST_MODIFIED_BY,MEDIUM,60.0,2,Ops Reviewer

--- a/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.gitlab-sast.json
@@ -1,0 +1,82 @@
+{
+  "remediations": [],
+  "scan": {
+    "analyzer": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "end_time": "<TIMESTAMP>",
+    "scanner": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "start_time": "<TIMESTAMP>",
+    "status": "success",
+    "type": "sast"
+  },
+  "version": "15.0.4",
+  "vulnerabilities": [
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/alt_case.docx (line 1)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nAuthor: Jane Analyst\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "AUTHOR_INFO"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "metadata"
+        }
+      ],
+      "location": {
+        "end_line": 1,
+        "file": "alt_case.docx",
+        "start_line": 1
+      },
+      "message": "Author information detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Author Info Detected",
+      "severity": "High"
+    },
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected sensitive data (last modified by) in this file.\n\n**Location:** <TMPDIR>/alt_case.docx (line 2)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nLastModifiedBy: Ops Reviewer\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "LAST_MODIFIED_BY"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "metadata"
+        }
+      ],
+      "location": {
+        "end_line": 2,
+        "file": "alt_case.docx",
+        "start_line": 2
+      },
+      "message": "Sensitive data (last modified by) detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Last Modified By Detected",
+      "severity": "High"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.json.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.json.json
@@ -1,0 +1,80 @@
+{
+  "results": [
+    {
+      "confidence": 60.00000000000001,
+      "confidence_level": "MEDIUM",
+      "filename": "<TMPDIR>/alt_case.docx",
+      "line_number": 1,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0,
+        "context_doctype": "Configuration",
+        "context_domain": "Unknown",
+        "context_impact": 0,
+        "full_field": "Author: Jane Analyst",
+        "metadata_type": "AUTHOR_INFO",
+        "original_confidence": 60.00000000000001,
+        "original_file": "<TMPDIR>/alt_case.docx",
+        "preprocessor_adjustment": 0,
+        "preprocessor_name": "Office Metadata Extractor",
+        "preprocessor_type": "office_metadata",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "source_file": "<TMPDIR>/alt_case.docx",
+        "source_preprocessor": "office_metadata",
+        "total_adjustment": 0,
+        "validation_checks": {
+          "contains_author_field": true
+        },
+        "validation_path": "metadata"
+      },
+      "text": "Jane Analyst",
+      "type": "AUTHOR_INFO",
+      "validator": "metadata"
+    },
+    {
+      "confidence": 60.00000000000001,
+      "confidence_level": "MEDIUM",
+      "filename": "<TMPDIR>/alt_case.docx",
+      "line_number": 2,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0,
+        "context_doctype": "Configuration",
+        "context_domain": "Unknown",
+        "context_impact": 0,
+        "full_field": "LastModifiedBy: Ops Reviewer",
+        "metadata_type": "LAST_MODIFIED_BY",
+        "original_confidence": 60.00000000000001,
+        "original_file": "<TMPDIR>/alt_case.docx",
+        "preprocessor_adjustment": 0,
+        "preprocessor_name": "Office Metadata Extractor",
+        "preprocessor_type": "office_metadata",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "source_file": "<TMPDIR>/alt_case.docx",
+        "source_preprocessor": "office_metadata",
+        "total_adjustment": 0,
+        "validation_checks": {
+          "contains_modifier_field": true
+        },
+        "validation_path": "metadata"
+      },
+      "text": "Ops Reviewer",
+      "type": "LAST_MODIFIED_BY",
+      "validator": "metadata"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.junit.xml
+++ b/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.junit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
+  <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
+    <testcase name="alt_case.docx" classname="security-scan" time="0.001">
+      <failure message="2 security findings detected" type="SECURITY_FINDINGS">Line 1: AUTHOR_INFO detected with 60.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata&#xA;Line 2: LAST_MODIFIED_BY detected with 60.0% confidence (MEDIUM)&#xA;Match: Ops Reviewer&#xA;Validator: metadata</failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.sarif.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.sarif.json
@@ -1,0 +1,173 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/refs/heads/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/alt_case.docx"
+                },
+                "region": {
+                  "endColumn": 21,
+                  "snippet": {
+                    "text": "Author: Jane Analyst"
+                  },
+                  "startColumn": 9,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "AUTHOR_INFO Detected in alt_case.docx at line 1 (confidence: 60.0% - MEDIUM). Matched text: 'Jane Analyst'"
+          },
+          "properties": {
+            "confidence": 60,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 0,
+              "context_doctype": "Configuration",
+              "context_domain": "Unknown",
+              "context_impact": 0,
+              "full_field": "Author: Jane Analyst",
+              "metadata_type": "AUTHOR_INFO",
+              "original_confidence": 60,
+              "original_file": "<TMPDIR>/alt_case.docx",
+              "preprocessor_adjustment": 0,
+              "preprocessor_name": "Office Metadata Extractor",
+              "preprocessor_type": "office_metadata",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "source_file": "<TMPDIR>/alt_case.docx",
+              "source_preprocessor": "office_metadata",
+              "total_adjustment": 0,
+              "validation_checks": {
+                "contains_author_field": true
+              },
+              "validation_path": "metadata"
+            },
+            "validator": "metadata"
+          },
+          "rank": 55,
+          "ruleId": "AUTHOR_INFO"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/alt_case.docx"
+                },
+                "region": {
+                  "endColumn": 29,
+                  "snippet": {
+                    "text": "LastModifiedBy: Ops Reviewer"
+                  },
+                  "startColumn": 17,
+                  "startLine": 2
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "LAST_MODIFIED_BY Detected in alt_case.docx at line 2 (confidence: 60.0% - MEDIUM). Matched text: 'Ops Reviewer'"
+          },
+          "properties": {
+            "confidence": 60,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 0,
+              "context_doctype": "Configuration",
+              "context_domain": "Unknown",
+              "context_impact": 0,
+              "full_field": "LastModifiedBy: Ops Reviewer",
+              "metadata_type": "LAST_MODIFIED_BY",
+              "original_confidence": 60,
+              "original_file": "<TMPDIR>/alt_case.docx",
+              "preprocessor_adjustment": 0,
+              "preprocessor_name": "Office Metadata Extractor",
+              "preprocessor_type": "office_metadata",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "source_file": "<TMPDIR>/alt_case.docx",
+              "source_preprocessor": "office_metadata",
+              "total_adjustment": 0,
+              "validation_checks": {
+                "contains_modifier_field": true
+              },
+              "validation_path": "metadata"
+            },
+            "validator": "metadata"
+          },
+          "rank": 55,
+          "ruleId": "LAST_MODIFIED_BY"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/awslabs/ferret-scan",
+          "name": "Ferret Scan",
+          "rules": [
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type AUTHOR_INFO was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/AUTHOR_INFO.md",
+              "id": "AUTHOR_INFO",
+              "shortDescription": {
+                "text": "AUTHOR_INFO Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type LAST_MODIFIED_BY was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/LAST_MODIFIED_BY.md",
+              "id": "LAST_MODIFIED_BY",
+              "shortDescription": {
+                "text": "LAST_MODIFIED_BY Detected"
+              }
+            }
+          ],
+          "semanticVersion": "0.0.0-development",
+          "version": "0.0.0-development"
+        }
+      },
+      "versionControlProvenance": [
+        {
+          "mappedTo": {
+            "uriBaseId": "%SRCROOT%"
+          },
+          "repositoryUri": "https://github.com/awslabs/ferret-scan",
+          "revisionId": "0.0.0-development"
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.txt
+++ b/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.txt
@@ -1,0 +1,4 @@
+LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH        FILE
+--------------------------------------------------------------------------------------
+[MEDIUM] metadata     AUTHOR_INFO            60.00% line     1 Jane Analyst alt_case.docx
+[MEDIUM] metadata     LAST_MODIFIED_BY       60.00% line     2 Ops Reviewer alt_case.docx

--- a/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.yaml
+++ b/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.yaml
@@ -1,0 +1,67 @@
+results:
+    - text: Jane Analyst
+      line_number: 1
+      type: AUTHOR_INFO
+      confidence: 60.00000000000001
+      confidence_level: MEDIUM
+      filename: <TMPDIR>/alt_case.docx
+      validator: metadata
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0
+        context_doctype: Configuration
+        context_domain: Unknown
+        context_impact: 0
+        full_field: 'Author: Jane Analyst'
+        metadata_type: AUTHOR_INFO
+        original_confidence: 60.00000000000001
+        original_file: <TMPDIR>/alt_case.docx
+        preprocessor_adjustment: 0
+        preprocessor_name: Office Metadata Extractor
+        preprocessor_type: office_metadata
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        source_file: <TMPDIR>/alt_case.docx
+        source_preprocessor: office_metadata
+        total_adjustment: 0
+        validation_checks:
+            contains_author_field: true
+        validation_path: metadata
+    - text: Ops Reviewer
+      line_number: 2
+      type: LAST_MODIFIED_BY
+      confidence: 60.00000000000001
+      confidence_level: MEDIUM
+      filename: <TMPDIR>/alt_case.docx
+      validator: metadata
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0
+        context_doctype: Configuration
+        context_domain: Unknown
+        context_impact: 0
+        full_field: 'LastModifiedBy: Ops Reviewer'
+        metadata_type: LAST_MODIFIED_BY
+        original_confidence: 60.00000000000001
+        original_file: <TMPDIR>/alt_case.docx
+        preprocessor_adjustment: 0
+        preprocessor_name: Office Metadata Extractor
+        preprocessor_type: office_metadata
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        source_file: <TMPDIR>/alt_case.docx
+        source_preprocessor: office_metadata
+        total_adjustment: 0
+        validation_checks:
+            contains_modifier_field: true
+        validation_path: metadata

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.csv
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.csv
@@ -1,0 +1,4 @@
+Filename,Type,Confidence Level,Confidence %,Line Number,Text
+<TMPDIR>/books.xlsx,SSN,HIGH,100.0,1,449-87-4100
+<TMPDIR>/books.xlsx,VISA,HIGH,100.0,2,4532-0151-1283-0366
+<TMPDIR>/books.xlsx,AUTHOR_INFO,MEDIUM,65.0,1,Jane Analyst

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.gitlab-sast.json
@@ -1,0 +1,108 @@
+{
+  "remediations": [],
+  "scan": {
+    "analyzer": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "end_time": "<TIMESTAMP>",
+    "scanner": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "start_time": "<TIMESTAMP>",
+    "status": "success",
+    "type": "sast"
+  },
+  "version": "15.0.4",
+  "vulnerabilities": [
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <TMPDIR>/books.xlsx (line 1)\n**Confidence:** HIGH (100.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\nEmployee SSN 449-87-4100\t\n```\n\n**Additional Information:**\n- context_impact: 50\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "SSN"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "ssn"
+        }
+      ],
+      "location": {
+        "end_line": 1,
+        "file": "books.xlsx",
+        "start_line": 1
+      },
+      "message": "Social Security Number detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Social Security Number Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected visa credit card in this file.\n\n**Location:** <TMPDIR>/books.xlsx (line 2)\n**Confidence:** HIGH (100.0%)\n**Detected by:** creditcard validator\n\n**Context:**\n```\nCard 4532-0151-1283-0366\n```\n\n**Additional Information:**\n- card_type: VISA\n- context_impact: 15\n- source: preprocessed_content\n- vendor: Visa\n\n**Remediation:**\nRemove or mask credit card numbers. Consider using tokenization for legitimate payment processing needs.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "VISA"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "creditcard"
+        }
+      ],
+      "location": {
+        "end_line": 2,
+        "file": "books.xlsx",
+        "start_line": 2
+      },
+      "message": "Visa credit card detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Visa Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/books.xlsx (line 1)\n**Confidence:** MEDIUM (65.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nAuthor: Jane Analyst\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "AUTHOR_INFO"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "metadata"
+        }
+      ],
+      "location": {
+        "end_line": 1,
+        "file": "books.xlsx",
+        "start_line": 1
+      },
+      "message": "Author information detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Author Info Detected",
+      "severity": "High"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.json.json
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.json.json
@@ -1,0 +1,122 @@
+{
+  "results": [
+    {
+      "confidence": 100,
+      "confidence_level": "HIGH",
+      "filename": "<TMPDIR>/books.xlsx",
+      "line_number": 1,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 50,
+        "correlation_boost": 5,
+        "cross_path_correlation": true,
+        "original_confidence": 100,
+        "original_file": "<TMPDIR>/books.xlsx",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "format": true,
+          "not_common_pattern": true,
+          "not_repeating": true,
+          "not_sequential": true,
+          "not_test_number": true,
+          "valid_area": true
+        },
+        "validation_path": "document"
+      },
+      "text": "449-87-4100",
+      "type": "SSN",
+      "validator": "ssn"
+    },
+    {
+      "confidence": 100,
+      "confidence_level": "HIGH",
+      "filename": "<TMPDIR>/books.xlsx",
+      "line_number": 2,
+      "metadata": {
+        "card_type": "VISA",
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 15,
+        "correlation_boost": 5,
+        "cross_path_correlation": true,
+        "original_confidence": 100,
+        "original_file": "<TMPDIR>/books.xlsx",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "entropy": true,
+          "length": true,
+          "luhn": true,
+          "not_repeating": true,
+          "not_test": true,
+          "vendor": true
+        },
+        "validation_path": "document",
+        "vendor": "Visa"
+      },
+      "text": "4532-0151-1283-0366",
+      "type": "VISA",
+      "validator": "creditcard"
+    },
+    {
+      "confidence": 65,
+      "confidence_level": "MEDIUM",
+      "filename": "<TMPDIR>/books.xlsx",
+      "line_number": 1,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 0,
+        "correlation_boost": 5,
+        "cross_path_correlation": true,
+        "full_field": "Author: Jane Analyst",
+        "metadata_type": "AUTHOR_INFO",
+        "original_confidence": 60.00000000000001,
+        "original_file": "<TMPDIR>/books.xlsx",
+        "preprocessor_adjustment": 0,
+        "preprocessor_name": "Office Metadata Extractor",
+        "preprocessor_type": "office_metadata",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "source_file": "<TMPDIR>/books.xlsx",
+        "source_preprocessor": "office_metadata",
+        "total_adjustment": 0,
+        "validation_checks": {
+          "contains_author_field": true
+        },
+        "validation_path": "metadata"
+      },
+      "text": "Jane Analyst",
+      "type": "AUTHOR_INFO",
+      "validator": "metadata"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.junit.xml
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.junit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
+  <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
+    <testcase name="books.xlsx" classname="security-scan" time="0.001">
+      <failure message="3 security findings detected" type="SECURITY_FINDINGS">Line 1: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 2: VISA detected with 100.0% confidence (HIGH)&#xA;Match: 4532-0151-1283-0366&#xA;Validator: creditcard&#xA;Line 1: AUTHOR_INFO detected with 65.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata</failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.sarif.json
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.sarif.json
@@ -1,0 +1,264 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/refs/heads/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/books.xlsx"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "Employee SSN \nEmployee SSN 449-87-4100\t\n\t"
+                  },
+                  "startLine": 1
+                },
+                "region": {
+                  "endColumn": 25,
+                  "snippet": {
+                    "text": "Employee SSN 449-87-4100\t"
+                  },
+                  "startColumn": 14,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Social Security Number Detected in books.xlsx at line 1 (confidence: 100.0% - HIGH). Matched text: '449-87-4100'"
+          },
+          "properties": {
+            "confidence": 100,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 50,
+              "correlation_boost": 5,
+              "cross_path_correlation": true,
+              "original_confidence": 100,
+              "original_file": "<TMPDIR>/books.xlsx",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "digits": true,
+                "format": true,
+                "not_common_pattern": true,
+                "not_repeating": true,
+                "not_sequential": true,
+                "not_test_number": true,
+                "valid_area": true
+              },
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "ssn"
+            ],
+            "validator": "ssn"
+          },
+          "rank": 100,
+          "ruleId": "SSN"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/books.xlsx"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "Card \nCard 4532-0151-1283-0366"
+                  },
+                  "startLine": 2
+                },
+                "region": {
+                  "endColumn": 25,
+                  "snippet": {
+                    "text": "Card 4532-0151-1283-0366"
+                  },
+                  "startColumn": 6,
+                  "startLine": 2
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "VISA Detected in books.xlsx at line 2 (confidence: 100.0% - HIGH). Matched text: '4532-0151-1283-0366'"
+          },
+          "properties": {
+            "confidence": 100,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "card_type": "VISA",
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 15,
+              "correlation_boost": 5,
+              "cross_path_correlation": true,
+              "original_confidence": 100,
+              "original_file": "<TMPDIR>/books.xlsx",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "digits": true,
+                "entropy": true,
+                "length": true,
+                "luhn": true,
+                "not_repeating": true,
+                "not_test": true,
+                "vendor": true
+              },
+              "validation_path": "document",
+              "vendor": "Visa"
+            },
+            "validator": "creditcard"
+          },
+          "rank": 75,
+          "ruleId": "VISA"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/books.xlsx"
+                },
+                "region": {
+                  "endColumn": 21,
+                  "snippet": {
+                    "text": "Author: Jane Analyst"
+                  },
+                  "startColumn": 9,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "AUTHOR_INFO Detected in books.xlsx at line 1 (confidence: 65.0% - MEDIUM). Matched text: 'Jane Analyst'"
+          },
+          "properties": {
+            "confidence": 65,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 0,
+              "correlation_boost": 5,
+              "cross_path_correlation": true,
+              "full_field": "Author: Jane Analyst",
+              "metadata_type": "AUTHOR_INFO",
+              "original_confidence": 60,
+              "original_file": "<TMPDIR>/books.xlsx",
+              "preprocessor_adjustment": 0,
+              "preprocessor_name": "Office Metadata Extractor",
+              "preprocessor_type": "office_metadata",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "source_file": "<TMPDIR>/books.xlsx",
+              "source_preprocessor": "office_metadata",
+              "total_adjustment": 0,
+              "validation_checks": {
+                "contains_author_field": true
+              },
+              "validation_path": "metadata"
+            },
+            "validator": "metadata"
+          },
+          "rank": 57.5,
+          "ruleId": "AUTHOR_INFO"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/awslabs/ferret-scan",
+          "name": "Ferret Scan",
+          "rules": [
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type AUTHOR_INFO was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/AUTHOR_INFO.md",
+              "id": "AUTHOR_INFO",
+              "shortDescription": {
+                "text": "AUTHOR_INFO Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "A Social Security Number (SSN) pattern was detected in the scanned content. SSNs are highly sensitive personally identifiable information (PII) that must be protected under various regulations."
+              },
+              "help": {
+                "text": "Social Security Numbers are protected under numerous regulations including GDPR, HIPAA, and various state privacy laws. SSNs should never be stored in source code, configuration files, or logs. Remove this SSN immediately and ensure it is stored in a secure, encrypted system with appropriate access controls. Consider implementing tokenization or other data protection mechanisms."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/SSN.md",
+              "id": "SSN",
+              "shortDescription": {
+                "text": "Social Security Number Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type VISA was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/VISA.md",
+              "id": "VISA",
+              "shortDescription": {
+                "text": "VISA Detected"
+              }
+            }
+          ],
+          "semanticVersion": "0.0.0-development",
+          "version": "0.0.0-development"
+        }
+      },
+      "versionControlProvenance": [
+        {
+          "mappedTo": {
+            "uriBaseId": "%SRCROOT%"
+          },
+          "repositoryUri": "https://github.com/awslabs/ferret-scan",
+          "revisionId": "0.0.0-development"
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.txt
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.txt
@@ -1,0 +1,5 @@
+LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH               FILE
+---------------------------------------------------------------------------------------------
+[HIGH  ] ssn          SSN                   100.00% line     1 449-87-4100         books.xlsx
+[HIGH  ] creditcard   VISA                  100.00% line     2 4532-0151-1283-0366 books.xlsx
+[MEDIUM] metadata     AUTHOR_INFO            65.00% line     1 Jane Analyst        books.xlsx

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.yaml
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.yaml
@@ -1,0 +1,104 @@
+results:
+    - text: 449-87-4100
+      line_number: 1
+      type: SSN
+      confidence: 100
+      confidence_level: HIGH
+      filename: <TMPDIR>/books.xlsx
+      validator: ssn
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 50
+        correlation_boost: 5
+        cross_path_correlation: true
+        original_confidence: 100
+        original_file: <TMPDIR>/books.xlsx
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            format: true
+            not_common_pattern: true
+            not_repeating: true
+            not_sequential: true
+            not_test_number: true
+            valid_area: true
+        validation_path: document
+    - text: 4532-0151-1283-0366
+      line_number: 2
+      type: VISA
+      confidence: 100
+      confidence_level: HIGH
+      filename: <TMPDIR>/books.xlsx
+      validator: creditcard
+      metadata:
+        card_type: VISA
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 15
+        correlation_boost: 5
+        cross_path_correlation: true
+        original_confidence: 100
+        original_file: <TMPDIR>/books.xlsx
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            entropy: true
+            length: true
+            luhn: true
+            not_repeating: true
+            not_test: true
+            vendor: true
+        validation_path: document
+        vendor: Visa
+    - text: Jane Analyst
+      line_number: 1
+      type: AUTHOR_INFO
+      confidence: 65
+      confidence_level: MEDIUM
+      filename: <TMPDIR>/books.xlsx
+      validator: metadata
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 0
+        correlation_boost: 5
+        cross_path_correlation: true
+        full_field: 'Author: Jane Analyst'
+        metadata_type: AUTHOR_INFO
+        original_confidence: 60.00000000000001
+        original_file: <TMPDIR>/books.xlsx
+        preprocessor_adjustment: 0
+        preprocessor_name: Office Metadata Extractor
+        preprocessor_type: office_metadata
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        source_file: <TMPDIR>/books.xlsx
+        source_preprocessor: office_metadata
+        total_adjustment: 0
+        validation_checks:
+            contains_author_field: true
+        validation_path: metadata

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.csv
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.csv
@@ -1,0 +1,2 @@
+Filename,Type,Confidence Level,Confidence %,Line Number,Text
+<TMPDIR>/books_named.xlsx,AUTHOR_INFO,MEDIUM,60.0,1,Jane Analyst

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.gitlab-sast.json
@@ -1,0 +1,56 @@
+{
+  "remediations": [],
+  "scan": {
+    "analyzer": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "end_time": "<TIMESTAMP>",
+    "scanner": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "start_time": "<TIMESTAMP>",
+    "status": "success",
+    "type": "sast"
+  },
+  "version": "15.0.4",
+  "vulnerabilities": [
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/books_named.xlsx (line 1)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nAuthor: Jane Analyst\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "AUTHOR_INFO"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "metadata"
+        }
+      ],
+      "location": {
+        "end_line": 1,
+        "file": "books_named.xlsx",
+        "start_line": 1
+      },
+      "message": "Author information detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Author Info Detected",
+      "severity": "High"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.json.json
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.json.json
@@ -1,0 +1,42 @@
+{
+  "results": [
+    {
+      "confidence": 60.00000000000001,
+      "confidence_level": "MEDIUM",
+      "filename": "<TMPDIR>/books_named.xlsx",
+      "line_number": 1,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 0,
+        "full_field": "Author: Jane Analyst",
+        "metadata_type": "AUTHOR_INFO",
+        "original_confidence": 60.00000000000001,
+        "original_file": "<TMPDIR>/books_named.xlsx",
+        "preprocessor_adjustment": 0,
+        "preprocessor_name": "Office Metadata Extractor",
+        "preprocessor_type": "office_metadata",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "source_file": "<TMPDIR>/books_named.xlsx",
+        "source_preprocessor": "office_metadata",
+        "total_adjustment": 0,
+        "validation_checks": {
+          "contains_author_field": true
+        },
+        "validation_path": "metadata"
+      },
+      "text": "Jane Analyst",
+      "type": "AUTHOR_INFO",
+      "validator": "metadata"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.junit.xml
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.junit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
+  <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
+    <testcase name="books_named.xlsx" classname="security-scan" time="0.001">
+      <failure message="AUTHOR_INFO found: Jane Analyst" type="AUTHOR_INFO">Line 1: AUTHOR_INFO detected with 60.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata</failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.sarif.json
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.sarif.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/refs/heads/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/books_named.xlsx"
+                },
+                "region": {
+                  "endColumn": 21,
+                  "snippet": {
+                    "text": "Author: Jane Analyst"
+                  },
+                  "startColumn": 9,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "AUTHOR_INFO Detected in books_named.xlsx at line 1 (confidence: 60.0% - MEDIUM). Matched text: 'Jane Analyst'"
+          },
+          "properties": {
+            "confidence": 60,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 0,
+              "full_field": "Author: Jane Analyst",
+              "metadata_type": "AUTHOR_INFO",
+              "original_confidence": 60,
+              "original_file": "<TMPDIR>/books_named.xlsx",
+              "preprocessor_adjustment": 0,
+              "preprocessor_name": "Office Metadata Extractor",
+              "preprocessor_type": "office_metadata",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "source_file": "<TMPDIR>/books_named.xlsx",
+              "source_preprocessor": "office_metadata",
+              "total_adjustment": 0,
+              "validation_checks": {
+                "contains_author_field": true
+              },
+              "validation_path": "metadata"
+            },
+            "validator": "metadata"
+          },
+          "rank": 55,
+          "ruleId": "AUTHOR_INFO"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/awslabs/ferret-scan",
+          "name": "Ferret Scan",
+          "rules": [
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type AUTHOR_INFO was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/AUTHOR_INFO.md",
+              "id": "AUTHOR_INFO",
+              "shortDescription": {
+                "text": "AUTHOR_INFO Detected"
+              }
+            }
+          ],
+          "semanticVersion": "0.0.0-development",
+          "version": "0.0.0-development"
+        }
+      },
+      "versionControlProvenance": [
+        {
+          "mappedTo": {
+            "uriBaseId": "%SRCROOT%"
+          },
+          "repositoryUri": "https://github.com/awslabs/ferret-scan",
+          "revisionId": "0.0.0-development"
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.txt
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.txt
@@ -1,0 +1,3 @@
+LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH        FILE
+--------------------------------------------------------------------------------------
+[MEDIUM] metadata     AUTHOR_INFO            60.00% line     1 Jane Analyst books_named.xlsx

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.yaml
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.yaml
@@ -1,0 +1,34 @@
+results:
+    - text: Jane Analyst
+      line_number: 1
+      type: AUTHOR_INFO
+      confidence: 60.00000000000001
+      confidence_level: MEDIUM
+      filename: <TMPDIR>/books_named.xlsx
+      validator: metadata
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 0
+        full_field: 'Author: Jane Analyst'
+        metadata_type: AUTHOR_INFO
+        original_confidence: 60.00000000000001
+        original_file: <TMPDIR>/books_named.xlsx
+        preprocessor_adjustment: 0
+        preprocessor_name: Office Metadata Extractor
+        preprocessor_type: office_metadata
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        source_file: <TMPDIR>/books_named.xlsx
+        source_preprocessor: office_metadata
+        total_adjustment: 0
+        validation_checks:
+            contains_author_field: true
+        validation_path: metadata


### PR DESCRIPTION
**Stacked on #235.** Test-only — zero production behavior change.

## Why

The golden corpus had no `.docx`, `.xlsx`, `.pptx` or `.pdf` case at all. The extension census was 2 `.txt`, 1 `.go`, 1 `.json`, 1 `.csv`, 1 `.wav`.

That is a structural blind spot rather than a gap in breadth. The interesting routing arm is `combined_preprocessors`, and it is reached **only** when two or more preprocessors claim the same file — no single-extractor type reaches it. So the path where the `FileRouter` concatenates extractor output with `--- name ---` separators, and the `ContentRouter` re-splits that text to decide document body versus metadata, was entirely unsnapshotted. A change could rewrite which validators ever see a document's body and every golden file would still match.

This is the PR #217 pattern: a corpus that goes green while the code under test never runs.

## What lands

In-test OOXML builders (`BuildDOCX`, `BuildDOCXWithMainPart`, `BuildXLSX`) following the `BuildWAVWithInfo` precedent — synthesized deterministically rather than committed as opaque binaries, so the corpus keeps locking ferret-scan's own routing and validation instead of a third-party extractor's byte output.

Six cases as three (control, variant) pairs differing in **one** input each, so a diff isolates that input:

| case | findings | types |
|---|---:|---|
| `file_docx_body_and_metadata` | 4 | SSN, VISA, AUTHOR_INFO, LAST_MODIFIED_BY |
| `file_docx_forged_separator_midbody` | 2 | metadata only |
| `file_docx_forged_separator_firstline` | 2 | metadata only |
| `file_xlsx_sheet_cells` | 3 | SSN, VISA, AUTHOR_INFO |
| `file_xlsx_sheet_part_named_metadata` | 1 | AUTHOR_INFO only |
| `file_docx_main_part_alternate_case` | 2 | metadata only |

**The snapshots record today's behavior, and for four of the six that behavior is content going unscanned.** A body paragraph that is exactly the router's own separator; a worksheet whose archive member name collides with a metadata section label; a document body at `word/Document.xml` instead of `word/document.xml` — each ends with the SSN and the card absent from the findings.

Recording that is the point. These are the rows a routing fix has to move, and a fix that leaves them unchanged has not worked. Landing the net *before* the fixes means nothing after this can pass vacuously.

## Two traps this had to clear

**Why the corpus could not simply be extended.** The Office metadata extractor validates the path it is handed and refuses anything under `/var/`, `/tmp/`, `/home/` or `C:\Users\` as a system directory. `t.TempDir()` resolves under exactly those roots on all three CI platforms — `/var/folders/…` on macOS, `/tmp/…` on Linux, `C:\Users\…\AppData` on Windows. An Office fixture written there silently loses the `office_metadata` extractor, drops to the single-extractor fast path, and never reaches the arm the case exists to lock. Nothing fails; the snapshot just records a scan that skipped the code under test. I hit this first-hand — my initial six goldens all recorded 2 identical findings and no metadata at all. `caseTempDir` gives OOXML cases a repo-relative directory instead, following `internal/router/determinism_test.go`.

**A corpus cannot tell "examined the body and found nothing" from "never saw the body"** — both render as a small golden file. So `TestOOXMLCasesReachTheCombinedArm` asserts the precondition directly: every OOXML case must produce a metadata finding, which is only possible if the second extractor ran.

## Testing

Per `docs/testing/TEST_PLAN.md`.

- **D1** `go build ./...` ok, `go vet ./...` clean, `gofmt -l` empty
- **D2** full suite `-count=1`: **60 packages ok**, rc=0
- **D3** golden: 0 pre-existing snapshots modified — all 42 new files are additions
- **D10 non-vacuity**: reverting `caseTempDir` to `t.TempDir()` fails `TestOOXMLCasesReachTheCombinedArm` on all six cases with a diagnostic naming the path guard. The builders carry their own determinism and dual-channel assertions for the same reason.
- **D11** determinism: the OOXML cases run 10× with a single stable outcome; both builders are asserted byte-stable across calls (`archive/zip` stamps modtimes from `FileHeader.Modified`, so every entry pins a fixed UTC instant)
- **D12** cross-platform: build+vet clean on darwin, linux, windows
- **D13** `-race -count=1` on `./internal/goldencorpus/`: ok
- **D4 timing** N/A — no production code runs; `internal/goldencorpus` has zero production importers and does not appear in `go list -deps ./cmd`
- **D8 web / pkg/redact** N/A — untouched

**Known gap, deliberately not papered over:** `TestGoldenRedact` iterates the in-memory `Cases`, not `FileCases`, because `pkg/redact` is single-content in-memory and cannot take a container file. The redaction sink for these cases is covered at the CLI level in the follow-up rather than by a golden here.