### PR TITLE
fix(router): take document structure from the extractor, not from the document

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build clean vet fmt run install-config install check-go-version pr-checklist integration-branch
+.PHONY: build clean vet vet-host fmt run install-config install check-go-version pr-checklist integration-branch test-compile-all-platforms
 
 # Default target
 all: check-go-version fmt vet build
@@ -36,6 +36,7 @@ help:
 	@echo ""
 	@echo "🧪 Testing:"
 	@echo "  test               - Run all tests"
+	@echo "  test-compile-all-platforms - Cross-compile test binaries for every platform"
 	@echo "  test-ci            - Run CI-equivalent tests (race detector, no cache)"
 	@echo "  test-windows       - Run Windows-specific tests"
 	@echo "  test-cross-platform - Run cross-platform compatibility tests"
@@ -55,7 +56,8 @@ help:
 	@echo "  uninstall          - Remove system-wide installation"
 	@echo "  fmt                - Format code"
 
-	@echo "  vet                - Run go vet"
+	@echo "  vet                - Run go vet for darwin, linux and windows (compile-only)"
+	@echo "  vet-host           - Run go vet for this platform only (fast inner loop)"
 	@echo ""
 	@echo "🐳 Container:"
 	@echo "  container-run      - Run container"
@@ -215,9 +217,38 @@ clean-everything: clean-all clean-precommit uninstall
 
 
 
-# Run go vet
+# Run go vet for every supported platform, not just this one.
+#
+# `go vet` type-checks TEST files as well as production code, and it is the only cheap
+# local gate that does: `GOOS=windows go build ./...` skips _test.go entirely and passes
+# happily while the Windows CI job fails to compile. That is not hypothetical — a test
+# calling syscall.Mkfifo (absent on Windows) behind a `runtime.GOOS == "windows"` skip
+# broke windows-latest after `GOOS=windows go build` reported clean locally. A runtime
+# skip cannot save a symbol the compiler must still resolve; only a build tag can, and
+# only cross-platform vet catches the mistake.
+#
+# Compile-only, so it is seconds rather than a full test matrix. Failures print the
+# offending platform's output rather than being swallowed.
+GOOS_TARGETS ?= darwin linux windows
+
 vet:
-	@echo "Vetting..."
+	@echo "Vetting (GOOS: $(GOOS_TARGETS))..."
+	@rc=0; \
+	for goos in $(GOOS_TARGETS); do \
+		printf '  %-8s ' "$$goos"; \
+		if out=$$(GOOS=$$goos go vet ./... 2>&1); then \
+			echo "ok"; \
+		else \
+			echo "FAILED"; \
+			echo "$$out" | sed 's/^/    /'; \
+			rc=1; \
+		fi; \
+	done; \
+	exit $$rc
+
+# Host-only vet, for a fast inner loop. `make vet` is the gate.
+vet-host:
+	@echo "Vetting (host only)..."
 	@go vet ./...
 
 # Format code
@@ -479,6 +510,37 @@ setup-direct-precommit:
 # Testing targets
 test: test-unit test-integration
 	@echo "✓ All tests completed"
+
+# Cross-compile the TEST binaries for every supported platform without running them.
+#
+# A test can only be EXECUTED on its own platform, but it must COMPILE on all of them or
+# the CI job for that platform fails before a single assertion runs. `go vet` already
+# type-checks test files (see the vet target), and this goes one step further by building
+# the actual test binaries, which also catches link-level problems vet does not see —
+# a missing platform-specific symbol behind a build tag, for instance.
+#
+# `go test -c -o /dev/null` compiles and discards. Packages with no test files are
+# skipped by `go list` rather than reported as failures.
+test-compile-all-platforms:
+	@echo "Compiling test binaries (GOOS: $(GOOS_TARGETS))..."
+	@rc=0; \
+	for goos in $(GOOS_TARGETS); do \
+		printf '  %-8s ' "$$goos"; \
+		failed=""; \
+		for pkg in $$(GOOS=$$goos go list -f '{{if or .TestGoFiles .XTestGoFiles}}{{.ImportPath}}{{end}}' ./... 2>/dev/null); do \
+			if ! out=$$(GOOS=$$goos go test -c -o /dev/null "$$pkg" 2>&1); then \
+				failed="$$failed$$out\n"; \
+			fi; \
+		done; \
+		if [ -z "$$failed" ]; then \
+			echo "ok"; \
+		else \
+			echo "FAILED"; \
+			printf "$$failed" | sed 's/^/    /'; \
+			rc=1; \
+		fi; \
+	done; \
+	exit $$rc
 
 test-unit:
 	@echo "Running unit tests..."

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -717,6 +717,36 @@ func writeUnredactedFilesWarning(w io.Writer, unredactedFiles []parallel.FileDia
 	return true
 }
 
+// writeEmptyExtractionWarning emits a warning to w for every file whose
+// extraction succeeded but produced no document-body text, for a file type that
+// carries one. It returns true if a warning was written.
+//
+// This is the fourth member of the family, and it covers the quietest failure of
+// the four. The other three describe something that went wrong; this one describes
+// a scan that reported success over nothing. An OOXML container's body is selected
+// by part name, and a name we do not recognize — one differing only in case, say —
+// yields zero extracted text. Zero extracted text was indistinguishable from a
+// genuinely empty document: extraction returned Success with textLen 0, the router
+// stamped Success:true, no output format mentioned it, and --fail-on-incomplete
+// exited 0. So a 40-page document that contributed nothing to the scan read
+// exactly like a blank one.
+//
+// Gated only on pre-commit mode, like its siblings. Goes to stderr (never
+// stdout/JSON). It does not change the exit code by itself; these files are
+// counted toward --fail-on-incomplete alongside cut-short and unreadable ones,
+// which is the same opt-in escalation PR #235 gave unreadable files.
+func writeEmptyExtractionWarning(w io.Writer, emptyFiles []parallel.FileDiagnostic, totalFiles int) bool {
+	if len(emptyFiles) == 0 {
+		return false
+	}
+	fmt.Fprintf(w, "WARNING: extraction empty — %d of %d file(s) yielded no document text, so their contents were NOT scanned; any sensitive data in them was NOT detected:\n",
+		len(emptyFiles), totalFiles)
+	for _, fd := range emptyFiles {
+		fmt.Fprintf(w, "  %s: %s\n", fd.FilePath, fd.Reason)
+	}
+	return true
+}
+
 // writeUnreadableFilesWarning emits a warning to w for every file that could not
 // be opened or stat'ed — a permission error, a dangling symlink, a file deleted
 // mid-scan. It returns true if a warning was written.
@@ -902,7 +932,7 @@ func main() {
 	showSuppressed := flag.Bool("show-suppressed", false, "Include suppressed findings in output with suppression details (marked as [SUPP] in text format)")
 	quiet := flag.Bool("quiet", false, "Suppress progress output (useful for scripts and CI/CD)")
 	precommitMode := flag.Bool("pre-commit-mode", false, "Enable pre-commit optimizations (quiet mode, no colors, appropriate exit codes)")
-	failOnIncomplete := flag.Bool("fail-on-incomplete", false, "Exit non-zero (3) if any file was not fully scanned — coverage cut short (timeout, cancellation, or budget) or the file could not be opened at all. Default off: both conditions only warn on stderr.")
+	failOnIncomplete := flag.Bool("fail-on-incomplete", false, "Exit non-zero (3) if any file was not fully scanned — coverage cut short (timeout, cancellation, or budget), the file could not be opened at all, or a document yielded no extractable text. Default off: all three conditions only warn on stderr.")
 
 	// Redaction flags
 	enableRedaction := flag.Bool("enable-redaction", false, "Enable redaction of sensitive data found in documents")
@@ -1563,6 +1593,11 @@ func main() {
 	// stderr warning: the findings are still reported, but the sensitive values
 	// remain in cleartext at the original path with no shareable artifact.
 	var unredactedFiles []parallel.FileDiagnostic
+	// emptyExtractionFiles captures files whose extraction succeeded but produced
+	// no document text, for a file type that carries some. Surfaced as its own
+	// stderr warning and counted as a coverage gap: nothing was extracted, so no
+	// validator saw anything, so the file reported clean.
+	var emptyExtractionFiles []parallel.FileDiagnostic
 
 	// Report config keys the schema does not recognize. Gated only on pre-commit
 	// mode, NOT on quiet/non-interactive — the same rule as the
@@ -1701,6 +1736,7 @@ func main() {
 			processedFiles = stats.ProcessedFiles
 			incompleteFiles = stats.IncompleteFiles
 			unredactedFiles = stats.UnredactedFiles
+			emptyExtractionFiles = stats.EmptyExtractionFiles
 
 			// Handle inline redaction results if redaction was enabled
 			if finalConfig.enableRedaction && redactionManager != nil {
@@ -1764,6 +1800,7 @@ func main() {
 	// unchanged (default still 0) — this is an advisory warning.
 	if precommitConfig == nil {
 		writeUnreadableFilesWarning(os.Stderr, unreadableFiles, len(filesToProcess))
+		writeEmptyExtractionWarning(os.Stderr, emptyExtractionFiles, len(supportedFiles))
 		writeIncompleteCoverageWarning(os.Stderr, incompleteFiles, len(supportedFiles))
 		writeUnredactedFilesWarning(os.Stderr, unredactedFiles, len(supportedFiles))
 	}
@@ -1973,7 +2010,11 @@ func main() {
 	// more severe case: a cut-short scan looked at part of the file, an unreadable
 	// one was never looked at. Both mean findings may be missing, so both feed the
 	// same opt-in escalation.
-	coverageGaps := len(incompleteFiles) + len(unreadableFiles)
+	//
+	// A file that was opened and extracted to NOTHING is the third member of that
+	// set and the hardest to notice without help: unlike the other two it produces
+	// no error anywhere, just an empty document body and a clean report.
+	coverageGaps := len(incompleteFiles) + len(unreadableFiles) + len(emptyExtractionFiles)
 	if precommitConfig != nil {
 		exitCode := precommit.GetExitCode(hasFindings, hasErrors, highestConfidence, precommitConfig)
 		os.Exit(resolveIncompleteExitCode(exitCode, finalConfig.failOnIncomplete, coverageGaps))

--- a/docs/development/content-routing-troubleshooting.md
+++ b/docs/development/content-routing-troubleshooting.md
@@ -141,35 +141,27 @@ ferret-scan --file document.pdf --debug-content-routing --dry-run
 
 **Solutions:**
 
-1. **Update Preprocessor Configuration:**
-```yaml
-# Ensure preprocessors include proper section markers
-preprocessors:
-  metadata_extractor:
-    include_section_markers: true
-    marker_format: "--- {type}_metadata ---"
-```
+> **Do not fix this by matching section markers in the extracted text.** Section
+> boundaries are *declared* by the producing preprocessor in
+> `ProcessedContent.Sections`, not recovered from the text. Matching
+> `--- image_metadata ---` in content lets a document author choose the routing,
+> because the author writes the text — and because the metadata path runs one
+> field-name scanner rather than the full validator set, a forged marker deletes
+> findings instead of relabelling them. A finding that is never reported is never
+> redacted.
 
-2. **Fix Section Pattern Matching:**
-```go
-// Update pattern matching logic if needed
-func (cr *ContentRouter) identifyPreprocessorType(section ContentSection) string {
-    patterns := map[string]string{
-        "image_metadata":    `(?i)---\s*image_metadata\s*---`,
-        "document_metadata": `(?i)---\s*document_metadata\s*---`,
-        "audio_metadata":    `(?i)---\s*audio_metadata\s*---`,
-        "video_metadata":    `(?i)---\s*video_metadata\s*---`,
-    }
+1. **Check that the preprocessor populates `Sections`:**
+   A preprocessor that returns text but no sections is treated as *all document
+   body* (fail-closed). Coverage is intact, but metadata labelling is lost, which
+   is what "missing preprocessor type information" looks like. The fix belongs in
+   the preprocessor: return one `ContentSection` per distinct run of its output,
+   as `office_metadata` does for its property block and each embedded media item.
 
-    for preprocessorType, pattern := range patterns {
-        if matched, _ := regexp.MatchString(pattern, section.Header); matched {
-            return preprocessorType
-        }
-    }
-
-    return "unknown"
-}
-```
+2. **Check that the section's `Name` is in the classifier:**
+   `preprocessors.ClassifySection` switches on the preprocessor's `GetName()`.
+   An unrecognized name classifies as body, so a newly added metadata
+   preprocessor needs a case there — and a corresponding rule set in the METADATA
+   validator's table, keyed by the type the classifier returns.
 
 ### Issue: Content Router Performance Degradation
 
@@ -408,42 +400,38 @@ ferret-scan --file document.pdf --debug-content-routing --preprocess-only
 
 **Solutions:**
 
-1. **Improve Type Detection Logic:**
+1. **Set the type at the producer, where it is known:**
+
+A `ContentSection` carries its own `Type`, and the producing preprocessor fills it
+in. There is no detection step to improve — and adding one that reads the section
+header or the content would reintroduce the in-band signalling this design exists
+to remove (see the boxed warning above).
+
 ```go
-func (cr *ContentRouter) identifyPreprocessorType(section ContentSection) string {
-    // Check explicit type markers first
-    if section.Metadata != nil {
-        if pType, exists := section.Metadata["preprocessor_type"]; exists {
-            return pType.(string)
-        }
-    }
-
-    // Check section headers
-    headerLower := strings.ToLower(section.Header)
-    switch {
-    case strings.Contains(headerLower, "image") && strings.Contains(headerLower, "metadata"):
-        return PreprocessorTypeImageMetadata
-    case strings.Contains(headerLower, "document") && strings.Contains(headerLower, "metadata"):
-        return PreprocessorTypeDocumentMetadata
-    case strings.Contains(headerLower, "audio") && strings.Contains(headerLower, "metadata"):
-        return PreprocessorTypeAudioMetadata
-    case strings.Contains(headerLower, "video") && strings.Contains(headerLower, "metadata"):
-        return PreprocessorTypeVideoMetadata
-    }
-
-    // Fallback to content analysis
-    return cr.analyzeContentForType(section.Content)
-}
+// internal/preprocessors/office_metadata_preprocessor.go
+sections := []ContentSection{{
+    Name:       omp.GetName(), // our own constant, not document bytes
+    Kind:       SectionKindMetadata,
+    Type:       ProcessorTypeOfficeMetadata,
+    SourceFile: filePath,
+    Text:       text,
+    LineOffset: 0,
+}}
 ```
 
-2. **Update Preprocessor Output Format:**
+2. **For nested content, carry the inner producer's type:**
+
+An embedded item routes to a *different* rule set than its container: a `.wav`
+inside a `.docx` has an `Artist:` field, which is on the audio sensitive-field list
+but not the office one. Label the sub-section with the extractor that actually read
+it, or that field reports nothing.
+
 ```go
-// Ensure preprocessors include type information
-type PreprocessorOutput struct {
-    Content          string
-    PreprocessorType string
-    SectionMarker    string
-    Metadata         map[string]interface{}
+// The sub-result's own sections are re-anchored, not overwritten.
+for _, sub := range processed.Sections {
+    sub.SourceFile = sectionSource // "container.docx -> audio1.wav"
+    sub.LineOffset += contentLine
+    sections = append(sections, sub)
 }
 ```
 

--- a/docs/development/enhanced-processing-sequence.md
+++ b/docs/development/enhanced-processing-sequence.md
@@ -238,26 +238,40 @@ func (cr *ContentRouter) RouteContent(content *ProcessedContent) (*RoutedContent
 ```
 
 #### 3.3 Preprocessor Type Identification
-```go
-func (cr *ContentRouter) identifyPreprocessorType(section ContentSection) string {
-    // Check section markers
-    if strings.Contains(section.Header, "image_metadata") {
-        return PreprocessorTypeImageMetadata
-    }
-    if strings.Contains(section.Header, "document_metadata") {
-        return PreprocessorTypeDocumentMetadata
-    }
-    if strings.Contains(section.Header, "audio_metadata") {
-        return PreprocessorTypeAudioMetadata
-    }
-    if strings.Contains(section.Header, "video_metadata") {
-        return PreprocessorTypeVideoMetadata
-    }
 
-    // Fallback to content analysis
-    return cr.analyzeContentType(section.Content)
+A section's type is **declared by the producer, not detected from the content**. The
+file router builds `ProcessedContent.Sections` in the same loop that concatenates
+the extractors' output, and classifies each one from the preprocessor's
+`GetName()` — a constant in our own code:
+
+```go
+// internal/preprocessors/preprocessor.go
+func ClassifySection(preprocessorName string) (SectionKind, string) {
+    switch preprocessorName {
+    case ProcessorTypeImageMetadata:
+        return SectionKindMetadata, ProcessorTypeImageMetadata
+    case ProcessorTypePDFMetadata:
+        return SectionKindMetadata, "document_metadata"
+    // ... one case per preprocessor ...
+    default:
+        // "Text Extractor", "Plain Text Preprocessor", anything unknown.
+        return SectionKindBody, ""
+    }
 }
 ```
+
+Two properties are deliberate and must not be "improved" away:
+
+- **Exact match on a closed set, never a substring or regex over section text.**
+  Deriving the type by matching markers such as `--- image_metadata ---` in the
+  extracted text means a document author decides the type, because the author
+  writes the text. A paragraph typed as `--- office_metadata ---` used to move the
+  rest of the document onto the metadata path, which runs a single field-name
+  scanner instead of the full validator set — so findings were deleted, not
+  relabelled, and an unreported finding is never redacted.
+- **Unknown names classify as body, not metadata.** That is the fail-closed
+  direction: the document path runs every validator, so a preprocessor added
+  without updating the switch loses a metadata *label*, never coverage.
 
 ### 4. Dual-Path Validation (NEW)
 

--- a/internal/core/routing_coverage_test.go
+++ b/internal/core/routing_coverage_test.go
@@ -1,0 +1,239 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package core_test
+
+import (
+	"archive/zip"
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/core"
+)
+
+// The invariant under test: routing may change how a finding is LABELLED, but never
+// whether the content is scanned.
+//
+// Routing decides what counts as "metadata" by reading "--- name ---" section headers
+// out of the extracted text — text a document author supplies. The two paths do not
+// run the same validators: the document path runs the full set, the metadata path
+// runs a single field-name scanner with no SSN or card logic. So a section header in
+// the wrong place used to remove findings rather than relabel them, and because only
+// reported findings reach the redactor, a removed finding is a value left in
+// cleartext.
+//
+// These tests drive core.ScanFile with real .docx bytes rather than calling the
+// router or the bridge directly. That is deliberate on two counts: the defect lived
+// in the seam BETWEEN those two components, so exercising either alone would miss it;
+// and a hand-wired bridge would test the wiring in the test rather than the wiring
+// that ships.
+
+const (
+	// A valid SSN and a Luhn-valid card, each with strong surrounding context, so
+	// detection does not hinge on scoring subtleties unrelated to routing.
+	ssnLine  = "Employee SSN 449-87-4100 on file."
+	cardLine = "Card 4532-0151-1283-0366 expires soon."
+
+	// The router's own section separator — typeable as a document paragraph.
+	forgedHeader = "--- office_metadata ---"
+)
+
+// TestForgedSectionHeaderCannotRemoveFindings is the regression, run across every
+// placement of the header. Each variant must detect the same PII as the control.
+func TestForgedSectionHeaderCannotRemoveFindings(t *testing.T) {
+	cases := []struct {
+		name  string
+		paras []string
+	}{
+		{
+			name:  "control_no_header",
+			paras: []string{"Quarterly summary follows.", ssnLine, cardLine},
+		},
+		{
+			// The originally reported shape: header between body paragraphs.
+			name:  "header_before_payload",
+			paras: []string{"Quarterly summary follows.", forgedHeader, ssnLine, cardLine},
+		},
+		{
+			// The placement that defeats a fix which only swaps the document path's
+			// INPUT: with the header first there is no pre-header body, so a gate on
+			// the routed DocumentBody skips the document path entirely and the
+			// pre-routing text is never read.
+			name:  "header_is_first_paragraph",
+			paras: []string{forgedHeader, ssnLine, cardLine},
+		},
+		{
+			// Section names are matched loosely, so a header need not name a real
+			// preprocessor to be treated as a boundary.
+			name:  "header_with_arbitrary_name",
+			paras: []string{"--- Employee Metadata ---", ssnLine, cardLine},
+		},
+		{
+			// Interleaved: under a positional split, no paragraph is ever "body".
+			name:  "headers_interleaved",
+			paras: []string{forgedHeader, ssnLine, forgedHeader, cardLine},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			types := scanDOCX(t, tc.paras)
+
+			for _, want := range []string{"SSN", "VISA"} {
+				if !types[want] {
+					t.Errorf("%s was not detected.\n"+
+						"  paragraphs: %q\n"+
+						"  types found: %v\n"+
+						"A section header in the document text changed WHETHER content is "+
+						"scanned rather than how it is labelled. The value would also go "+
+						"unredacted, because redaction only rewrites what is reported.",
+						want, tc.paras, keys(types))
+				}
+			}
+		})
+	}
+}
+
+// TestForgedHeaderDoesNotChangeTheDetectedTypeSet states the invariant as an equality
+// rather than a threshold. A "detects at least the SSN" assertion would not notice a
+// header that removed some OTHER type, and the guarantee is about all of them.
+func TestForgedHeaderDoesNotChangeTheDetectedTypeSet(t *testing.T) {
+	control := scanDOCX(t, []string{"Quarterly summary follows.", ssnLine, cardLine})
+	forged := scanDOCX(t, []string{forgedHeader, ssnLine, cardLine})
+
+	if got, want := joined(forged), joined(control); got != want {
+		t.Errorf("a forged section header changed the detected type set.\n"+
+			"  without header: %s\n"+
+			"  with header:    %s\n"+
+			"Routing must decide labelling, not coverage.", want, got)
+	}
+}
+
+// TestMetadataStillReportedUnderItsOwnType is the non-vacuity floor in the other
+// direction. Scanning the union must not be achieved by abandoning the metadata path:
+// AUTHOR_INFO comes only from the metadata validator, so its presence proves both
+// paths still run. Without this, a "fix" that simply routed everything to the
+// document path would satisfy every assertion above while silently dropping
+// metadata-specific detection.
+func TestMetadataStillReportedUnderItsOwnType(t *testing.T) {
+	types := scanDOCX(t, []string{"Quarterly summary follows.", ssnLine, cardLine})
+
+	if !types["AUTHOR_INFO"] {
+		t.Errorf("no AUTHOR_INFO finding, so the metadata path did not run or did not "+
+			"report; types found: %v.\nThe coverage guarantee must be additive — the "+
+			"document path scanning everything must not replace metadata validation.",
+			keys(types))
+	}
+}
+
+// scanDOCX writes a minimal dual-extractor .docx and returns the set of finding types
+// core.ScanFile reports for it.
+func scanDOCX(t *testing.T, paras []string) map[string]bool {
+	t.Helper()
+
+	// The Office metadata extractor rejects paths under /var/, /tmp/, /home/ and
+	// C:\Users\ as system directories, and t.TempDir() lives under exactly those on
+	// all three CI platforms. A fixture written there would silently lose that
+	// extractor, take the single-extractor fast path, and never reach the routing arm
+	// this test is about — passing for the wrong reason. So use a repo-relative dir,
+	// as internal/router/determinism_test.go does.
+	dir, err := os.MkdirTemp(".", "routing-coverage-")
+	if err != nil {
+		t.Fatalf("creating fixture dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	path := filepath.Join(dir, "report.docx")
+	if err := os.WriteFile(path, minimalDOCX(paras), 0o600); err != nil {
+		t.Fatalf("writing fixture: %v", err)
+	}
+
+	res, err := core.ScanFile(core.ScanConfig{
+		FilePath:            filepath.ToSlash(path),
+		Checks:              []string{"SSN", "CREDIT_CARD", "METADATA"},
+		EnablePreprocessors: true,
+		LogWriter:           io.Discard,
+	})
+	if err != nil {
+		t.Fatalf("ScanFile: %v", err)
+	}
+
+	types := map[string]bool{}
+	for _, m := range res.Matches {
+		types[m.Type] = true
+	}
+	return types
+}
+
+// minimalDOCX builds a .docx carrying both a document body and core properties, so
+// two preprocessors claim it and the combined-output routing arm is exercised. A
+// .docx with only word/document.xml would take a different path.
+func minimalDOCX(paras []string) []byte {
+	var body strings.Builder
+	for _, p := range paras {
+		body.WriteString(`<w:p><w:r><w:t xml:space="preserve">` + p + `</w:t></w:r></w:p>`)
+	}
+
+	const decl = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>`
+	parts := []struct{ name, body string }{
+		{"[Content_Types].xml", decl +
+			`<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+			`<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+			`<Default Extension="xml" ContentType="application/xml"/>` +
+			`<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>` +
+			`<Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/>` +
+			`</Types>`},
+		{"_rels/.rels", decl +
+			`<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+			`<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>` +
+			`<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" Target="docProps/core.xml"/>` +
+			`</Relationships>`},
+		{"docProps/core.xml", decl +
+			`<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/">` +
+			`<dc:creator>Jane Analyst</dc:creator><cp:lastModifiedBy>Ops Reviewer</cp:lastModifiedBy>` +
+			`</cp:coreProperties>`},
+		{"word/document.xml", decl +
+			`<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>` +
+			body.String() + `</w:body></w:document>`},
+	}
+
+	out := new(bytes.Buffer)
+	zw := zip.NewWriter(out)
+	for _, p := range parts {
+		w, err := zw.Create(p.name)
+		if err != nil {
+			panic(err)
+		}
+		if _, err := io.WriteString(w, p.body); err != nil {
+			panic(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		panic(err)
+	}
+	return out.Bytes()
+}
+
+func keys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// joined renders a type set in a stable order for comparison in failure messages.
+func joined(m map[string]bool) string {
+	ks := keys(m)
+	for i := 1; i < len(ks); i++ {
+		for j := i; j > 0 && ks[j] < ks[j-1]; j-- {
+			ks[j], ks[j-1] = ks[j-1], ks[j]
+		}
+	}
+	return strings.Join(ks, ",")
+}

--- a/internal/core/scanner.go
+++ b/internal/core/scanner.go
@@ -201,6 +201,11 @@ func ScanFile(scanConfig ScanConfig) (*ScanResult, error) {
 	// Incomplete so a partially-scanned run is never mistaken for a clean one.
 	// Matches are still returned (the worker pool keeps the partial results);
 	// this only adds the signal. Defaults false when every file completed.
+	//
+	// A file that extracted to NOTHING counts as incomplete for the same reason
+	// and is checked second: it produces no error at all, so without this the
+	// library path reported a document whose body was never extracted as a
+	// complete, clean scan.
 	incomplete := false
 	incompleteReason := ""
 	if stats != nil && len(stats.IncompleteFiles) > 0 {
@@ -211,6 +216,15 @@ func ScanFile(scanConfig ScanConfig) (*ScanResult, error) {
 		} else {
 			incompleteReason = fmt.Sprintf("validation did not complete for %d of %d files",
 				len(stats.IncompleteFiles), stats.TotalFiles)
+		}
+	} else if stats != nil && len(stats.EmptyExtractionFiles) > 0 {
+		incomplete = true
+		if len(stats.EmptyExtractionFiles) == 1 {
+			incompleteReason = fmt.Sprintf("no document text extracted from %s: %s",
+				stats.EmptyExtractionFiles[0].FilePath, stats.EmptyExtractionFiles[0].Reason)
+		} else {
+			incompleteReason = fmt.Sprintf("no document text extracted from %d of %d files",
+				len(stats.EmptyExtractionFiles), stats.TotalFiles)
 		}
 	}
 

--- a/internal/goldencorpus/corpus.go
+++ b/internal/goldencorpus/corpus.go
@@ -664,7 +664,8 @@ var FileCases = []FileCase{
 	{
 		Name: "file_docx_main_part_alternate_case",
 		Description: "Tier 3: the document body at \"word/Document.xml\" instead of \"word/document.xml\" — a part name that differs only in case. " +
-			"Locks whether body text at a non-conventional part name is still extracted and scanned. Diff against file_docx_body_and_metadata.",
+			"Locks that body text at a non-conventional part name is still extracted and scanned; it previously was not, which cost this case its SSN and VISA findings. " +
+			"Diff against file_docx_body_and_metadata.",
 		Checks:   []string{"SSN", "CREDIT_CARD", "METADATA"},
 		Filename: "alt_case.docx",
 		Content: BuildDOCXWithMainPart("word/Document.xml", "Jane Analyst", "Ops Reviewer", []string{
@@ -801,10 +802,15 @@ func BuildDOCX(creator, lastModifiedBy string, paras []string) []byte {
 
 // BuildDOCXWithMainPart is BuildDOCX with control over the main part's NAME, so a
 // case can lock what happens when the document body is not at the conventional
-// path. The text extractor matches part names as literal, case-sensitive strings,
-// so "word/Document.xml" is a different part to it than "word/document.xml" — the
-// golden then records whether the body is still extracted (and therefore still
-// scanned) or silently skipped.
+// path. It also points the package relationship at that name, as a real producer
+// would.
+//
+// The text extractor used to match part names as literal, case-SENSITIVE strings,
+// so "word/Document.xml" was a different part from "word/document.xml" and the
+// body was never extracted — one capital letter took the case from 4 findings to 2
+// and put the SSN and card number outside everything the scanner could see.
+// Selection is now driven by the relationships and by case-insensitive
+// conventional names, so this case records the body being scanned.
 func BuildDOCXWithMainPart(mainPart, creator, lastModifiedBy string, paras []string) []byte {
 	return buildOOXML(docxParts(mainPart, creator, lastModifiedBy, paras))
 }

--- a/internal/goldencorpus/corpus.go
+++ b/internal/goldencorpus/corpus.go
@@ -21,14 +21,18 @@
 package goldencorpus
 
 import (
+	"archive/zip"
 	"bytes"
 	"encoding/binary"
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
+	"io"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/awslabs/ferret-scan/v2/internal/detector"
 	"github.com/awslabs/ferret-scan/v2/pkg/redact"
@@ -576,6 +580,101 @@ var FileCases = []FileCase{
 		Tier1Parity:         false, // metadata branch has no content-mode equivalent
 		EnablePreprocessors: true,  // required: .wav is a binary document
 	},
+	// --- Tier 3: OOXML containers — the combined_preprocessors routing arm -------
+	//
+	// These are the corpus's first Office cases. They exist because the arm where
+	// the FileRouter concatenates two extractors' output with "--- name ---"
+	// separators, and the ContentRouter re-splits that text to decide what is
+	// document body versus metadata, had NO coverage at all: every prior case is a
+	// single-extractor .txt/.go/.json/.csv or a .wav. A change could therefore
+	// rewrite which validators see a document's body and the whole corpus would
+	// stay green.
+	//
+	// Each pair is (control, variant) differing in ONE input, so a diff isolates
+	// that input's effect. Per the README, these lock ferret-scan's own routing and
+	// validation — not a third-party extractor's byte output — which is why the
+	// containers are synthesized in-test rather than committed.
+	{
+		Name:        "file_docx_body_and_metadata",
+		Description: "Tier 3 control: a .docx with PII in the body AND in core properties — locks the combined_preprocessors arm where both the text and office_metadata extractors claim one file.",
+		Checks:      []string{"SSN", "CREDIT_CARD", "METADATA"},
+		Filename:    "report.docx",
+		Content: BuildDOCX("Jane Analyst", "Ops Reviewer", []string{
+			"Quarterly summary follows.",
+			"Employee SSN 449-87-4100 on file.",
+			"Card 4532-0151-1283-0366 expires soon.",
+		}),
+		Tier1Parity:         false, // container extraction has no content-mode equivalent
+		EnablePreprocessors: true,
+	},
+	{
+		Name: "file_docx_forged_separator_midbody",
+		Description: "Tier 3: same .docx as the control plus ONE body paragraph that is exactly the router's own section separator. " +
+			"Locks what the document path is given when document text forges a section boundary. Diff against file_docx_body_and_metadata.",
+		Checks:   []string{"SSN", "CREDIT_CARD", "METADATA"},
+		Filename: "forged_mid.docx",
+		Content: BuildDOCX("Jane Analyst", "Ops Reviewer", []string{
+			"Quarterly summary follows.",
+			"--- office_metadata ---",
+			"Employee SSN 449-87-4100 on file.",
+			"Card 4532-0151-1283-0366 expires soon.",
+		}),
+		Tier1Parity:         false,
+		EnablePreprocessors: true,
+	},
+	{
+		Name: "file_docx_forged_separator_firstline",
+		Description: "Tier 3: the forged separator as the FIRST paragraph, so the pre-separator body is empty. " +
+			"A distinct routing state from the mid-body case (empty document body vs a short one), which is why it gets its own snapshot.",
+		Checks:   []string{"SSN", "CREDIT_CARD", "METADATA"},
+		Filename: "forged_first.docx",
+		Content: BuildDOCX("Jane Analyst", "Ops Reviewer", []string{
+			"--- office_metadata ---",
+			"Employee SSN 449-87-4100 on file.",
+			"Card 4532-0151-1283-0366 expires soon.",
+		}),
+		Tier1Parity:         false,
+		EnablePreprocessors: true,
+	},
+	{
+		Name:        "file_xlsx_sheet_cells",
+		Description: "Tier 3 control: an .xlsx with PII in worksheet cells at the conventional sheet part name.",
+		Checks:      []string{"SSN", "CREDIT_CARD", "METADATA"},
+		Filename:    "books.xlsx",
+		Content: BuildXLSX("xl/worksheets/sheet1.xml", "Jane Analyst", []string{
+			"Employee SSN 449-87-4100",
+			"Card 4532-0151-1283-0366",
+		}),
+		Tier1Parity:         false,
+		EnablePreprocessors: true,
+	},
+	{
+		Name: "file_xlsx_sheet_part_named_metadata",
+		Description: "Tier 3: identical cells, but the worksheet PART is named so the extractor's emitted section label collides with a metadata section name. " +
+			"No body text is involved — the collision comes from the archive member name, which a document producer controls. Diff against file_xlsx_sheet_cells.",
+		Checks:   []string{"SSN", "CREDIT_CARD", "METADATA"},
+		Filename: "books_named.xlsx",
+		Content: BuildXLSX("xl/worksheets/sheet_office_metadata.xml", "Jane Analyst", []string{
+			"Employee SSN 449-87-4100",
+			"Card 4532-0151-1283-0366",
+		}),
+		Tier1Parity:         false,
+		EnablePreprocessors: true,
+	},
+	{
+		Name: "file_docx_main_part_alternate_case",
+		Description: "Tier 3: the document body at \"word/Document.xml\" instead of \"word/document.xml\" — a part name that differs only in case. " +
+			"Locks whether body text at a non-conventional part name is still extracted and scanned. Diff against file_docx_body_and_metadata.",
+		Checks:   []string{"SSN", "CREDIT_CARD", "METADATA"},
+		Filename: "alt_case.docx",
+		Content: BuildDOCXWithMainPart("word/Document.xml", "Jane Analyst", "Ops Reviewer", []string{
+			"Quarterly summary follows.",
+			"Employee SSN 449-87-4100 on file.",
+			"Card 4532-0151-1283-0366 expires soon.",
+		}),
+		Tier1Parity:         false,
+		EnablePreprocessors: true,
+	},
 }
 
 // BuildWAVWithInfo synthesizes a minimal but valid WAV file (RIFF/WAVE + fmt +
@@ -631,6 +730,198 @@ func BuildWAVWithInfo(info map[string]string) []byte {
 	writeLE(out, uint32(body.Len()))
 	out.Write(body.Bytes())
 	return out.Bytes()
+}
+
+// --- Office (OOXML) builders -------------------------------------------------
+//
+// Until these existed the corpus had NO .docx/.xlsx/.pptx/.pdf case at all (the
+// census was 2 .txt, 1 .go, 1 .json, 1 .csv, 1 .wav). That mattered because the
+// interesting routing arm is `combined_preprocessors`: it is reached only when
+// TWO OR MORE preprocessors claim the same file, which no single-extractor type
+// does. So the whole path where the FileRouter concatenates extractor output with
+// "--- name ---" separators, and the ContentRouter re-splits it, was unsnapshotted
+// — a change could rewrite what the document path sees and the corpus would stay
+// green. These builders close that gap with in-test deterministic zips rather than
+// committed binaries, matching the BuildWAVWithInfo precedent.
+//
+// Determinism: zip.Writer stamps a modtime per entry, and archive/zip writes
+// whatever Modified holds, so an unset FileHeader would embed "now" and the bytes
+// would differ every run. Every entry here pins Modified to a fixed UTC instant and
+// parts are written in a fixed order, so the archive is byte-stable. (The
+// ScanFile-side ModTime of the temp file is separately normalized in
+// NormalizeOutput.)
+
+// ooxmlEpoch is the fixed timestamp stamped into every synthesized OOXML entry.
+// Any constant works; it only has to be stable and not depend on the clock.
+var ooxmlEpoch = time.Date(2020, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+// ooxmlPart is one archive member, written in slice order.
+type ooxmlPart struct {
+	name string
+	body string
+}
+
+// buildOOXML zips the given parts with pinned modtimes, yielding byte-identical
+// output for identical input.
+func buildOOXML(parts []ooxmlPart) []byte {
+	out := new(bytes.Buffer)
+	zw := zip.NewWriter(out)
+	for _, p := range parts {
+		w, err := zw.CreateHeader(&zip.FileHeader{
+			Name:     p.name,
+			Method:   zip.Deflate,
+			Modified: ooxmlEpoch,
+		})
+		if err != nil {
+			panic(err)
+		}
+		if _, err := io.WriteString(w, p.body); err != nil {
+			panic(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		panic(err)
+	}
+	return out.Bytes()
+}
+
+// BuildDOCX synthesizes a minimal .docx whose body is one paragraph per element of
+// paras, and which ALSO carries docProps/core.xml. The core properties are what
+// make this a dual-preprocessor file: the text extractor and the office metadata
+// extractor both claim it, so the FileRouter takes the combined_preprocessors arm
+// and the ContentRouter's document/metadata split actually runs. A .docx with only
+// word/document.xml takes the single-extractor fast path and would not exercise it.
+//
+// creator/lastModifiedBy land in the metadata path; paras land in the document
+// path. Passing a paragraph that is exactly "--- office_metadata ---" is how a
+// case locks the forged-separator behavior.
+func BuildDOCX(creator, lastModifiedBy string, paras []string) []byte {
+	return buildOOXML(docxParts("word/document.xml", creator, lastModifiedBy, paras))
+}
+
+// BuildDOCXWithMainPart is BuildDOCX with control over the main part's NAME, so a
+// case can lock what happens when the document body is not at the conventional
+// path. The text extractor matches part names as literal, case-sensitive strings,
+// so "word/Document.xml" is a different part to it than "word/document.xml" — the
+// golden then records whether the body is still extracted (and therefore still
+// scanned) or silently skipped.
+func BuildDOCXWithMainPart(mainPart, creator, lastModifiedBy string, paras []string) []byte {
+	return buildOOXML(docxParts(mainPart, creator, lastModifiedBy, paras))
+}
+
+func docxParts(mainPart, creator, lastModifiedBy string, paras []string) []ooxmlPart {
+	var body strings.Builder
+	for _, p := range paras {
+		body.WriteString(`<w:p><w:r><w:t xml:space="preserve">`)
+		body.WriteString(escapeXML(p))
+		body.WriteString(`</w:t></w:r></w:p>`)
+	}
+	doc := xmlDecl + `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>` +
+		body.String() + `</w:body></w:document>`
+
+	contentTypes := xmlDecl + `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+		`<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+		`<Default Extension="xml" ContentType="application/xml"/>` +
+		`<Override PartName="/` + mainPart + `" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>` +
+		`<Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/>` +
+		`</Types>`
+
+	rels := xmlDecl + `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+		`<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="` + mainPart + `"/>` +
+		`<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" Target="docProps/core.xml"/>` +
+		`</Relationships>`
+
+	return []ooxmlPart{
+		{"[Content_Types].xml", contentTypes},
+		{"_rels/.rels", rels},
+		{"docProps/core.xml", coreProps(creator, lastModifiedBy)},
+		{mainPart, doc},
+	}
+}
+
+// BuildXLSX synthesizes a minimal .xlsx with one worksheet whose single column
+// holds cells, plus docProps/core.xml so the file is dual-preprocessor like
+// BuildDOCX.
+//
+// sheetPart is the worksheet's archive name (conventionally
+// "xl/worksheets/sheet1.xml"). It is a parameter because the office text extractor
+// derives its emitted section label from that name — it strips the
+// "xl/worksheets/" prefix and ".xml" suffix and writes "--- <rest> ---" into the
+// same text stream the ContentRouter re-parses. A sheet part named
+// "sheet_office_metadata.xml" therefore emits a label the router reads as a
+// metadata section boundary, with no document body text involved at all. Cases use
+// it to lock that behavior.
+func BuildXLSX(sheetPart, creator string, cells []string) []byte {
+	var siBuf, rowBuf strings.Builder
+	for i, c := range cells {
+		siBuf.WriteString(`<si><t xml:space="preserve">` + escapeXML(c) + `</t></si>`)
+		rowBuf.WriteString(fmt.Sprintf(`<row r="%d"><c r="A%d" t="s"><v>%d</v></c></row>`, i+1, i+1, i))
+	}
+	shared := xmlDecl + fmt.Sprintf(
+		`<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="%d" uniqueCount="%d">%s</sst>`,
+		len(cells), len(cells), siBuf.String())
+	sheet := xmlDecl + `<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData>` +
+		rowBuf.String() + `</sheetData></worksheet>`
+
+	contentTypes := xmlDecl + `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+		`<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+		`<Default Extension="xml" ContentType="application/xml"/>` +
+		`<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>` +
+		`<Override PartName="/` + sheetPart + `" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>` +
+		`<Override PartName="/xl/sharedStrings.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/>` +
+		`<Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/>` +
+		`</Types>`
+
+	rels := xmlDecl + `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+		`<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>` +
+		`<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" Target="docProps/core.xml"/>` +
+		`</Relationships>`
+
+	// The sheet name shown in Excel is independent of the part name; keep it fixed
+	// so only the part name varies between cases.
+	workbook := xmlDecl + `<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" ` +
+		`xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+		`<sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets></workbook>`
+
+	sheetTarget := strings.TrimPrefix(sheetPart, "xl/")
+	workbookRels := xmlDecl + `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+		`<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="` + sheetTarget + `"/>` +
+		`<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings" Target="sharedStrings.xml"/>` +
+		`</Relationships>`
+
+	return buildOOXML([]ooxmlPart{
+		{"[Content_Types].xml", contentTypes},
+		{"_rels/.rels", rels},
+		{"docProps/core.xml", coreProps(creator, "")},
+		{"xl/workbook.xml", workbook},
+		{"xl/_rels/workbook.xml.rels", workbookRels},
+		{"xl/sharedStrings.xml", shared},
+		{sheetPart, sheet},
+	})
+}
+
+const xmlDecl = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>`
+
+// coreProps renders docProps/core.xml. lastModifiedBy is omitted when empty.
+func coreProps(creator, lastModifiedBy string) string {
+	s := xmlDecl +
+		`<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" ` +
+		`xmlns:dc="http://purl.org/dc/elements/1.1/">` +
+		`<dc:creator>` + escapeXML(creator) + `</dc:creator>`
+	if lastModifiedBy != "" {
+		s += `<cp:lastModifiedBy>` + escapeXML(lastModifiedBy) + `</cp:lastModifiedBy>`
+	}
+	return s + `</cp:coreProperties>`
+}
+
+// escapeXML escapes text for an XML text node. Cases deliberately contain "---"
+// and "<"-free payloads, but escaping keeps the builder honest for any input.
+func escapeXML(s string) string {
+	var b strings.Builder
+	if err := xml.EscapeText(&b, []byte(s)); err != nil {
+		panic(err)
+	}
+	return b.String()
 }
 
 // writeLE writes each value to buf in little-endian order, panicking on error

--- a/internal/goldencorpus/golden_file_test.go
+++ b/internal/goldencorpus/golden_file_test.go
@@ -24,18 +24,6 @@ func TestGoldenFileScanFormats(t *testing.T) {
 	for _, fc := range FileCases {
 		fc := fc
 		t.Run(fc.Name, func(t *testing.T) {
-			// An OOXML snapshot is only meaningful where both extractors can run. On a
-			// checkout under a path the Office extractor rejects, the metadata half is
-			// unreachable and the recorded output would differ from every other
-			// platform's — so skip instead of locking a machine-specific result.
-			if needsGuardFreePath(fc.Filename) {
-				if cwd, blocked := officePathGuardApplies(); blocked {
-					t.Skipf("checkout is under a path the Office metadata extractor rejects (%s), "+
-						"so office_metadata cannot run for any fixture in this repo and this "+
-						"snapshot would not match other platforms; see caseTempDir", cwd)
-				}
-			}
-
 			tmpDir := caseTempDir(t, fc)
 			path := writeFixture(t, tmpDir, fc) // forward-slash scan path
 
@@ -141,80 +129,36 @@ func writeFixture(t *testing.T, tmpDir string, fc FileCase) string {
 	return filepath.ToSlash(nativePath) // "/"-normalized path for the scan
 }
 
-// caseTempDir returns the directory a case's fixture is written to.
+// caseTempDir returns the directory a case's fixture is written to: t.TempDir()
+// for every case.
 //
-// It is NOT always t.TempDir(). The Office metadata extractor validates the path it is
-// handed and refuses anything whose absolute form starts with /var/, /tmp/, /home/,
-// C:\Users\ and similar (meta-extract-officelib/office-extractor.go validateFilePath).
-// t.TempDir() resolves under exactly those roots on every platform. An Office fixture
-// written there silently loses the office_metadata extractor: the file then has only
-// ONE capable preprocessor, takes the single-extractor fast path, and never reaches the
-// combined_preprocessors routing arm these cases exist to lock. Nothing fails — the
-// snapshot just records a scan that skipped the code under test.
+// It used to hand OOXML cases a repo-relative directory instead, and the OOXML
+// tests used to skip entirely on a checkout under /home/. Both existed to work
+// around the Office metadata extractor's system-directory denylist, which refused
+// /var/, /tmp/, /home/ and C:\Users\ — i.e. wherever t.TempDir() lives on every
+// platform, and on GitHub's Linux runners the checkout itself. An Office fixture
+// under a refused path silently lost the office_metadata extractor and the case
+// recorded a scan that skipped the code under test.
 //
-// OOXML cases therefore get a repo-relative directory, following
-// internal/router/determinism_test.go. Note this is NOT sufficient everywhere: on a
-// checkout under a rejected prefix (GitHub's Linux runners use
-// /home/runner/work/...) the repo itself is inside the denylist and no fixture location
-// can escape it. officePathGuardApplies reports that case so the affected tests skip
-// with an explanation rather than recording, or asserting, unreachable behavior.
-func caseTempDir(t *testing.T, fc FileCase) string {
+// That denylist is gone (meta-extract-officelib/office-extractor.go
+// validateFilePath), so a temp dir works everywhere and the six OOXML cases are
+// real assertions on all three platforms instead of platform-dependent skips.
+// TestOOXMLCasesReachTheCombinedArm still checks the precondition every run, so a
+// regression that re-broke extraction under temp paths would fail rather than skip.
+func caseTempDir(t *testing.T, _ FileCase) string {
 	t.Helper()
-	if !needsGuardFreePath(fc.Filename) {
-		return t.TempDir()
-	}
-	dir, err := os.MkdirTemp(".", "golden-ooxml-")
-	if err != nil {
-		t.Fatalf("creating repo-relative fixture dir: %v", err)
-	}
-	t.Cleanup(func() { os.RemoveAll(dir) })
-	abs, err := filepath.Abs(dir)
-	if err != nil {
-		t.Fatalf("resolving fixture dir: %v", err)
-	}
-	return abs
+	return t.TempDir()
 }
 
-// needsGuardFreePath reports whether a fixture's extension routes through the
-// path-validating Office metadata extractor.
+// needsGuardFreePath reports whether a fixture is an OOXML container, and so
+// routes through BOTH the text and Office metadata extractors — the
+// dual-preprocessor arm the OOXML cases exist to lock.
 func needsGuardFreePath(filename string) bool {
 	switch strings.ToLower(filepath.Ext(filename)) {
 	case ".docx", ".xlsx", ".pptx", ".docm", ".xlsm", ".pptm":
 		return true
 	}
 	return false
-}
-
-// officePathGuardRejectedPrefixes mirrors the extractor's denylist for the roots a test
-// checkout can plausibly live under. It is intentionally a copy rather than an exported
-// hook: the extractor's list is a private implementation detail, and the copy exists
-// only so tests can DETECT the condition, never to depend on it.
-var officePathGuardRejectedPrefixes = []string{"/var/", "/tmp/", "/home/", "/root/", "c:/users/"}
-
-// officePathGuardApplies reports whether this checkout sits under a path the Office
-// metadata extractor refuses, which makes office_metadata extraction impossible for any
-// fixture written anywhere inside the repo.
-//
-// This is a property of where the repository happens to be checked out, not of the code
-// under test, so tests that need the extractor skip rather than fail. The underlying
-// guard is a real defect — it also means an ordinary Linux user's ~/report.docx gets no
-// Office metadata extraction — but fixing it belongs to the extraction layer, not to a
-// corpus change.
-func officePathGuardApplies() (string, bool) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return "", false
-	}
-	norm := strings.ToLower(filepath.ToSlash(cwd))
-	if !strings.HasSuffix(norm, "/") {
-		norm += "/"
-	}
-	for _, p := range officePathGuardRejectedPrefixes {
-		if strings.HasPrefix(norm, p) {
-			return cwd, true
-		}
-	}
-	return cwd, false
 }
 
 // matchKeys reduces a match slice to a sorted, path-independent identity list

--- a/internal/goldencorpus/golden_file_test.go
+++ b/internal/goldencorpus/golden_file_test.go
@@ -24,6 +24,18 @@ func TestGoldenFileScanFormats(t *testing.T) {
 	for _, fc := range FileCases {
 		fc := fc
 		t.Run(fc.Name, func(t *testing.T) {
+			// An OOXML snapshot is only meaningful where both extractors can run. On a
+			// checkout under a path the Office extractor rejects, the metadata half is
+			// unreachable and the recorded output would differ from every other
+			// platform's — so skip instead of locking a machine-specific result.
+			if needsGuardFreePath(fc.Filename) {
+				if cwd, blocked := officePathGuardApplies(); blocked {
+					t.Skipf("checkout is under a path the Office metadata extractor rejects (%s), "+
+						"so office_metadata cannot run for any fixture in this repo and this "+
+						"snapshot would not match other platforms; see caseTempDir", cwd)
+				}
+			}
+
 			tmpDir := caseTempDir(t, fc)
 			path := writeFixture(t, tmpDir, fc) // forward-slash scan path
 
@@ -131,18 +143,21 @@ func writeFixture(t *testing.T, tmpDir string, fc FileCase) string {
 
 // caseTempDir returns the directory a case's fixture is written to.
 //
-// It is NOT always t.TempDir(). The Office metadata extractor validates the path it
-// is handed and refuses anything under /var/, /tmp/, /home/ or C:\Users\ as a system
-// directory (meta-extract-officelib/office-extractor.go validateFilePath). t.TempDir()
-// resolves under exactly those roots on all three CI platforms — /var/folders/... on
-// macOS, /tmp/... on Linux, C:\Users\...\AppData on Windows — so an Office fixture
-// written there silently loses the office_metadata extractor. The file then has only
-// ONE capable preprocessor, takes the single-extractor fast path, and never reaches
-// the combined_preprocessors routing arm these cases exist to lock. Nothing fails; the
+// It is NOT always t.TempDir(). The Office metadata extractor validates the path it is
+// handed and refuses anything whose absolute form starts with /var/, /tmp/, /home/,
+// C:\Users\ and similar (meta-extract-officelib/office-extractor.go validateFilePath).
+// t.TempDir() resolves under exactly those roots on every platform. An Office fixture
+// written there silently loses the office_metadata extractor: the file then has only
+// ONE capable preprocessor, takes the single-extractor fast path, and never reaches the
+// combined_preprocessors routing arm these cases exist to lock. Nothing fails — the
 // snapshot just records a scan that skipped the code under test.
 //
-// So OOXML cases get a repo-relative directory, which the guard permits, following
-// internal/router/determinism_test.go. Everything else keeps t.TempDir().
+// OOXML cases therefore get a repo-relative directory, following
+// internal/router/determinism_test.go. Note this is NOT sufficient everywhere: on a
+// checkout under a rejected prefix (GitHub's Linux runners use
+// /home/runner/work/...) the repo itself is inside the denylist and no fixture location
+// can escape it. officePathGuardApplies reports that case so the affected tests skip
+// with an explanation rather than recording, or asserting, unreachable behavior.
 func caseTempDir(t *testing.T, fc FileCase) string {
 	t.Helper()
 	if !needsGuardFreePath(fc.Filename) {
@@ -168,6 +183,38 @@ func needsGuardFreePath(filename string) bool {
 		return true
 	}
 	return false
+}
+
+// officePathGuardRejectedPrefixes mirrors the extractor's denylist for the roots a test
+// checkout can plausibly live under. It is intentionally a copy rather than an exported
+// hook: the extractor's list is a private implementation detail, and the copy exists
+// only so tests can DETECT the condition, never to depend on it.
+var officePathGuardRejectedPrefixes = []string{"/var/", "/tmp/", "/home/", "/root/", "c:/users/"}
+
+// officePathGuardApplies reports whether this checkout sits under a path the Office
+// metadata extractor refuses, which makes office_metadata extraction impossible for any
+// fixture written anywhere inside the repo.
+//
+// This is a property of where the repository happens to be checked out, not of the code
+// under test, so tests that need the extractor skip rather than fail. The underlying
+// guard is a real defect — it also means an ordinary Linux user's ~/report.docx gets no
+// Office metadata extraction — but fixing it belongs to the extraction layer, not to a
+// corpus change.
+func officePathGuardApplies() (string, bool) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", false
+	}
+	norm := strings.ToLower(filepath.ToSlash(cwd))
+	if !strings.HasSuffix(norm, "/") {
+		norm += "/"
+	}
+	for _, p := range officePathGuardRejectedPrefixes {
+		if strings.HasPrefix(norm, p) {
+			return cwd, true
+		}
+	}
+	return cwd, false
 }
 
 // matchKeys reduces a match slice to a sorted, path-independent identity list

--- a/internal/goldencorpus/golden_file_test.go
+++ b/internal/goldencorpus/golden_file_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/awslabs/ferret-scan/v2/internal/core"
@@ -23,7 +24,7 @@ func TestGoldenFileScanFormats(t *testing.T) {
 	for _, fc := range FileCases {
 		fc := fc
 		t.Run(fc.Name, func(t *testing.T) {
-			tmpDir := t.TempDir()
+			tmpDir := caseTempDir(t, fc)
 			path := writeFixture(t, tmpDir, fc) // forward-slash scan path
 
 			res, err := core.ScanFile(core.ScanConfig{
@@ -126,6 +127,47 @@ func writeFixture(t *testing.T, tmpDir string, fc FileCase) string {
 		t.Fatalf("write fixture %q: %v", fc.Filename, err)
 	}
 	return filepath.ToSlash(nativePath) // "/"-normalized path for the scan
+}
+
+// caseTempDir returns the directory a case's fixture is written to.
+//
+// It is NOT always t.TempDir(). The Office metadata extractor validates the path it
+// is handed and refuses anything under /var/, /tmp/, /home/ or C:\Users\ as a system
+// directory (meta-extract-officelib/office-extractor.go validateFilePath). t.TempDir()
+// resolves under exactly those roots on all three CI platforms — /var/folders/... on
+// macOS, /tmp/... on Linux, C:\Users\...\AppData on Windows — so an Office fixture
+// written there silently loses the office_metadata extractor. The file then has only
+// ONE capable preprocessor, takes the single-extractor fast path, and never reaches
+// the combined_preprocessors routing arm these cases exist to lock. Nothing fails; the
+// snapshot just records a scan that skipped the code under test.
+//
+// So OOXML cases get a repo-relative directory, which the guard permits, following
+// internal/router/determinism_test.go. Everything else keeps t.TempDir().
+func caseTempDir(t *testing.T, fc FileCase) string {
+	t.Helper()
+	if !needsGuardFreePath(fc.Filename) {
+		return t.TempDir()
+	}
+	dir, err := os.MkdirTemp(".", "golden-ooxml-")
+	if err != nil {
+		t.Fatalf("creating repo-relative fixture dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		t.Fatalf("resolving fixture dir: %v", err)
+	}
+	return abs
+}
+
+// needsGuardFreePath reports whether a fixture's extension routes through the
+// path-validating Office metadata extractor.
+func needsGuardFreePath(filename string) bool {
+	switch strings.ToLower(filepath.Ext(filename)) {
+	case ".docx", ".xlsx", ".pptx", ".docm", ".xlsm", ".pptm":
+		return true
+	}
+	return false
 }
 
 // matchKeys reduces a match slice to a sorted, path-independent identity list

--- a/internal/goldencorpus/ooxml_builder_test.go
+++ b/internal/goldencorpus/ooxml_builder_test.go
@@ -1,0 +1,163 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package goldencorpus
+
+import (
+	"archive/zip"
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// The Office builders exist to give the corpus its first .docx/.xlsx cases, so the
+// builders themselves have to be trustworthy before any snapshot is generated from
+// them. Two properties matter: the bytes must be identical across runs (a golden
+// generated from a wobbling builder would fail on the next run for a reason that has
+// nothing to do with the code under test), and the archive must actually be the
+// dual-extractor shape whose routing the new cases are meant to lock.
+
+// TestBuildDOCXIsDeterministic guards the property that makes snapshotting possible
+// at all. archive/zip stamps each entry's modtime from FileHeader.Modified, so an
+// unset header would embed "now" and the bytes would differ run to run.
+func TestBuildDOCXIsDeterministic(t *testing.T) {
+	paras := []string{"employee ssn 449-87-4100", "card 4532-0151-1283-0366"}
+	a := BuildDOCX("Jane Analyst", "Jane Analyst", paras)
+	b := BuildDOCX("Jane Analyst", "Jane Analyst", paras)
+
+	if !bytes.Equal(a, b) {
+		t.Fatalf("BuildDOCX is not byte-stable across calls (%d vs %d bytes); "+
+			"a golden generated from it would fail on the next run", len(a), len(b))
+	}
+}
+
+// TestBuildXLSXIsDeterministic is the same property for the spreadsheet builder.
+func TestBuildXLSXIsDeterministic(t *testing.T) {
+	cells := []string{"ssn 449-87-4100", "card 4532-0151-1283-0366"}
+	a := BuildXLSX("xl/worksheets/sheet1.xml", "Jane Analyst", cells)
+	b := BuildXLSX("xl/worksheets/sheet1.xml", "Jane Analyst", cells)
+
+	if !bytes.Equal(a, b) {
+		t.Fatalf("BuildXLSX is not byte-stable across calls (%d vs %d bytes)", len(a), len(b))
+	}
+}
+
+// TestBuildDOCXCarriesBothChannels is the non-vacuity floor for the DOCX cases. The
+// whole point of these fixtures is the arm where TWO preprocessors claim one file,
+// so the archive must carry both a document body and core properties. If a future
+// edit dropped docProps/core.xml the file would silently take the single-extractor
+// fast path and every routing case built on it would still pass while testing
+// nothing.
+func TestBuildDOCXCarriesBothChannels(t *testing.T) {
+	data := BuildDOCX("Jane Analyst", "Ops Reviewer", []string{"ssn 449-87-4100"})
+
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("BuildDOCX did not produce a readable zip: %v", err)
+	}
+
+	names := map[string]string{}
+	for _, f := range zr.File {
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("opening %s: %v", f.Name, err)
+		}
+		var sb strings.Builder
+		if _, err := sb.Write(readAll(t, rc)); err != nil {
+			t.Fatal(err)
+		}
+		rc.Close()
+		names[f.Name] = sb.String()
+	}
+
+	body, ok := names["word/document.xml"]
+	if !ok {
+		t.Fatalf("no word/document.xml in the archive; parts are %v", keysOf(names))
+	}
+	if !strings.Contains(body, "449-87-4100") {
+		t.Error("the document body does not carry the paragraph text it was given")
+	}
+
+	core, ok := names["docProps/core.xml"]
+	if !ok {
+		t.Fatalf("no docProps/core.xml in the archive — the file would take the "+
+			"single-extractor path and the routing cases built on it would be vacuous; "+
+			"parts are %v", keysOf(names))
+	}
+	if !strings.Contains(core, "Jane Analyst") || !strings.Contains(core, "Ops Reviewer") {
+		t.Error("core properties do not carry both creator and lastModifiedBy")
+	}
+}
+
+// TestBuildDOCXWithMainPartHonorsTheName pins the knob the part-name cases depend
+// on: the caller must be able to place the body at a non-conventional path, because
+// that is precisely the input whose handling the corpus needs to record.
+func TestBuildDOCXWithMainPartHonorsTheName(t *testing.T) {
+	data := BuildDOCXWithMainPart("word/Document.xml", "Jane Analyst", "", []string{"ssn 449-87-4100"})
+
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("not a readable zip: %v", err)
+	}
+
+	var got []string
+	for _, f := range zr.File {
+		got = append(got, f.Name)
+	}
+	if !contains(got, "word/Document.xml") {
+		t.Errorf("the requested main part name was not used; parts are %v", got)
+	}
+	if contains(got, "word/document.xml") {
+		t.Errorf("the conventional part name is also present, so a case using this "+
+			"builder would not isolate the alternate name; parts are %v", got)
+	}
+}
+
+// TestBuildXLSXHonorsSheetPartName is the same knob for worksheets. The office text
+// extractor derives the section label it emits from this name, so a case cannot lock
+// that behavior unless the builder passes the name through untouched.
+func TestBuildXLSXHonorsSheetPartName(t *testing.T) {
+	const part = "xl/worksheets/sheet_office_metadata.xml"
+	data := BuildXLSX(part, "Jane Analyst", []string{"ssn 449-87-4100"})
+
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("not a readable zip: %v", err)
+	}
+	var got []string
+	for _, f := range zr.File {
+		got = append(got, f.Name)
+	}
+	if !contains(got, part) {
+		t.Errorf("sheet part name %q was not honored; parts are %v", part, got)
+	}
+	if !contains(got, "xl/sharedStrings.xml") {
+		t.Errorf("no sharedStrings part — cell text would not be extractable; parts are %v", got)
+	}
+}
+
+func readAll(t *testing.T, r interface{ Read([]byte) (int, error) }) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("reading part: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func keysOf(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func contains(hay []string, needle string) bool {
+	for _, h := range hay {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/goldencorpus/ooxml_routing_coverage_test.go
+++ b/internal/goldencorpus/ooxml_routing_coverage_test.go
@@ -5,6 +5,7 @@ package goldencorpus
 
 import (
 	"io"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -26,10 +27,11 @@ import (
 // "--- name ---" separators and the ContentRouter re-splits it. A case that quietly
 // drops to one extractor would still produce a stable snapshot while testing nothing.
 //
-// The specific way that happens is a path guard: the Office metadata extractor
-// refuses paths under /var/, /tmp/, /home/ and C:\Users\, which is where t.TempDir()
-// lives on all three CI platforms. caseTempDir exists to avoid it, and this test
-// fails if that ever regresses.
+// The specific way that happened was a path guard: the Office metadata extractor
+// refused paths under /var/, /tmp/, /home/ and C:\Users\, which is where t.TempDir()
+// lives on all three CI platforms. That guard is gone, so this test now runs
+// everywhere instead of skipping — and it is what fails if the guard, or anything
+// else that costs a fixture its second extractor, comes back.
 func TestOOXMLCasesReachTheCombinedArm(t *testing.T) {
 	var seen int
 	for _, fc := range FileCases {
@@ -39,17 +41,6 @@ func TestOOXMLCasesReachTheCombinedArm(t *testing.T) {
 		seen++
 		fc := fc
 		t.Run(fc.Name, func(t *testing.T) {
-			// Where the checkout itself sits under a path the Office extractor refuses,
-			// no fixture location inside the repo can reach the second extractor. That
-			// is a property of the environment, not of the routing code, so report it as
-			// a skip. (The guard is itself a defect — an ordinary Linux user's
-			// ~/report.docx also loses Office metadata extraction — but that fix belongs
-			// to the extraction layer.)
-			if cwd, blocked := officePathGuardApplies(); blocked {
-				t.Skipf("checkout is under a path the Office metadata extractor rejects (%s); "+
-					"office_metadata cannot run for any fixture in this repo", cwd)
-			}
-
 			dir := caseTempDir(t, fc)
 			path := writeFixture(t, dir, fc)
 
@@ -97,33 +88,68 @@ func TestOOXMLCasesReachTheCombinedArm(t *testing.T) {
 	}
 }
 
-// TestCaseTempDirAvoidsTheOfficePathGuard pins the helper's contract directly, so the
-// reason for the repo-relative directory survives future refactoring. Without it, a
-// well-meaning simplification back to t.TempDir() would make six corpus cases vacuous
-// and nothing would fail.
-func TestCaseTempDirAvoidsTheOfficePathGuard(t *testing.T) {
-	ooxml := FileCase{Filename: "book.xlsx"}
-	dir := caseTempDir(t, ooxml)
-
-	// Only assert the property caseTempDir can actually deliver. When the checkout is
-	// already inside the denylist, no directory under the repo escapes it, and that is
-	// the extractor's defect rather than this helper's.
-	if cwd, blocked := officePathGuardApplies(); blocked {
-		t.Skipf("checkout is under a rejected path (%s); caseTempDir cannot escape it", cwd)
+// TestOfficeMetadataWorksUnderATempPath pins the fix that let the tests above stop
+// skipping: an Office fixture written to an ordinary temp directory must still get
+// Office metadata extraction.
+//
+// It asserts the user-facing property directly rather than the shape of a path
+// list. The old guard refused /var/, /tmp/, /home/ and C:\Users\, which is both
+// where t.TempDir() resolves on every platform and — more importantly — where all
+// of a Linux user's own files live: `ferret-scan --file ~/report.docx` lost
+// metadata extraction with no error shown. Measured on this fixture with the
+// pre-fix binary: 2 findings at a temp path versus 4 at an allowed one, the two
+// missing ones being the metadata fields.
+//
+// This is deliberately a separate assertion from the corpus snapshots. A future
+// change that re-introduced any location-dependent refusal would make six cases
+// quietly cover less; this fails outright and names the reason.
+func TestOfficeMetadataWorksUnderATempPath(t *testing.T) {
+	dir := t.TempDir()
+	lower := strings.ToLower(filepath.ToSlash(dir))
+	if !strings.HasPrefix(lower, "/var/") && !strings.HasPrefix(lower, "/tmp/") &&
+		!strings.HasPrefix(lower, "/home/") && !strings.Contains(lower, ":/users/") {
+		t.Skipf("t.TempDir() returned %q, which is not under any of the roots the old "+
+			"guard refused, so this platform cannot exercise the regression", dir)
 	}
 
-	lower := strings.ToLower(strings.ReplaceAll(dir, "\\", "/"))
-	for _, bad := range officePathGuardRejectedPrefixes {
-		if strings.HasPrefix(lower, bad) {
-			t.Errorf("caseTempDir returned %q for an OOXML case, which starts with the "+
-				"rejected prefix %q; the Office metadata extractor will refuse it and the "+
-				"case will silently lose a preprocessor", dir, bad)
+	fc := FileCase{
+		Filename: "guard_probe.docx",
+		Checks:   []string{"SSN", "METADATA"},
+		Content: BuildDOCX("Jane Analyst", "Ops Reviewer", []string{
+			"Employee SSN 449-87-4100 on file.",
+		}),
+		EnablePreprocessors: true,
+	}
+	path := writeFixture(t, dir, fc)
+
+	res, err := core.ScanFile(core.ScanConfig{
+		FilePath:            path,
+		Checks:              fc.Checks,
+		EnablePreprocessors: fc.EnablePreprocessors,
+		LogWriter:           io.Discard,
+	})
+	if err != nil {
+		t.Fatalf("ScanFile: %v", err)
+	}
+
+	var sawMeta, sawBody bool
+	var got []string
+	for _, m := range res.Matches {
+		got = append(got, m.Type)
+		switch m.Type {
+		case "AUTHOR_INFO", "LAST_MODIFIED_BY":
+			sawMeta = true
+		case "SSN":
+			sawBody = true
 		}
 	}
-
-	// And the plain-text path must NOT pay the cost of a repo-relative dir.
-	plain := caseTempDir(t, FileCase{Filename: "notes.txt"})
-	if plain == dir {
-		t.Error("caseTempDir returned the same directory for a .txt and an .xlsx case")
+	if !sawBody {
+		t.Errorf("no SSN finding from a fixture at %s; the document body was not scanned. types=%v", dir, got)
+	}
+	if !sawMeta {
+		t.Errorf("no metadata finding from a fixture at %s, so the Office metadata extractor "+
+			"refused this path. That is the guard this PR removed: every file a Linux user owns "+
+			"is under /home/, so it silently dropped author/company/custom properties from every "+
+			"scan. types=%v", dir, got)
 	}
 }

--- a/internal/goldencorpus/ooxml_routing_coverage_test.go
+++ b/internal/goldencorpus/ooxml_routing_coverage_test.go
@@ -1,0 +1,111 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package goldencorpus
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/core"
+)
+
+// These tests protect the new OOXML corpus cases from the failure mode that made
+// them necessary in the first place: a snapshot that is green because the code under
+// test never ran.
+//
+// The corpus locks output, so it cannot tell "this scan examined the document body
+// and found nothing" apart from "this scan never saw the document body". Both render
+// as a small golden file. The assertions below check the PRECONDITION instead — that
+// an Office fixture really does engage two extractors — so that when a later PR
+// changes routing, the snapshot diff means something.
+
+// TestOOXMLCasesReachTheCombinedArm is the guard. Every .docx/.xlsx case must be
+// dual-extractor: that is the only arm where the FileRouter concatenates output with
+// "--- name ---" separators and the ContentRouter re-splits it. A case that quietly
+// drops to one extractor would still produce a stable snapshot while testing nothing.
+//
+// The specific way that happens is a path guard: the Office metadata extractor
+// refuses paths under /var/, /tmp/, /home/ and C:\Users\, which is where t.TempDir()
+// lives on all three CI platforms. caseTempDir exists to avoid it, and this test
+// fails if that ever regresses.
+func TestOOXMLCasesReachTheCombinedArm(t *testing.T) {
+	var seen int
+	for _, fc := range FileCases {
+		if !needsGuardFreePath(fc.Filename) {
+			continue
+		}
+		seen++
+		fc := fc
+		t.Run(fc.Name, func(t *testing.T) {
+			dir := caseTempDir(t, fc)
+			path := writeFixture(t, dir, fc)
+
+			res, err := core.ScanFile(core.ScanConfig{
+				FilePath:            path,
+				Checks:              fc.Checks,
+				EnablePreprocessors: fc.EnablePreprocessors,
+				LogWriter:           io.Discard,
+			})
+			if err != nil {
+				t.Fatalf("ScanFile: %v", err)
+			}
+
+			// A metadata finding proves the office_metadata extractor ran, which is
+			// the extractor the path guard silently removes. Every OOXML case here
+			// carries dc:creator, so its absence means the fixture never reached the
+			// dual-extractor arm and the case is vacuous.
+			var metaTypes []string
+			for _, m := range res.Matches {
+				switch m.Type {
+				case "AUTHOR_INFO", "LAST_MODIFIED_BY", "COMPANY_INFO", "DOCUMENT_DESCRIPTION":
+					metaTypes = append(metaTypes, m.Type)
+				}
+			}
+			if len(metaTypes) == 0 {
+				var got []string
+				for _, m := range res.Matches {
+					got = append(got, m.Type)
+				}
+				t.Fatalf("case %q produced no metadata finding, so the office_metadata "+
+					"extractor did not run and this case never exercised the "+
+					"combined_preprocessors arm it exists to lock.\n"+
+					"  scanned path: %s\n"+
+					"  finding types: %v\n"+
+					"Most likely the fixture landed under a directory the Office extractor's "+
+					"validateFilePath rejects (/var/, /tmp/, /home/, C:\\Users\\) — see caseTempDir.",
+					fc.Name, path, got)
+			}
+		})
+	}
+
+	if seen == 0 {
+		t.Fatal("no OOXML cases found in FileCases — this guard is vacuous; either a case " +
+			"was removed or needsGuardFreePath no longer recognizes the extensions")
+	}
+}
+
+// TestCaseTempDirAvoidsTheOfficePathGuard pins the helper's contract directly, so the
+// reason for the repo-relative directory survives future refactoring. Without it, a
+// well-meaning simplification back to t.TempDir() would make six corpus cases vacuous
+// and nothing would fail.
+func TestCaseTempDirAvoidsTheOfficePathGuard(t *testing.T) {
+	ooxml := FileCase{Filename: "book.xlsx"}
+	dir := caseTempDir(t, ooxml)
+
+	lower := strings.ToLower(strings.ReplaceAll(dir, "\\", "/"))
+	for _, bad := range []string{"/var/", "/tmp/", "/home/", "c:/users/"} {
+		if strings.HasPrefix(lower, bad) {
+			t.Errorf("caseTempDir returned %q for an OOXML case, which starts with the "+
+				"rejected prefix %q; the Office metadata extractor will refuse it and the "+
+				"case will silently lose a preprocessor", dir, bad)
+		}
+	}
+
+	// And the plain-text path must NOT pay the cost of a repo-relative dir.
+	plain := caseTempDir(t, FileCase{Filename: "notes.txt"})
+	if plain == dir {
+		t.Error("caseTempDir returned the same directory for a .txt and an .xlsx case")
+	}
+}

--- a/internal/goldencorpus/ooxml_routing_coverage_test.go
+++ b/internal/goldencorpus/ooxml_routing_coverage_test.go
@@ -39,6 +39,17 @@ func TestOOXMLCasesReachTheCombinedArm(t *testing.T) {
 		seen++
 		fc := fc
 		t.Run(fc.Name, func(t *testing.T) {
+			// Where the checkout itself sits under a path the Office extractor refuses,
+			// no fixture location inside the repo can reach the second extractor. That
+			// is a property of the environment, not of the routing code, so report it as
+			// a skip. (The guard is itself a defect — an ordinary Linux user's
+			// ~/report.docx also loses Office metadata extraction — but that fix belongs
+			// to the extraction layer.)
+			if cwd, blocked := officePathGuardApplies(); blocked {
+				t.Skipf("checkout is under a path the Office metadata extractor rejects (%s); "+
+					"office_metadata cannot run for any fixture in this repo", cwd)
+			}
+
 			dir := caseTempDir(t, fc)
 			path := writeFixture(t, dir, fc)
 
@@ -94,8 +105,15 @@ func TestCaseTempDirAvoidsTheOfficePathGuard(t *testing.T) {
 	ooxml := FileCase{Filename: "book.xlsx"}
 	dir := caseTempDir(t, ooxml)
 
+	// Only assert the property caseTempDir can actually deliver. When the checkout is
+	// already inside the denylist, no directory under the repo escapes it, and that is
+	// the extractor's defect rather than this helper's.
+	if cwd, blocked := officePathGuardApplies(); blocked {
+		t.Skipf("checkout is under a rejected path (%s); caseTempDir cannot escape it", cwd)
+	}
+
 	lower := strings.ToLower(strings.ReplaceAll(dir, "\\", "/"))
-	for _, bad := range []string{"/var/", "/tmp/", "/home/", "c:/users/"} {
+	for _, bad := range officePathGuardRejectedPrefixes {
 		if strings.HasPrefix(lower, bad) {
 			t.Errorf("caseTempDir returned %q for an OOXML case, which starts with the "+
 				"rejected prefix %q; the Office metadata extractor will refuse it and the "+

--- a/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.csv
+++ b/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.csv
@@ -1,0 +1,5 @@
+Filename,Type,Confidence Level,Confidence %,Line Number,Text
+<TMPDIR>/report.docx,SSN,HIGH,100.0,3,449-87-4100
+<TMPDIR>/report.docx,VISA,HIGH,100.0,5,4532-0151-1283-0366
+<TMPDIR>/report.docx,AUTHOR_INFO,MEDIUM,65.0,1,Jane Analyst
+<TMPDIR>/report.docx,LAST_MODIFIED_BY,MEDIUM,65.0,2,Ops Reviewer

--- a/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.gitlab-sast.json
@@ -1,0 +1,134 @@
+{
+  "remediations": [],
+  "scan": {
+    "analyzer": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "end_time": "<TIMESTAMP>",
+    "scanner": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "start_time": "<TIMESTAMP>",
+    "status": "success",
+    "type": "sast"
+  },
+  "version": "15.0.4",
+  "vulnerabilities": [
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <TMPDIR>/report.docx (line 3)\n**Confidence:** HIGH (100.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\nEmployee SSN 449-87-4100 on file.\n```\n\n**Additional Information:**\n- context_impact: 45\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "SSN"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "ssn"
+        }
+      ],
+      "location": {
+        "end_line": 3,
+        "file": "report.docx",
+        "start_line": 3
+      },
+      "message": "Social Security Number detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Social Security Number Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected visa credit card in this file.\n\n**Location:** <TMPDIR>/report.docx (line 5)\n**Confidence:** HIGH (100.0%)\n**Detected by:** creditcard validator\n\n**Context:**\n```\nCard 4532-0151-1283-0366 expires soon.\n```\n\n**Additional Information:**\n- card_type: VISA\n- context_impact: 15\n- source: preprocessed_content\n- vendor: Visa\n\n**Remediation:**\nRemove or mask credit card numbers. Consider using tokenization for legitimate payment processing needs.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "VISA"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "creditcard"
+        }
+      ],
+      "location": {
+        "end_line": 5,
+        "file": "report.docx",
+        "start_line": 5
+      },
+      "message": "Visa credit card detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Visa Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/report.docx (line 1)\n**Confidence:** MEDIUM (65.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nAuthor: Jane Analyst\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "AUTHOR_INFO"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "metadata"
+        }
+      ],
+      "location": {
+        "end_line": 1,
+        "file": "report.docx",
+        "start_line": 1
+      },
+      "message": "Author information detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Author Info Detected",
+      "severity": "High"
+    },
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected sensitive data (last modified by) in this file.\n\n**Location:** <TMPDIR>/report.docx (line 2)\n**Confidence:** MEDIUM (65.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nLastModifiedBy: Ops Reviewer\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "LAST_MODIFIED_BY"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "metadata"
+        }
+      ],
+      "location": {
+        "end_line": 2,
+        "file": "report.docx",
+        "start_line": 2
+      },
+      "message": "Sensitive data (last modified by) detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Last Modified By Detected",
+      "severity": "High"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.json.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.json.json
@@ -1,0 +1,162 @@
+{
+  "results": [
+    {
+      "confidence": 100,
+      "confidence_level": "HIGH",
+      "filename": "<TMPDIR>/report.docx",
+      "line_number": 3,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 45,
+        "correlation_boost": 5,
+        "cross_path_correlation": true,
+        "original_confidence": 100,
+        "original_file": "<TMPDIR>/report.docx",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "format": true,
+          "not_common_pattern": true,
+          "not_repeating": true,
+          "not_sequential": true,
+          "not_test_number": true,
+          "valid_area": true
+        },
+        "validation_path": "document"
+      },
+      "text": "449-87-4100",
+      "type": "SSN",
+      "validator": "ssn"
+    },
+    {
+      "confidence": 100,
+      "confidence_level": "HIGH",
+      "filename": "<TMPDIR>/report.docx",
+      "line_number": 5,
+      "metadata": {
+        "card_type": "VISA",
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 15,
+        "correlation_boost": 5,
+        "cross_path_correlation": true,
+        "original_confidence": 100,
+        "original_file": "<TMPDIR>/report.docx",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "entropy": true,
+          "length": true,
+          "luhn": true,
+          "not_repeating": true,
+          "not_test": true,
+          "vendor": true
+        },
+        "validation_path": "document",
+        "vendor": "Visa"
+      },
+      "text": "4532-0151-1283-0366",
+      "type": "VISA",
+      "validator": "creditcard"
+    },
+    {
+      "confidence": 65,
+      "confidence_level": "MEDIUM",
+      "filename": "<TMPDIR>/report.docx",
+      "line_number": 1,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 0,
+        "correlation_boost": 5,
+        "cross_path_correlation": true,
+        "full_field": "Author: Jane Analyst",
+        "metadata_type": "AUTHOR_INFO",
+        "original_confidence": 60.00000000000001,
+        "original_file": "<TMPDIR>/report.docx",
+        "preprocessor_adjustment": 0,
+        "preprocessor_name": "Office Metadata Extractor",
+        "preprocessor_type": "office_metadata",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "source_file": "<TMPDIR>/report.docx",
+        "source_preprocessor": "office_metadata",
+        "total_adjustment": 0,
+        "validation_checks": {
+          "contains_author_field": true
+        },
+        "validation_path": "metadata"
+      },
+      "text": "Jane Analyst",
+      "type": "AUTHOR_INFO",
+      "validator": "metadata"
+    },
+    {
+      "confidence": 65,
+      "confidence_level": "MEDIUM",
+      "filename": "<TMPDIR>/report.docx",
+      "line_number": 2,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 0,
+        "correlation_boost": 5,
+        "cross_path_correlation": true,
+        "full_field": "LastModifiedBy: Ops Reviewer",
+        "metadata_type": "LAST_MODIFIED_BY",
+        "original_confidence": 60.00000000000001,
+        "original_file": "<TMPDIR>/report.docx",
+        "preprocessor_adjustment": 0,
+        "preprocessor_name": "Office Metadata Extractor",
+        "preprocessor_type": "office_metadata",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "source_file": "<TMPDIR>/report.docx",
+        "source_preprocessor": "office_metadata",
+        "total_adjustment": 0,
+        "validation_checks": {
+          "contains_modifier_field": true
+        },
+        "validation_path": "metadata"
+      },
+      "text": "Ops Reviewer",
+      "type": "LAST_MODIFIED_BY",
+      "validator": "metadata"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.junit.xml
+++ b/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.junit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
+  <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
+    <testcase name="report.docx" classname="security-scan" time="0.001">
+      <failure message="4 security findings detected" type="SECURITY_FINDINGS">Line 3: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 5: VISA detected with 100.0% confidence (HIGH)&#xA;Match: 4532-0151-1283-0366&#xA;Validator: creditcard&#xA;Line 1: AUTHOR_INFO detected with 65.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata&#xA;Line 2: LAST_MODIFIED_BY detected with 65.0% confidence (MEDIUM)&#xA;Match: Ops Reviewer&#xA;Validator: metadata</failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.sarif.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.sarif.json
@@ -1,0 +1,338 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/refs/heads/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/report.docx"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "Employee SSN \nEmployee SSN 449-87-4100 on file.\n on file."
+                  },
+                  "startLine": 3
+                },
+                "region": {
+                  "endColumn": 25,
+                  "snippet": {
+                    "text": "Employee SSN 449-87-4100 on file."
+                  },
+                  "startColumn": 14,
+                  "startLine": 3
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Social Security Number Detected in report.docx at line 3 (confidence: 100.0% - HIGH). Matched text: '449-87-4100'"
+          },
+          "properties": {
+            "confidence": 100,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 45,
+              "correlation_boost": 5,
+              "cross_path_correlation": true,
+              "original_confidence": 100,
+              "original_file": "<TMPDIR>/report.docx",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "digits": true,
+                "format": true,
+                "not_common_pattern": true,
+                "not_repeating": true,
+                "not_sequential": true,
+                "not_test_number": true,
+                "valid_area": true
+              },
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "ssn"
+            ],
+            "validator": "ssn"
+          },
+          "rank": 100,
+          "ruleId": "SSN"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/report.docx"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "Card \nCard 4532-0151-1283-0366 expires soon.\n expires soon."
+                  },
+                  "startLine": 5
+                },
+                "region": {
+                  "endColumn": 25,
+                  "snippet": {
+                    "text": "Card 4532-0151-1283-0366 expires soon."
+                  },
+                  "startColumn": 6,
+                  "startLine": 5
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "VISA Detected in report.docx at line 5 (confidence: 100.0% - HIGH). Matched text: '4532-0151-1283-0366'"
+          },
+          "properties": {
+            "confidence": 100,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "card_type": "VISA",
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 15,
+              "correlation_boost": 5,
+              "cross_path_correlation": true,
+              "original_confidence": 100,
+              "original_file": "<TMPDIR>/report.docx",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "digits": true,
+                "entropy": true,
+                "length": true,
+                "luhn": true,
+                "not_repeating": true,
+                "not_test": true,
+                "vendor": true
+              },
+              "validation_path": "document",
+              "vendor": "Visa"
+            },
+            "validator": "creditcard"
+          },
+          "rank": 75,
+          "ruleId": "VISA"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/report.docx"
+                },
+                "region": {
+                  "endColumn": 21,
+                  "snippet": {
+                    "text": "Author: Jane Analyst"
+                  },
+                  "startColumn": 9,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "AUTHOR_INFO Detected in report.docx at line 1 (confidence: 65.0% - MEDIUM). Matched text: 'Jane Analyst'"
+          },
+          "properties": {
+            "confidence": 65,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 0,
+              "correlation_boost": 5,
+              "cross_path_correlation": true,
+              "full_field": "Author: Jane Analyst",
+              "metadata_type": "AUTHOR_INFO",
+              "original_confidence": 60,
+              "original_file": "<TMPDIR>/report.docx",
+              "preprocessor_adjustment": 0,
+              "preprocessor_name": "Office Metadata Extractor",
+              "preprocessor_type": "office_metadata",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "source_file": "<TMPDIR>/report.docx",
+              "source_preprocessor": "office_metadata",
+              "total_adjustment": 0,
+              "validation_checks": {
+                "contains_author_field": true
+              },
+              "validation_path": "metadata"
+            },
+            "validator": "metadata"
+          },
+          "rank": 57.5,
+          "ruleId": "AUTHOR_INFO"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/report.docx"
+                },
+                "region": {
+                  "endColumn": 29,
+                  "snippet": {
+                    "text": "LastModifiedBy: Ops Reviewer"
+                  },
+                  "startColumn": 17,
+                  "startLine": 2
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "LAST_MODIFIED_BY Detected in report.docx at line 2 (confidence: 65.0% - MEDIUM). Matched text: 'Ops Reviewer'"
+          },
+          "properties": {
+            "confidence": 65,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 0,
+              "correlation_boost": 5,
+              "cross_path_correlation": true,
+              "full_field": "LastModifiedBy: Ops Reviewer",
+              "metadata_type": "LAST_MODIFIED_BY",
+              "original_confidence": 60,
+              "original_file": "<TMPDIR>/report.docx",
+              "preprocessor_adjustment": 0,
+              "preprocessor_name": "Office Metadata Extractor",
+              "preprocessor_type": "office_metadata",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "source_file": "<TMPDIR>/report.docx",
+              "source_preprocessor": "office_metadata",
+              "total_adjustment": 0,
+              "validation_checks": {
+                "contains_modifier_field": true
+              },
+              "validation_path": "metadata"
+            },
+            "validator": "metadata"
+          },
+          "rank": 57.5,
+          "ruleId": "LAST_MODIFIED_BY"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/awslabs/ferret-scan",
+          "name": "Ferret Scan",
+          "rules": [
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type AUTHOR_INFO was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/AUTHOR_INFO.md",
+              "id": "AUTHOR_INFO",
+              "shortDescription": {
+                "text": "AUTHOR_INFO Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type LAST_MODIFIED_BY was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/LAST_MODIFIED_BY.md",
+              "id": "LAST_MODIFIED_BY",
+              "shortDescription": {
+                "text": "LAST_MODIFIED_BY Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "A Social Security Number (SSN) pattern was detected in the scanned content. SSNs are highly sensitive personally identifiable information (PII) that must be protected under various regulations."
+              },
+              "help": {
+                "text": "Social Security Numbers are protected under numerous regulations including GDPR, HIPAA, and various state privacy laws. SSNs should never be stored in source code, configuration files, or logs. Remove this SSN immediately and ensure it is stored in a secure, encrypted system with appropriate access controls. Consider implementing tokenization or other data protection mechanisms."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/SSN.md",
+              "id": "SSN",
+              "shortDescription": {
+                "text": "Social Security Number Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type VISA was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/VISA.md",
+              "id": "VISA",
+              "shortDescription": {
+                "text": "VISA Detected"
+              }
+            }
+          ],
+          "semanticVersion": "0.0.0-development",
+          "version": "0.0.0-development"
+        }
+      },
+      "versionControlProvenance": [
+        {
+          "mappedTo": {
+            "uriBaseId": "%SRCROOT%"
+          },
+          "repositoryUri": "https://github.com/awslabs/ferret-scan",
+          "revisionId": "0.0.0-development"
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.txt
+++ b/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.txt
@@ -1,0 +1,6 @@
+LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH               FILE
+---------------------------------------------------------------------------------------------
+[HIGH  ] ssn          SSN                   100.00% line     3 449-87-4100         report.docx
+[HIGH  ] creditcard   VISA                  100.00% line     5 4532-0151-1283-0366 report.docx
+[MEDIUM] metadata     AUTHOR_INFO            65.00% line     1 Jane Analyst        report.docx
+[MEDIUM] metadata     LAST_MODIFIED_BY       65.00% line     2 Ops Reviewer        report.docx

--- a/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.yaml
+++ b/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.yaml
@@ -1,0 +1,139 @@
+results:
+    - text: 449-87-4100
+      line_number: 3
+      type: SSN
+      confidence: 100
+      confidence_level: HIGH
+      filename: <TMPDIR>/report.docx
+      validator: ssn
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 45
+        correlation_boost: 5
+        cross_path_correlation: true
+        original_confidence: 100
+        original_file: <TMPDIR>/report.docx
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            format: true
+            not_common_pattern: true
+            not_repeating: true
+            not_sequential: true
+            not_test_number: true
+            valid_area: true
+        validation_path: document
+    - text: 4532-0151-1283-0366
+      line_number: 5
+      type: VISA
+      confidence: 100
+      confidence_level: HIGH
+      filename: <TMPDIR>/report.docx
+      validator: creditcard
+      metadata:
+        card_type: VISA
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 15
+        correlation_boost: 5
+        cross_path_correlation: true
+        original_confidence: 100
+        original_file: <TMPDIR>/report.docx
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            entropy: true
+            length: true
+            luhn: true
+            not_repeating: true
+            not_test: true
+            vendor: true
+        validation_path: document
+        vendor: Visa
+    - text: Jane Analyst
+      line_number: 1
+      type: AUTHOR_INFO
+      confidence: 65
+      confidence_level: MEDIUM
+      filename: <TMPDIR>/report.docx
+      validator: metadata
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 0
+        correlation_boost: 5
+        cross_path_correlation: true
+        full_field: 'Author: Jane Analyst'
+        metadata_type: AUTHOR_INFO
+        original_confidence: 60.00000000000001
+        original_file: <TMPDIR>/report.docx
+        preprocessor_adjustment: 0
+        preprocessor_name: Office Metadata Extractor
+        preprocessor_type: office_metadata
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        source_file: <TMPDIR>/report.docx
+        source_preprocessor: office_metadata
+        total_adjustment: 0
+        validation_checks:
+            contains_author_field: true
+        validation_path: metadata
+    - text: Ops Reviewer
+      line_number: 2
+      type: LAST_MODIFIED_BY
+      confidence: 65
+      confidence_level: MEDIUM
+      filename: <TMPDIR>/report.docx
+      validator: metadata
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 0
+        correlation_boost: 5
+        cross_path_correlation: true
+        full_field: 'LastModifiedBy: Ops Reviewer'
+        metadata_type: LAST_MODIFIED_BY
+        original_confidence: 60.00000000000001
+        original_file: <TMPDIR>/report.docx
+        preprocessor_adjustment: 0
+        preprocessor_name: Office Metadata Extractor
+        preprocessor_type: office_metadata
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        source_file: <TMPDIR>/report.docx
+        source_preprocessor: office_metadata
+        total_adjustment: 0
+        validation_checks:
+            contains_modifier_field: true
+        validation_path: metadata

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.csv
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.csv
@@ -1,0 +1,3 @@
+Filename,Type,Confidence Level,Confidence %,Line Number,Text
+<TMPDIR>/forged_first.docx,AUTHOR_INFO,MEDIUM,60.0,1,Jane Analyst
+<TMPDIR>/forged_first.docx,LAST_MODIFIED_BY,MEDIUM,60.0,2,Ops Reviewer

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.csv
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.csv
@@ -1,3 +1,5 @@
 Filename,Type,Confidence Level,Confidence %,Line Number,Text
-<TMPDIR>/forged_first.docx,AUTHOR_INFO,MEDIUM,60.0,1,Jane Analyst
-<TMPDIR>/forged_first.docx,LAST_MODIFIED_BY,MEDIUM,60.0,2,Ops Reviewer
+<TMPDIR>/forged_first.docx,SSN,HIGH,100.0,3,449-87-4100
+<TMPDIR>/forged_first.docx,VISA,HIGH,100.0,5,4532-0151-1283-0366
+<TMPDIR>/forged_first.docx,AUTHOR_INFO,MEDIUM,65.0,1,Jane Analyst
+<TMPDIR>/forged_first.docx,LAST_MODIFIED_BY,MEDIUM,65.0,2,Ops Reviewer

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.gitlab-sast.json
@@ -1,0 +1,82 @@
+{
+  "remediations": [],
+  "scan": {
+    "analyzer": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "end_time": "<TIMESTAMP>",
+    "scanner": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "start_time": "<TIMESTAMP>",
+    "status": "success",
+    "type": "sast"
+  },
+  "version": "15.0.4",
+  "vulnerabilities": [
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/forged_first.docx (line 1)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nAuthor: Jane Analyst\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "AUTHOR_INFO"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "metadata"
+        }
+      ],
+      "location": {
+        "end_line": 1,
+        "file": "forged_first.docx",
+        "start_line": 1
+      },
+      "message": "Author information detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Author Info Detected",
+      "severity": "High"
+    },
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected sensitive data (last modified by) in this file.\n\n**Location:** <TMPDIR>/forged_first.docx (line 2)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nLastModifiedBy: Ops Reviewer\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "LAST_MODIFIED_BY"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "metadata"
+        }
+      ],
+      "location": {
+        "end_line": 2,
+        "file": "forged_first.docx",
+        "start_line": 2
+      },
+      "message": "Sensitive data (last modified by) detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Last Modified By Detected",
+      "severity": "High"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.gitlab-sast.json
@@ -28,8 +28,60 @@
   "vulnerabilities": [
     {
       "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <TMPDIR>/forged_first.docx (line 3)\n**Confidence:** HIGH (100.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\nEmployee SSN 449-87-4100 on file.\n```\n\n**Additional Information:**\n- context_impact: 45\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "SSN"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "ssn"
+        }
+      ],
+      "location": {
+        "end_line": 3,
+        "file": "forged_first.docx",
+        "start_line": 3
+      },
+      "message": "Social Security Number detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Social Security Number Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected visa credit card in this file.\n\n**Location:** <TMPDIR>/forged_first.docx (line 5)\n**Confidence:** HIGH (100.0%)\n**Detected by:** creditcard validator\n\n**Context:**\n```\nCard 4532-0151-1283-0366 expires soon.\n```\n\n**Additional Information:**\n- card_type: VISA\n- context_impact: 15\n- source: preprocessed_content\n- vendor: Visa\n\n**Remediation:**\nRemove or mask credit card numbers. Consider using tokenization for legitimate payment processing needs.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "VISA"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "creditcard"
+        }
+      ],
+      "location": {
+        "end_line": 5,
+        "file": "forged_first.docx",
+        "start_line": 5
+      },
+      "message": "Visa credit card detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Visa Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
       "confidence": "Medium",
-      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/forged_first.docx (line 1)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nAuthor: Jane Analyst\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/forged_first.docx (line 1)\n**Confidence:** MEDIUM (65.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nAuthor: Jane Analyst\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {
@@ -55,7 +107,7 @@
     {
       "category": "sast",
       "confidence": "Medium",
-      "description": "Ferret Scan detected sensitive data (last modified by) in this file.\n\n**Location:** <TMPDIR>/forged_first.docx (line 2)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nLastModifiedBy: Ops Reviewer\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "description": "Ferret Scan detected sensitive data (last modified by) in this file.\n\n**Location:** <TMPDIR>/forged_first.docx (line 2)\n**Confidence:** MEDIUM (65.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nLastModifiedBy: Ops Reviewer\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.json.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.json.json
@@ -1,0 +1,80 @@
+{
+  "results": [
+    {
+      "confidence": 60.00000000000001,
+      "confidence_level": "MEDIUM",
+      "filename": "<TMPDIR>/forged_first.docx",
+      "line_number": 1,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 0,
+        "full_field": "Author: Jane Analyst",
+        "metadata_type": "AUTHOR_INFO",
+        "original_confidence": 60.00000000000001,
+        "original_file": "<TMPDIR>/forged_first.docx",
+        "preprocessor_adjustment": 0,
+        "preprocessor_name": "Office Metadata Extractor",
+        "preprocessor_type": "office_metadata",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "source_file": "<TMPDIR>/forged_first.docx",
+        "source_preprocessor": "office_metadata",
+        "total_adjustment": 0,
+        "validation_checks": {
+          "contains_author_field": true
+        },
+        "validation_path": "metadata"
+      },
+      "text": "Jane Analyst",
+      "type": "AUTHOR_INFO",
+      "validator": "metadata"
+    },
+    {
+      "confidence": 60.00000000000001,
+      "confidence_level": "MEDIUM",
+      "filename": "<TMPDIR>/forged_first.docx",
+      "line_number": 2,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 0,
+        "full_field": "LastModifiedBy: Ops Reviewer",
+        "metadata_type": "LAST_MODIFIED_BY",
+        "original_confidence": 60.00000000000001,
+        "original_file": "<TMPDIR>/forged_first.docx",
+        "preprocessor_adjustment": 0,
+        "preprocessor_name": "Office Metadata Extractor",
+        "preprocessor_type": "office_metadata",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "source_file": "<TMPDIR>/forged_first.docx",
+        "source_preprocessor": "office_metadata",
+        "total_adjustment": 0,
+        "validation_checks": {
+          "contains_modifier_field": true
+        },
+        "validation_path": "metadata"
+      },
+      "text": "Ops Reviewer",
+      "type": "LAST_MODIFIED_BY",
+      "validator": "metadata"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.json.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.json.json
@@ -1,7 +1,85 @@
 {
   "results": [
     {
-      "confidence": 60.00000000000001,
+      "confidence": 100,
+      "confidence_level": "HIGH",
+      "filename": "<TMPDIR>/forged_first.docx",
+      "line_number": 3,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 45,
+        "correlation_boost": 5,
+        "cross_path_correlation": true,
+        "original_confidence": 100,
+        "original_file": "<TMPDIR>/forged_first.docx",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "format": true,
+          "not_common_pattern": true,
+          "not_repeating": true,
+          "not_sequential": true,
+          "not_test_number": true,
+          "valid_area": true
+        },
+        "validation_path": "document"
+      },
+      "text": "449-87-4100",
+      "type": "SSN",
+      "validator": "ssn"
+    },
+    {
+      "confidence": 100,
+      "confidence_level": "HIGH",
+      "filename": "<TMPDIR>/forged_first.docx",
+      "line_number": 5,
+      "metadata": {
+        "card_type": "VISA",
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 15,
+        "correlation_boost": 5,
+        "cross_path_correlation": true,
+        "original_confidence": 100,
+        "original_file": "<TMPDIR>/forged_first.docx",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "entropy": true,
+          "length": true,
+          "luhn": true,
+          "not_repeating": true,
+          "not_test": true,
+          "vendor": true
+        },
+        "validation_path": "document",
+        "vendor": "Visa"
+      },
+      "text": "4532-0151-1283-0366",
+      "type": "VISA",
+      "validator": "creditcard"
+    },
+    {
+      "confidence": 65,
       "confidence_level": "MEDIUM",
       "filename": "<TMPDIR>/forged_first.docx",
       "line_number": 1,
@@ -11,6 +89,8 @@
         "context_doctype": "Unknown",
         "context_domain": "HR_Payroll",
         "context_impact": 0,
+        "correlation_boost": 5,
+        "cross_path_correlation": true,
         "full_field": "Author: Jane Analyst",
         "metadata_type": "AUTHOR_INFO",
         "original_confidence": 60.00000000000001,
@@ -39,7 +119,7 @@
       "validator": "metadata"
     },
     {
-      "confidence": 60.00000000000001,
+      "confidence": 65,
       "confidence_level": "MEDIUM",
       "filename": "<TMPDIR>/forged_first.docx",
       "line_number": 2,
@@ -49,6 +129,8 @@
         "context_doctype": "Unknown",
         "context_domain": "HR_Payroll",
         "context_impact": 0,
+        "correlation_boost": 5,
+        "cross_path_correlation": true,
         "full_field": "LastModifiedBy: Ops Reviewer",
         "metadata_type": "LAST_MODIFIED_BY",
         "original_confidence": 60.00000000000001,

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.junit.xml
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.junit.xml
@@ -2,7 +2,7 @@
 <testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
   <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
     <testcase name="forged_first.docx" classname="security-scan" time="0.001">
-      <failure message="2 security findings detected" type="SECURITY_FINDINGS">Line 1: AUTHOR_INFO detected with 60.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata&#xA;Line 2: LAST_MODIFIED_BY detected with 60.0% confidence (MEDIUM)&#xA;Match: Ops Reviewer&#xA;Validator: metadata</failure>
+      <failure message="4 security findings detected" type="SECURITY_FINDINGS">Line 3: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 5: VISA detected with 100.0% confidence (HIGH)&#xA;Match: 4532-0151-1283-0366&#xA;Validator: creditcard&#xA;Line 1: AUTHOR_INFO detected with 65.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata&#xA;Line 2: LAST_MODIFIED_BY detected with 65.0% confidence (MEDIUM)&#xA;Match: Ops Reviewer&#xA;Validator: metadata</failure>
     </testcase>
   </testsuite>
 </testsuites>

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.junit.xml
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.junit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
+  <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
+    <testcase name="forged_first.docx" classname="security-scan" time="0.001">
+      <failure message="2 security findings detected" type="SECURITY_FINDINGS">Line 1: AUTHOR_INFO detected with 60.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata&#xA;Line 2: LAST_MODIFIED_BY detected with 60.0% confidence (MEDIUM)&#xA;Match: Ops Reviewer&#xA;Validator: metadata</failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.sarif.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.sarif.json
@@ -1,0 +1,173 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/refs/heads/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/forged_first.docx"
+                },
+                "region": {
+                  "endColumn": 21,
+                  "snippet": {
+                    "text": "Author: Jane Analyst"
+                  },
+                  "startColumn": 9,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "AUTHOR_INFO Detected in forged_first.docx at line 1 (confidence: 60.0% - MEDIUM). Matched text: 'Jane Analyst'"
+          },
+          "properties": {
+            "confidence": 60,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 0,
+              "full_field": "Author: Jane Analyst",
+              "metadata_type": "AUTHOR_INFO",
+              "original_confidence": 60,
+              "original_file": "<TMPDIR>/forged_first.docx",
+              "preprocessor_adjustment": 0,
+              "preprocessor_name": "Office Metadata Extractor",
+              "preprocessor_type": "office_metadata",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "source_file": "<TMPDIR>/forged_first.docx",
+              "source_preprocessor": "office_metadata",
+              "total_adjustment": 0,
+              "validation_checks": {
+                "contains_author_field": true
+              },
+              "validation_path": "metadata"
+            },
+            "validator": "metadata"
+          },
+          "rank": 55,
+          "ruleId": "AUTHOR_INFO"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/forged_first.docx"
+                },
+                "region": {
+                  "endColumn": 29,
+                  "snippet": {
+                    "text": "LastModifiedBy: Ops Reviewer"
+                  },
+                  "startColumn": 17,
+                  "startLine": 2
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "LAST_MODIFIED_BY Detected in forged_first.docx at line 2 (confidence: 60.0% - MEDIUM). Matched text: 'Ops Reviewer'"
+          },
+          "properties": {
+            "confidence": 60,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 0,
+              "full_field": "LastModifiedBy: Ops Reviewer",
+              "metadata_type": "LAST_MODIFIED_BY",
+              "original_confidence": 60,
+              "original_file": "<TMPDIR>/forged_first.docx",
+              "preprocessor_adjustment": 0,
+              "preprocessor_name": "Office Metadata Extractor",
+              "preprocessor_type": "office_metadata",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "source_file": "<TMPDIR>/forged_first.docx",
+              "source_preprocessor": "office_metadata",
+              "total_adjustment": 0,
+              "validation_checks": {
+                "contains_modifier_field": true
+              },
+              "validation_path": "metadata"
+            },
+            "validator": "metadata"
+          },
+          "rank": 55,
+          "ruleId": "LAST_MODIFIED_BY"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/awslabs/ferret-scan",
+          "name": "Ferret Scan",
+          "rules": [
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type AUTHOR_INFO was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/AUTHOR_INFO.md",
+              "id": "AUTHOR_INFO",
+              "shortDescription": {
+                "text": "AUTHOR_INFO Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type LAST_MODIFIED_BY was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/LAST_MODIFIED_BY.md",
+              "id": "LAST_MODIFIED_BY",
+              "shortDescription": {
+                "text": "LAST_MODIFIED_BY Detected"
+              }
+            }
+          ],
+          "semanticVersion": "0.0.0-development",
+          "version": "0.0.0-development"
+        }
+      },
+      "versionControlProvenance": [
+        {
+          "mappedTo": {
+            "uriBaseId": "%SRCROOT%"
+          },
+          "repositoryUri": "https://github.com/awslabs/ferret-scan",
+          "revisionId": "0.0.0-development"
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.sarif.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.sarif.json
@@ -11,6 +11,141 @@
                 "artifactLocation": {
                   "uri": "file://<TMPDIR>/forged_first.docx"
                 },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "Employee SSN \nEmployee SSN 449-87-4100 on file.\n on file."
+                  },
+                  "startLine": 3
+                },
+                "region": {
+                  "endColumn": 25,
+                  "snippet": {
+                    "text": "Employee SSN 449-87-4100 on file."
+                  },
+                  "startColumn": 14,
+                  "startLine": 3
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Social Security Number Detected in forged_first.docx at line 3 (confidence: 100.0% - HIGH). Matched text: '449-87-4100'"
+          },
+          "properties": {
+            "confidence": 100,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 45,
+              "correlation_boost": 5,
+              "cross_path_correlation": true,
+              "original_confidence": 100,
+              "original_file": "<TMPDIR>/forged_first.docx",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "digits": true,
+                "format": true,
+                "not_common_pattern": true,
+                "not_repeating": true,
+                "not_sequential": true,
+                "not_test_number": true,
+                "valid_area": true
+              },
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "ssn"
+            ],
+            "validator": "ssn"
+          },
+          "rank": 100,
+          "ruleId": "SSN"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/forged_first.docx"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "Card \nCard 4532-0151-1283-0366 expires soon.\n expires soon."
+                  },
+                  "startLine": 5
+                },
+                "region": {
+                  "endColumn": 25,
+                  "snippet": {
+                    "text": "Card 4532-0151-1283-0366 expires soon."
+                  },
+                  "startColumn": 6,
+                  "startLine": 5
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "VISA Detected in forged_first.docx at line 5 (confidence: 100.0% - HIGH). Matched text: '4532-0151-1283-0366'"
+          },
+          "properties": {
+            "confidence": 100,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "card_type": "VISA",
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 15,
+              "correlation_boost": 5,
+              "cross_path_correlation": true,
+              "original_confidence": 100,
+              "original_file": "<TMPDIR>/forged_first.docx",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "digits": true,
+                "entropy": true,
+                "length": true,
+                "luhn": true,
+                "not_repeating": true,
+                "not_test": true,
+                "vendor": true
+              },
+              "validation_path": "document",
+              "vendor": "Visa"
+            },
+            "validator": "creditcard"
+          },
+          "rank": 75,
+          "ruleId": "VISA"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/forged_first.docx"
+                },
                 "region": {
                   "endColumn": 21,
                   "snippet": {
@@ -23,10 +158,10 @@
             }
           ],
           "message": {
-            "text": "AUTHOR_INFO Detected in forged_first.docx at line 1 (confidence: 60.0% - MEDIUM). Matched text: 'Jane Analyst'"
+            "text": "AUTHOR_INFO Detected in forged_first.docx at line 1 (confidence: 65.0% - MEDIUM). Matched text: 'Jane Analyst'"
           },
           "properties": {
-            "confidence": 60,
+            "confidence": 65,
             "confidenceLevel": "MEDIUM",
             "metadata": {
               "confidence_adjustment": 0,
@@ -34,6 +169,8 @@
               "context_doctype": "Unknown",
               "context_domain": "HR_Payroll",
               "context_impact": 0,
+              "correlation_boost": 5,
+              "cross_path_correlation": true,
               "full_field": "Author: Jane Analyst",
               "metadata_type": "AUTHOR_INFO",
               "original_confidence": 60,
@@ -59,7 +196,7 @@
             },
             "validator": "metadata"
           },
-          "rank": 55,
+          "rank": 57.5,
           "ruleId": "AUTHOR_INFO"
         },
         {
@@ -82,10 +219,10 @@
             }
           ],
           "message": {
-            "text": "LAST_MODIFIED_BY Detected in forged_first.docx at line 2 (confidence: 60.0% - MEDIUM). Matched text: 'Ops Reviewer'"
+            "text": "LAST_MODIFIED_BY Detected in forged_first.docx at line 2 (confidence: 65.0% - MEDIUM). Matched text: 'Ops Reviewer'"
           },
           "properties": {
-            "confidence": 60,
+            "confidence": 65,
             "confidenceLevel": "MEDIUM",
             "metadata": {
               "confidence_adjustment": 0,
@@ -93,6 +230,8 @@
               "context_doctype": "Unknown",
               "context_domain": "HR_Payroll",
               "context_impact": 0,
+              "correlation_boost": 5,
+              "cross_path_correlation": true,
               "full_field": "LastModifiedBy: Ops Reviewer",
               "metadata_type": "LAST_MODIFIED_BY",
               "original_confidence": 60,
@@ -118,7 +257,7 @@
             },
             "validator": "metadata"
           },
-          "rank": 55,
+          "rank": 57.5,
           "ruleId": "LAST_MODIFIED_BY"
         }
       ],
@@ -151,6 +290,32 @@
               "id": "LAST_MODIFIED_BY",
               "shortDescription": {
                 "text": "LAST_MODIFIED_BY Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "A Social Security Number (SSN) pattern was detected in the scanned content. SSNs are highly sensitive personally identifiable information (PII) that must be protected under various regulations."
+              },
+              "help": {
+                "text": "Social Security Numbers are protected under numerous regulations including GDPR, HIPAA, and various state privacy laws. SSNs should never be stored in source code, configuration files, or logs. Remove this SSN immediately and ensure it is stored in a secure, encrypted system with appropriate access controls. Consider implementing tokenization or other data protection mechanisms."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/SSN.md",
+              "id": "SSN",
+              "shortDescription": {
+                "text": "Social Security Number Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type VISA was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/VISA.md",
+              "id": "VISA",
+              "shortDescription": {
+                "text": "VISA Detected"
               }
             }
           ],

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.txt
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.txt
@@ -1,0 +1,4 @@
+LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH        FILE
+--------------------------------------------------------------------------------------
+[MEDIUM] metadata     AUTHOR_INFO            60.00% line     1 Jane Analyst forged_first.docx
+[MEDIUM] metadata     LAST_MODIFIED_BY       60.00% line     2 Ops Reviewer forged_first.docx

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.txt
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.txt
@@ -1,4 +1,6 @@
-LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH        FILE
---------------------------------------------------------------------------------------
-[MEDIUM] metadata     AUTHOR_INFO            60.00% line     1 Jane Analyst forged_first.docx
-[MEDIUM] metadata     LAST_MODIFIED_BY       60.00% line     2 Ops Reviewer forged_first.docx
+LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH               FILE
+---------------------------------------------------------------------------------------------
+[HIGH  ] ssn          SSN                   100.00% line     3 449-87-4100         forged_first.docx
+[HIGH  ] creditcard   VISA                  100.00% line     5 4532-0151-1283-0366 forged_first.docx
+[MEDIUM] metadata     AUTHOR_INFO            65.00% line     1 Jane Analyst        forged_first.docx
+[MEDIUM] metadata     LAST_MODIFIED_BY       65.00% line     2 Ops Reviewer        forged_first.docx

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.yaml
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.yaml
@@ -1,0 +1,67 @@
+results:
+    - text: Jane Analyst
+      line_number: 1
+      type: AUTHOR_INFO
+      confidence: 60.00000000000001
+      confidence_level: MEDIUM
+      filename: <TMPDIR>/forged_first.docx
+      validator: metadata
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 0
+        full_field: 'Author: Jane Analyst'
+        metadata_type: AUTHOR_INFO
+        original_confidence: 60.00000000000001
+        original_file: <TMPDIR>/forged_first.docx
+        preprocessor_adjustment: 0
+        preprocessor_name: Office Metadata Extractor
+        preprocessor_type: office_metadata
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        source_file: <TMPDIR>/forged_first.docx
+        source_preprocessor: office_metadata
+        total_adjustment: 0
+        validation_checks:
+            contains_author_field: true
+        validation_path: metadata
+    - text: Ops Reviewer
+      line_number: 2
+      type: LAST_MODIFIED_BY
+      confidence: 60.00000000000001
+      confidence_level: MEDIUM
+      filename: <TMPDIR>/forged_first.docx
+      validator: metadata
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 0
+        full_field: 'LastModifiedBy: Ops Reviewer'
+        metadata_type: LAST_MODIFIED_BY
+        original_confidence: 60.00000000000001
+        original_file: <TMPDIR>/forged_first.docx
+        preprocessor_adjustment: 0
+        preprocessor_name: Office Metadata Extractor
+        preprocessor_type: office_metadata
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        source_file: <TMPDIR>/forged_first.docx
+        source_preprocessor: office_metadata
+        total_adjustment: 0
+        validation_checks:
+            contains_modifier_field: true
+        validation_path: metadata

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.yaml
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.yaml
@@ -1,8 +1,76 @@
 results:
+    - text: 449-87-4100
+      line_number: 3
+      type: SSN
+      confidence: 100
+      confidence_level: HIGH
+      filename: <TMPDIR>/forged_first.docx
+      validator: ssn
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 45
+        correlation_boost: 5
+        cross_path_correlation: true
+        original_confidence: 100
+        original_file: <TMPDIR>/forged_first.docx
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            format: true
+            not_common_pattern: true
+            not_repeating: true
+            not_sequential: true
+            not_test_number: true
+            valid_area: true
+        validation_path: document
+    - text: 4532-0151-1283-0366
+      line_number: 5
+      type: VISA
+      confidence: 100
+      confidence_level: HIGH
+      filename: <TMPDIR>/forged_first.docx
+      validator: creditcard
+      metadata:
+        card_type: VISA
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 15
+        correlation_boost: 5
+        cross_path_correlation: true
+        original_confidence: 100
+        original_file: <TMPDIR>/forged_first.docx
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            entropy: true
+            length: true
+            luhn: true
+            not_repeating: true
+            not_test: true
+            vendor: true
+        validation_path: document
+        vendor: Visa
     - text: Jane Analyst
       line_number: 1
       type: AUTHOR_INFO
-      confidence: 60.00000000000001
+      confidence: 65
       confidence_level: MEDIUM
       filename: <TMPDIR>/forged_first.docx
       validator: metadata
@@ -12,6 +80,8 @@ results:
         context_doctype: Unknown
         context_domain: HR_Payroll
         context_impact: 0
+        correlation_boost: 5
+        cross_path_correlation: true
         full_field: 'Author: Jane Analyst'
         metadata_type: AUTHOR_INFO
         original_confidence: 60.00000000000001
@@ -35,7 +105,7 @@ results:
     - text: Ops Reviewer
       line_number: 2
       type: LAST_MODIFIED_BY
-      confidence: 60.00000000000001
+      confidence: 65
       confidence_level: MEDIUM
       filename: <TMPDIR>/forged_first.docx
       validator: metadata
@@ -45,6 +115,8 @@ results:
         context_doctype: Unknown
         context_domain: HR_Payroll
         context_impact: 0
+        correlation_boost: 5
+        cross_path_correlation: true
         full_field: 'LastModifiedBy: Ops Reviewer'
         metadata_type: LAST_MODIFIED_BY
         original_confidence: 60.00000000000001

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.csv
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.csv
@@ -1,3 +1,5 @@
 Filename,Type,Confidence Level,Confidence %,Line Number,Text
-<TMPDIR>/forged_mid.docx,AUTHOR_INFO,MEDIUM,60.0,1,Jane Analyst
-<TMPDIR>/forged_mid.docx,LAST_MODIFIED_BY,MEDIUM,60.0,2,Ops Reviewer
+<TMPDIR>/forged_mid.docx,SSN,HIGH,100.0,5,449-87-4100
+<TMPDIR>/forged_mid.docx,VISA,HIGH,100.0,7,4532-0151-1283-0366
+<TMPDIR>/forged_mid.docx,AUTHOR_INFO,MEDIUM,65.0,1,Jane Analyst
+<TMPDIR>/forged_mid.docx,LAST_MODIFIED_BY,MEDIUM,65.0,2,Ops Reviewer

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.csv
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.csv
@@ -1,0 +1,3 @@
+Filename,Type,Confidence Level,Confidence %,Line Number,Text
+<TMPDIR>/forged_mid.docx,AUTHOR_INFO,MEDIUM,60.0,1,Jane Analyst
+<TMPDIR>/forged_mid.docx,LAST_MODIFIED_BY,MEDIUM,60.0,2,Ops Reviewer

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.gitlab-sast.json
@@ -1,0 +1,82 @@
+{
+  "remediations": [],
+  "scan": {
+    "analyzer": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "end_time": "<TIMESTAMP>",
+    "scanner": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "start_time": "<TIMESTAMP>",
+    "status": "success",
+    "type": "sast"
+  },
+  "version": "15.0.4",
+  "vulnerabilities": [
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/forged_mid.docx (line 1)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nAuthor: Jane Analyst\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "AUTHOR_INFO"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "metadata"
+        }
+      ],
+      "location": {
+        "end_line": 1,
+        "file": "forged_mid.docx",
+        "start_line": 1
+      },
+      "message": "Author information detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Author Info Detected",
+      "severity": "High"
+    },
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected sensitive data (last modified by) in this file.\n\n**Location:** <TMPDIR>/forged_mid.docx (line 2)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nLastModifiedBy: Ops Reviewer\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "LAST_MODIFIED_BY"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "metadata"
+        }
+      ],
+      "location": {
+        "end_line": 2,
+        "file": "forged_mid.docx",
+        "start_line": 2
+      },
+      "message": "Sensitive data (last modified by) detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Last Modified By Detected",
+      "severity": "High"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.gitlab-sast.json
@@ -28,8 +28,60 @@
   "vulnerabilities": [
     {
       "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <TMPDIR>/forged_mid.docx (line 5)\n**Confidence:** HIGH (100.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\nEmployee SSN 449-87-4100 on file.\n```\n\n**Additional Information:**\n- context_impact: 45\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "SSN"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "ssn"
+        }
+      ],
+      "location": {
+        "end_line": 5,
+        "file": "forged_mid.docx",
+        "start_line": 5
+      },
+      "message": "Social Security Number detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Social Security Number Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected visa credit card in this file.\n\n**Location:** <TMPDIR>/forged_mid.docx (line 7)\n**Confidence:** HIGH (100.0%)\n**Detected by:** creditcard validator\n\n**Context:**\n```\nCard 4532-0151-1283-0366 expires soon.\n```\n\n**Additional Information:**\n- card_type: VISA\n- context_impact: 15\n- source: preprocessed_content\n- vendor: Visa\n\n**Remediation:**\nRemove or mask credit card numbers. Consider using tokenization for legitimate payment processing needs.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "VISA"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "creditcard"
+        }
+      ],
+      "location": {
+        "end_line": 7,
+        "file": "forged_mid.docx",
+        "start_line": 7
+      },
+      "message": "Visa credit card detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Visa Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
       "confidence": "Medium",
-      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/forged_mid.docx (line 1)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nAuthor: Jane Analyst\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/forged_mid.docx (line 1)\n**Confidence:** MEDIUM (65.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nAuthor: Jane Analyst\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {
@@ -55,7 +107,7 @@
     {
       "category": "sast",
       "confidence": "Medium",
-      "description": "Ferret Scan detected sensitive data (last modified by) in this file.\n\n**Location:** <TMPDIR>/forged_mid.docx (line 2)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nLastModifiedBy: Ops Reviewer\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "description": "Ferret Scan detected sensitive data (last modified by) in this file.\n\n**Location:** <TMPDIR>/forged_mid.docx (line 2)\n**Confidence:** MEDIUM (65.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nLastModifiedBy: Ops Reviewer\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.json.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.json.json
@@ -1,0 +1,80 @@
+{
+  "results": [
+    {
+      "confidence": 60.00000000000001,
+      "confidence_level": "MEDIUM",
+      "filename": "<TMPDIR>/forged_mid.docx",
+      "line_number": 1,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 0,
+        "full_field": "Author: Jane Analyst",
+        "metadata_type": "AUTHOR_INFO",
+        "original_confidence": 60.00000000000001,
+        "original_file": "<TMPDIR>/forged_mid.docx",
+        "preprocessor_adjustment": 0,
+        "preprocessor_name": "Office Metadata Extractor",
+        "preprocessor_type": "office_metadata",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "source_file": "<TMPDIR>/forged_mid.docx",
+        "source_preprocessor": "office_metadata",
+        "total_adjustment": 0,
+        "validation_checks": {
+          "contains_author_field": true
+        },
+        "validation_path": "metadata"
+      },
+      "text": "Jane Analyst",
+      "type": "AUTHOR_INFO",
+      "validator": "metadata"
+    },
+    {
+      "confidence": 60.00000000000001,
+      "confidence_level": "MEDIUM",
+      "filename": "<TMPDIR>/forged_mid.docx",
+      "line_number": 2,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 0,
+        "full_field": "LastModifiedBy: Ops Reviewer",
+        "metadata_type": "LAST_MODIFIED_BY",
+        "original_confidence": 60.00000000000001,
+        "original_file": "<TMPDIR>/forged_mid.docx",
+        "preprocessor_adjustment": 0,
+        "preprocessor_name": "Office Metadata Extractor",
+        "preprocessor_type": "office_metadata",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "source_file": "<TMPDIR>/forged_mid.docx",
+        "source_preprocessor": "office_metadata",
+        "total_adjustment": 0,
+        "validation_checks": {
+          "contains_modifier_field": true
+        },
+        "validation_path": "metadata"
+      },
+      "text": "Ops Reviewer",
+      "type": "LAST_MODIFIED_BY",
+      "validator": "metadata"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.json.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.json.json
@@ -1,7 +1,85 @@
 {
   "results": [
     {
-      "confidence": 60.00000000000001,
+      "confidence": 100,
+      "confidence_level": "HIGH",
+      "filename": "<TMPDIR>/forged_mid.docx",
+      "line_number": 5,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 45,
+        "correlation_boost": 5,
+        "cross_path_correlation": true,
+        "original_confidence": 100,
+        "original_file": "<TMPDIR>/forged_mid.docx",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "format": true,
+          "not_common_pattern": true,
+          "not_repeating": true,
+          "not_sequential": true,
+          "not_test_number": true,
+          "valid_area": true
+        },
+        "validation_path": "document"
+      },
+      "text": "449-87-4100",
+      "type": "SSN",
+      "validator": "ssn"
+    },
+    {
+      "confidence": 100,
+      "confidence_level": "HIGH",
+      "filename": "<TMPDIR>/forged_mid.docx",
+      "line_number": 7,
+      "metadata": {
+        "card_type": "VISA",
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 15,
+        "correlation_boost": 5,
+        "cross_path_correlation": true,
+        "original_confidence": 100,
+        "original_file": "<TMPDIR>/forged_mid.docx",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "entropy": true,
+          "length": true,
+          "luhn": true,
+          "not_repeating": true,
+          "not_test": true,
+          "vendor": true
+        },
+        "validation_path": "document",
+        "vendor": "Visa"
+      },
+      "text": "4532-0151-1283-0366",
+      "type": "VISA",
+      "validator": "creditcard"
+    },
+    {
+      "confidence": 65,
       "confidence_level": "MEDIUM",
       "filename": "<TMPDIR>/forged_mid.docx",
       "line_number": 1,
@@ -11,6 +89,8 @@
         "context_doctype": "Unknown",
         "context_domain": "HR_Payroll",
         "context_impact": 0,
+        "correlation_boost": 5,
+        "cross_path_correlation": true,
         "full_field": "Author: Jane Analyst",
         "metadata_type": "AUTHOR_INFO",
         "original_confidence": 60.00000000000001,
@@ -39,7 +119,7 @@
       "validator": "metadata"
     },
     {
-      "confidence": 60.00000000000001,
+      "confidence": 65,
       "confidence_level": "MEDIUM",
       "filename": "<TMPDIR>/forged_mid.docx",
       "line_number": 2,
@@ -49,6 +129,8 @@
         "context_doctype": "Unknown",
         "context_domain": "HR_Payroll",
         "context_impact": 0,
+        "correlation_boost": 5,
+        "cross_path_correlation": true,
         "full_field": "LastModifiedBy: Ops Reviewer",
         "metadata_type": "LAST_MODIFIED_BY",
         "original_confidence": 60.00000000000001,

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.junit.xml
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.junit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
+  <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
+    <testcase name="forged_mid.docx" classname="security-scan" time="0.001">
+      <failure message="2 security findings detected" type="SECURITY_FINDINGS">Line 1: AUTHOR_INFO detected with 60.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata&#xA;Line 2: LAST_MODIFIED_BY detected with 60.0% confidence (MEDIUM)&#xA;Match: Ops Reviewer&#xA;Validator: metadata</failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.junit.xml
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.junit.xml
@@ -2,7 +2,7 @@
 <testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
   <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
     <testcase name="forged_mid.docx" classname="security-scan" time="0.001">
-      <failure message="2 security findings detected" type="SECURITY_FINDINGS">Line 1: AUTHOR_INFO detected with 60.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata&#xA;Line 2: LAST_MODIFIED_BY detected with 60.0% confidence (MEDIUM)&#xA;Match: Ops Reviewer&#xA;Validator: metadata</failure>
+      <failure message="4 security findings detected" type="SECURITY_FINDINGS">Line 5: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 7: VISA detected with 100.0% confidence (HIGH)&#xA;Match: 4532-0151-1283-0366&#xA;Validator: creditcard&#xA;Line 1: AUTHOR_INFO detected with 65.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata&#xA;Line 2: LAST_MODIFIED_BY detected with 65.0% confidence (MEDIUM)&#xA;Match: Ops Reviewer&#xA;Validator: metadata</failure>
     </testcase>
   </testsuite>
 </testsuites>

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.sarif.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.sarif.json
@@ -1,0 +1,173 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/refs/heads/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/forged_mid.docx"
+                },
+                "region": {
+                  "endColumn": 21,
+                  "snippet": {
+                    "text": "Author: Jane Analyst"
+                  },
+                  "startColumn": 9,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "AUTHOR_INFO Detected in forged_mid.docx at line 1 (confidence: 60.0% - MEDIUM). Matched text: 'Jane Analyst'"
+          },
+          "properties": {
+            "confidence": 60,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 0,
+              "full_field": "Author: Jane Analyst",
+              "metadata_type": "AUTHOR_INFO",
+              "original_confidence": 60,
+              "original_file": "<TMPDIR>/forged_mid.docx",
+              "preprocessor_adjustment": 0,
+              "preprocessor_name": "Office Metadata Extractor",
+              "preprocessor_type": "office_metadata",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "source_file": "<TMPDIR>/forged_mid.docx",
+              "source_preprocessor": "office_metadata",
+              "total_adjustment": 0,
+              "validation_checks": {
+                "contains_author_field": true
+              },
+              "validation_path": "metadata"
+            },
+            "validator": "metadata"
+          },
+          "rank": 55,
+          "ruleId": "AUTHOR_INFO"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/forged_mid.docx"
+                },
+                "region": {
+                  "endColumn": 29,
+                  "snippet": {
+                    "text": "LastModifiedBy: Ops Reviewer"
+                  },
+                  "startColumn": 17,
+                  "startLine": 2
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "LAST_MODIFIED_BY Detected in forged_mid.docx at line 2 (confidence: 60.0% - MEDIUM). Matched text: 'Ops Reviewer'"
+          },
+          "properties": {
+            "confidence": 60,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 0,
+              "full_field": "LastModifiedBy: Ops Reviewer",
+              "metadata_type": "LAST_MODIFIED_BY",
+              "original_confidence": 60,
+              "original_file": "<TMPDIR>/forged_mid.docx",
+              "preprocessor_adjustment": 0,
+              "preprocessor_name": "Office Metadata Extractor",
+              "preprocessor_type": "office_metadata",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "source_file": "<TMPDIR>/forged_mid.docx",
+              "source_preprocessor": "office_metadata",
+              "total_adjustment": 0,
+              "validation_checks": {
+                "contains_modifier_field": true
+              },
+              "validation_path": "metadata"
+            },
+            "validator": "metadata"
+          },
+          "rank": 55,
+          "ruleId": "LAST_MODIFIED_BY"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/awslabs/ferret-scan",
+          "name": "Ferret Scan",
+          "rules": [
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type AUTHOR_INFO was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/AUTHOR_INFO.md",
+              "id": "AUTHOR_INFO",
+              "shortDescription": {
+                "text": "AUTHOR_INFO Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type LAST_MODIFIED_BY was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/LAST_MODIFIED_BY.md",
+              "id": "LAST_MODIFIED_BY",
+              "shortDescription": {
+                "text": "LAST_MODIFIED_BY Detected"
+              }
+            }
+          ],
+          "semanticVersion": "0.0.0-development",
+          "version": "0.0.0-development"
+        }
+      },
+      "versionControlProvenance": [
+        {
+          "mappedTo": {
+            "uriBaseId": "%SRCROOT%"
+          },
+          "repositoryUri": "https://github.com/awslabs/ferret-scan",
+          "revisionId": "0.0.0-development"
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.sarif.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.sarif.json
@@ -11,6 +11,141 @@
                 "artifactLocation": {
                   "uri": "file://<TMPDIR>/forged_mid.docx"
                 },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "Employee SSN \nEmployee SSN 449-87-4100 on file.\n on file."
+                  },
+                  "startLine": 5
+                },
+                "region": {
+                  "endColumn": 25,
+                  "snippet": {
+                    "text": "Employee SSN 449-87-4100 on file."
+                  },
+                  "startColumn": 14,
+                  "startLine": 5
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Social Security Number Detected in forged_mid.docx at line 5 (confidence: 100.0% - HIGH). Matched text: '449-87-4100'"
+          },
+          "properties": {
+            "confidence": 100,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 45,
+              "correlation_boost": 5,
+              "cross_path_correlation": true,
+              "original_confidence": 100,
+              "original_file": "<TMPDIR>/forged_mid.docx",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "digits": true,
+                "format": true,
+                "not_common_pattern": true,
+                "not_repeating": true,
+                "not_sequential": true,
+                "not_test_number": true,
+                "valid_area": true
+              },
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "ssn"
+            ],
+            "validator": "ssn"
+          },
+          "rank": 100,
+          "ruleId": "SSN"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/forged_mid.docx"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "Card \nCard 4532-0151-1283-0366 expires soon.\n expires soon."
+                  },
+                  "startLine": 7
+                },
+                "region": {
+                  "endColumn": 25,
+                  "snippet": {
+                    "text": "Card 4532-0151-1283-0366 expires soon."
+                  },
+                  "startColumn": 6,
+                  "startLine": 7
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "VISA Detected in forged_mid.docx at line 7 (confidence: 100.0% - HIGH). Matched text: '4532-0151-1283-0366'"
+          },
+          "properties": {
+            "confidence": 100,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "card_type": "VISA",
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 15,
+              "correlation_boost": 5,
+              "cross_path_correlation": true,
+              "original_confidence": 100,
+              "original_file": "<TMPDIR>/forged_mid.docx",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "digits": true,
+                "entropy": true,
+                "length": true,
+                "luhn": true,
+                "not_repeating": true,
+                "not_test": true,
+                "vendor": true
+              },
+              "validation_path": "document",
+              "vendor": "Visa"
+            },
+            "validator": "creditcard"
+          },
+          "rank": 75,
+          "ruleId": "VISA"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/forged_mid.docx"
+                },
                 "region": {
                   "endColumn": 21,
                   "snippet": {
@@ -23,10 +158,10 @@
             }
           ],
           "message": {
-            "text": "AUTHOR_INFO Detected in forged_mid.docx at line 1 (confidence: 60.0% - MEDIUM). Matched text: 'Jane Analyst'"
+            "text": "AUTHOR_INFO Detected in forged_mid.docx at line 1 (confidence: 65.0% - MEDIUM). Matched text: 'Jane Analyst'"
           },
           "properties": {
-            "confidence": 60,
+            "confidence": 65,
             "confidenceLevel": "MEDIUM",
             "metadata": {
               "confidence_adjustment": 0,
@@ -34,6 +169,8 @@
               "context_doctype": "Unknown",
               "context_domain": "HR_Payroll",
               "context_impact": 0,
+              "correlation_boost": 5,
+              "cross_path_correlation": true,
               "full_field": "Author: Jane Analyst",
               "metadata_type": "AUTHOR_INFO",
               "original_confidence": 60,
@@ -59,7 +196,7 @@
             },
             "validator": "metadata"
           },
-          "rank": 55,
+          "rank": 57.5,
           "ruleId": "AUTHOR_INFO"
         },
         {
@@ -82,10 +219,10 @@
             }
           ],
           "message": {
-            "text": "LAST_MODIFIED_BY Detected in forged_mid.docx at line 2 (confidence: 60.0% - MEDIUM). Matched text: 'Ops Reviewer'"
+            "text": "LAST_MODIFIED_BY Detected in forged_mid.docx at line 2 (confidence: 65.0% - MEDIUM). Matched text: 'Ops Reviewer'"
           },
           "properties": {
-            "confidence": 60,
+            "confidence": 65,
             "confidenceLevel": "MEDIUM",
             "metadata": {
               "confidence_adjustment": 0,
@@ -93,6 +230,8 @@
               "context_doctype": "Unknown",
               "context_domain": "HR_Payroll",
               "context_impact": 0,
+              "correlation_boost": 5,
+              "cross_path_correlation": true,
               "full_field": "LastModifiedBy: Ops Reviewer",
               "metadata_type": "LAST_MODIFIED_BY",
               "original_confidence": 60,
@@ -118,7 +257,7 @@
             },
             "validator": "metadata"
           },
-          "rank": 55,
+          "rank": 57.5,
           "ruleId": "LAST_MODIFIED_BY"
         }
       ],
@@ -151,6 +290,32 @@
               "id": "LAST_MODIFIED_BY",
               "shortDescription": {
                 "text": "LAST_MODIFIED_BY Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "A Social Security Number (SSN) pattern was detected in the scanned content. SSNs are highly sensitive personally identifiable information (PII) that must be protected under various regulations."
+              },
+              "help": {
+                "text": "Social Security Numbers are protected under numerous regulations including GDPR, HIPAA, and various state privacy laws. SSNs should never be stored in source code, configuration files, or logs. Remove this SSN immediately and ensure it is stored in a secure, encrypted system with appropriate access controls. Consider implementing tokenization or other data protection mechanisms."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/SSN.md",
+              "id": "SSN",
+              "shortDescription": {
+                "text": "Social Security Number Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type VISA was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/VISA.md",
+              "id": "VISA",
+              "shortDescription": {
+                "text": "VISA Detected"
               }
             }
           ],

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.txt
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.txt
@@ -1,4 +1,6 @@
-LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH        FILE
---------------------------------------------------------------------------------------
-[MEDIUM] metadata     AUTHOR_INFO            60.00% line     1 Jane Analyst forged_mid.docx
-[MEDIUM] metadata     LAST_MODIFIED_BY       60.00% line     2 Ops Reviewer forged_mid.docx
+LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH               FILE
+---------------------------------------------------------------------------------------------
+[HIGH  ] ssn          SSN                   100.00% line     5 449-87-4100         forged_mid.docx
+[HIGH  ] creditcard   VISA                  100.00% line     7 4532-0151-1283-0366 forged_mid.docx
+[MEDIUM] metadata     AUTHOR_INFO            65.00% line     1 Jane Analyst        forged_mid.docx
+[MEDIUM] metadata     LAST_MODIFIED_BY       65.00% line     2 Ops Reviewer        forged_mid.docx

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.txt
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.txt
@@ -1,0 +1,4 @@
+LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH        FILE
+--------------------------------------------------------------------------------------
+[MEDIUM] metadata     AUTHOR_INFO            60.00% line     1 Jane Analyst forged_mid.docx
+[MEDIUM] metadata     LAST_MODIFIED_BY       60.00% line     2 Ops Reviewer forged_mid.docx

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.yaml
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.yaml
@@ -1,8 +1,76 @@
 results:
+    - text: 449-87-4100
+      line_number: 5
+      type: SSN
+      confidence: 100
+      confidence_level: HIGH
+      filename: <TMPDIR>/forged_mid.docx
+      validator: ssn
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 45
+        correlation_boost: 5
+        cross_path_correlation: true
+        original_confidence: 100
+        original_file: <TMPDIR>/forged_mid.docx
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            format: true
+            not_common_pattern: true
+            not_repeating: true
+            not_sequential: true
+            not_test_number: true
+            valid_area: true
+        validation_path: document
+    - text: 4532-0151-1283-0366
+      line_number: 7
+      type: VISA
+      confidence: 100
+      confidence_level: HIGH
+      filename: <TMPDIR>/forged_mid.docx
+      validator: creditcard
+      metadata:
+        card_type: VISA
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 15
+        correlation_boost: 5
+        cross_path_correlation: true
+        original_confidence: 100
+        original_file: <TMPDIR>/forged_mid.docx
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            entropy: true
+            length: true
+            luhn: true
+            not_repeating: true
+            not_test: true
+            vendor: true
+        validation_path: document
+        vendor: Visa
     - text: Jane Analyst
       line_number: 1
       type: AUTHOR_INFO
-      confidence: 60.00000000000001
+      confidence: 65
       confidence_level: MEDIUM
       filename: <TMPDIR>/forged_mid.docx
       validator: metadata
@@ -12,6 +80,8 @@ results:
         context_doctype: Unknown
         context_domain: HR_Payroll
         context_impact: 0
+        correlation_boost: 5
+        cross_path_correlation: true
         full_field: 'Author: Jane Analyst'
         metadata_type: AUTHOR_INFO
         original_confidence: 60.00000000000001
@@ -35,7 +105,7 @@ results:
     - text: Ops Reviewer
       line_number: 2
       type: LAST_MODIFIED_BY
-      confidence: 60.00000000000001
+      confidence: 65
       confidence_level: MEDIUM
       filename: <TMPDIR>/forged_mid.docx
       validator: metadata
@@ -45,6 +115,8 @@ results:
         context_doctype: Unknown
         context_domain: HR_Payroll
         context_impact: 0
+        correlation_boost: 5
+        cross_path_correlation: true
         full_field: 'LastModifiedBy: Ops Reviewer'
         metadata_type: LAST_MODIFIED_BY
         original_confidence: 60.00000000000001

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.yaml
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.yaml
@@ -1,0 +1,67 @@
+results:
+    - text: Jane Analyst
+      line_number: 1
+      type: AUTHOR_INFO
+      confidence: 60.00000000000001
+      confidence_level: MEDIUM
+      filename: <TMPDIR>/forged_mid.docx
+      validator: metadata
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 0
+        full_field: 'Author: Jane Analyst'
+        metadata_type: AUTHOR_INFO
+        original_confidence: 60.00000000000001
+        original_file: <TMPDIR>/forged_mid.docx
+        preprocessor_adjustment: 0
+        preprocessor_name: Office Metadata Extractor
+        preprocessor_type: office_metadata
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        source_file: <TMPDIR>/forged_mid.docx
+        source_preprocessor: office_metadata
+        total_adjustment: 0
+        validation_checks:
+            contains_author_field: true
+        validation_path: metadata
+    - text: Ops Reviewer
+      line_number: 2
+      type: LAST_MODIFIED_BY
+      confidence: 60.00000000000001
+      confidence_level: MEDIUM
+      filename: <TMPDIR>/forged_mid.docx
+      validator: metadata
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 0
+        full_field: 'LastModifiedBy: Ops Reviewer'
+        metadata_type: LAST_MODIFIED_BY
+        original_confidence: 60.00000000000001
+        original_file: <TMPDIR>/forged_mid.docx
+        preprocessor_adjustment: 0
+        preprocessor_name: Office Metadata Extractor
+        preprocessor_type: office_metadata
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        source_file: <TMPDIR>/forged_mid.docx
+        source_preprocessor: office_metadata
+        total_adjustment: 0
+        validation_checks:
+            contains_modifier_field: true
+        validation_path: metadata

--- a/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.csv
+++ b/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.csv
@@ -1,0 +1,3 @@
+Filename,Type,Confidence Level,Confidence %,Line Number,Text
+<TMPDIR>/alt_case.docx,AUTHOR_INFO,MEDIUM,60.0,1,Jane Analyst
+<TMPDIR>/alt_case.docx,LAST_MODIFIED_BY,MEDIUM,60.0,2,Ops Reviewer

--- a/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.csv
+++ b/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.csv
@@ -1,3 +1,5 @@
 Filename,Type,Confidence Level,Confidence %,Line Number,Text
-<TMPDIR>/alt_case.docx,AUTHOR_INFO,MEDIUM,60.0,1,Jane Analyst
-<TMPDIR>/alt_case.docx,LAST_MODIFIED_BY,MEDIUM,60.0,2,Ops Reviewer
+<TMPDIR>/alt_case.docx,SSN,HIGH,100.0,3,449-87-4100
+<TMPDIR>/alt_case.docx,VISA,HIGH,100.0,5,4532-0151-1283-0366
+<TMPDIR>/alt_case.docx,AUTHOR_INFO,MEDIUM,65.0,1,Jane Analyst
+<TMPDIR>/alt_case.docx,LAST_MODIFIED_BY,MEDIUM,65.0,2,Ops Reviewer

--- a/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.gitlab-sast.json
@@ -1,0 +1,82 @@
+{
+  "remediations": [],
+  "scan": {
+    "analyzer": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "end_time": "<TIMESTAMP>",
+    "scanner": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "start_time": "<TIMESTAMP>",
+    "status": "success",
+    "type": "sast"
+  },
+  "version": "15.0.4",
+  "vulnerabilities": [
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/alt_case.docx (line 1)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nAuthor: Jane Analyst\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "AUTHOR_INFO"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "metadata"
+        }
+      ],
+      "location": {
+        "end_line": 1,
+        "file": "alt_case.docx",
+        "start_line": 1
+      },
+      "message": "Author information detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Author Info Detected",
+      "severity": "High"
+    },
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected sensitive data (last modified by) in this file.\n\n**Location:** <TMPDIR>/alt_case.docx (line 2)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nLastModifiedBy: Ops Reviewer\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "LAST_MODIFIED_BY"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "metadata"
+        }
+      ],
+      "location": {
+        "end_line": 2,
+        "file": "alt_case.docx",
+        "start_line": 2
+      },
+      "message": "Sensitive data (last modified by) detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Last Modified By Detected",
+      "severity": "High"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.gitlab-sast.json
@@ -28,8 +28,60 @@
   "vulnerabilities": [
     {
       "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <TMPDIR>/alt_case.docx (line 3)\n**Confidence:** HIGH (100.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\nEmployee SSN 449-87-4100 on file.\n```\n\n**Additional Information:**\n- context_impact: 45\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "SSN"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "ssn"
+        }
+      ],
+      "location": {
+        "end_line": 3,
+        "file": "alt_case.docx",
+        "start_line": 3
+      },
+      "message": "Social Security Number detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Social Security Number Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected visa credit card in this file.\n\n**Location:** <TMPDIR>/alt_case.docx (line 5)\n**Confidence:** HIGH (100.0%)\n**Detected by:** creditcard validator\n\n**Context:**\n```\nCard 4532-0151-1283-0366 expires soon.\n```\n\n**Additional Information:**\n- card_type: VISA\n- context_impact: 15\n- source: preprocessed_content\n- vendor: Visa\n\n**Remediation:**\nRemove or mask credit card numbers. Consider using tokenization for legitimate payment processing needs.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "VISA"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "creditcard"
+        }
+      ],
+      "location": {
+        "end_line": 5,
+        "file": "alt_case.docx",
+        "start_line": 5
+      },
+      "message": "Visa credit card detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Visa Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
       "confidence": "Medium",
-      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/alt_case.docx (line 1)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nAuthor: Jane Analyst\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/alt_case.docx (line 1)\n**Confidence:** MEDIUM (65.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nAuthor: Jane Analyst\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {
@@ -55,7 +107,7 @@
     {
       "category": "sast",
       "confidence": "Medium",
-      "description": "Ferret Scan detected sensitive data (last modified by) in this file.\n\n**Location:** <TMPDIR>/alt_case.docx (line 2)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nLastModifiedBy: Ops Reviewer\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "description": "Ferret Scan detected sensitive data (last modified by) in this file.\n\n**Location:** <TMPDIR>/alt_case.docx (line 2)\n**Confidence:** MEDIUM (65.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nLastModifiedBy: Ops Reviewer\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {

--- a/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.json.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.json.json
@@ -1,0 +1,80 @@
+{
+  "results": [
+    {
+      "confidence": 60.00000000000001,
+      "confidence_level": "MEDIUM",
+      "filename": "<TMPDIR>/alt_case.docx",
+      "line_number": 1,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0,
+        "context_doctype": "Configuration",
+        "context_domain": "Unknown",
+        "context_impact": 0,
+        "full_field": "Author: Jane Analyst",
+        "metadata_type": "AUTHOR_INFO",
+        "original_confidence": 60.00000000000001,
+        "original_file": "<TMPDIR>/alt_case.docx",
+        "preprocessor_adjustment": 0,
+        "preprocessor_name": "Office Metadata Extractor",
+        "preprocessor_type": "office_metadata",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "source_file": "<TMPDIR>/alt_case.docx",
+        "source_preprocessor": "office_metadata",
+        "total_adjustment": 0,
+        "validation_checks": {
+          "contains_author_field": true
+        },
+        "validation_path": "metadata"
+      },
+      "text": "Jane Analyst",
+      "type": "AUTHOR_INFO",
+      "validator": "metadata"
+    },
+    {
+      "confidence": 60.00000000000001,
+      "confidence_level": "MEDIUM",
+      "filename": "<TMPDIR>/alt_case.docx",
+      "line_number": 2,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0,
+        "context_doctype": "Configuration",
+        "context_domain": "Unknown",
+        "context_impact": 0,
+        "full_field": "LastModifiedBy: Ops Reviewer",
+        "metadata_type": "LAST_MODIFIED_BY",
+        "original_confidence": 60.00000000000001,
+        "original_file": "<TMPDIR>/alt_case.docx",
+        "preprocessor_adjustment": 0,
+        "preprocessor_name": "Office Metadata Extractor",
+        "preprocessor_type": "office_metadata",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "source_file": "<TMPDIR>/alt_case.docx",
+        "source_preprocessor": "office_metadata",
+        "total_adjustment": 0,
+        "validation_checks": {
+          "contains_modifier_field": true
+        },
+        "validation_path": "metadata"
+      },
+      "text": "Ops Reviewer",
+      "type": "LAST_MODIFIED_BY",
+      "validator": "metadata"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.json.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.json.json
@@ -1,16 +1,96 @@
 {
   "results": [
     {
-      "confidence": 60.00000000000001,
+      "confidence": 100,
+      "confidence_level": "HIGH",
+      "filename": "<TMPDIR>/alt_case.docx",
+      "line_number": 3,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 45,
+        "correlation_boost": 5,
+        "cross_path_correlation": true,
+        "original_confidence": 100,
+        "original_file": "<TMPDIR>/alt_case.docx",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "format": true,
+          "not_common_pattern": true,
+          "not_repeating": true,
+          "not_sequential": true,
+          "not_test_number": true,
+          "valid_area": true
+        },
+        "validation_path": "document"
+      },
+      "text": "449-87-4100",
+      "type": "SSN",
+      "validator": "ssn"
+    },
+    {
+      "confidence": 100,
+      "confidence_level": "HIGH",
+      "filename": "<TMPDIR>/alt_case.docx",
+      "line_number": 5,
+      "metadata": {
+        "card_type": "VISA",
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 15,
+        "correlation_boost": 5,
+        "cross_path_correlation": true,
+        "original_confidence": 100,
+        "original_file": "<TMPDIR>/alt_case.docx",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "entropy": true,
+          "length": true,
+          "luhn": true,
+          "not_repeating": true,
+          "not_test": true,
+          "vendor": true
+        },
+        "validation_path": "document",
+        "vendor": "Visa"
+      },
+      "text": "4532-0151-1283-0366",
+      "type": "VISA",
+      "validator": "creditcard"
+    },
+    {
+      "confidence": 65,
       "confidence_level": "MEDIUM",
       "filename": "<TMPDIR>/alt_case.docx",
       "line_number": 1,
       "metadata": {
         "confidence_adjustment": 0,
-        "context_confidence": 0,
-        "context_doctype": "Configuration",
-        "context_domain": "Unknown",
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
         "context_impact": 0,
+        "correlation_boost": 5,
+        "cross_path_correlation": true,
         "full_field": "Author: Jane Analyst",
         "metadata_type": "AUTHOR_INFO",
         "original_confidence": 60.00000000000001,
@@ -39,16 +119,18 @@
       "validator": "metadata"
     },
     {
-      "confidence": 60.00000000000001,
+      "confidence": 65,
       "confidence_level": "MEDIUM",
       "filename": "<TMPDIR>/alt_case.docx",
       "line_number": 2,
       "metadata": {
         "confidence_adjustment": 0,
-        "context_confidence": 0,
-        "context_doctype": "Configuration",
-        "context_domain": "Unknown",
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
         "context_impact": 0,
+        "correlation_boost": 5,
+        "cross_path_correlation": true,
         "full_field": "LastModifiedBy: Ops Reviewer",
         "metadata_type": "LAST_MODIFIED_BY",
         "original_confidence": 60.00000000000001,

--- a/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.junit.xml
+++ b/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.junit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
+  <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
+    <testcase name="alt_case.docx" classname="security-scan" time="0.001">
+      <failure message="2 security findings detected" type="SECURITY_FINDINGS">Line 1: AUTHOR_INFO detected with 60.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata&#xA;Line 2: LAST_MODIFIED_BY detected with 60.0% confidence (MEDIUM)&#xA;Match: Ops Reviewer&#xA;Validator: metadata</failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.junit.xml
+++ b/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.junit.xml
@@ -2,7 +2,7 @@
 <testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
   <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
     <testcase name="alt_case.docx" classname="security-scan" time="0.001">
-      <failure message="2 security findings detected" type="SECURITY_FINDINGS">Line 1: AUTHOR_INFO detected with 60.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata&#xA;Line 2: LAST_MODIFIED_BY detected with 60.0% confidence (MEDIUM)&#xA;Match: Ops Reviewer&#xA;Validator: metadata</failure>
+      <failure message="4 security findings detected" type="SECURITY_FINDINGS">Line 3: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 5: VISA detected with 100.0% confidence (HIGH)&#xA;Match: 4532-0151-1283-0366&#xA;Validator: creditcard&#xA;Line 1: AUTHOR_INFO detected with 65.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata&#xA;Line 2: LAST_MODIFIED_BY detected with 65.0% confidence (MEDIUM)&#xA;Match: Ops Reviewer&#xA;Validator: metadata</failure>
     </testcase>
   </testsuite>
 </testsuites>

--- a/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.sarif.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.sarif.json
@@ -11,6 +11,141 @@
                 "artifactLocation": {
                   "uri": "file://<TMPDIR>/alt_case.docx"
                 },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "Employee SSN \nEmployee SSN 449-87-4100 on file.\n on file."
+                  },
+                  "startLine": 3
+                },
+                "region": {
+                  "endColumn": 25,
+                  "snippet": {
+                    "text": "Employee SSN 449-87-4100 on file."
+                  },
+                  "startColumn": 14,
+                  "startLine": 3
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Social Security Number Detected in alt_case.docx at line 3 (confidence: 100.0% - HIGH). Matched text: '449-87-4100'"
+          },
+          "properties": {
+            "confidence": 100,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 45,
+              "correlation_boost": 5,
+              "cross_path_correlation": true,
+              "original_confidence": 100,
+              "original_file": "<TMPDIR>/alt_case.docx",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "digits": true,
+                "format": true,
+                "not_common_pattern": true,
+                "not_repeating": true,
+                "not_sequential": true,
+                "not_test_number": true,
+                "valid_area": true
+              },
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "ssn"
+            ],
+            "validator": "ssn"
+          },
+          "rank": 100,
+          "ruleId": "SSN"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/alt_case.docx"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "Card \nCard 4532-0151-1283-0366 expires soon.\n expires soon."
+                  },
+                  "startLine": 5
+                },
+                "region": {
+                  "endColumn": 25,
+                  "snippet": {
+                    "text": "Card 4532-0151-1283-0366 expires soon."
+                  },
+                  "startColumn": 6,
+                  "startLine": 5
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "VISA Detected in alt_case.docx at line 5 (confidence: 100.0% - HIGH). Matched text: '4532-0151-1283-0366'"
+          },
+          "properties": {
+            "confidence": 100,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "card_type": "VISA",
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 15,
+              "correlation_boost": 5,
+              "cross_path_correlation": true,
+              "original_confidence": 100,
+              "original_file": "<TMPDIR>/alt_case.docx",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "digits": true,
+                "entropy": true,
+                "length": true,
+                "luhn": true,
+                "not_repeating": true,
+                "not_test": true,
+                "vendor": true
+              },
+              "validation_path": "document",
+              "vendor": "Visa"
+            },
+            "validator": "creditcard"
+          },
+          "rank": 75,
+          "ruleId": "VISA"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/alt_case.docx"
+                },
                 "region": {
                   "endColumn": 21,
                   "snippet": {
@@ -23,17 +158,19 @@
             }
           ],
           "message": {
-            "text": "AUTHOR_INFO Detected in alt_case.docx at line 1 (confidence: 60.0% - MEDIUM). Matched text: 'Jane Analyst'"
+            "text": "AUTHOR_INFO Detected in alt_case.docx at line 1 (confidence: 65.0% - MEDIUM). Matched text: 'Jane Analyst'"
           },
           "properties": {
-            "confidence": 60,
+            "confidence": 65,
             "confidenceLevel": "MEDIUM",
             "metadata": {
               "confidence_adjustment": 0,
-              "context_confidence": 0,
-              "context_doctype": "Configuration",
-              "context_domain": "Unknown",
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
               "context_impact": 0,
+              "correlation_boost": 5,
+              "cross_path_correlation": true,
               "full_field": "Author: Jane Analyst",
               "metadata_type": "AUTHOR_INFO",
               "original_confidence": 60,
@@ -59,7 +196,7 @@
             },
             "validator": "metadata"
           },
-          "rank": 55,
+          "rank": 57.5,
           "ruleId": "AUTHOR_INFO"
         },
         {
@@ -82,17 +219,19 @@
             }
           ],
           "message": {
-            "text": "LAST_MODIFIED_BY Detected in alt_case.docx at line 2 (confidence: 60.0% - MEDIUM). Matched text: 'Ops Reviewer'"
+            "text": "LAST_MODIFIED_BY Detected in alt_case.docx at line 2 (confidence: 65.0% - MEDIUM). Matched text: 'Ops Reviewer'"
           },
           "properties": {
-            "confidence": 60,
+            "confidence": 65,
             "confidenceLevel": "MEDIUM",
             "metadata": {
               "confidence_adjustment": 0,
-              "context_confidence": 0,
-              "context_doctype": "Configuration",
-              "context_domain": "Unknown",
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
               "context_impact": 0,
+              "correlation_boost": 5,
+              "cross_path_correlation": true,
               "full_field": "LastModifiedBy: Ops Reviewer",
               "metadata_type": "LAST_MODIFIED_BY",
               "original_confidence": 60,
@@ -118,7 +257,7 @@
             },
             "validator": "metadata"
           },
-          "rank": 55,
+          "rank": 57.5,
           "ruleId": "LAST_MODIFIED_BY"
         }
       ],
@@ -151,6 +290,32 @@
               "id": "LAST_MODIFIED_BY",
               "shortDescription": {
                 "text": "LAST_MODIFIED_BY Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "A Social Security Number (SSN) pattern was detected in the scanned content. SSNs are highly sensitive personally identifiable information (PII) that must be protected under various regulations."
+              },
+              "help": {
+                "text": "Social Security Numbers are protected under numerous regulations including GDPR, HIPAA, and various state privacy laws. SSNs should never be stored in source code, configuration files, or logs. Remove this SSN immediately and ensure it is stored in a secure, encrypted system with appropriate access controls. Consider implementing tokenization or other data protection mechanisms."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/SSN.md",
+              "id": "SSN",
+              "shortDescription": {
+                "text": "Social Security Number Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type VISA was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/VISA.md",
+              "id": "VISA",
+              "shortDescription": {
+                "text": "VISA Detected"
               }
             }
           ],

--- a/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.sarif.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.sarif.json
@@ -1,0 +1,173 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/refs/heads/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/alt_case.docx"
+                },
+                "region": {
+                  "endColumn": 21,
+                  "snippet": {
+                    "text": "Author: Jane Analyst"
+                  },
+                  "startColumn": 9,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "AUTHOR_INFO Detected in alt_case.docx at line 1 (confidence: 60.0% - MEDIUM). Matched text: 'Jane Analyst'"
+          },
+          "properties": {
+            "confidence": 60,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 0,
+              "context_doctype": "Configuration",
+              "context_domain": "Unknown",
+              "context_impact": 0,
+              "full_field": "Author: Jane Analyst",
+              "metadata_type": "AUTHOR_INFO",
+              "original_confidence": 60,
+              "original_file": "<TMPDIR>/alt_case.docx",
+              "preprocessor_adjustment": 0,
+              "preprocessor_name": "Office Metadata Extractor",
+              "preprocessor_type": "office_metadata",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "source_file": "<TMPDIR>/alt_case.docx",
+              "source_preprocessor": "office_metadata",
+              "total_adjustment": 0,
+              "validation_checks": {
+                "contains_author_field": true
+              },
+              "validation_path": "metadata"
+            },
+            "validator": "metadata"
+          },
+          "rank": 55,
+          "ruleId": "AUTHOR_INFO"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/alt_case.docx"
+                },
+                "region": {
+                  "endColumn": 29,
+                  "snippet": {
+                    "text": "LastModifiedBy: Ops Reviewer"
+                  },
+                  "startColumn": 17,
+                  "startLine": 2
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "LAST_MODIFIED_BY Detected in alt_case.docx at line 2 (confidence: 60.0% - MEDIUM). Matched text: 'Ops Reviewer'"
+          },
+          "properties": {
+            "confidence": 60,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 0,
+              "context_doctype": "Configuration",
+              "context_domain": "Unknown",
+              "context_impact": 0,
+              "full_field": "LastModifiedBy: Ops Reviewer",
+              "metadata_type": "LAST_MODIFIED_BY",
+              "original_confidence": 60,
+              "original_file": "<TMPDIR>/alt_case.docx",
+              "preprocessor_adjustment": 0,
+              "preprocessor_name": "Office Metadata Extractor",
+              "preprocessor_type": "office_metadata",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "source_file": "<TMPDIR>/alt_case.docx",
+              "source_preprocessor": "office_metadata",
+              "total_adjustment": 0,
+              "validation_checks": {
+                "contains_modifier_field": true
+              },
+              "validation_path": "metadata"
+            },
+            "validator": "metadata"
+          },
+          "rank": 55,
+          "ruleId": "LAST_MODIFIED_BY"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/awslabs/ferret-scan",
+          "name": "Ferret Scan",
+          "rules": [
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type AUTHOR_INFO was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/AUTHOR_INFO.md",
+              "id": "AUTHOR_INFO",
+              "shortDescription": {
+                "text": "AUTHOR_INFO Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type LAST_MODIFIED_BY was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/LAST_MODIFIED_BY.md",
+              "id": "LAST_MODIFIED_BY",
+              "shortDescription": {
+                "text": "LAST_MODIFIED_BY Detected"
+              }
+            }
+          ],
+          "semanticVersion": "0.0.0-development",
+          "version": "0.0.0-development"
+        }
+      },
+      "versionControlProvenance": [
+        {
+          "mappedTo": {
+            "uriBaseId": "%SRCROOT%"
+          },
+          "repositoryUri": "https://github.com/awslabs/ferret-scan",
+          "revisionId": "0.0.0-development"
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.txt
+++ b/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.txt
@@ -1,0 +1,4 @@
+LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH        FILE
+--------------------------------------------------------------------------------------
+[MEDIUM] metadata     AUTHOR_INFO            60.00% line     1 Jane Analyst alt_case.docx
+[MEDIUM] metadata     LAST_MODIFIED_BY       60.00% line     2 Ops Reviewer alt_case.docx

--- a/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.txt
+++ b/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.txt
@@ -1,4 +1,6 @@
-LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH        FILE
---------------------------------------------------------------------------------------
-[MEDIUM] metadata     AUTHOR_INFO            60.00% line     1 Jane Analyst alt_case.docx
-[MEDIUM] metadata     LAST_MODIFIED_BY       60.00% line     2 Ops Reviewer alt_case.docx
+LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH               FILE
+---------------------------------------------------------------------------------------------
+[HIGH  ] ssn          SSN                   100.00% line     3 449-87-4100         alt_case.docx
+[HIGH  ] creditcard   VISA                  100.00% line     5 4532-0151-1283-0366 alt_case.docx
+[MEDIUM] metadata     AUTHOR_INFO            65.00% line     1 Jane Analyst        alt_case.docx
+[MEDIUM] metadata     LAST_MODIFIED_BY       65.00% line     2 Ops Reviewer        alt_case.docx

--- a/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.yaml
+++ b/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.yaml
@@ -1,0 +1,67 @@
+results:
+    - text: Jane Analyst
+      line_number: 1
+      type: AUTHOR_INFO
+      confidence: 60.00000000000001
+      confidence_level: MEDIUM
+      filename: <TMPDIR>/alt_case.docx
+      validator: metadata
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0
+        context_doctype: Configuration
+        context_domain: Unknown
+        context_impact: 0
+        full_field: 'Author: Jane Analyst'
+        metadata_type: AUTHOR_INFO
+        original_confidence: 60.00000000000001
+        original_file: <TMPDIR>/alt_case.docx
+        preprocessor_adjustment: 0
+        preprocessor_name: Office Metadata Extractor
+        preprocessor_type: office_metadata
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        source_file: <TMPDIR>/alt_case.docx
+        source_preprocessor: office_metadata
+        total_adjustment: 0
+        validation_checks:
+            contains_author_field: true
+        validation_path: metadata
+    - text: Ops Reviewer
+      line_number: 2
+      type: LAST_MODIFIED_BY
+      confidence: 60.00000000000001
+      confidence_level: MEDIUM
+      filename: <TMPDIR>/alt_case.docx
+      validator: metadata
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0
+        context_doctype: Configuration
+        context_domain: Unknown
+        context_impact: 0
+        full_field: 'LastModifiedBy: Ops Reviewer'
+        metadata_type: LAST_MODIFIED_BY
+        original_confidence: 60.00000000000001
+        original_file: <TMPDIR>/alt_case.docx
+        preprocessor_adjustment: 0
+        preprocessor_name: Office Metadata Extractor
+        preprocessor_type: office_metadata
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        source_file: <TMPDIR>/alt_case.docx
+        source_preprocessor: office_metadata
+        total_adjustment: 0
+        validation_checks:
+            contains_modifier_field: true
+        validation_path: metadata

--- a/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.yaml
+++ b/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.yaml
@@ -1,17 +1,87 @@
 results:
+    - text: 449-87-4100
+      line_number: 3
+      type: SSN
+      confidence: 100
+      confidence_level: HIGH
+      filename: <TMPDIR>/alt_case.docx
+      validator: ssn
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 45
+        correlation_boost: 5
+        cross_path_correlation: true
+        original_confidence: 100
+        original_file: <TMPDIR>/alt_case.docx
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            format: true
+            not_common_pattern: true
+            not_repeating: true
+            not_sequential: true
+            not_test_number: true
+            valid_area: true
+        validation_path: document
+    - text: 4532-0151-1283-0366
+      line_number: 5
+      type: VISA
+      confidence: 100
+      confidence_level: HIGH
+      filename: <TMPDIR>/alt_case.docx
+      validator: creditcard
+      metadata:
+        card_type: VISA
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 15
+        correlation_boost: 5
+        cross_path_correlation: true
+        original_confidence: 100
+        original_file: <TMPDIR>/alt_case.docx
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            entropy: true
+            length: true
+            luhn: true
+            not_repeating: true
+            not_test: true
+            vendor: true
+        validation_path: document
+        vendor: Visa
     - text: Jane Analyst
       line_number: 1
       type: AUTHOR_INFO
-      confidence: 60.00000000000001
+      confidence: 65
       confidence_level: MEDIUM
       filename: <TMPDIR>/alt_case.docx
       validator: metadata
       metadata:
         confidence_adjustment: 0
-        context_confidence: 0
-        context_doctype: Configuration
-        context_domain: Unknown
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
         context_impact: 0
+        correlation_boost: 5
+        cross_path_correlation: true
         full_field: 'Author: Jane Analyst'
         metadata_type: AUTHOR_INFO
         original_confidence: 60.00000000000001
@@ -35,16 +105,18 @@ results:
     - text: Ops Reviewer
       line_number: 2
       type: LAST_MODIFIED_BY
-      confidence: 60.00000000000001
+      confidence: 65
       confidence_level: MEDIUM
       filename: <TMPDIR>/alt_case.docx
       validator: metadata
       metadata:
         confidence_adjustment: 0
-        context_confidence: 0
-        context_doctype: Configuration
-        context_domain: Unknown
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
         context_impact: 0
+        correlation_boost: 5
+        cross_path_correlation: true
         full_field: 'LastModifiedBy: Ops Reviewer'
         metadata_type: LAST_MODIFIED_BY
         original_confidence: 60.00000000000001

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.csv
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.csv
@@ -1,0 +1,4 @@
+Filename,Type,Confidence Level,Confidence %,Line Number,Text
+<TMPDIR>/books.xlsx,SSN,HIGH,100.0,1,449-87-4100
+<TMPDIR>/books.xlsx,VISA,HIGH,100.0,2,4532-0151-1283-0366
+<TMPDIR>/books.xlsx,AUTHOR_INFO,MEDIUM,65.0,1,Jane Analyst

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.csv
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.csv
@@ -1,4 +1,4 @@
 Filename,Type,Confidence Level,Confidence %,Line Number,Text
-<TMPDIR>/books.xlsx,SSN,HIGH,100.0,1,449-87-4100
-<TMPDIR>/books.xlsx,VISA,HIGH,100.0,2,4532-0151-1283-0366
+<TMPDIR>/books.xlsx,SSN,HIGH,100.0,2,449-87-4100
+<TMPDIR>/books.xlsx,VISA,HIGH,100.0,3,4532-0151-1283-0366
 <TMPDIR>/books.xlsx,AUTHOR_INFO,MEDIUM,65.0,1,Jane Analyst

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.gitlab-sast.json
@@ -29,7 +29,7 @@
     {
       "category": "sast",
       "confidence": "High",
-      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <TMPDIR>/books.xlsx (line 1)\n**Confidence:** HIGH (100.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\nEmployee SSN 449-87-4100\t\n```\n\n**Additional Information:**\n- context_impact: 50\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
+      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <TMPDIR>/books.xlsx (line 2)\n**Confidence:** HIGH (100.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\nEmployee SSN 449-87-4100\t\n```\n\n**Additional Information:**\n- context_impact: 50\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {
@@ -44,9 +44,9 @@
         }
       ],
       "location": {
-        "end_line": 1,
+        "end_line": 2,
         "file": "books.xlsx",
-        "start_line": 1
+        "start_line": 2
       },
       "message": "Social Security Number detected: [HIDDEN] (confidence: HIGH)",
       "name": "Social Security Number Detected",
@@ -55,7 +55,7 @@
     {
       "category": "sast",
       "confidence": "High",
-      "description": "Ferret Scan detected visa credit card in this file.\n\n**Location:** <TMPDIR>/books.xlsx (line 2)\n**Confidence:** HIGH (100.0%)\n**Detected by:** creditcard validator\n\n**Context:**\n```\nCard 4532-0151-1283-0366\n```\n\n**Additional Information:**\n- card_type: VISA\n- context_impact: 15\n- source: preprocessed_content\n- vendor: Visa\n\n**Remediation:**\nRemove or mask credit card numbers. Consider using tokenization for legitimate payment processing needs.",
+      "description": "Ferret Scan detected visa credit card in this file.\n\n**Location:** <TMPDIR>/books.xlsx (line 3)\n**Confidence:** HIGH (100.0%)\n**Detected by:** creditcard validator\n\n**Context:**\n```\nCard 4532-0151-1283-0366\t\n```\n\n**Additional Information:**\n- card_type: VISA\n- context_impact: 15\n- source: preprocessed_content\n- vendor: Visa\n\n**Remediation:**\nRemove or mask credit card numbers. Consider using tokenization for legitimate payment processing needs.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {
@@ -70,9 +70,9 @@
         }
       ],
       "location": {
-        "end_line": 2,
+        "end_line": 3,
         "file": "books.xlsx",
-        "start_line": 2
+        "start_line": 3
       },
       "message": "Visa credit card detected: [HIDDEN] (confidence: HIGH)",
       "name": "Visa Detected",

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.gitlab-sast.json
@@ -1,0 +1,108 @@
+{
+  "remediations": [],
+  "scan": {
+    "analyzer": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "end_time": "<TIMESTAMP>",
+    "scanner": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "start_time": "<TIMESTAMP>",
+    "status": "success",
+    "type": "sast"
+  },
+  "version": "15.0.4",
+  "vulnerabilities": [
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <TMPDIR>/books.xlsx (line 1)\n**Confidence:** HIGH (100.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\nEmployee SSN 449-87-4100\t\n```\n\n**Additional Information:**\n- context_impact: 50\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "SSN"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "ssn"
+        }
+      ],
+      "location": {
+        "end_line": 1,
+        "file": "books.xlsx",
+        "start_line": 1
+      },
+      "message": "Social Security Number detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Social Security Number Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected visa credit card in this file.\n\n**Location:** <TMPDIR>/books.xlsx (line 2)\n**Confidence:** HIGH (100.0%)\n**Detected by:** creditcard validator\n\n**Context:**\n```\nCard 4532-0151-1283-0366\n```\n\n**Additional Information:**\n- card_type: VISA\n- context_impact: 15\n- source: preprocessed_content\n- vendor: Visa\n\n**Remediation:**\nRemove or mask credit card numbers. Consider using tokenization for legitimate payment processing needs.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "VISA"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "creditcard"
+        }
+      ],
+      "location": {
+        "end_line": 2,
+        "file": "books.xlsx",
+        "start_line": 2
+      },
+      "message": "Visa credit card detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Visa Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/books.xlsx (line 1)\n**Confidence:** MEDIUM (65.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nAuthor: Jane Analyst\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "AUTHOR_INFO"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "metadata"
+        }
+      ],
+      "location": {
+        "end_line": 1,
+        "file": "books.xlsx",
+        "start_line": 1
+      },
+      "message": "Author information detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Author Info Detected",
+      "severity": "High"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.json.json
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.json.json
@@ -4,7 +4,7 @@
       "confidence": 100,
       "confidence_level": "HIGH",
       "filename": "<TMPDIR>/books.xlsx",
-      "line_number": 1,
+      "line_number": 2,
       "metadata": {
         "confidence_adjustment": 0,
         "context_confidence": 1,
@@ -42,7 +42,7 @@
       "confidence": 100,
       "confidence_level": "HIGH",
       "filename": "<TMPDIR>/books.xlsx",
-      "line_number": 2,
+      "line_number": 3,
       "metadata": {
         "card_type": "VISA",
         "confidence_adjustment": 0,

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.json.json
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.json.json
@@ -1,0 +1,122 @@
+{
+  "results": [
+    {
+      "confidence": 100,
+      "confidence_level": "HIGH",
+      "filename": "<TMPDIR>/books.xlsx",
+      "line_number": 1,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 50,
+        "correlation_boost": 5,
+        "cross_path_correlation": true,
+        "original_confidence": 100,
+        "original_file": "<TMPDIR>/books.xlsx",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "format": true,
+          "not_common_pattern": true,
+          "not_repeating": true,
+          "not_sequential": true,
+          "not_test_number": true,
+          "valid_area": true
+        },
+        "validation_path": "document"
+      },
+      "text": "449-87-4100",
+      "type": "SSN",
+      "validator": "ssn"
+    },
+    {
+      "confidence": 100,
+      "confidence_level": "HIGH",
+      "filename": "<TMPDIR>/books.xlsx",
+      "line_number": 2,
+      "metadata": {
+        "card_type": "VISA",
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 15,
+        "correlation_boost": 5,
+        "cross_path_correlation": true,
+        "original_confidence": 100,
+        "original_file": "<TMPDIR>/books.xlsx",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "entropy": true,
+          "length": true,
+          "luhn": true,
+          "not_repeating": true,
+          "not_test": true,
+          "vendor": true
+        },
+        "validation_path": "document",
+        "vendor": "Visa"
+      },
+      "text": "4532-0151-1283-0366",
+      "type": "VISA",
+      "validator": "creditcard"
+    },
+    {
+      "confidence": 65,
+      "confidence_level": "MEDIUM",
+      "filename": "<TMPDIR>/books.xlsx",
+      "line_number": 1,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 0,
+        "correlation_boost": 5,
+        "cross_path_correlation": true,
+        "full_field": "Author: Jane Analyst",
+        "metadata_type": "AUTHOR_INFO",
+        "original_confidence": 60.00000000000001,
+        "original_file": "<TMPDIR>/books.xlsx",
+        "preprocessor_adjustment": 0,
+        "preprocessor_name": "Office Metadata Extractor",
+        "preprocessor_type": "office_metadata",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "source_file": "<TMPDIR>/books.xlsx",
+        "source_preprocessor": "office_metadata",
+        "total_adjustment": 0,
+        "validation_checks": {
+          "contains_author_field": true
+        },
+        "validation_path": "metadata"
+      },
+      "text": "Jane Analyst",
+      "type": "AUTHOR_INFO",
+      "validator": "metadata"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.junit.xml
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.junit.xml
@@ -2,7 +2,7 @@
 <testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
   <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
     <testcase name="books.xlsx" classname="security-scan" time="0.001">
-      <failure message="3 security findings detected" type="SECURITY_FINDINGS">Line 1: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 2: VISA detected with 100.0% confidence (HIGH)&#xA;Match: 4532-0151-1283-0366&#xA;Validator: creditcard&#xA;Line 1: AUTHOR_INFO detected with 65.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata</failure>
+      <failure message="3 security findings detected" type="SECURITY_FINDINGS">Line 2: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 3: VISA detected with 100.0% confidence (HIGH)&#xA;Match: 4532-0151-1283-0366&#xA;Validator: creditcard&#xA;Line 1: AUTHOR_INFO detected with 65.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata</failure>
     </testcase>
   </testsuite>
 </testsuites>

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.junit.xml
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.junit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
+  <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
+    <testcase name="books.xlsx" classname="security-scan" time="0.001">
+      <failure message="3 security findings detected" type="SECURITY_FINDINGS">Line 1: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 2: VISA detected with 100.0% confidence (HIGH)&#xA;Match: 4532-0151-1283-0366&#xA;Validator: creditcard&#xA;Line 1: AUTHOR_INFO detected with 65.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata</failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.sarif.json
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.sarif.json
@@ -15,7 +15,7 @@
                   "snippet": {
                     "text": "Employee SSN \nEmployee SSN 449-87-4100\t\n\t"
                   },
-                  "startLine": 1
+                  "startLine": 2
                 },
                 "region": {
                   "endColumn": 25,
@@ -23,13 +23,13 @@
                     "text": "Employee SSN 449-87-4100\t"
                   },
                   "startColumn": 14,
-                  "startLine": 1
+                  "startLine": 2
                 }
               }
             }
           ],
           "message": {
-            "text": "Social Security Number Detected in books.xlsx at line 1 (confidence: 100.0% - HIGH). Matched text: '449-87-4100'"
+            "text": "Social Security Number Detected in books.xlsx at line 2 (confidence: 100.0% - HIGH). Matched text: '449-87-4100'"
           },
           "properties": {
             "confidence": 100,
@@ -81,23 +81,23 @@
                 },
                 "contextRegion": {
                   "snippet": {
-                    "text": "Card \nCard 4532-0151-1283-0366"
+                    "text": "Card \nCard 4532-0151-1283-0366\t\n\t"
                   },
-                  "startLine": 2
+                  "startLine": 3
                 },
                 "region": {
                   "endColumn": 25,
                   "snippet": {
-                    "text": "Card 4532-0151-1283-0366"
+                    "text": "Card 4532-0151-1283-0366\t"
                   },
                   "startColumn": 6,
-                  "startLine": 2
+                  "startLine": 3
                 }
               }
             }
           ],
           "message": {
-            "text": "VISA Detected in books.xlsx at line 2 (confidence: 100.0% - HIGH). Matched text: '4532-0151-1283-0366'"
+            "text": "VISA Detected in books.xlsx at line 3 (confidence: 100.0% - HIGH). Matched text: '4532-0151-1283-0366'"
           },
           "properties": {
             "confidence": 100,

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.sarif.json
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.sarif.json
@@ -1,0 +1,264 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/refs/heads/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/books.xlsx"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "Employee SSN \nEmployee SSN 449-87-4100\t\n\t"
+                  },
+                  "startLine": 1
+                },
+                "region": {
+                  "endColumn": 25,
+                  "snippet": {
+                    "text": "Employee SSN 449-87-4100\t"
+                  },
+                  "startColumn": 14,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Social Security Number Detected in books.xlsx at line 1 (confidence: 100.0% - HIGH). Matched text: '449-87-4100'"
+          },
+          "properties": {
+            "confidence": 100,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 50,
+              "correlation_boost": 5,
+              "cross_path_correlation": true,
+              "original_confidence": 100,
+              "original_file": "<TMPDIR>/books.xlsx",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "digits": true,
+                "format": true,
+                "not_common_pattern": true,
+                "not_repeating": true,
+                "not_sequential": true,
+                "not_test_number": true,
+                "valid_area": true
+              },
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "ssn"
+            ],
+            "validator": "ssn"
+          },
+          "rank": 100,
+          "ruleId": "SSN"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/books.xlsx"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "Card \nCard 4532-0151-1283-0366"
+                  },
+                  "startLine": 2
+                },
+                "region": {
+                  "endColumn": 25,
+                  "snippet": {
+                    "text": "Card 4532-0151-1283-0366"
+                  },
+                  "startColumn": 6,
+                  "startLine": 2
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "VISA Detected in books.xlsx at line 2 (confidence: 100.0% - HIGH). Matched text: '4532-0151-1283-0366'"
+          },
+          "properties": {
+            "confidence": 100,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "card_type": "VISA",
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 15,
+              "correlation_boost": 5,
+              "cross_path_correlation": true,
+              "original_confidence": 100,
+              "original_file": "<TMPDIR>/books.xlsx",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "digits": true,
+                "entropy": true,
+                "length": true,
+                "luhn": true,
+                "not_repeating": true,
+                "not_test": true,
+                "vendor": true
+              },
+              "validation_path": "document",
+              "vendor": "Visa"
+            },
+            "validator": "creditcard"
+          },
+          "rank": 75,
+          "ruleId": "VISA"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/books.xlsx"
+                },
+                "region": {
+                  "endColumn": 21,
+                  "snippet": {
+                    "text": "Author: Jane Analyst"
+                  },
+                  "startColumn": 9,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "AUTHOR_INFO Detected in books.xlsx at line 1 (confidence: 65.0% - MEDIUM). Matched text: 'Jane Analyst'"
+          },
+          "properties": {
+            "confidence": 65,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 0,
+              "correlation_boost": 5,
+              "cross_path_correlation": true,
+              "full_field": "Author: Jane Analyst",
+              "metadata_type": "AUTHOR_INFO",
+              "original_confidence": 60,
+              "original_file": "<TMPDIR>/books.xlsx",
+              "preprocessor_adjustment": 0,
+              "preprocessor_name": "Office Metadata Extractor",
+              "preprocessor_type": "office_metadata",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "source_file": "<TMPDIR>/books.xlsx",
+              "source_preprocessor": "office_metadata",
+              "total_adjustment": 0,
+              "validation_checks": {
+                "contains_author_field": true
+              },
+              "validation_path": "metadata"
+            },
+            "validator": "metadata"
+          },
+          "rank": 57.5,
+          "ruleId": "AUTHOR_INFO"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/awslabs/ferret-scan",
+          "name": "Ferret Scan",
+          "rules": [
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type AUTHOR_INFO was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/AUTHOR_INFO.md",
+              "id": "AUTHOR_INFO",
+              "shortDescription": {
+                "text": "AUTHOR_INFO Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "A Social Security Number (SSN) pattern was detected in the scanned content. SSNs are highly sensitive personally identifiable information (PII) that must be protected under various regulations."
+              },
+              "help": {
+                "text": "Social Security Numbers are protected under numerous regulations including GDPR, HIPAA, and various state privacy laws. SSNs should never be stored in source code, configuration files, or logs. Remove this SSN immediately and ensure it is stored in a secure, encrypted system with appropriate access controls. Consider implementing tokenization or other data protection mechanisms."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/SSN.md",
+              "id": "SSN",
+              "shortDescription": {
+                "text": "Social Security Number Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type VISA was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/VISA.md",
+              "id": "VISA",
+              "shortDescription": {
+                "text": "VISA Detected"
+              }
+            }
+          ],
+          "semanticVersion": "0.0.0-development",
+          "version": "0.0.0-development"
+        }
+      },
+      "versionControlProvenance": [
+        {
+          "mappedTo": {
+            "uriBaseId": "%SRCROOT%"
+          },
+          "repositoryUri": "https://github.com/awslabs/ferret-scan",
+          "revisionId": "0.0.0-development"
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.txt
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.txt
@@ -1,5 +1,5 @@
 LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH               FILE
 ---------------------------------------------------------------------------------------------
-[HIGH  ] ssn          SSN                   100.00% line     1 449-87-4100         books.xlsx
-[HIGH  ] creditcard   VISA                  100.00% line     2 4532-0151-1283-0366 books.xlsx
+[HIGH  ] ssn          SSN                   100.00% line     2 449-87-4100         books.xlsx
+[HIGH  ] creditcard   VISA                  100.00% line     3 4532-0151-1283-0366 books.xlsx
 [MEDIUM] metadata     AUTHOR_INFO            65.00% line     1 Jane Analyst        books.xlsx

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.txt
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.txt
@@ -1,0 +1,5 @@
+LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH               FILE
+---------------------------------------------------------------------------------------------
+[HIGH  ] ssn          SSN                   100.00% line     1 449-87-4100         books.xlsx
+[HIGH  ] creditcard   VISA                  100.00% line     2 4532-0151-1283-0366 books.xlsx
+[MEDIUM] metadata     AUTHOR_INFO            65.00% line     1 Jane Analyst        books.xlsx

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.yaml
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.yaml
@@ -1,6 +1,6 @@
 results:
     - text: 449-87-4100
-      line_number: 1
+      line_number: 2
       type: SSN
       confidence: 100
       confidence_level: HIGH
@@ -33,7 +33,7 @@ results:
             valid_area: true
         validation_path: document
     - text: 4532-0151-1283-0366
-      line_number: 2
+      line_number: 3
       type: VISA
       confidence: 100
       confidence_level: HIGH

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.yaml
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.yaml
@@ -1,0 +1,104 @@
+results:
+    - text: 449-87-4100
+      line_number: 1
+      type: SSN
+      confidence: 100
+      confidence_level: HIGH
+      filename: <TMPDIR>/books.xlsx
+      validator: ssn
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 50
+        correlation_boost: 5
+        cross_path_correlation: true
+        original_confidence: 100
+        original_file: <TMPDIR>/books.xlsx
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            format: true
+            not_common_pattern: true
+            not_repeating: true
+            not_sequential: true
+            not_test_number: true
+            valid_area: true
+        validation_path: document
+    - text: 4532-0151-1283-0366
+      line_number: 2
+      type: VISA
+      confidence: 100
+      confidence_level: HIGH
+      filename: <TMPDIR>/books.xlsx
+      validator: creditcard
+      metadata:
+        card_type: VISA
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 15
+        correlation_boost: 5
+        cross_path_correlation: true
+        original_confidence: 100
+        original_file: <TMPDIR>/books.xlsx
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            entropy: true
+            length: true
+            luhn: true
+            not_repeating: true
+            not_test: true
+            vendor: true
+        validation_path: document
+        vendor: Visa
+    - text: Jane Analyst
+      line_number: 1
+      type: AUTHOR_INFO
+      confidence: 65
+      confidence_level: MEDIUM
+      filename: <TMPDIR>/books.xlsx
+      validator: metadata
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 0
+        correlation_boost: 5
+        cross_path_correlation: true
+        full_field: 'Author: Jane Analyst'
+        metadata_type: AUTHOR_INFO
+        original_confidence: 60.00000000000001
+        original_file: <TMPDIR>/books.xlsx
+        preprocessor_adjustment: 0
+        preprocessor_name: Office Metadata Extractor
+        preprocessor_type: office_metadata
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        source_file: <TMPDIR>/books.xlsx
+        source_preprocessor: office_metadata
+        total_adjustment: 0
+        validation_checks:
+            contains_author_field: true
+        validation_path: metadata

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.csv
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.csv
@@ -1,0 +1,2 @@
+Filename,Type,Confidence Level,Confidence %,Line Number,Text
+<TMPDIR>/books_named.xlsx,AUTHOR_INFO,MEDIUM,60.0,1,Jane Analyst

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.csv
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.csv
@@ -1,2 +1,4 @@
 Filename,Type,Confidence Level,Confidence %,Line Number,Text
-<TMPDIR>/books_named.xlsx,AUTHOR_INFO,MEDIUM,60.0,1,Jane Analyst
+<TMPDIR>/books_named.xlsx,SSN,HIGH,100.0,2,449-87-4100
+<TMPDIR>/books_named.xlsx,VISA,HIGH,100.0,3,4532-0151-1283-0366
+<TMPDIR>/books_named.xlsx,AUTHOR_INFO,MEDIUM,65.0,1,Jane Analyst

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.gitlab-sast.json
@@ -1,0 +1,56 @@
+{
+  "remediations": [],
+  "scan": {
+    "analyzer": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "end_time": "<TIMESTAMP>",
+    "scanner": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/bank-vaults/ferret-scan",
+      "vendor": {
+        "name": "Bank Vaults"
+      },
+      "version": "0.0.0-development"
+    },
+    "start_time": "<TIMESTAMP>",
+    "status": "success",
+    "type": "sast"
+  },
+  "version": "15.0.4",
+  "vulnerabilities": [
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/books_named.xlsx (line 1)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nAuthor: Jane Analyst\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "AUTHOR_INFO"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "metadata"
+        }
+      ],
+      "location": {
+        "end_line": 1,
+        "file": "books_named.xlsx",
+        "start_line": 1
+      },
+      "message": "Author information detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Author Info Detected",
+      "severity": "High"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.gitlab-sast.json
@@ -28,8 +28,60 @@
   "vulnerabilities": [
     {
       "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <TMPDIR>/books_named.xlsx (line 2)\n**Confidence:** HIGH (100.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\nEmployee SSN 449-87-4100\t\n```\n\n**Additional Information:**\n- context_impact: 50\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "SSN"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "ssn"
+        }
+      ],
+      "location": {
+        "end_line": 2,
+        "file": "books_named.xlsx",
+        "start_line": 2
+      },
+      "message": "Social Security Number detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Social Security Number Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected visa credit card in this file.\n\n**Location:** <TMPDIR>/books_named.xlsx (line 3)\n**Confidence:** HIGH (100.0%)\n**Detected by:** creditcard validator\n\n**Context:**\n```\nCard 4532-0151-1283-0366\t\n```\n\n**Additional Information:**\n- card_type: VISA\n- context_impact: 15\n- source: preprocessed_content\n- vendor: Visa\n\n**Remediation:**\nRemove or mask credit card numbers. Consider using tokenization for legitimate payment processing needs.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "VISA"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "creditcard"
+        }
+      ],
+      "location": {
+        "end_line": 3,
+        "file": "books_named.xlsx",
+        "start_line": 3
+      },
+      "message": "Visa credit card detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Visa Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
       "confidence": "Medium",
-      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/books_named.xlsx (line 1)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nAuthor: Jane Analyst\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/books_named.xlsx (line 1)\n**Confidence:** MEDIUM (65.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nAuthor: Jane Analyst\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.json.json
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.json.json
@@ -1,0 +1,42 @@
+{
+  "results": [
+    {
+      "confidence": 60.00000000000001,
+      "confidence_level": "MEDIUM",
+      "filename": "<TMPDIR>/books_named.xlsx",
+      "line_number": 1,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 0,
+        "full_field": "Author: Jane Analyst",
+        "metadata_type": "AUTHOR_INFO",
+        "original_confidence": 60.00000000000001,
+        "original_file": "<TMPDIR>/books_named.xlsx",
+        "preprocessor_adjustment": 0,
+        "preprocessor_name": "Office Metadata Extractor",
+        "preprocessor_type": "office_metadata",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "source_file": "<TMPDIR>/books_named.xlsx",
+        "source_preprocessor": "office_metadata",
+        "total_adjustment": 0,
+        "validation_checks": {
+          "contains_author_field": true
+        },
+        "validation_path": "metadata"
+      },
+      "text": "Jane Analyst",
+      "type": "AUTHOR_INFO",
+      "validator": "metadata"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.json.json
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.json.json
@@ -1,7 +1,85 @@
 {
   "results": [
     {
-      "confidence": 60.00000000000001,
+      "confidence": 100,
+      "confidence_level": "HIGH",
+      "filename": "<TMPDIR>/books_named.xlsx",
+      "line_number": 2,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 50,
+        "correlation_boost": 5,
+        "cross_path_correlation": true,
+        "original_confidence": 100,
+        "original_file": "<TMPDIR>/books_named.xlsx",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "format": true,
+          "not_common_pattern": true,
+          "not_repeating": true,
+          "not_sequential": true,
+          "not_test_number": true,
+          "valid_area": true
+        },
+        "validation_path": "document"
+      },
+      "text": "449-87-4100",
+      "type": "SSN",
+      "validator": "ssn"
+    },
+    {
+      "confidence": 100,
+      "confidence_level": "HIGH",
+      "filename": "<TMPDIR>/books_named.xlsx",
+      "line_number": 3,
+      "metadata": {
+        "card_type": "VISA",
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 15,
+        "correlation_boost": 5,
+        "cross_path_correlation": true,
+        "original_confidence": 100,
+        "original_file": "<TMPDIR>/books_named.xlsx",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "entropy": true,
+          "length": true,
+          "luhn": true,
+          "not_repeating": true,
+          "not_test": true,
+          "vendor": true
+        },
+        "validation_path": "document",
+        "vendor": "Visa"
+      },
+      "text": "4532-0151-1283-0366",
+      "type": "VISA",
+      "validator": "creditcard"
+    },
+    {
+      "confidence": 65,
       "confidence_level": "MEDIUM",
       "filename": "<TMPDIR>/books_named.xlsx",
       "line_number": 1,
@@ -11,6 +89,8 @@
         "context_doctype": "Unknown",
         "context_domain": "HR_Payroll",
         "context_impact": 0,
+        "correlation_boost": 5,
+        "cross_path_correlation": true,
         "full_field": "Author: Jane Analyst",
         "metadata_type": "AUTHOR_INFO",
         "original_confidence": 60.00000000000001,

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.junit.xml
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.junit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
+  <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
+    <testcase name="books_named.xlsx" classname="security-scan" time="0.001">
+      <failure message="AUTHOR_INFO found: Jane Analyst" type="AUTHOR_INFO">Line 1: AUTHOR_INFO detected with 60.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata</failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.junit.xml
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.junit.xml
@@ -2,7 +2,7 @@
 <testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
   <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
     <testcase name="books_named.xlsx" classname="security-scan" time="0.001">
-      <failure message="AUTHOR_INFO found: Jane Analyst" type="AUTHOR_INFO">Line 1: AUTHOR_INFO detected with 60.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata</failure>
+      <failure message="3 security findings detected" type="SECURITY_FINDINGS">Line 2: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 3: VISA detected with 100.0% confidence (HIGH)&#xA;Match: 4532-0151-1283-0366&#xA;Validator: creditcard&#xA;Line 1: AUTHOR_INFO detected with 65.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata</failure>
     </testcase>
   </testsuite>
 </testsuites>

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.sarif.json
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.sarif.json
@@ -11,6 +11,141 @@
                 "artifactLocation": {
                   "uri": "file://<TMPDIR>/books_named.xlsx"
                 },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "Employee SSN \nEmployee SSN 449-87-4100\t\n\t"
+                  },
+                  "startLine": 2
+                },
+                "region": {
+                  "endColumn": 25,
+                  "snippet": {
+                    "text": "Employee SSN 449-87-4100\t"
+                  },
+                  "startColumn": 14,
+                  "startLine": 2
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Social Security Number Detected in books_named.xlsx at line 2 (confidence: 100.0% - HIGH). Matched text: '449-87-4100'"
+          },
+          "properties": {
+            "confidence": 100,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 50,
+              "correlation_boost": 5,
+              "cross_path_correlation": true,
+              "original_confidence": 100,
+              "original_file": "<TMPDIR>/books_named.xlsx",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "digits": true,
+                "format": true,
+                "not_common_pattern": true,
+                "not_repeating": true,
+                "not_sequential": true,
+                "not_test_number": true,
+                "valid_area": true
+              },
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "ssn"
+            ],
+            "validator": "ssn"
+          },
+          "rank": 100,
+          "ruleId": "SSN"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/books_named.xlsx"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "Card \nCard 4532-0151-1283-0366\t\n\t"
+                  },
+                  "startLine": 3
+                },
+                "region": {
+                  "endColumn": 25,
+                  "snippet": {
+                    "text": "Card 4532-0151-1283-0366\t"
+                  },
+                  "startColumn": 6,
+                  "startLine": 3
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "VISA Detected in books_named.xlsx at line 3 (confidence: 100.0% - HIGH). Matched text: '4532-0151-1283-0366'"
+          },
+          "properties": {
+            "confidence": 100,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "card_type": "VISA",
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 15,
+              "correlation_boost": 5,
+              "cross_path_correlation": true,
+              "original_confidence": 100,
+              "original_file": "<TMPDIR>/books_named.xlsx",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "digits": true,
+                "entropy": true,
+                "length": true,
+                "luhn": true,
+                "not_repeating": true,
+                "not_test": true,
+                "vendor": true
+              },
+              "validation_path": "document",
+              "vendor": "Visa"
+            },
+            "validator": "creditcard"
+          },
+          "rank": 75,
+          "ruleId": "VISA"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/books_named.xlsx"
+                },
                 "region": {
                   "endColumn": 21,
                   "snippet": {
@@ -23,10 +158,10 @@
             }
           ],
           "message": {
-            "text": "AUTHOR_INFO Detected in books_named.xlsx at line 1 (confidence: 60.0% - MEDIUM). Matched text: 'Jane Analyst'"
+            "text": "AUTHOR_INFO Detected in books_named.xlsx at line 1 (confidence: 65.0% - MEDIUM). Matched text: 'Jane Analyst'"
           },
           "properties": {
-            "confidence": 60,
+            "confidence": 65,
             "confidenceLevel": "MEDIUM",
             "metadata": {
               "confidence_adjustment": 0,
@@ -34,6 +169,8 @@
               "context_doctype": "Unknown",
               "context_domain": "HR_Payroll",
               "context_impact": 0,
+              "correlation_boost": 5,
+              "cross_path_correlation": true,
               "full_field": "Author: Jane Analyst",
               "metadata_type": "AUTHOR_INFO",
               "original_confidence": 60,
@@ -59,7 +196,7 @@
             },
             "validator": "metadata"
           },
-          "rank": 55,
+          "rank": 57.5,
           "ruleId": "AUTHOR_INFO"
         }
       ],
@@ -79,6 +216,32 @@
               "id": "AUTHOR_INFO",
               "shortDescription": {
                 "text": "AUTHOR_INFO Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "A Social Security Number (SSN) pattern was detected in the scanned content. SSNs are highly sensitive personally identifiable information (PII) that must be protected under various regulations."
+              },
+              "help": {
+                "text": "Social Security Numbers are protected under numerous regulations including GDPR, HIPAA, and various state privacy laws. SSNs should never be stored in source code, configuration files, or logs. Remove this SSN immediately and ensure it is stored in a secure, encrypted system with appropriate access controls. Consider implementing tokenization or other data protection mechanisms."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/SSN.md",
+              "id": "SSN",
+              "shortDescription": {
+                "text": "Social Security Number Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type VISA was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/VISA.md",
+              "id": "VISA",
+              "shortDescription": {
+                "text": "VISA Detected"
               }
             }
           ],

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.sarif.json
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.sarif.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/refs/heads/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/books_named.xlsx"
+                },
+                "region": {
+                  "endColumn": 21,
+                  "snippet": {
+                    "text": "Author: Jane Analyst"
+                  },
+                  "startColumn": 9,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "AUTHOR_INFO Detected in books_named.xlsx at line 1 (confidence: 60.0% - MEDIUM). Matched text: 'Jane Analyst'"
+          },
+          "properties": {
+            "confidence": 60,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 0,
+              "full_field": "Author: Jane Analyst",
+              "metadata_type": "AUTHOR_INFO",
+              "original_confidence": 60,
+              "original_file": "<TMPDIR>/books_named.xlsx",
+              "preprocessor_adjustment": 0,
+              "preprocessor_name": "Office Metadata Extractor",
+              "preprocessor_type": "office_metadata",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "source_file": "<TMPDIR>/books_named.xlsx",
+              "source_preprocessor": "office_metadata",
+              "total_adjustment": 0,
+              "validation_checks": {
+                "contains_author_field": true
+              },
+              "validation_path": "metadata"
+            },
+            "validator": "metadata"
+          },
+          "rank": 55,
+          "ruleId": "AUTHOR_INFO"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/awslabs/ferret-scan",
+          "name": "Ferret Scan",
+          "rules": [
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type AUTHOR_INFO was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/AUTHOR_INFO.md",
+              "id": "AUTHOR_INFO",
+              "shortDescription": {
+                "text": "AUTHOR_INFO Detected"
+              }
+            }
+          ],
+          "semanticVersion": "0.0.0-development",
+          "version": "0.0.0-development"
+        }
+      },
+      "versionControlProvenance": [
+        {
+          "mappedTo": {
+            "uriBaseId": "%SRCROOT%"
+          },
+          "repositoryUri": "https://github.com/awslabs/ferret-scan",
+          "revisionId": "0.0.0-development"
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.txt
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.txt
@@ -1,3 +1,5 @@
-LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH        FILE
---------------------------------------------------------------------------------------
-[MEDIUM] metadata     AUTHOR_INFO            60.00% line     1 Jane Analyst books_named.xlsx
+LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH               FILE
+---------------------------------------------------------------------------------------------
+[HIGH  ] ssn          SSN                   100.00% line     2 449-87-4100         books_named.xlsx
+[HIGH  ] creditcard   VISA                  100.00% line     3 4532-0151-1283-0366 books_named.xlsx
+[MEDIUM] metadata     AUTHOR_INFO            65.00% line     1 Jane Analyst        books_named.xlsx

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.txt
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.txt
@@ -1,0 +1,3 @@
+LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH        FILE
+--------------------------------------------------------------------------------------
+[MEDIUM] metadata     AUTHOR_INFO            60.00% line     1 Jane Analyst books_named.xlsx

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.yaml
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.yaml
@@ -1,8 +1,76 @@
 results:
+    - text: 449-87-4100
+      line_number: 2
+      type: SSN
+      confidence: 100
+      confidence_level: HIGH
+      filename: <TMPDIR>/books_named.xlsx
+      validator: ssn
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 50
+        correlation_boost: 5
+        cross_path_correlation: true
+        original_confidence: 100
+        original_file: <TMPDIR>/books_named.xlsx
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            format: true
+            not_common_pattern: true
+            not_repeating: true
+            not_sequential: true
+            not_test_number: true
+            valid_area: true
+        validation_path: document
+    - text: 4532-0151-1283-0366
+      line_number: 3
+      type: VISA
+      confidence: 100
+      confidence_level: HIGH
+      filename: <TMPDIR>/books_named.xlsx
+      validator: creditcard
+      metadata:
+        card_type: VISA
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 15
+        correlation_boost: 5
+        cross_path_correlation: true
+        original_confidence: 100
+        original_file: <TMPDIR>/books_named.xlsx
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            entropy: true
+            length: true
+            luhn: true
+            not_repeating: true
+            not_test: true
+            vendor: true
+        validation_path: document
+        vendor: Visa
     - text: Jane Analyst
       line_number: 1
       type: AUTHOR_INFO
-      confidence: 60.00000000000001
+      confidence: 65
       confidence_level: MEDIUM
       filename: <TMPDIR>/books_named.xlsx
       validator: metadata
@@ -12,6 +80,8 @@ results:
         context_doctype: Unknown
         context_domain: HR_Payroll
         context_impact: 0
+        correlation_boost: 5
+        cross_path_correlation: true
         full_field: 'Author: Jane Analyst'
         metadata_type: AUTHOR_INFO
         original_confidence: 60.00000000000001

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.yaml
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.yaml
@@ -1,0 +1,34 @@
+results:
+    - text: Jane Analyst
+      line_number: 1
+      type: AUTHOR_INFO
+      confidence: 60.00000000000001
+      confidence_level: MEDIUM
+      filename: <TMPDIR>/books_named.xlsx
+      validator: metadata
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 0
+        full_field: 'Author: Jane Analyst'
+        metadata_type: AUTHOR_INFO
+        original_confidence: 60.00000000000001
+        original_file: <TMPDIR>/books_named.xlsx
+        preprocessor_adjustment: 0
+        preprocessor_name: Office Metadata Extractor
+        preprocessor_type: office_metadata
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        source_file: <TMPDIR>/books_named.xlsx
+        source_preprocessor: office_metadata
+        total_adjustment: 0
+        validation_checks:
+            contains_author_field: true
+        validation_path: metadata

--- a/internal/parallel/parallel_processor.go
+++ b/internal/parallel/parallel_processor.go
@@ -38,6 +38,14 @@ type ProcessingStats struct {
 	// not finish scanning".
 	IncompleteFiles []FileDiagnostic `json:"incomplete_files,omitempty"`
 
+	// EmptyExtractionFiles lists files whose extraction SUCCEEDED but produced no
+	// document-body text, for a file type that carries one. These are the files a
+	// scan is most likely to have silently under-covered: nothing was extracted, so
+	// no validator saw anything, so the file reports clean. Populated from
+	// Result.ExtractionWarning; empty on a normal run. Counted as a coverage gap
+	// alongside IncompleteFiles so --fail-on-incomplete can catch it.
+	EmptyExtractionFiles []FileDiagnostic `json:"empty_extraction_files,omitempty"`
+
 	// UnredactedFiles lists files that HAVE findings but for which no redacted
 	// copy could be produced (populated from Result.RedactionError; empty unless
 	// --enable-redaction is on). These files' findings are reported normally —
@@ -113,6 +121,7 @@ func (pp *ParallelProcessor) ProcessFilesWithProgress(filePaths []string, valida
 	totalDuration := time.Duration(0)
 	var incompleteFiles []FileDiagnostic
 	var unredactedFiles []FileDiagnostic
+	var emptyExtractionFiles []FileDiagnostic
 
 	for i := 0; i < jobCount; i++ {
 		result := <-pp.workerPool.Results()
@@ -133,6 +142,16 @@ func (pp *ParallelProcessor) ProcessFilesWithProgress(filePaths []string, valida
 		// runs after validation, so a redaction failure says nothing about the
 		// correctness of what was found; treating it as fatal is what silently
 		// erased findings for every file type with no registered redactor.
+		// Record a file that extracted to nothing. Not an error — the file was read
+		// and its (empty) content validated — but the single strongest signal that
+		// a file was not really covered, so it is collected here rather than left
+		// to a debug log nobody reads.
+		if result.ExtractionWarning != "" {
+			emptyExtractionFiles = append(emptyExtractionFiles, FileDiagnostic{
+				FilePath: result.FilePath,
+				Reason:   result.ExtractionWarning,
+			})
+		}
 		if result.RedactionError != nil {
 			unredactedFiles = append(unredactedFiles, FileDiagnostic{
 				FilePath: result.FilePath,
@@ -182,6 +201,8 @@ func (pp *ParallelProcessor) ProcessFilesWithProgress(filePaths []string, valida
 		AvgFileTime:     totalDuration / time.Duration(max(processedCount, 1)),
 		IncompleteFiles: incompleteFiles,
 		UnredactedFiles: unredactedFiles,
+
+		EmptyExtractionFiles: emptyExtractionFiles,
 	}
 
 	if finishTiming != nil {

--- a/internal/parallel/worker_pool.go
+++ b/internal/parallel/worker_pool.go
@@ -118,6 +118,13 @@ type Result struct {
 	// Nil when redaction was disabled, skipped (no matches) or succeeded.
 	RedactionError error
 
+	// ExtractionWarning is a payload-free note that extraction succeeded but
+	// yielded suspiciously nothing — currently, a container whose format carries a
+	// document body from which no body text came out. Like the two errors above it
+	// is kept out of Error so the file's matches survive; unlike them it is not an
+	// error at all, only a coverage signal. Empty on a normal extraction.
+	ExtractionWarning string
+
 	// Redaction results
 	RedactionResult *redactors.RedactionResult
 	RedactedPath    string
@@ -362,16 +369,22 @@ func (wp *WorkerPool) processJob(job *Job, workerID int) *Result {
 		})
 	}
 
+	var extractionWarning string
+	if processedContent != nil {
+		extractionWarning = processedContent.ExtractionWarning
+	}
+
 	return &Result{
-		JobID:           job.JobID,
-		FilePath:        job.FilePath,
-		Matches:         allMatches,
-		Error:           lastError,
-		ValidationError: validationErr,
-		RedactionError:  redactionErr,
-		Duration:        duration,
-		RedactionResult: redactionResult,
-		RedactedPath:    redactedPath,
+		JobID:             job.JobID,
+		FilePath:          job.FilePath,
+		Matches:           allMatches,
+		Error:             lastError,
+		ValidationError:   validationErr,
+		RedactionError:    redactionErr,
+		ExtractionWarning: extractionWarning,
+		Duration:          duration,
+		RedactionResult:   redactionResult,
+		RedactedPath:      redactedPath,
 	}
 }
 

--- a/internal/preprocessors/base_metadata_preprocessor.go
+++ b/internal/preprocessors/base_metadata_preprocessor.go
@@ -6,6 +6,8 @@ package preprocessors
 import (
 	"context"
 	"fmt"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/awslabs/ferret-scan/v2/internal/observability"
@@ -177,13 +179,29 @@ func (bmp *BaseMetadataPreprocessor) processWithRetryInternal(filePath string, p
 	return content, err
 }
 
-// ProcessEmbeddedMedia processes embedded media through the router if available
-func (bmp *BaseMetadataPreprocessor) ProcessEmbeddedMedia(originalFilePath string, embeddedMedia []EmbeddedMedia) string {
+// ProcessEmbeddedMedia processes embedded media through the router if available.
+//
+// It returns the text to append to the container's own metadata text, AND one
+// ContentSection per embedded item describing that text out of band. The sections'
+// LineOffset values are relative to the START OF THE RETURNED TEXT; the caller
+// shifts them by the length of whatever it puts in front.
+//
+// The sections matter because an embedded item is a section INSIDE one
+// preprocessor's output, and it routes to a DIFFERENT metadata rule set than its
+// container: a .wav inside a .docx carries an "Artist:" field, which is on the
+// audio rule list but not the office one. Without a declared sub-section the whole
+// blob would be labelled office_metadata and that field would report nothing.
+// Measured: the AUTHOR_INFO finding for an embedded clip's artist address
+// disappeared until these sections were carried.
+func (bmp *BaseMetadataPreprocessor) ProcessEmbeddedMedia(originalFilePath string, embeddedMedia []EmbeddedMedia) (string, []ContentSection) {
 	if bmp.router == nil || len(embeddedMedia) == 0 {
-		return ""
+		return "", nil
 	}
 
 	var result string
+	var sections []ContentSection
+	// Line cursor into `result`, maintained incrementally.
+	line := 0
 
 	for i, media := range embeddedMedia {
 		// Create context showing original file relationship
@@ -196,11 +214,49 @@ func (bmp *BaseMetadataPreprocessor) ProcessEmbeddedMedia(originalFilePath strin
 			processed.Filename = embeddedPath
 
 			// Format and append embedded media section
-			result += bmp.utilities.RouterHelper.FormatEmbeddedMediaSection(i, media.OriginalName, processed.Text)
+			block := bmp.utilities.RouterHelper.FormatEmbeddedMediaSection(i, media.OriginalName, processed.Text)
+			result += block
+
+			// FormatEmbeddedMediaSection prefixes "\n--- ... ---\n", so the
+			// item's own text starts two lines further on.
+			contentLine := line + 2
+
+			// Attribute findings to "container.docx -> audio1.wav", i.e. the BARE
+			// media filename. CreateEmbeddedMediaPath keeps the full archive member
+			// name ("word/media/audio1.wav"); the label the deleted text-parsing
+			// path produced was the basename, and it is what appears in the FILE
+			// column of every report, so keep it identical.
+			sectionSource := bmp.utilities.RouterHelper.CreateEmbeddedMediaPath(
+				originalFilePath, filepath.Base(media.OriginalName))
+
+			// Prefer the sub-result's OWN declared sections — the router built
+			// them from that file's preprocessor names — and just re-anchor them
+			// onto this text and onto the "container -> item" source label. This
+			// composes: a section nested two levels deep still carries the rule
+			// set of the extractor that actually produced it.
+			if len(processed.Sections) > 0 {
+				for _, sub := range processed.Sections {
+					sub.SourceFile = sectionSource
+					sub.LineOffset += contentLine
+					sections = append(sections, sub)
+				}
+			} else {
+				kind, metaType := ClassifySection(processed.ProcessorType)
+				sections = append(sections, ContentSection{
+					Name:       processed.ProcessorType,
+					Kind:       kind,
+					Type:       metaType,
+					SourceFile: embeddedPath,
+					Text:       processed.Text,
+					LineOffset: contentLine,
+				})
+			}
+
+			line += strings.Count(block, "\n")
 		}
 	}
 
-	return result
+	return result, sections
 }
 
 // EmbeddedMedia represents embedded media extracted from documents

--- a/internal/preprocessors/meta-extractors/meta-extract-officelib/office-extractor.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-officelib/office-extractor.go
@@ -109,32 +109,67 @@ type Metadata struct {
 	SharedDocument    bool
 }
 
-// validateFilePath validates file path to prevent directory traversal attacks
+// validateFilePath rejects paths this extractor must not open.
+//
+// It used to refuse any path under a list of "system directories" that included
+// /home/, /var/ and /tmp/. That denylist protected nothing and broke the tool's
+// primary use case: on Linux EVERY file a user owns is under /home/, so
+// `ferret-scan --file ~/report.docx` silently lost Office metadata extraction — no
+// error surfaced, the file simply dropped to a single preprocessor and its author,
+// company and custom properties were never scanned. Measured on one .docx: an
+// allowed path yields {SSN, PERSON_NAME, AUTHOR_INFO}, a /tmp path yields {SSN}
+// alone. Since only reported findings are redacted, that was a cleartext leak of
+// every metadata field, on the default path, for a whole platform. It also made the
+// repository unusable as a fixture location on GitHub's Linux runners, which check
+// out under /home/runner/work.
+//
+// The denylist was never a control. This function is not a trust boundary: the path
+// arrives from the CLI, which has already resolved and stat'd it, and the tool's
+// entire purpose is to read files the invoking user named and can already read. A
+// prefix denylist over such a path stops nothing — a symlink, a relative path or a
+// bind mount reaches the same bytes — and per BSC1 input-validation guidance a
+// denylist is incomplete by construction.
+//
+// A first attempt at replacing it kept a smaller denylist for the kernel
+// pseudo-filesystems (/proc/, /sys/, /dev/). That reproduced the same class of bug
+// one directory down: /dev/shm is world-writable tmpfs that scripts and CI use for
+// ordinary temporary files, and those are ordinary regular files, so a .docx there
+// was refused for no reason. It was also Unix-only — the Windows device namespace
+// (\\.\PhysicalDrive0) and reserved DOS names (CON, NUL, COM1) all passed straight
+// through, so on one of three supported platforms it read as protection while
+// providing none.
+//
+// The real concern behind it — do not try to read something that has no size and
+// may never end — is a property of the file's MODE, not of its name, so it now
+// lives in the router's CanProcessFile as an os.FileMode().IsRegular() check. That
+// covers devices, FIFOs and sockets on every platform, with no list to maintain and
+// no false positive on /dev/shm, and it applies to all seven extractors rather than
+// only to this one, which was the sole extractor that ever carried a path denylist.
+//
+// What remains here is cheap defence in depth for a path that reaches this package
+// by some route other than the router:
+//   - a LEADING "..", which after filepath.Clean is the only form a real traversal
+//     can survive in. The previous strings.Contains check also rejected legitimate
+//     names like "my..report.docx" and any directory whose name contains two dots.
+//   - "://", so a URL mistaken for a path fails with a clear message instead of
+//     being read as a bizarre relative filename.
+//
+// The bounds that actually matter for hostile input are elsewhere and unchanged: the
+// 100MB size gate (validateFileSize), the per-entry decompression cap, and
+// XXE-disabled XML parsing.
 func validateFilePath(filePath string) error {
-	// Clean the path and check for traversal attempts
 	cleanPath := filepath.Clean(filePath)
 
-	// Check for path traversal patterns
-	if strings.Contains(cleanPath, "..") {
+	// Reject escaping the working directory. Post-Clean, an interior ".." has been
+	// resolved away, so only a leading one is a traversal.
+	if cleanPath == ".." || strings.HasPrefix(cleanPath, ".."+string(filepath.Separator)) ||
+		strings.HasPrefix(filepath.ToSlash(cleanPath), "../") {
 		return fmt.Errorf("path traversal attempt detected in: %s", filePath)
 	}
 
-	// Check for suspicious absolute paths (system directories)
-	suspiciousPaths := []string{
-		"/etc/", "/bin/", "/usr/bin/", "/sbin/", "/usr/sbin/",
-		"/root/", "/home/", "/var/", "/tmp/", "/sys/", "/proc/",
-		"C:\\Windows\\", "C:\\Program Files\\", "C:\\Users\\",
-		"\\Windows\\", "\\Program Files\\", "\\Users\\",
-	}
-
-	cleanPathLower := strings.ToLower(cleanPath)
-	for _, suspiciousPath := range suspiciousPaths {
-		if strings.HasPrefix(cleanPathLower, strings.ToLower(suspiciousPath)) {
-			return fmt.Errorf("access to system directory denied: %s", filePath)
-		}
-	}
-
-	// Check for URL schemes that might be used for attacks
+	// Checked on the RAW path, not the cleaned one: filepath.Clean collapses the
+	// double slash, so "https://host/x" becomes "https:/host/x" and the "://" marker
+	// is gone.
 	if strings.Contains(filePath, "://") {
 		return fmt.Errorf("URL schemes not allowed in file paths: %s", filePath)
 	}
@@ -414,19 +449,39 @@ type CustomProperties struct {
 	Properties []CustomProperty `xml:"property"`
 }
 
-// createFileIndex creates an index of files for efficient lookup
+// createFileIndex creates an index of files for efficient lookup, keyed by
+// LOWERCASED part name.
+//
+// A zip entry name is data the document producer chose, and nothing requires the
+// conventional casing. Keyed exactly, "docProps/Core.xml" was a different part
+// from "docProps/core.xml", so one capital letter made a document's author,
+// company and custom properties invisible to this extractor while the file still
+// scanned "successfully" — the same class of defect the text extractor had for
+// word/document.xml (see text-extract-officetextlib/ooxml_parts.go). Lookups
+// therefore go through lookupPart. First entry wins, so a package carrying two
+// spellings of the same part resolves deterministically to the earlier one.
 func createFileIndex(reader *zip.ReadCloser) map[string]*zip.File {
 	// Pre-allocate map with capacity to reduce rehashing
 	fileIndex := make(map[string]*zip.File, len(reader.File))
 	for _, file := range reader.File {
-		fileIndex[file.Name] = file
+		key := strings.ToLower(file.Name)
+		if _, seen := fileIndex[key]; !seen {
+			fileIndex[key] = file
+		}
 	}
 	return fileIndex
 }
 
+// lookupPart finds a part in an index built by createFileIndex, ignoring the case
+// the producer used.
+func lookupPart(fileIndex map[string]*zip.File, name string) (*zip.File, bool) {
+	f, ok := fileIndex[strings.ToLower(name)]
+	return f, ok
+}
+
 // extractCorePropertiesOptimized extracts core properties using file index
 func extractCorePropertiesOptimized(fileIndex map[string]*zip.File) (*CoreProperties, error) {
-	corePropsFile, exists := fileIndex["docProps/core.xml"]
+	corePropsFile, exists := lookupPart(fileIndex, "docProps/core.xml")
 	if !exists {
 		return nil, fmt.Errorf("core properties file not found")
 	}
@@ -462,7 +517,7 @@ func extractCorePropertiesFromFile(corePropsFile *zip.File) (*CoreProperties, er
 
 // extractAppPropertiesOptimized extracts app properties using file index
 func extractAppPropertiesOptimized(fileIndex map[string]*zip.File) (*AppProperties, error) {
-	appPropsFile, exists := fileIndex["docProps/app.xml"]
+	appPropsFile, exists := lookupPart(fileIndex, "docProps/app.xml")
 	if !exists {
 		return nil, fmt.Errorf("app properties file not found")
 	}
@@ -498,7 +553,7 @@ func extractAppPropertiesFromFile(appPropsFile *zip.File) (*AppProperties, error
 
 // extractCustomPropertiesOptimized extracts custom properties using file index
 func extractCustomPropertiesOptimized(fileIndex map[string]*zip.File) (map[string]string, error) {
-	customPropsFile, exists := fileIndex["docProps/custom.xml"]
+	customPropsFile, exists := lookupPart(fileIndex, "docProps/custom.xml")
 	if !exists {
 		return nil, fmt.Errorf("custom properties file not found")
 	}

--- a/internal/preprocessors/meta-extractors/meta-extract-officelib/path_guard_test.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-officelib/path_guard_test.go
@@ -1,0 +1,248 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package metaextractofficelib
+
+import (
+	"archive/zip"
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// validateFilePath used to refuse any path under a hardcoded list of "system
+// directories" that included /home/, /var/ and /tmp/. On Linux that is every file
+// a user owns, so `ferret-scan --file ~/report.docx` silently lost Office metadata
+// extraction — the document's author, company and custom properties were never
+// scanned, never reported, and therefore never redacted.
+//
+// These tests pin the paths that must now work, and the much smaller set that must
+// still be refused.
+
+// TestValidateFilePathAcceptsOrdinaryUserPaths is the non-vacuity test for the
+// guard change: every path here returned "access to system directory denied"
+// before, and every one of them is where real user data lives.
+func TestValidateFilePathAcceptsOrdinaryUserPaths(t *testing.T) {
+	paths := []string{
+		"/home/alice/report.docx",
+		"/home/runner/work/ferret-scan/ferret-scan/fixture.docx", // GitHub's Linux runners
+		"/var/folders/xy/T/scan-123/book.xlsx",                   // macOS TMPDIR
+		"/tmp/scan-123/deck.pptx",
+		"/root/audit.docx",
+		"/Users/alice/Documents/report.docx",
+		"C:\\Users\\alice\\Documents\\report.docx",
+		"C:\\Program Files\\CorpApp\\template.docx",
+		"/etc/corp-templates/letterhead.docx",
+		"/usr/bin/../share/doc/example.docx",
+	}
+
+	for _, p := range paths {
+		t.Run(p, func(t *testing.T) {
+			err := validateFilePath(p)
+			// The last entry contains ".." and is caught by the traversal check,
+			// which is unchanged and deliberately kept.
+			if strings.Contains(filepath.Clean(p), "..") {
+				if err == nil {
+					t.Errorf("validateFilePath(%q) = nil, want the traversal rejection", p)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("validateFilePath(%q) = %v; ordinary user data lives here, and refusing "+
+					"it drops Office metadata extraction with no error shown to the user", p, err)
+			}
+		})
+	}
+}
+
+// TestValidateFilePathRejects pins what the guard still refuses.
+//
+// Note the traversal check catches only a ".." that filepath.Clean cannot resolve
+// away — i.e. one that escapes above the starting point. "/home/a/../../etc/x"
+// cleans to "/etc/x", an ordinary absolute path with no ".." left in it, and is
+// accepted. That is correct rather than a hole: it names the same file the caller
+// could have named directly, and this function guards neither a sandbox nor a
+// document root.
+func TestValidateFilePathRejects(t *testing.T) {
+	cases := []struct {
+		path, why string
+	}{
+		{"../../etc/passwd", "traversal"},
+		{"docs/../../../secret.docx", "traversal"},
+		{"https://example.com/report.docx", "URL scheme"},
+		{"file:///home/alice/report.docx", "URL scheme"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			if err := validateFilePath(tc.path); err == nil {
+				t.Errorf("validateFilePath(%q) = nil, want a %s rejection", tc.path, tc.why)
+			}
+		})
+	}
+}
+
+// TestValidateFilePathAcceptsRealFilesUnderDeviceLikePaths is the regression for the
+// second version of the same mistake.
+//
+// The first replacement for the /home/-blocking denylist kept a smaller one for the
+// kernel pseudo-filesystems: /proc/, /sys/, /dev/. That reproduced the bug one
+// directory down. /dev/shm is world-writable tmpfs which scripts and CI use for
+// ordinary temporary files, and the files in it are ordinary regular files — so a
+// .docx written there was refused, silently losing Office metadata extraction exactly
+// as before. The concern behind that list (do not read something with no size that may
+// never end) is a property of the file's MODE, not its name, and it now lives in the
+// router as an os.FileMode().IsRegular() check.
+func TestValidateFilePathAcceptsRealFilesUnderDeviceLikePaths(t *testing.T) {
+	for _, p := range []string{
+		"/dev/shm/report.docx",     // world-writable tmpfs; a real regular file
+		"/dev/shm/tmp/book.xlsx",   // ditto, nested
+		"/home/proc/report.docx",   // a directory merely NAMED proc
+		"/var/proc/quarterly.docx", // ditto
+	} {
+		t.Run(p, func(t *testing.T) {
+			if err := validateFilePath(p); err != nil {
+				t.Errorf("validateFilePath(%q) = %v, want nil.\nThese are ordinary regular "+
+					"files. Refusing them by path prefix silently drops Office metadata "+
+					"extraction, which is the defect this guard was rewritten to remove.", p, err)
+			}
+		})
+	}
+}
+
+// TestValidateFilePathAcceptsNamesContainingDots is the regression for the over-broad
+// traversal check. It used to be strings.Contains(cleanPath, ".."), which rejected any
+// legitimate name carrying two consecutive dots.
+func TestValidateFilePathAcceptsNamesContainingDots(t *testing.T) {
+	for _, p := range []string{
+		"/home/alice/my..report.docx",
+		"/home/alice/notes../summary.xlsx",
+		"/home/alice/2024..2025/budget.xlsx",
+	} {
+		t.Run(p, func(t *testing.T) {
+			if err := validateFilePath(p); err != nil {
+				t.Errorf("validateFilePath(%q) = %v, want nil.\nAfter filepath.Clean only a "+
+					"LEADING \"..\" is a traversal; an interior one is part of a legitimate name.", p, err)
+			}
+		})
+	}
+}
+
+// TestValidateFilePathResolvesInteriorDotDot documents the boundary the test above
+// describes, so the behavior is pinned rather than merely asserted in prose.
+func TestValidateFilePathResolvesInteriorDotDot(t *testing.T) {
+	const p = "/home/alice/../../etc/passwd"
+	if err := validateFilePath(p); err != nil {
+		t.Errorf("validateFilePath(%q) = %v; Clean resolves this to /etc/passwd, which is an "+
+			"ordinary absolute path the caller could name directly", p, err)
+	}
+}
+
+// TestExtractMetadataFromATempPath is the end-to-end half: a real .docx written
+// under t.TempDir() — which resolves under /var/ on macOS and /tmp/ on Linux, both
+// previously refused — must yield its core properties.
+func TestExtractMetadataFromATempPath(t *testing.T) {
+	dir := t.TempDir()
+	lower := strings.ToLower(filepath.ToSlash(dir))
+	refusedBefore := strings.HasPrefix(lower, "/var/") || strings.HasPrefix(lower, "/tmp/") ||
+		strings.HasPrefix(lower, "/home/") || strings.Contains(lower, ":/users/")
+	if !refusedBefore && runtime.GOOS != "windows" {
+		t.Skipf("t.TempDir() = %q is not under a previously-refused root, so this platform "+
+			"cannot exercise the regression", dir)
+	}
+
+	path := filepath.Join(dir, "report.docx")
+	if err := os.WriteFile(path, buildMinimalDOCX(t), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	meta, err := ExtractMetadata(path)
+	if err != nil {
+		t.Fatalf("ExtractMetadata(%s): %v — the path guard refused an ordinary temp path, "+
+			"which is also every path under a Linux user's home directory", path, err)
+	}
+	if meta.Creator != "Jane Analyst" {
+		t.Errorf("Creator = %q, want %q; core properties were not extracted", meta.Creator, "Jane Analyst")
+	}
+	if meta.LastModifiedBy != "Ops Reviewer" {
+		t.Errorf("LastModifiedBy = %q, want %q", meta.LastModifiedBy, "Ops Reviewer")
+	}
+}
+
+// TestCorePropertiesPartNameIsCaseInsensitive covers the metadata extractor's own
+// share of the part-name problem: its file index was keyed by exact name, so
+// "docProps/Core.xml" was a different part and the author vanished while the scan
+// still reported success.
+func TestCorePropertiesPartNameIsCaseInsensitive(t *testing.T) {
+	for _, partName := range []string{
+		"docProps/core.xml",
+		"docProps/Core.xml",
+		"DOCPROPS/CORE.XML",
+		"docprops/core.xml",
+	} {
+		t.Run(partName, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "report.docx")
+			if err := os.WriteFile(path, buildDOCXWithCorePart(t, partName), 0o600); err != nil {
+				t.Fatalf("write fixture: %v", err)
+			}
+
+			meta, err := ExtractMetadata(path)
+			if err != nil {
+				t.Fatalf("ExtractMetadata: %v", err)
+			}
+			if meta.Creator != "Jane Analyst" {
+				t.Errorf("Creator = %q, want %q: core properties at %q were not found, so the "+
+					"document's author was never scanned", meta.Creator, "Jane Analyst", partName)
+			}
+		})
+	}
+}
+
+const testXMLDecl = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>`
+
+func testCoreProps() string {
+	return testXMLDecl +
+		`<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" ` +
+		`xmlns:dc="http://purl.org/dc/elements/1.1/">` +
+		`<dc:creator>Jane Analyst</dc:creator>` +
+		`<cp:lastModifiedBy>Ops Reviewer</cp:lastModifiedBy>` +
+		`</cp:coreProperties>`
+}
+
+func buildMinimalDOCX(t *testing.T) []byte {
+	t.Helper()
+	return buildDOCXWithCorePart(t, "docProps/core.xml")
+}
+
+func buildDOCXWithCorePart(t *testing.T, corePart string) []byte {
+	t.Helper()
+	doc := testXMLDecl +
+		`<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
+		`<w:body><w:p><w:r><w:t>Employee SSN 449-87-4100 on file.</w:t></w:r></w:p></w:body></w:document>`
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for _, p := range []struct{ name, body string }{
+		{"_rels/.rels", testXMLDecl + `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+			`<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>` +
+			`</Relationships>`},
+		{corePart, testCoreProps()},
+		{"word/document.xml", doc},
+	} {
+		w, err := zw.Create(p.name)
+		if err != nil {
+			t.Fatalf("zip create %q: %v", p.name, err)
+		}
+		if _, err := w.Write([]byte(p.body)); err != nil {
+			t.Fatalf("zip write %q: %v", p.name, err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zip close: %v", err)
+	}
+	return buf.Bytes()
+}

--- a/internal/preprocessors/office_metadata_preprocessor.go
+++ b/internal/preprocessors/office_metadata_preprocessor.go
@@ -52,15 +52,40 @@ func (omp *OfficeMetadataPreprocessor) processOfficeMetadata(filePath string) (*
 	text := omp.formatOfficeMetadata(meta)
 
 	// Process embedded media through router if available
-	embeddedText := omp.processEmbeddedMedia(filePath)
+	embeddedText, embeddedSections := omp.processEmbeddedMedia(filePath)
+
+	// Declare this extractor's own structure out of band. The container's own
+	// property block is one office_metadata section; each embedded item is its own
+	// section carrying the rule set of whichever extractor read it (a .wav's
+	// "Artist:" field is on the audio list, not the office one).
+	//
+	// Built here rather than in the router because only this function knows the
+	// split point: the router sees one opaque string from this preprocessor.
+	sections := []ContentSection{{
+		Name:       omp.GetName(),
+		Kind:       SectionKindMetadata,
+		Type:       ProcessorTypeOfficeMetadata,
+		SourceFile: filePath,
+		Text:       text,
+		LineOffset: 0,
+	}}
 	if embeddedText != "" {
+		// The embedded sections were anchored relative to embeddedText, which is
+		// appended after the property block.
+		shift := strings.Count(text, "\n")
+		for _, s := range embeddedSections {
+			s.LineOffset += shift
+			sections = append(sections, s)
+		}
 		text += embeddedText
 	}
 
 	// Log successful processing
 	omp.LogSuccessfulProcessing(meta.Filename, meta.FileSize, meta.MimeType)
 
-	return omp.BuildSuccessContent(filePath, text, "office_metadata", meta.PageCount), nil
+	content := omp.BuildSuccessContent(filePath, text, "office_metadata", meta.PageCount)
+	content.Sections = sections
+	return content, nil
 }
 
 // formatOfficeMetadata formats Office metadata into text format for validation
@@ -141,12 +166,13 @@ func (omp *OfficeMetadataPreprocessor) formatOfficeMetadata(meta *meta_extract_o
 	return result.String()
 }
 
-// processEmbeddedMedia processes embedded media through router integration
-func (omp *OfficeMetadataPreprocessor) processEmbeddedMedia(filePath string) string {
+// processEmbeddedMedia processes embedded media through router integration,
+// returning the text to append and the out-of-band sections describing it.
+func (omp *OfficeMetadataPreprocessor) processEmbeddedMedia(filePath string) (string, []ContentSection) {
 	// Extract embedded media for processing
 	embeddedMedia, err := meta_extract_officelib.ExtractEmbeddedMediaForProcessing(filePath)
 	if err != nil || len(embeddedMedia) == 0 {
-		return ""
+		return "", nil
 	}
 
 	// Ensure cleanup of temporary files

--- a/internal/preprocessors/preprocessor.go
+++ b/internal/preprocessors/preprocessor.go
@@ -50,6 +50,107 @@ type ProcessedContent struct {
 
 	// Additional metadata for embedded media and other extensions
 	Metadata map[string]interface{}
+
+	// Sections carries the structure of Text OUT OF BAND: one entry per
+	// preprocessor whose output was concatenated into Text, in the same order.
+	//
+	// It exists because the structure used to be carried IN BAND. The file router
+	// flattens every extractor's output into Text with literal "\n\n--- name ---\n"
+	// separators, and the content router then re-parsed that text to recover which
+	// bytes came from which extractor. Document authors control the text, so they
+	// controlled the recovered "structure": a paragraph typed as
+	// "--- office_metadata ---" became a section boundary. That is in-band
+	// signalling, the same class of defect as SQL injection, and it has the same
+	// answer — carry the structure alongside the data instead of re-deriving it
+	// from the data.
+	//
+	// Text stays the flat concatenation, byte for byte, so every existing consumer
+	// is unaffected; this field is purely additive. A nil/empty Sections means "no
+	// structure was declared", which consumers must treat as "all of Text is
+	// document body" — the safe direction, since the document path runs the full
+	// validator set and the metadata path runs one field-name scanner.
+	Sections []ContentSection
+}
+
+// ContentSection describes one contiguous run of ProcessedContent.Text and where
+// it came from. Every field is derived from OUR OWN code — the preprocessor's
+// GetName() and the router's classification of it — never from the scanned
+// document's bytes. That provenance is the entire point: it is what makes a
+// section boundary unforgeable by a document author.
+type ContentSection struct {
+	// Name is the producing preprocessor's GetName(), e.g. "Text Extractor" or
+	// "office_metadata". This is the string the flat separator used to spell out.
+	Name string
+
+	// Kind is the routing decision: SectionKindBody or SectionKindMetadata.
+	Kind SectionKind
+
+	// Type is the metadata preprocessor type ("office_metadata",
+	// "image_metadata", ...) for a metadata section, and empty for a body
+	// section. It is what the METADATA validator keys its per-preprocessor
+	// field rules off.
+	Type string
+
+	// SourceFile is the path to attribute findings in this section to. It is the
+	// scanned file for a normal section, and the "container.docx -> image1.jpg"
+	// form for a section extracted from embedded media.
+	SourceFile string
+
+	// Text is this section's bytes. It is a substring of ProcessedContent.Text
+	// (Go strings share backing storage, so this is a reference, not a copy).
+	Text string
+
+	// LineOffset is the 0-based line index at which Text begins within
+	// ProcessedContent.Text, so a finding's line number inside a section can be
+	// reported against the whole extracted document.
+	LineOffset int
+}
+
+// SectionKind is the routing classification of a ContentSection.
+type SectionKind int
+
+const (
+	// SectionKindBody is document body text: the full validator set applies.
+	SectionKindBody SectionKind = iota
+	// SectionKindMetadata is extracted metadata fields: the METADATA validator's
+	// per-preprocessor field rules apply. Note this is about LABELLING, not
+	// coverage — the document path scans the union of all sections regardless.
+	SectionKindMetadata
+)
+
+// ClassifySection maps a preprocessor's GetName() to a section Kind and metadata
+// Type. It lives next to the metadata_constants.go names it matches, and it is a
+// CLOSED switch on the seven names this repo's preprocessors actually return
+// (verified against every GetName() implementation) rather than a substring
+// search.
+//
+// A closed switch is the security-relevant part. The name it classifies is our
+// own code's constant, so an exact match is always possible; substring matching
+// was how the old text-parsing path turned a document paragraph named
+// "--- Employee Metadata ---" into a metadata section. Anything unrecognized
+// classifies as BODY, which is the fail-closed direction: the document path runs
+// the full validator set, so a preprocessor added later without updating this
+// switch loses a label, not coverage.
+func ClassifySection(preprocessorName string) (SectionKind, string) {
+	switch preprocessorName {
+	case ProcessorTypeImageMetadata:
+		return SectionKindMetadata, ProcessorTypeImageMetadata
+	case ProcessorTypePDFMetadata:
+		// The METADATA validator keys PDF metadata rules under
+		// "document_metadata", not "pdf_metadata" — see the content router's
+		// PreprocessorTypeDocumentMetadata. Preserving that remap here keeps the
+		// same rule set (and therefore the same findings) selected.
+		return SectionKindMetadata, "document_metadata"
+	case ProcessorTypeOfficeMetadata:
+		return SectionKindMetadata, ProcessorTypeOfficeMetadata
+	case ProcessorTypeAudioMetadata:
+		return SectionKindMetadata, ProcessorTypeAudioMetadata
+	case ProcessorTypeVideoMetadata:
+		return SectionKindMetadata, ProcessorTypeVideoMetadata
+	default:
+		// "Text Extractor", "Plain Text Preprocessor", and anything unknown.
+		return SectionKindBody, ""
+	}
 }
 
 // PositionMapping represents a mapping between extracted text positions and original document positions

--- a/internal/preprocessors/preprocessor.go
+++ b/internal/preprocessors/preprocessor.go
@@ -31,6 +31,15 @@ type ProcessedContent struct {
 	Success       bool
 	Error         error
 
+	// ExtractionWarning is a short, payload-free note that extraction SUCCEEDED
+	// but produced suspiciously nothing — e.g. a container whose format carries a
+	// document body yielded no body text. It is deliberately not an Error: the
+	// file was read and whatever was extracted is valid, so the scan continues and
+	// the findings stand. It exists because "extracted nothing" and "the document
+	// is empty" used to be indistinguishable — both were Success with textLen 0 —
+	// which made a skipped document body look like a clean scan.
+	ExtractionWarning string
+
 	// Position mapping information for redaction
 	PositionMappings []PositionMapping `json:"position_mappings,omitempty"`
 

--- a/internal/preprocessors/text-extractors/text-extract-officetextlib/office-text-extractor.go
+++ b/internal/preprocessors/text-extractors/text-extract-officetextlib/office-text-extractor.go
@@ -63,6 +63,20 @@ type TextContent struct {
 	CharCount  int
 	LineCount  int
 	Paragraphs int
+
+	// BodyParts counts the archive members this extractor identified as document
+	// body (the main document, the worksheets, the slides). Zero means the
+	// container held nothing recognizable as body content at all — as opposed to a
+	// body that was read and turned out to be empty.
+	BodyParts int
+
+	// ExtractionWarning is a short, payload-free note set when a container that
+	// CAN carry a document body yielded no body text. Nothing used to distinguish
+	// that from a genuinely empty document: extraction reported Success with
+	// textLen 0, the router stamped Success, and --fail-on-incomplete returned 0,
+	// so a file whose body was skipped was indistinguishable from an empty one and
+	// the run looked clean. Callers surface this and count it as a coverage gap.
+	ExtractionWarning string
 }
 
 // ExtractText extracts text from an Office document
@@ -83,25 +97,56 @@ func ExtractText(filePath string) (*TextContent, error) {
 	switch ext {
 	case ".docx":
 		content.Format = "Word Document"
-		return extractDocxText(filePath, content)
+		content, err = extractDocxText(filePath, content)
 	case ".xlsx":
 		content.Format = "Excel Spreadsheet"
-		return extractXlsxText(filePath, content)
+		content, err = extractXlsxText(filePath, content)
 	case ".pptx":
 		content.Format = "PowerPoint Presentation"
-		return extractPptxText(filePath, content)
+		content, err = extractPptxText(filePath, content)
 	case ".odt":
 		content.Format = "OpenDocument Text"
-		return extractOdtText(filePath, content)
+		content, err = extractOdtText(filePath, content)
 	case ".ods":
 		content.Format = "OpenDocument Spreadsheet"
-		return extractOdsText(filePath, content)
+		content, err = extractOdsText(filePath, content)
 	case ".odp":
 		content.Format = "OpenDocument Presentation"
-		return extractOdpText(filePath, content)
+		content, err = extractOdpText(filePath, content)
 	default:
 		return nil, fmt.Errorf("unsupported file format: %s", ext)
 	}
+
+	noteEmptyExtraction(content, ext)
+	return content, err
+}
+
+// noteEmptyExtraction records an ExtractionWarning when a container whose format
+// carries a document body produced no body text.
+//
+// This is the visibility half of the part-selection fix. Selecting the body by
+// name means a name we do not recognize yields zero text, and zero text used to be
+// reported exactly like an empty document — Success=true, textLen=0, exit 0. So
+// the failure mode the part-name fix addresses was, by construction, silent: the
+// operator had no signal that a 40-page document contributed nothing to the scan.
+// The warning fires on the OUTCOME (no body text) rather than on any specific
+// cause, so it also covers whatever part-naming trick we have not thought of.
+func noteEmptyExtraction(content *TextContent, ext string) {
+	if content == nil || content.ExtractionWarning != "" {
+		return
+	}
+	if strings.TrimSpace(content.Text) != "" {
+		return
+	}
+	if content.BodyParts > 0 {
+		content.ExtractionWarning = fmt.Sprintf(
+			"no text extracted from %s: %d body part(s) were read but held no text",
+			ext, content.BodyParts)
+		return
+	}
+	content.ExtractionWarning = fmt.Sprintf(
+		"no text extracted from %s: no document body part was found in the archive, "+
+			"so document content was NOT scanned", ext)
 }
 
 // extractDocxText extracts text from a Word document
@@ -113,40 +158,47 @@ func extractDocxText(filePath string, content *TextContent) (*TextContent, error
 	}
 	defer reader.Close()
 
-	// Find document content files
-	var documentFile *zip.File
-	var headerFiles []*zip.File
-	var footerFiles []*zip.File
-	var corePropsFile *zip.File
-	for _, file := range reader.File {
-		if file.Name == "word/document.xml" {
-			documentFile = file
-		} else if strings.HasPrefix(file.Name, "word/header") && strings.HasSuffix(file.Name, ".xml") {
-			headerFiles = append(headerFiles, file)
-		} else if strings.HasPrefix(file.Name, "word/footer") && strings.HasSuffix(file.Name, ".xml") {
-			footerFiles = append(footerFiles, file)
-		} else if file.Name == "docProps/core.xml" {
-			corePropsFile = file
-		}
-	}
+	// Find document content files. Part names are producer-controlled, so the main
+	// document is located through the package relationships and by conventional
+	// name case-insensitively, then unioned — see ooxml_parts.go for why one
+	// capital letter used to drop the entire body.
+	pkg := newOOXMLPackage(reader.File)
+	documentFiles := unionParts(
+		pkg.relatedParts("", "officeDocument"),
+		[]*zip.File{pkg.lookup("word/document.xml"), pkg.lookup("word/main.xml")},
+	)
+	headerFiles := pkg.matching("word/header", ".xml")
+	footerFiles := pkg.matching("word/footer", ".xml")
+	corePropsFile := pkg.lookup("docProps/core.xml")
 
-	if documentFile == nil {
+	if len(documentFiles) == 0 {
 		return content, fmt.Errorf("document.xml not found in the archive")
 	}
+	content.BodyParts = len(documentFiles)
 
-	// Extract raw XML content
-	rc, err := documentFile.Open()
-	if err != nil {
-		return content, err
-	}
-	docContent, err := readZipEntryLimited(rc)
-	rc.Close()
-	if err != nil {
-		return content, err
+	// Extract raw XML content. Where a package names more than one main-document
+	// part (relationships pointing somewhere other than the conventional name, or
+	// two entries differing only in case) every one is extracted: dropping the
+	// ones we did not expect is exactly how content escaped scanning before.
+	var rawDoc strings.Builder
+	for _, documentFile := range documentFiles {
+		if rawDoc.Len() > MaxTotalTextBytes {
+			break
+		}
+		rc, err := documentFile.Open()
+		if err != nil {
+			continue
+		}
+		part, err := readZipEntryLimited(rc)
+		rc.Close()
+		if err != nil {
+			continue
+		}
+		rawDoc.Write(part)
 	}
 
 	// First, remove all XML tags that aren't text content
-	cleanedXML := string(docContent)
+	cleanedXML := rawDoc.String()
 
 	// Handle table cells and tabs - preserve tabular structure
 	// Convert table cell boundaries to tabs
@@ -263,20 +315,35 @@ func extractXlsxText(filePath string, content *TextContent) (*TextContent, error
 	}
 	defer reader.Close()
 
-	// Find shared strings and worksheets
-	var sharedStringsFile *zip.File
-	var worksheets []*zip.File
-	var corePropsFile *zip.File
+	// Find shared strings and worksheets. Resolved through the workbook's
+	// relationships and by conventional name case-insensitively, then unioned —
+	// see ooxml_parts.go. A capitalized "xl/Worksheets/" or "xl/SharedStrings.xml"
+	// used to make the whole sheet, or every shared string in it, invisible.
+	pkg := newOOXMLPackage(reader.File)
+	workbookParts := unionParts(
+		pkg.relatedParts("", "officeDocument"),
+		[]*zip.File{pkg.lookup("xl/workbook.xml")},
+	)
 
-	for _, file := range reader.File {
-		if file.Name == "xl/sharedStrings.xml" {
-			sharedStringsFile = file
-		} else if strings.HasPrefix(file.Name, "xl/worksheets/sheet") && strings.HasSuffix(file.Name, ".xml") {
-			worksheets = append(worksheets, file)
-		} else if file.Name == "docProps/core.xml" {
-			corePropsFile = file
-		}
+	var relSheets, relShared []*zip.File
+	for _, wb := range workbookParts {
+		relSheets = append(relSheets, pkg.relatedParts(wb.Name, "worksheet")...)
+		relShared = append(relShared, pkg.relatedParts(wb.Name, "sharedStrings")...)
 	}
+
+	worksheets := unionParts(relSheets, pkg.matching("xl/worksheets/", ".xml"))
+	sharedStringsFiles := unionParts(relShared, []*zip.File{pkg.lookup("xl/sharedStrings.xml")})
+	corePropsFile := pkg.lookup("docProps/core.xml")
+
+	// Shared strings are referenced by POSITION, so only one table can be
+	// authoritative; the relationship-resolved one leads and a conventional-name
+	// hit is the fallback. Concatenating two tables would shift every index.
+	var sharedStringsFile *zip.File
+	if len(sharedStringsFiles) > 0 {
+		sharedStringsFile = sharedStringsFiles[0]
+	}
+
+	content.BodyParts = len(worksheets)
 
 	// Extract shared strings
 	sharedStrings := extractSharedStringsSimple(sharedStringsFile)
@@ -293,9 +360,9 @@ func extractXlsxText(filePath string, content *TextContent) (*TextContent, error
 		if allText.Len() > MaxTotalTextBytes {
 			break
 		}
-		// Get sheet name
-		sheetName := strings.TrimPrefix(worksheet.Name, "xl/worksheets/")
-		sheetName = strings.TrimSuffix(sheetName, ".xml")
+		// Get sheet name (case-insensitive trim: a capitalized "xl/Worksheets/"
+		// otherwise left the directory in the emitted section label).
+		sheetName := trimPartLabel(worksheet.Name, "xl/worksheets/")
 
 		allText.WriteString("--- " + sheetName + " ---\n")
 
@@ -329,23 +396,27 @@ func extractPptxText(filePath string, content *TextContent) (*TextContent, error
 	}
 	defer reader.Close()
 
-	// Find all presentation content files. byName lets us resolve a slide's notes
-	// through its relationships part, rather than guessing by position.
-	var slides []*zip.File
-	var masters []*zip.File
-	var corePropsFile *zip.File
-	byName := make(map[string]*zip.File, len(reader.File))
+	// Find all presentation content files. Slides come from the presentation's
+	// relationships unioned with the conventional name matched case-insensitively
+	// (see ooxml_parts.go); pkg also resolves each slide's notes through its own
+	// relationships part, rather than guessing by position.
+	pkg := newOOXMLPackage(reader.File)
+	presentationParts := unionParts(
+		pkg.relatedParts("", "officeDocument"),
+		[]*zip.File{pkg.lookup("ppt/presentation.xml")},
+	)
 
-	for _, file := range reader.File {
-		byName[file.Name] = file
-		if strings.HasPrefix(file.Name, "ppt/slides/slide") && strings.HasSuffix(file.Name, ".xml") {
-			slides = append(slides, file)
-		} else if strings.HasPrefix(file.Name, "ppt/slideMasters/") && strings.HasSuffix(file.Name, ".xml") {
-			masters = append(masters, file)
-		} else if file.Name == "docProps/core.xml" {
-			corePropsFile = file
-		}
+	var relSlides, relMasters []*zip.File
+	for _, pres := range presentationParts {
+		relSlides = append(relSlides, pkg.relatedParts(pres.Name, "slide")...)
+		relMasters = append(relMasters, pkg.relatedParts(pres.Name, "slideMaster")...)
 	}
+
+	slides := unionParts(relSlides, pkg.matching("ppt/slides/slide", ".xml"))
+	masters := unionParts(relMasters, pkg.matching("ppt/slideMasters/", ".xml"))
+	corePropsFile := pkg.lookup("docProps/core.xml")
+
+	content.BodyParts = len(slides) + len(masters)
 
 	// Order slides and masters by their numeric index. zip.OpenReader returns
 	// entries in the archive's central-directory order, which the producer
@@ -378,7 +449,7 @@ func extractPptxText(filePath string, content *TextContent) (*TextContent, error
 		// have notes on only some slides and in a different order — so a slide
 		// got another slide's speaker notes (or none), mislabeling where that
 		// text, and any PII in it, came from.
-		if notesFile := pptxNotesForSlide(slide, byName); notesFile != nil {
+		if notesFile := pptxNotesForSlide(slide, pkg); notesFile != nil {
 			notesText, err := extractTextFromXML(notesFile, "//a:t")
 			if err == nil && notesText != "" {
 				allText.WriteString("\n[SPEAKER NOTES]\n")
@@ -427,23 +498,18 @@ func extractOdtText(filePath string, content *TextContent) (*TextContent, error)
 	}
 	defer reader.Close()
 
-	// Find content and style files
-	var contentFile *zip.File
-	var stylesFile *zip.File
-	var metaFile *zip.File
-	for _, file := range reader.File {
-		if file.Name == "content.xml" {
-			contentFile = file
-		} else if file.Name == "styles.xml" {
-			stylesFile = file
-		} else if file.Name == "meta.xml" {
-			metaFile = file
-		}
-	}
+	// Find content and style files. ODF has no relationship parts, but the entry
+	// names are still producer-controlled, so match them case-insensitively for the
+	// same reason the OOXML paths do (ooxml_parts.go).
+	pkg := newOOXMLPackage(reader.File)
+	contentFile := pkg.lookup("content.xml")
+	stylesFile := pkg.lookup("styles.xml")
+	metaFile := pkg.lookup("meta.xml")
 
 	if contentFile == nil {
 		return content, fmt.Errorf("content.xml not found in the archive")
 	}
+	content.BodyParts = 1
 
 	// Extract text from content.xml
 	docText, err := extractTextFromXML(contentFile, "//text:p")
@@ -489,20 +555,16 @@ func extractOdsText(filePath string, content *TextContent) (*TextContent, error)
 	}
 	defer reader.Close()
 
-	// Find the content.xml file which contains the spreadsheet data
-	var contentFile *zip.File
-	var metaFile *zip.File
-	for _, file := range reader.File {
-		if file.Name == "content.xml" {
-			contentFile = file
-		} else if file.Name == "meta.xml" {
-			metaFile = file
-		}
-	}
+	// Find the content.xml file which contains the spreadsheet data, matched
+	// case-insensitively like the other container paths (ooxml_parts.go).
+	pkg := newOOXMLPackage(reader.File)
+	contentFile := pkg.lookup("content.xml")
+	metaFile := pkg.lookup("meta.xml")
 
 	if contentFile == nil {
 		return content, fmt.Errorf("content.xml not found in the archive")
 	}
+	content.BodyParts = 1
 
 	// Extract text from content.xml
 	// For ODS, we need to extract cell values
@@ -534,23 +596,17 @@ func extractOdpText(filePath string, content *TextContent) (*TextContent, error)
 	}
 	defer reader.Close()
 
-	// Find content and style files
-	var contentFile *zip.File
-	var stylesFile *zip.File
-	var metaFile *zip.File
-	for _, file := range reader.File {
-		if file.Name == "content.xml" {
-			contentFile = file
-		} else if file.Name == "styles.xml" {
-			stylesFile = file
-		} else if file.Name == "meta.xml" {
-			metaFile = file
-		}
-	}
+	// Find content and style files, matched case-insensitively like the other
+	// container paths (ooxml_parts.go).
+	pkg := newOOXMLPackage(reader.File)
+	contentFile := pkg.lookup("content.xml")
+	stylesFile := pkg.lookup("styles.xml")
+	metaFile := pkg.lookup("meta.xml")
 
 	if contentFile == nil {
 		return content, fmt.Errorf("content.xml not found in the archive")
 	}
+	content.BodyParts = 1
 
 	// Extract text from content.xml
 	docText, err := extractTextFromXML(contentFile, "//text:p")
@@ -947,48 +1003,21 @@ func sortByNumericSuffix(files []*zip.File) {
 	})
 }
 
-// slideRelTargetRe matches a notesSlide relationship target inside a slide's
-// .rels part, e.g. Target="../notesSlides/notesSlide3.xml".
-var slideRelTargetRe = regexp.MustCompile(`Target="([^"]*notesSlides/notesSlide\d+\.xml)"`)
-
 // pptxNotesForSlide resolves the notesSlide part that belongs to the given slide
-// by reading the slide's relationships (ppt/slides/_rels/slideN.xml.rels), which
-// is the authoritative link. Returns nil if the slide has no notes or the rels
-// part is missing/unreadable. This replaces the previous positional pairing of
-// notes[i] with slides[i], which mis-attached notes because notesSlideN is not
-// aligned with slideN.
-func pptxNotesForSlide(slide *zip.File, byName map[string]*zip.File) *zip.File {
-	// ppt/slides/slideN.xml -> ppt/slides/_rels/slideN.xml.rels
-	base := slide.Name[strings.LastIndex(slide.Name, "/")+1:]
-	relsName := "ppt/slides/_rels/" + base + ".rels"
-	relsFile := byName[relsName]
-	if relsFile == nil {
+// through the slide's own relationships, which is the authoritative link. Returns
+// nil if the slide has no notes or its rels part is missing/unreadable. This
+// replaces the previous positional pairing of notes[i] with slides[i], which
+// mis-attached notes because notesSlideN is not aligned with slideN.
+//
+// Relationship lookup now goes through ooxmlPackage, so the slide's .rels part is
+// found regardless of the case the producer used and the target is resolved by the
+// shared relative-target rules rather than by trimming "../" by hand.
+func pptxNotesForSlide(slide *zip.File, pkg *ooxmlPackage) *zip.File {
+	notes := pkg.relatedParts(slide.Name, "notesSlide")
+	if len(notes) == 0 {
 		return nil
 	}
-
-	rc, err := relsFile.Open()
-	if err != nil {
-		return nil
-	}
-	defer rc.Close()
-
-	data, err := readZipEntryLimited(rc)
-	if err != nil {
-		return nil
-	}
-
-	m := slideRelTargetRe.FindSubmatch(data)
-	if len(m) != 2 {
-		return nil
-	}
-
-	// Resolve the (possibly relative) target against the ppt/ base and look it up.
-	target := string(m[1])
-	target = strings.TrimPrefix(target, "../")
-	if !strings.HasPrefix(target, "ppt/") {
-		target = "ppt/" + target
-	}
-	return byName[target]
+	return notes[0]
 }
 
 // sortWorksheets sorts worksheets by sheet number

--- a/internal/preprocessors/text-extractors/text-extract-officetextlib/ooxml_parts.go
+++ b/internal/preprocessors/text-extractors/text-extract-officetextlib/ooxml_parts.go
@@ -1,0 +1,196 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package textextractofficetextlib
+
+import (
+	"archive/zip"
+	"path"
+	"regexp"
+	"strings"
+)
+
+// Part selection for OOXML containers.
+//
+// This file exists because the extractors used to pick parts by hardcoded,
+// case-SENSITIVE literal names ("word/document.xml", "xl/sharedStrings.xml",
+// prefix "ppt/slides/slide"). A zip entry name is producer-controlled data, and
+// nothing in the OOXML specification makes those literals normative — the package
+// relationships do. So one capital letter defeated extraction entirely: measured
+// with a prebuilt binary, renaming word/document.xml to word/Document.xml took a
+// .docx from 4 findings {SSN, VISA, AUTHOR_INFO, LAST_MODIFIED_BY} to 2
+// (metadata only). The SSN and the card number never entered the extracted text,
+// so no validator could see them and — since only reported findings are redacted
+// — they passed through --enable-redaction in cleartext. Renaming the part to
+// word/main.xml did the same. No routing or validator change can reach this: the
+// bytes are simply absent from what gets scanned.
+//
+// Selection is therefore done two ways and the results are UNIONED:
+//
+//  1. Through the package relationships (_rels/.rels and the part-level .rels),
+//     which is how the format actually specifies which part is the document, the
+//     workbook, a worksheet, a slide. This is authoritative and case-exact.
+//  2. Through the conventional names, matched case-INSENSITIVELY, as a fallback
+//     for a package whose relationships are missing, malformed, or deliberately
+//     point elsewhere.
+//
+// The union is the point. Taking only (1) would LOSE content today's code finds:
+// a package whose .rels points at word/evil.xml while word/document.xml also
+// carries PII would have that second part dropped, and unreferenced parts are
+// still bytes sitting in the file. Taking only (2) is the bug being fixed.
+// Scanning both can only add text, never remove it, so a conventional document —
+// where both routes name the same single part and dedup collapses them — extracts
+// byte-identically to before.
+
+// ooxmlPackage indexes an opened OOXML archive so parts can be found without
+// relying on the producer's choice of letter case, and so relationships can be
+// followed.
+type ooxmlPackage struct {
+	files   []*zip.File
+	byLower map[string]*zip.File
+}
+
+func newOOXMLPackage(files []*zip.File) *ooxmlPackage {
+	p := &ooxmlPackage{files: files, byLower: make(map[string]*zip.File, len(files))}
+	for _, f := range files {
+		key := strings.ToLower(f.Name)
+		// First writer wins, so a package carrying both "word/document.xml" and
+		// "word/Document.xml" resolves deterministically to the earlier entry
+		// rather than to whichever the map happened to see last.
+		if _, seen := p.byLower[key]; !seen {
+			p.byLower[key] = f
+		}
+	}
+	return p
+}
+
+// lookup finds a part by name, ignoring case.
+func (p *ooxmlPackage) lookup(name string) *zip.File {
+	return p.byLower[strings.ToLower(name)]
+}
+
+// matching returns every part whose name has the given prefix and suffix,
+// compared case-insensitively, in archive order.
+func (p *ooxmlPackage) matching(prefix, suffix string) []*zip.File {
+	var out []*zip.File
+	lp, ls := strings.ToLower(prefix), strings.ToLower(suffix)
+	for _, f := range p.files {
+		ln := strings.ToLower(f.Name)
+		if strings.HasPrefix(ln, lp) && strings.HasSuffix(ln, ls) {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+var (
+	// relElemRe isolates each <Relationship .../> element; relAttrRe then pulls its
+	// attributes, so Type/Target/TargetMode order does not matter.
+	relElemRe = regexp.MustCompile(`(?s)<Relationship\b[^>]*>`)
+	relAttrRe = regexp.MustCompile(`([A-Za-z:]+)\s*=\s*"([^"]*)"`)
+)
+
+// relsPartFor returns the name of the .rels part describing ownerPart's
+// relationships. The package-level relationships (ownerPart "") live in
+// "_rels/.rels"; a part's live alongside it under "_rels/<base>.rels".
+func relsPartFor(ownerPart string) string {
+	if ownerPart == "" {
+		return "_rels/.rels"
+	}
+	dir, base := path.Split(ownerPart)
+	return dir + "_rels/" + base + ".rels"
+}
+
+// resolveTarget turns a relationship Target into a package part name. Targets are
+// relative to the owning part's directory unless they begin with "/", in which
+// case they are already package-absolute.
+func resolveTarget(ownerPart, target string) string {
+	if target == "" {
+		return ""
+	}
+	if strings.HasPrefix(target, "/") {
+		return strings.TrimPrefix(path.Clean(target), "/")
+	}
+	dir, _ := path.Split(ownerPart)
+	// path.Join cleans as it joins, which is what resolves a leading "../".
+	return strings.TrimPrefix(path.Join(dir, target), "/")
+}
+
+// relatedParts returns the parts reachable from ownerPart by a relationship whose
+// Type ends in "/"+relType (e.g. "officeDocument", "worksheet", "slide"). Targets
+// that do not resolve to a part in this archive, and external targets, are
+// skipped — a relationship is a claim about the package, not a guarantee.
+func (p *ooxmlPackage) relatedParts(ownerPart, relType string) []*zip.File {
+	relsFile := p.lookup(relsPartFor(ownerPart))
+	if relsFile == nil {
+		return nil
+	}
+
+	rc, err := relsFile.Open()
+	if err != nil {
+		return nil
+	}
+	data, err := readZipEntryLimited(rc)
+	rc.Close()
+	if err != nil {
+		return nil
+	}
+
+	wantSuffix := "/" + strings.ToLower(relType)
+
+	var out []*zip.File
+	for _, elem := range relElemRe.FindAll(data, -1) {
+		var relTypeAttr, target string
+		external := false
+		for _, attr := range relAttrRe.FindAllSubmatch(elem, -1) {
+			switch strings.ToLower(string(attr[1])) {
+			case "type":
+				relTypeAttr = string(attr[2])
+			case "target":
+				target = string(attr[2])
+			case "targetmode":
+				external = strings.EqualFold(string(attr[2]), "External")
+			}
+		}
+		if external || !strings.HasSuffix(strings.ToLower(relTypeAttr), wantSuffix) {
+			continue
+		}
+		if f := p.lookup(resolveTarget(ownerPart, target)); f != nil {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// unionParts concatenates part lists, keeping the first occurrence of each part
+// and preserving the order given. Relationship-resolved parts are passed first so
+// the authoritative ordering leads.
+func unionParts(lists ...[]*zip.File) []*zip.File {
+	var out []*zip.File
+	seen := make(map[string]bool)
+	for _, list := range lists {
+		for _, f := range list {
+			if f == nil || seen[f.Name] {
+				continue
+			}
+			seen[f.Name] = true
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// trimPartLabel strips a directory prefix and the ".xml" suffix from a part name
+// case-insensitively, yielding the section label the extractor emits (e.g.
+// "xl/Worksheets/sheet1.xml" -> "sheet1"). A case-sensitive strings.TrimPrefix
+// left the whole path in the label whenever the producer capitalized the
+// directory.
+func trimPartLabel(name, prefix string) string {
+	if len(name) >= len(prefix) && strings.EqualFold(name[:len(prefix)], prefix) {
+		name = name[len(prefix):]
+	}
+	if strings.HasSuffix(strings.ToLower(name), ".xml") {
+		name = name[:len(name)-len(".xml")]
+	}
+	return name
+}

--- a/internal/preprocessors/text-extractors/text-extract-officetextlib/ooxml_parts_test.go
+++ b/internal/preprocessors/text-extractors/text-extract-officetextlib/ooxml_parts_test.go
@@ -1,0 +1,467 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package textextractofficetextlib
+
+import (
+	"archive/zip"
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// These tests cover part-name evasion: the document body must be extracted no
+// matter what case, or what conventional-but-unexpected name, the producer used
+// for the archive member holding it.
+//
+// The stakes are recall, not cosmetics. Body text that is not extracted is not
+// scanned, so it is not reported, so it is not redacted — the value leaves the
+// tool in cleartext. Measured before the fix with a prebuilt binary: renaming
+// word/document.xml to word/Document.xml took a .docx from 4 findings
+// {SSN, VISA, AUTHOR_INFO, LAST_MODIFIED_BY} to 2 (metadata only).
+
+const (
+	testSSN  = "449-87-4100"
+	testCard = "4532-0151-1283-0366"
+)
+
+const xmlDecl = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>`
+
+// part is one archive member.
+type part struct {
+	name string
+	body string
+}
+
+// writeZip builds a zip at dir/name from parts and returns its path.
+func writeZip(t *testing.T, dir, name string, parts []part) string {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for _, p := range parts {
+		w, err := zw.Create(p.name)
+		if err != nil {
+			t.Fatalf("zip create %q: %v", p.name, err)
+		}
+		if _, err := w.Write([]byte(p.body)); err != nil {
+			t.Fatalf("zip write %q: %v", p.name, err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zip close: %v", err)
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatalf("write %q: %v", path, err)
+	}
+	return path
+}
+
+func docBody() string {
+	return xmlDecl + `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>` +
+		`<w:p><w:r><w:t>Employee SSN ` + testSSN + ` on file.</w:t></w:r></w:p>` +
+		`<w:p><w:r><w:t>Card ` + testCard + ` expires soon.</w:t></w:r></w:p>` +
+		`</w:body></w:document>`
+}
+
+func pkgRels(target string) string {
+	return xmlDecl + `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+		`<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="` + target + `"/>` +
+		`</Relationships>`
+}
+
+// docxWith builds a .docx whose main document part is named mainPart, with the
+// package relationship pointing at relTarget (mainPart when empty).
+func docxWith(t *testing.T, dir, name, mainPart, relTarget string) string {
+	t.Helper()
+	if relTarget == "" {
+		relTarget = mainPart
+	}
+	return writeZip(t, dir, name, []part{
+		{"_rels/.rels", pkgRels(relTarget)},
+		{mainPart, docBody()},
+	})
+}
+
+// assertBodyExtracted fails when either sensitive value is missing from the
+// extracted text. Both values are checked because the two live in different
+// paragraphs of the same part, so a partial extraction is distinguishable from
+// none.
+func assertBodyExtracted(t *testing.T, path string) {
+	t.Helper()
+	got, err := ExtractText(path)
+	if err != nil {
+		t.Fatalf("ExtractText(%s): %v", filepath.Base(path), err)
+	}
+	for _, want := range []string{testSSN, testCard} {
+		if !strings.Contains(got.Text, want) {
+			t.Errorf("%s: extracted text is missing %s, so no validator can see it and "+
+				"redaction cannot rewrite it — the value leaves the tool in cleartext.\n"+
+				"  extracted %d bytes: %q",
+				filepath.Base(path), want, len(got.Text), got.Text)
+		}
+	}
+	if got.ExtractionWarning != "" {
+		t.Errorf("%s: unexpected extraction warning %q for a document whose body WAS found",
+			filepath.Base(path), got.ExtractionWarning)
+	}
+}
+
+// TestDocxMainPartNameVariants is the primary non-vacuity test for the docx half.
+// Every case here returns zero body text on the pre-fix code.
+func TestDocxMainPartNameVariants(t *testing.T) {
+	dir := t.TempDir()
+
+	cases := []struct {
+		name      string
+		mainPart  string
+		relTarget string
+	}{
+		// The conventional name — the only one that worked before.
+		{"conventional", "word/document.xml", ""},
+		// One capital letter. This is the measured 3-findings-to-2 case.
+		{"capitalized_basename", "word/Document.xml", ""},
+		// Whole path uppercased, as some producers and archivers emit.
+		{"all_caps", "WORD/DOCUMENT.XML", ""},
+		// Capitalized directory only.
+		{"capitalized_dir", "Word/document.xml", ""},
+		// A name that is not a case variant at all: found only by following the
+		// package relationship, which is what the format actually specifies.
+		{"unconventional_name", "word/main.xml", ""},
+		{"arbitrary_name", "word/body-content.xml", ""},
+		// A relationship target given package-absolute, and one that has to be
+		// resolved relative to the owning part's directory.
+		{"absolute_rel_target", "word/document2.xml", "/word/document2.xml"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := docxWith(t, dir, tc.name+".docx", tc.mainPart, tc.relTarget)
+			assertBodyExtracted(t, path)
+		})
+	}
+}
+
+// TestDocxTwoMainPartsBothExtracted pins the union rule. A package that names one
+// main document through its relationship while ALSO carrying a conventionally-named
+// part must have both scanned: selecting only the relationship target would newly
+// drop content that the old name-matching code did find, turning a recall fix into
+// a recall regression.
+func TestDocxTwoMainPartsBothExtracted(t *testing.T) {
+	dir := t.TempDir()
+	decoy := xmlDecl + `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
+		`<w:body><w:p><w:r><w:t>Card ` + testCard + ` expires soon.</w:t></w:r></w:p></w:body></w:document>`
+	unreferenced := xmlDecl + `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
+		`<w:body><w:p><w:r><w:t>Employee SSN ` + testSSN + ` on file.</w:t></w:r></w:p></w:body></w:document>`
+
+	path := writeZip(t, dir, "two_parts.docx", []part{
+		{"_rels/.rels", pkgRels("word/elsewhere.xml")},
+		{"word/elsewhere.xml", decoy},
+		{"word/document.xml", unreferenced},
+	})
+
+	got, err := ExtractText(path)
+	if err != nil {
+		t.Fatalf("ExtractText: %v", err)
+	}
+	if !strings.Contains(got.Text, testCard) {
+		t.Errorf("relationship-named part was not extracted; missing %s from %q", testCard, got.Text)
+	}
+	if !strings.Contains(got.Text, testSSN) {
+		t.Errorf("conventionally-named part was not extracted; missing %s. Selecting ONLY the "+
+			"relationship target would drop bytes the old code did scan.\n  got %q", testSSN, got.Text)
+	}
+}
+
+// TestDocxDuplicateCaseVariantsExtractOnce guards against the union double-counting
+// a single part reached by two routes.
+func TestDocxDuplicateCaseVariantsExtractOnce(t *testing.T) {
+	dir := t.TempDir()
+	// The relationship and the conventional-name fallback both resolve to this one
+	// part, so its text must appear exactly once.
+	path := docxWith(t, dir, "once.docx", "word/document.xml", "")
+
+	got, err := ExtractText(path)
+	if err != nil {
+		t.Fatalf("ExtractText: %v", err)
+	}
+	if n := strings.Count(got.Text, testSSN); n != 1 {
+		t.Errorf("SSN appears %d times, want 1: the same part was extracted twice, which "+
+			"would double-report every finding in it.\n  got %q", n, got.Text)
+	}
+}
+
+// --- xlsx -------------------------------------------------------------------
+
+func xlsxParts(sheetPart, sharedPart string) []part {
+	shared := xmlDecl + `<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="2" uniqueCount="2">` +
+		`<si><t>Employee SSN ` + testSSN + `</t></si>` +
+		`<si><t>Card ` + testCard + `</t></si></sst>`
+	sheet := xmlDecl + `<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData>` +
+		`<row r="1"><c r="A1" t="s"><v>0</v></c></row>` +
+		`<row r="2"><c r="A2" t="s"><v>1</v></c></row>` +
+		`</sheetData></worksheet>`
+	workbook := xmlDecl + `<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" ` +
+		`xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+		`<sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets></workbook>`
+	wbRels := xmlDecl + `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+		`<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="/` + sheetPart + `"/>` +
+		`<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings" Target="/` + sharedPart + `"/>` +
+		`</Relationships>`
+	return []part{
+		{"_rels/.rels", pkgRels("xl/workbook.xml")},
+		{"xl/workbook.xml", workbook},
+		{"xl/_rels/workbook.xml.rels", wbRels},
+		{sharedPart, shared},
+		{sheetPart, sheet},
+	}
+}
+
+// TestXlsxPartNameVariants covers the spreadsheet half. Cell text lives in the
+// shared-strings table, so a missed sharedStrings part empties every sheet even
+// when the sheet part itself is found — two distinct ways to lose the whole body.
+func TestXlsxPartNameVariants(t *testing.T) {
+	dir := t.TempDir()
+
+	cases := []struct {
+		name       string
+		sheetPart  string
+		sharedPart string
+	}{
+		{"conventional", "xl/worksheets/sheet1.xml", "xl/sharedStrings.xml"},
+		{"capitalized_sheet", "xl/worksheets/Sheet1.xml", "xl/sharedStrings.xml"},
+		{"capitalized_sheet_dir", "xl/Worksheets/sheet1.xml", "xl/sharedStrings.xml"},
+		{"lowercased_sharedstrings", "xl/worksheets/sheet1.xml", "xl/sharedstrings.xml"},
+		{"capitalized_sharedstrings", "xl/worksheets/sheet1.xml", "xl/SharedStrings.xml"},
+		{"both_capitalized", "xl/Worksheets/Sheet1.xml", "xl/SharedStrings.xml"},
+		{"unconventional_sheet", "xl/data/grid1.xml", "xl/strings.xml"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeZip(t, dir, tc.name+".xlsx", xlsxParts(tc.sheetPart, tc.sharedPart))
+			assertBodyExtracted(t, path)
+		})
+	}
+}
+
+// TestXlsxSheetLabelDropsDirectory pins the emitted section label. The label is
+// derived from the part name and written into the same text stream the content
+// router re-parses, so leaving a capitalized directory in it ("Worksheets/sheet1"
+// instead of "sheet1") changes what downstream sees.
+func TestXlsxSheetLabelDropsDirectory(t *testing.T) {
+	dir := t.TempDir()
+	path := writeZip(t, dir, "label.xlsx", xlsxParts("xl/Worksheets/sheet1.xml", "xl/sharedStrings.xml"))
+
+	got, err := ExtractText(path)
+	if err != nil {
+		t.Fatalf("ExtractText: %v", err)
+	}
+	if !strings.Contains(got.Text, "--- sheet1 ---") {
+		t.Errorf("expected the section label %q; a case-sensitive prefix trim left the "+
+			"directory in it.\n  got %q", "--- sheet1 ---", got.Text)
+	}
+}
+
+// --- pptx -------------------------------------------------------------------
+
+func pptxParts(slidePart string) []part {
+	slide := xmlDecl + `<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" ` +
+		`xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><p:cSld><p:spTree><p:sp><p:txBody>` +
+		`<a:p><a:r><a:t>Employee SSN ` + testSSN + ` on file.</a:t></a:r></a:p>` +
+		`<a:p><a:r><a:t>Card ` + testCard + ` expires soon.</a:t></a:r></a:p>` +
+		`</p:txBody></p:sp></p:spTree></p:cSld></p:sld>`
+	pres := xmlDecl + `<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" ` +
+		`xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+		`<p:sldIdLst><p:sldId id="256" r:id="rId1"/></p:sldIdLst></p:presentation>`
+	presRels := xmlDecl + `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+		`<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="/` + slidePart + `"/>` +
+		`</Relationships>`
+	return []part{
+		{"_rels/.rels", pkgRels("ppt/presentation.xml")},
+		{"ppt/presentation.xml", pres},
+		{"ppt/_rels/presentation.xml.rels", presRels},
+		{slidePart, slide},
+	}
+}
+
+// TestPptxPartNameVariants covers the presentation half.
+func TestPptxPartNameVariants(t *testing.T) {
+	dir := t.TempDir()
+
+	cases := []struct{ name, slidePart string }{
+		{"conventional", "ppt/slides/slide1.xml"},
+		{"capitalized_slide", "ppt/slides/Slide1.xml"},
+		{"capitalized_slide_dir", "ppt/Slides/slide1.xml"},
+		{"all_caps", "PPT/SLIDES/SLIDE1.XML"},
+		{"unconventional_slide", "ppt/pages/page1.xml"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeZip(t, dir, tc.name+".pptx", pptxParts(tc.slidePart))
+			assertBodyExtracted(t, path)
+		})
+	}
+}
+
+// TestPptxNotesResolvedThroughRels keeps the notes-attachment behavior that the
+// relationship refactor inherited: notes come from the slide's own .rels, and the
+// rels part is found regardless of case.
+func TestPptxNotesResolvedThroughRels(t *testing.T) {
+	dir := t.TempDir()
+	notes := xmlDecl + `<p:notes xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" ` +
+		`xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><p:cSld><p:spTree><p:sp><p:txBody>` +
+		`<a:p><a:r><a:t>Speaker note SSN 529-11-2233</a:t></a:r></a:p></p:txBody></p:sp></p:spTree></p:cSld></p:notes>`
+	slideRels := xmlDecl + `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+		`<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/notesSlide" Target="../NotesSlides/notesSlide1.xml"/>` +
+		`</Relationships>`
+
+	parts := append(pptxParts("ppt/slides/slide1.xml"),
+		part{"ppt/slides/_Rels/slide1.xml.rels", slideRels},
+		part{"ppt/NotesSlides/notesSlide1.xml", notes},
+	)
+	path := writeZip(t, dir, "notes.pptx", parts)
+
+	got, err := ExtractText(path)
+	if err != nil {
+		t.Fatalf("ExtractText: %v", err)
+	}
+	if !strings.Contains(got.Text, "529-11-2233") {
+		t.Errorf("speaker-note text was not extracted; the slide's .rels was not resolved.\n  got %q", got.Text)
+	}
+}
+
+// --- empty extraction -------------------------------------------------------
+
+// TestEmptyExtractionIsReported pins the visibility half of the fix. A container
+// with no recognizable body part must say so, because "extracted nothing" and
+// "the document is empty" were previously the same observable outcome: Success,
+// textLen 0, exit 0.
+func TestEmptyExtractionIsReported(t *testing.T) {
+	dir := t.TempDir()
+
+	// An .xlsx carrying only a workbook with no sheet part at all.
+	workbook := xmlDecl + `<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheets/></workbook>`
+	path := writeZip(t, dir, "nobody.xlsx", []part{
+		{"_rels/.rels", pkgRels("xl/workbook.xml")},
+		{"xl/workbook.xml", workbook},
+	})
+
+	got, err := ExtractText(path)
+	if err != nil {
+		t.Fatalf("ExtractText: %v", err)
+	}
+	if got.Text != "" {
+		t.Fatalf("expected no extracted text, got %q", got.Text)
+	}
+	if got.BodyParts != 0 {
+		t.Errorf("BodyParts = %d, want 0", got.BodyParts)
+	}
+	if got.ExtractionWarning == "" {
+		t.Fatal("a container with no document body part produced no ExtractionWarning, so a " +
+			"file whose body was skipped is indistinguishable from a genuinely empty one and " +
+			"the scan reports it clean")
+	}
+	if !strings.Contains(got.ExtractionWarning, "NOT scanned") {
+		t.Errorf("warning does not say the content went unscanned: %q", got.ExtractionWarning)
+	}
+}
+
+// TestEmptyDocumentIsAlsoReported covers the other zero-text shape: the body part
+// EXISTS and is genuinely empty. It still warns — a scan that examined no text is
+// worth surfacing either way — but the reason distinguishes the two, so an
+// operator can tell a naming problem from an empty file.
+func TestEmptyDocumentIsAlsoReported(t *testing.T) {
+	dir := t.TempDir()
+	empty := xmlDecl + `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body/></w:document>`
+	path := writeZip(t, dir, "empty.docx", []part{
+		{"_rels/.rels", pkgRels("word/document.xml")},
+		{"word/document.xml", empty},
+	})
+
+	got, err := ExtractText(path)
+	if err != nil {
+		t.Fatalf("ExtractText: %v", err)
+	}
+	if got.BodyParts != 1 {
+		t.Errorf("BodyParts = %d, want 1 (the part exists, it is just empty)", got.BodyParts)
+	}
+	if got.ExtractionWarning == "" {
+		t.Fatal("an empty document produced no warning")
+	}
+	if strings.Contains(got.ExtractionWarning, "no document body part was found") {
+		t.Errorf("an EXISTING but empty body part was reported as a missing part, which "+
+			"points the operator at the wrong problem: %q", got.ExtractionWarning)
+	}
+}
+
+// TestNonEmptyExtractionHasNoWarning is the false-positive guard: an ordinary
+// document must not carry a warning, or the signal is noise and gets ignored.
+func TestNonEmptyExtractionHasNoWarning(t *testing.T) {
+	dir := t.TempDir()
+	path := docxWith(t, dir, "normal.docx", "word/document.xml", "")
+
+	got, err := ExtractText(path)
+	if err != nil {
+		t.Fatalf("ExtractText: %v", err)
+	}
+	if got.ExtractionWarning != "" {
+		t.Errorf("ordinary document carries a warning: %q", got.ExtractionWarning)
+	}
+}
+
+// --- relationship-target resolution ----------------------------------------
+
+// TestResolveTarget pins the relative-target rules, including the "../" form real
+// slide rels use and the package-absolute form.
+func TestResolveTarget(t *testing.T) {
+	cases := []struct{ owner, target, want string }{
+		{"", "word/document.xml", "word/document.xml"},
+		{"", "/word/document.xml", "word/document.xml"},
+		{"xl/workbook.xml", "worksheets/sheet1.xml", "xl/worksheets/sheet1.xml"},
+		{"xl/workbook.xml", "/xl/worksheets/sheet1.xml", "xl/worksheets/sheet1.xml"},
+		{"ppt/slides/slide1.xml", "../notesSlides/notesSlide1.xml", "ppt/notesSlides/notesSlide1.xml"},
+		{"ppt/slides/slide1.xml", "slide2.xml", "ppt/slides/slide2.xml"},
+		{"word/document.xml", "", ""},
+	}
+	for _, tc := range cases {
+		if got := resolveTarget(tc.owner, tc.target); got != tc.want {
+			t.Errorf("resolveTarget(%q, %q) = %q, want %q", tc.owner, tc.target, got, tc.want)
+		}
+	}
+}
+
+// TestRelsPartFor pins where a part's relationships live.
+func TestRelsPartFor(t *testing.T) {
+	cases := []struct{ owner, want string }{
+		{"", "_rels/.rels"},
+		{"xl/workbook.xml", "xl/_rels/workbook.xml.rels"},
+		{"ppt/slides/slide1.xml", "ppt/slides/_rels/slide1.xml.rels"},
+		{"word/document.xml", "word/_rels/document.xml.rels"},
+	}
+	for _, tc := range cases {
+		if got := relsPartFor(tc.owner); got != tc.want {
+			t.Errorf("relsPartFor(%q) = %q, want %q", tc.owner, got, tc.want)
+		}
+	}
+}
+
+// TestExternalRelationshipTargetIgnored keeps an external target (a URL) from
+// being treated as a package part.
+func TestExternalRelationshipTargetIgnored(t *testing.T) {
+	dir := t.TempDir()
+	rels := xmlDecl + `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+		`<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" ` +
+		`Target="https://example.com/document.xml" TargetMode="External"/>` +
+		`</Relationships>`
+	path := writeZip(t, dir, "external.docx", []part{
+		{"_rels/.rels", rels},
+		{"word/document.xml", docBody()},
+	})
+
+	// The conventional-name fallback still finds the real body.
+	assertBodyExtracted(t, path)
+}

--- a/internal/preprocessors/text_preprocessor.go
+++ b/internal/preprocessors/text_preprocessor.go
@@ -153,6 +153,15 @@ func (tp *TextPreprocessor) processPDF(filePath string, content *ProcessedConten
 func (tp *TextPreprocessor) processOffice(filePath string, content *ProcessedContent) (*ProcessedContent, error) {
 	officeContent, err := textextractofficetextlib.ExtractText(filePath)
 	if err != nil {
+		// Carry the extractor's note across the error return. The most consequential
+		// empty-extraction case — the archive has no recognizable document body part —
+		// is BOTH an error and a warning, and the warning is the half that reaches the
+		// user. Returning before copying it meant a .docx whose body was never found
+		// reported metadata-only findings at exit 0 with nothing said about the missing
+		// body.
+		if officeContent != nil {
+			content.ExtractionWarning = officeContent.ExtractionWarning
+		}
 		content.Error = fmt.Errorf("failed to extract text from Office document: %w", err)
 		return content, content.Error
 	}
@@ -165,6 +174,7 @@ func (tp *TextPreprocessor) processOffice(filePath string, content *ProcessedCon
 	content.CharCount = officeContent.CharCount
 	content.LineCount = officeContent.LineCount
 	content.Paragraphs = officeContent.Paragraphs
+	content.ExtractionWarning = officeContent.ExtractionWarning
 	content.Success = true
 
 	// Enable position tracking for Office documents

--- a/internal/redactors/office/part_name_case_test.go
+++ b/internal/redactors/office/part_name_case_test.go
@@ -1,0 +1,78 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package office
+
+import "testing"
+
+// The redactor's part selection has to agree with the extractor's.
+//
+// The extractor finds the text and the redactor rewrites it, so a part that only one of
+// them recognizes produces the worst possible outcome: a finding is reported, the user
+// is handed a file that looks redacted, and the value is still in it. Measured on a
+// .docx whose body part was named word/Document.xml — 4 findings detected, and both the
+// SSN and the card survived --enable-redaction in cleartext inside the rewritten
+// archive, because this predicate matched the entry name case-sensitively.
+//
+// A zip entry name is producer-controlled data and nothing makes the conventional
+// spelling normative, so matching is case-insensitive.
+
+func TestIsTextContainingFileIgnoresPartNameCase(t *testing.T) {
+	or := &OfficeRedactor{}
+
+	cases := []struct {
+		name    string
+		file    string
+		docType OfficeDocumentType
+		want    bool
+	}{
+		// Word: the conventional name, and the variants that used to be missed.
+		{"docx conventional", "word/document.xml", DocumentTypeDOCX, true},
+		{"docx capital D", "word/Document.xml", DocumentTypeDOCX, true},
+		{"docx all caps", "WORD/DOCUMENT.XML", DocumentTypeDOCX, true},
+		{"docx capital ext", "word/document.XML", DocumentTypeDOCX, true},
+		{"docx named main", "word/main.xml", DocumentTypeDOCX, true},
+		{"docx header", "word/header1.xml", DocumentTypeDOCX, true},
+		{"docx Header caps", "word/Header1.xml", DocumentTypeDOCX, true},
+		{"docx comments", "word/comments.xml", DocumentTypeDOCX, true},
+
+		// Word negatives: still not everything under word/ is prose.
+		{"docx styles", "word/styles.xml", DocumentTypeDOCX, false},
+		{"docx settings", "word/settings.xml", DocumentTypeDOCX, false},
+		{"docx rels", "word/_rels/document.xml.rels", DocumentTypeDOCX, false},
+		{"docx not xml", "word/document.bin", DocumentTypeDOCX, false},
+
+		// Excel.
+		{"xlsx sheet", "xl/worksheets/sheet1.xml", DocumentTypeXLSX, true},
+		{"xlsx Sheet caps", "xl/Worksheets/Sheet1.xml", DocumentTypeXLSX, true},
+		{"xlsx shared strings", "xl/sharedStrings.xml", DocumentTypeXLSX, true},
+		{"xlsx shared strings lower", "xl/sharedstrings.xml", DocumentTypeXLSX, true},
+		{"xlsx workbook is not text", "xl/workbook.xml", DocumentTypeXLSX, false},
+
+		// PowerPoint.
+		{"pptx slide", "ppt/slides/slide1.xml", DocumentTypePPTX, true},
+		{"pptx Slide caps", "ppt/Slides/Slide1.xml", DocumentTypePPTX, true},
+		{"pptx layout", "ppt/slideLayouts/slideLayout1.xml", DocumentTypePPTX, true},
+		{"pptx master", "ppt/slideMasters/slideMaster1.xml", DocumentTypePPTX, true},
+		{"pptx presentation is not a slide", "ppt/presentation.xml", DocumentTypePPTX, false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := or.isTextContainingFile(tc.file, tc.docType)
+			if got != tc.want {
+				verb := "was not selected for redaction"
+				why := "\nA part the extractor reads but the redactor skips yields a finding that " +
+					"cannot be redacted: the user gets a file that looks sanitized with the value " +
+					"still inside it."
+				if !tc.want {
+					verb = "was selected for redaction but should not be"
+					why = ""
+				}
+				t.Errorf("isTextContainingFile(%q, %v) = %v, want %v — %s%s",
+					tc.file, tc.docType, got, tc.want, verb, why)
+			}
+		})
+	}
+}

--- a/internal/redactors/office/redactor.go
+++ b/internal/redactors/office/redactor.go
@@ -373,26 +373,48 @@ func (or *OfficeRedactor) extractOfficeContent(filePath string, docType OfficeDo
 	return zipContents, extractedText.String(), textPositions, nil
 }
 
-// isTextContainingFile determines if a ZIP file contains text content based on document type
+// isTextContainingFile determines if a ZIP file contains text content based on document type.
+//
+// Matching is case-INSENSITIVE because a zip entry name is producer-controlled data and
+// nothing makes the conventional spelling normative. This mirrors the extractor's part
+// selection, and it has to: the extractor finds the text, the redactor rewrites it, and
+// if only one of them recognizes a part then the tool reports a finding it cannot
+// redact. Measured before this change, on a .docx whose body part was named
+// word/Document.xml: the SSN and card were detected (4 findings) yet both survived
+// --enable-redaction in cleartext inside the rewritten file, because this predicate's
+// strings.Contains(fileName, "document") is case-sensitive and never matched. A
+// reported-but-unredacted value is the same leak as an undetected one, dressed as a
+// success.
 func (or *OfficeRedactor) isTextContainingFile(fileName string, docType OfficeDocumentType) bool {
+	name := strings.ToLower(fileName)
+	if !strings.HasSuffix(name, ".xml") {
+		return false
+	}
+
 	switch docType {
 	case DocumentTypeDOCX:
-		// Word documents: main document, headers, footers, footnotes, etc.
-		return strings.HasPrefix(fileName, "word/") && strings.HasSuffix(fileName, ".xml") &&
-			(strings.Contains(fileName, "document") || strings.Contains(fileName, "header") ||
-				strings.Contains(fileName, "footer") || strings.Contains(fileName, "footnote") ||
-				strings.Contains(fileName, "endnote") || strings.Contains(fileName, "comment"))
+		// Word: the main document plus the parts that carry user-visible prose.
+		// "main" is included alongside "document" because a producer may name the
+		// body part word/main.xml; the extractor accepts it, so the redactor must.
+		if !strings.HasPrefix(name, "word/") {
+			return false
+		}
+		for _, part := range []string{"document", "main", "header", "footer", "footnote", "endnote", "comment"} {
+			if strings.Contains(name, part) {
+				return true
+			}
+		}
+		return false
 
 	case DocumentTypeXLSX:
-		// Excel documents: worksheets and shared strings
-		return (strings.HasPrefix(fileName, "xl/worksheets/") && strings.HasSuffix(fileName, ".xml")) ||
-			fileName == "xl/sharedStrings.xml"
+		// Excel: worksheets and the shared string table.
+		return strings.HasPrefix(name, "xl/worksheets/") || name == "xl/sharedstrings.xml"
 
 	case DocumentTypePPTX:
-		// PowerPoint documents: slides, slide layouts, slide masters
-		return (strings.HasPrefix(fileName, "ppt/slides/") && strings.HasSuffix(fileName, ".xml")) ||
-			(strings.HasPrefix(fileName, "ppt/slideLayouts/") && strings.HasSuffix(fileName, ".xml")) ||
-			(strings.HasPrefix(fileName, "ppt/slideMasters/") && strings.HasSuffix(fileName, ".xml"))
+		// PowerPoint: slides, layouts, masters.
+		return strings.HasPrefix(name, "ppt/slides/") ||
+			strings.HasPrefix(name, "ppt/slidelayouts/") ||
+			strings.HasPrefix(name, "ppt/slidemasters/")
 
 	default:
 		return false

--- a/internal/router/content_router.go
+++ b/internal/router/content_router.go
@@ -27,21 +27,26 @@ type RoutedContent struct {
 	// FullText is every byte the preprocessors extracted, captured BEFORE any
 	// routing decision is made.
 	//
-	// It exists because routing is decided by inspecting the extracted text itself
-	// — section headers of the form "--- name ---" — and document authors control
-	// that text. DocumentBody is therefore an attacker-influenced SUBSET, while the
-	// document validator set is the larger of the two (the metadata path runs a
-	// single field-name scanner that has no SSN, card, phone or email logic). So
-	// whenever the split moved content from the document path to the metadata path,
-	// it moved it from ~19 validators to 1 that cannot detect it, and the finding
-	// vanished. Since only reported findings reach the redactor, a vanished finding
-	// is a value left in cleartext.
+	// It is the SECOND of two independent controls, and it is deliberately kept now
+	// that structure is declared out of band rather than parsed out of the text.
+	// The first control removes the capability: routing reads
+	// ProcessedContent.Sections, built from our own preprocessor names, so a
+	// document author can no longer forge a section boundary. This one contains the
+	// consequence if the first is ever wrong — a bug in a producer, a preprocessor
+	// that populates Sections incorrectly, a caller that declares nothing.
 	//
-	// Keeping the pre-routing text lets the document path scan the union, which
-	// makes routing a LABELLING decision rather than a COVERAGE decision: a forged
-	// or merely unlucky section header can still change how a finding is described,
-	// but it can no longer delete one. That property holds for section names nobody
-	// has thought of yet, which a per-marker fix would not.
+	// It matters because the two paths do not run the same validators. The document
+	// path runs the full set; the metadata path runs a single field-name scanner
+	// with no SSN, card, phone or email logic. So any split that moves content from
+	// the document path to the metadata path moves it from ~19 validators to 1 that
+	// cannot detect it, and the finding does not get relabelled, it vanishes. Since
+	// only reported findings reach the redactor, a vanished finding is a value left
+	// in cleartext.
+	//
+	// Letting the document path scan the union makes routing a LABELLING decision
+	// rather than a COVERAGE decision, for section names nobody has thought of yet.
+	// Do not "simplify" this away on the grounds that the declared sections are now
+	// trustworthy: defence in depth is the point.
 	FullText string
 }
 
@@ -65,7 +70,14 @@ func (e *ContentRouterError) Error() string {
 	return fmt.Sprintf("content router %s failed for %s: %v", e.Operation, e.FilePath, e.Cause)
 }
 
-// Preprocessor type constants for identification
+// Preprocessor type constants. These are the keys the METADATA validator's
+// per-preprocessor rule table is indexed by, so a MetadataContent must carry one
+// of them or the wrong sensitive-field list is applied.
+//
+// "mixed_content" used to live here too. It was a category the deleted
+// text-sniffing classifier returned when it found metadata-looking markers in the
+// document text; nothing keys a rule set off it, and with structure now declared
+// out of band there is no way to reach it.
 const (
 	PreprocessorTypeImageMetadata    = "image_metadata"
 	PreprocessorTypeDocumentMetadata = "document_metadata"
@@ -74,7 +86,6 @@ const (
 	PreprocessorTypeVideoMetadata    = "video_metadata"
 	PreprocessorTypePlainText        = "plain_text"
 	PreprocessorTypeDocumentText     = "document_text"
-	PreprocessorTypeMixedContent     = "mixed_content"
 )
 
 // NewContentRouter creates a new content router
@@ -162,650 +173,164 @@ func (cr *ContentRouter) RouteContent(processedContent *preprocessors.ProcessedC
 		return routedContent, nil
 	}
 
-	// Determine preprocessor type and route accordingly
-	preprocessorType := cr.identifyPreprocessorType(processedContent)
-
-	switch preprocessorType {
-	case PreprocessorTypeImageMetadata, PreprocessorTypeDocumentMetadata, PreprocessorTypeOfficeMetadata,
-		PreprocessorTypeAudioMetadata, PreprocessorTypeVideoMetadata:
-		// This is metadata content - extract and route to metadata validator
-		metadataContent, err := cr.extractMetadataContent(processedContent, preprocessorType)
-		if err != nil {
-			// Graceful degradation - log error but continue
-			if cr.observer != nil {
-				cr.observer.LogOperation(observability.StandardObservabilityData{
-					Component: "content_router",
-					Operation: "extract_metadata",
-					FilePath:  processedContent.OriginalPath,
-					Success:   false,
-					Error:     err.Error(),
-				})
-			}
-		} else {
-			routedContent.Metadata = append(routedContent.Metadata, *metadataContent)
-		}
-
-		// The metadata text is ALSO the document body, so the text validators see it.
+	// Route from the OUT-OF-BAND structure when the producer declared one.
+	//
+	// This is the whole point of the change. The router previously recovered the
+	// structure by scanning processedContent.Text for "--- name ---" lines — and a
+	// document author types the text, so the author decided where the sections
+	// were. A paragraph reading "--- office_metadata ---" moved everything after it
+	// onto the metadata path, which runs ONE field-name scanner instead of the full
+	// validator set, so the finding was not relabelled but deleted. In-band
+	// signalling, same class as SQL injection, same answer: carry the structure
+	// beside the data instead of re-deriving it from the data.
+	//
+	// ProcessedContent.Sections is built by the file router in the same loop that
+	// builds the concatenation, from each Preprocessor's GetName(). That name is
+	// our own code's constant, never a byte of the scanned file, so a boundary here
+	// cannot be forged.
+	if len(processedContent.Sections) > 0 {
+		routedContent.DocumentBody, routedContent.Metadata = cr.routeSections(processedContent)
+	} else {
+		// FAIL CLOSED. No declared structure means we do not guess one from the
+		// text — the whole extraction is document body, which is the safe
+		// direction: the document path runs every validator, so the worst case is
+		// a missing metadata LABEL, never missing coverage. (Reversing it would
+		// hand the whole file to the single-field-name metadata scanner.)
 		//
-		// This used to be set to "", and dual_path_bridge.go gates the entire
-		// document path on `DocumentBody != ""` — so for a file whose only text is
-		// its metadata, exactly 1 of the 19 validators ran: METADATA. That is the
-		// routing outcome for every media type (.jpg/.png/.gif/.tiff/.webp,
-		// .wav/.mp3/.flac/.m4a, .mp4/.mov), because only one preprocessor is capable
-		// for those extensions, so ProcessorType has no "+" and lands in this arm.
-		// (.pdf/.docx/.xlsx are unaffected: two preprocessors are capable, so they
-		// route through "combined_preprocessors", which keeps a body.)
-		//
-		// The METADATA validator cannot cover for that. It is a field-NAME allowlist
-		// scanner: validateWithPreprocessorRules skips any line whose key is not in
-		// the per-preprocessor SensitiveFields list, and for a line that does match
-		// it emits ONE coarse type for the whole field value. So an SSN, a PAN or an
-		// AWS key sitting inside a metadata value is either skipped outright or
-		// reported as a single AUTHOR_INFO/DOCUMENT_COMMENTS row — never typed, and
-		// never individually redactable.
-		//
-		// Measured: an EXIF ImageDescription carrying an SSN, an email and a phone
-		// number produced ZERO findings at any confidence, and because there were no
-		// findings the redaction pipeline wrote no output file at all — the tool
-		// affirmatively reported the file clean while the PII sat in it. The
-		// byte-identical text saved as .txt yielded SSN 83 / PHONE 47 / EMAIL 33.
-		//
-		// This is also what the golden corpus was locking in: the file_wav_metadata_pii
-		// case declares Checks EMAIL, PHONE and SECRETS, and its committed snapshot
-		// contained none of them — an AKIA-prefixed access key went undetected inside
-		// a DOCUMENT_COMMENTS blob.
+		// ProcessorType is still consulted, and that is not a hole: it is
+		// strings.Join of the preprocessors' GetName() values, i.e. our own
+		// constants, not document content. It is the one trustworthy classifier
+		// available to a caller that builds ProcessedContent by hand (the pkg and
+		// ScanContent entry points, and older callers) rather than through the file
+		// router.
 		routedContent.DocumentBody = processedContent.Text
 
-	case PreprocessorTypePlainText, PreprocessorTypeDocumentText:
-		// This is document body content - route to document validators
-		routedContent.DocumentBody = processedContent.Text
-
-	case "combined_preprocessors":
-		// This is combined output from multiple preprocessors - separate them
-		documentBody, metadataItems, err := cr.separateMixedContent(processedContent)
-		if err != nil {
-			// Graceful degradation - treat as document body content
-			if cr.observer != nil {
-				cr.observer.LogOperation(observability.StandardObservabilityData{
-					Component: "content_router",
-					Operation: "separate_combined_preprocessors",
-					FilePath:  processedContent.OriginalPath,
-					Success:   false,
-					Error:     err.Error(),
-				})
-			}
-			routedContent.DocumentBody = processedContent.Text
-		} else {
-			routedContent.DocumentBody = documentBody
-			routedContent.Metadata = metadataItems
-		}
-
-	default:
-		// Mixed content or unknown type - attempt to separate
-		documentBody, metadataItems, err := cr.separateMixedContent(processedContent)
-		if err != nil {
-			// Graceful degradation - treat as document body content
-			if cr.observer != nil {
-				cr.observer.LogOperation(observability.StandardObservabilityData{
-					Component: "content_router",
-					Operation: "separate_mixed_content",
-					FilePath:  processedContent.OriginalPath,
-					Success:   false,
-					Error:     err.Error(),
-				})
-			}
-			routedContent.DocumentBody = processedContent.Text
-		} else {
-			routedContent.DocumentBody = documentBody
-			routedContent.Metadata = metadataItems
+		// A single metadata preprocessor's output is metadata as a whole, so it can
+		// still be labelled without inspecting the text. DocumentBody above already
+		// carries the same bytes to the document path: for a media file that is the
+		// only thing that detects an SSN inside an EXIF field, because the METADATA
+		// validator is a field-NAME allowlist that reports one coarse type per
+		// matching line and never an SSN, a PAN or a key inside the value.
+		if metaType := metadataTypeForProcessorType(processedContent.ProcessorType); metaType != "" &&
+			strings.TrimSpace(processedContent.Text) != "" {
+			routedContent.Metadata = append(routedContent.Metadata, MetadataContent{
+				Content:          processedContent.Text,
+				PreprocessorType: metaType,
+				PreprocessorName: cr.getPreprocessorName(metaType),
+				SourceFile:       processedContent.OriginalPath,
+				Metadata: map[string]interface{}{
+					"processor_type": processedContent.ProcessorType,
+					"format":         processedContent.Format,
+					"success":        processedContent.Success,
+					"declared":       false,
+				},
+			})
 		}
 	}
 
 	if finishTiming != nil {
+		// processor_type is the preprocessors' own joined GetName() string now,
+		// rather than a category inferred by sniffing the document text. The
+		// sniffing classifier is gone: it was the read half of the in-band
+		// signalling, and reporting a label derived from attacker-supplied text
+		// would have kept a use for it alive.
 		finishTiming(true, map[string]interface{}{
-			"preprocessor_type":    preprocessorType,
+			"processor_type":       processedContent.ProcessorType,
 			"document_body_length": len(routedContent.DocumentBody),
 			"metadata_items":       len(routedContent.Metadata),
+			"declared_sections":    len(processedContent.Sections),
 		})
 	}
 
 	return routedContent, nil
 }
 
-// identifyPreprocessorType determines the type of preprocessor that generated the content
-func (cr *ContentRouter) identifyPreprocessorType(processedContent *preprocessors.ProcessedContent) string {
-	// Check ProcessorType field first
-	if processedContent.ProcessorType != "" {
-		// Handle combined processor types (e.g., "pdf_metadata+text")
-		if strings.Contains(processedContent.ProcessorType, "+") {
-			return "combined_preprocessors"
-		}
+// routeSections turns the producer-declared sections into the routed body and
+// metadata items. It reads only ContentSection fields — never the section text —
+// so nothing in the scanned document influences the split.
+func (cr *ContentRouter) routeSections(processedContent *preprocessors.ProcessedContent) (string, []MetadataContent) {
+	var bodySections []string
+	metadataItems := make([]MetadataContent, 0, len(processedContent.Sections))
 
-		switch strings.ToLower(processedContent.ProcessorType) {
-		case "image_metadata", "image-metadata", "imagemetadata":
-			return PreprocessorTypeImageMetadata
-		case "document_metadata", "document-metadata", "documentmetadata":
-			return PreprocessorTypeDocumentMetadata
-		case "pdf_metadata", "pdf-metadata", "pdfmetadata":
-			return PreprocessorTypeDocumentMetadata
-		case "office_metadata", "office-metadata", "officemetadata":
-			return PreprocessorTypeOfficeMetadata
-		case "audio_metadata", "audio-metadata", "audiometadata":
-			return PreprocessorTypeAudioMetadata
-		case "video_metadata", "video-metadata", "videometadata":
-			return PreprocessorTypeVideoMetadata
-		case "plain_text", "plain-text", "plaintext":
-			return PreprocessorTypePlainText
-		case "document_text", "document-text", "documenttext":
-			return PreprocessorTypeDocumentText
-		case "mixed":
-			return PreprocessorTypeMixedContent
-		}
-	}
-
-	// Analyze content patterns to identify type
-	content := processedContent.Text
-	if content == "" {
-		return PreprocessorTypePlainText
-	}
-
-	// Check for metadata section markers
-	if cr.containsMetadataSections(content) {
-		return PreprocessorTypeMixedContent
-	}
-
-	// Check for specific metadata patterns
-	if cr.containsImageMetadataPatterns(content) {
-		return PreprocessorTypeImageMetadata
-	}
-
-	if cr.containsAudioMetadataPatterns(content) {
-		return PreprocessorTypeAudioMetadata
-	}
-
-	if cr.containsVideoMetadataPatterns(content) {
-		return PreprocessorTypeVideoMetadata
-	}
-
-	if cr.containsDocumentMetadataPatterns(content) {
-		return PreprocessorTypeDocumentMetadata
-	}
-
-	// Default to plain text if no specific patterns found
-	return PreprocessorTypePlainText
-}
-
-// extractMetadataContent creates a MetadataContent struct from processed content
-func (cr *ContentRouter) extractMetadataContent(processedContent *preprocessors.ProcessedContent, preprocessorType string) (*MetadataContent, error) {
-	if processedContent.Text == "" {
-		return nil, fmt.Errorf("no content to extract")
-	}
-
-	// Create human-readable preprocessor name
-	preprocessorName := cr.getPreprocessorName(preprocessorType)
-
-	metadataContent := &MetadataContent{
-		Content:          processedContent.Text,
-		PreprocessorType: preprocessorType,
-		PreprocessorName: preprocessorName,
-		SourceFile:       processedContent.OriginalPath,
-		Metadata: map[string]interface{}{
-			"processor_type": processedContent.ProcessorType,
-			"format":         processedContent.Format,
-			"success":        processedContent.Success,
-		},
-	}
-
-	// Add additional metadata if available
-	if processedContent.Metadata != nil {
-		for key, value := range processedContent.Metadata {
-			metadataContent.Metadata[key] = value
-		}
-	}
-
-	return metadataContent, nil
-}
-
-// separateMixedContent separates mixed content into document body and metadata sections
-func (cr *ContentRouter) separateMixedContent(processedContent *preprocessors.ProcessedContent) (string, []MetadataContent, error) {
-	content := processedContent.Text
-
-	// First, check if this is combined preprocessor output from file router
-	if cr.isCombinedPreprocessorOutput(processedContent) {
-		return cr.separateCombinedPreprocessorOutput(processedContent)
-	}
-
-	var documentBody strings.Builder
-	var metadataItems []MetadataContent
-
-	// Split content by lines for processing
-	lines := strings.Split(content, "\n")
-	currentSection := ""
-	var currentMetadataLines []string
-	inMetadataSection := false
-
-	for _, line := range lines {
-		// Check for metadata section markers
-		if metadataSection := cr.detectMetadataSection(line); metadataSection != "" {
-			// Save previous section if it was metadata
-			if inMetadataSection && currentSection != "" && len(currentMetadataLines) > 0 {
-				// Extract embedded media path from the first line of the previous section
-				sourceFile := processedContent.OriginalPath
-				if len(currentMetadataLines) > 0 {
-					sourceFile = cr.extractEmbeddedMediaPath(currentMetadataLines[0], processedContent.OriginalPath)
-				}
-				metadataContent := cr.createMetadataFromLines(currentMetadataLines, currentSection, sourceFile)
-				if metadataContent != nil {
-					metadataItems = append(metadataItems, *metadataContent)
-				}
-			}
-
-			// Start new metadata section
-			currentSection = metadataSection
-			currentMetadataLines = []string{line}
-			inMetadataSection = true
+	for _, section := range processedContent.Sections {
+		if section.Kind != preprocessors.SectionKindMetadata {
+			bodySections = append(bodySections, section.Text)
 			continue
 		}
 
-		// Determine if this line should be added to document body or metadata
-		addToDocumentBody := false
-
-		if inMetadataSection {
-			// Check if this line ends the metadata section BEFORE adding it to metadata
-			isEndMarker := cr.isMetadataSectionEnd(line)
-			if isEndMarker {
-				// End the current metadata section
-				sourceFile := processedContent.OriginalPath
-				if len(currentMetadataLines) > 0 {
-					sourceFile = cr.extractEmbeddedMediaPath(currentMetadataLines[0], processedContent.OriginalPath)
-				}
-				metadataContent := cr.createMetadataFromLines(currentMetadataLines, currentSection, sourceFile)
-				if metadataContent != nil {
-					metadataItems = append(metadataItems, *metadataContent)
-				}
-				inMetadataSection = false
-				currentSection = ""
-				currentMetadataLines = nil
-				addToDocumentBody = true
-			} else {
-				// Continue collecting metadata lines
-				currentMetadataLines = append(currentMetadataLines, line)
-			}
-		} else {
-			// This is document body content
-			addToDocumentBody = true
-		}
-
-		// Add line to document body if determined above
-		if addToDocumentBody {
-			documentBody.WriteString(line)
-			documentBody.WriteString("\n")
-		}
-	}
-
-	// Handle any remaining metadata section
-	if inMetadataSection && currentSection != "" && len(currentMetadataLines) > 0 {
-		// Check if the last few lines should be treated as document content
-		var finalMetadataLines []string
-		var documentLines []string
-
-		// Go through the metadata lines from the end and check if they should be document content
-		for i := len(currentMetadataLines) - 1; i >= 0; i-- {
-			line := currentMetadataLines[i]
-			if cr.isMetadataSectionEnd(line) {
-				// This line and all following lines should be document content
-				documentLines = append([]string{line}, documentLines...)
-			} else {
-				// This line and all previous lines are metadata
-				finalMetadataLines = currentMetadataLines[:i+1]
-				break
-			}
-		}
-
-		// If we found document lines at the end, add them to document body
-		if len(documentLines) > 0 {
-			for _, line := range documentLines {
-				documentBody.WriteString(line)
-				documentBody.WriteString("\n")
-			}
-		}
-
-		// Save the remaining metadata if any
-		if len(finalMetadataLines) > 0 {
-			sourceFile := processedContent.OriginalPath
-			if len(finalMetadataLines) > 0 {
-				sourceFile = cr.extractEmbeddedMediaPath(finalMetadataLines[0], processedContent.OriginalPath)
-			}
-			metadataContent := cr.createMetadataFromLines(finalMetadataLines, currentSection, sourceFile)
-			if metadataContent != nil {
-				metadataItems = append(metadataItems, *metadataContent)
-			}
-		} else if len(documentLines) == 0 {
-			// No document lines found, save all as metadata (original behavior)
-			sourceFile := processedContent.OriginalPath
-			if len(currentMetadataLines) > 0 {
-				sourceFile = cr.extractEmbeddedMediaPath(currentMetadataLines[0], processedContent.OriginalPath)
-			}
-			metadataContent := cr.createMetadataFromLines(currentMetadataLines, currentSection, sourceFile)
-			if metadataContent != nil {
-				metadataItems = append(metadataItems, *metadataContent)
-			}
-		}
-	}
-
-	// Post-process metadata items to move obvious document content to document body
-	var finalMetadataItems []MetadataContent
-	for _, item := range metadataItems {
-		cleanedContent, documentContent := cr.cleanMetadataContent(item.Content)
-		if cleanedContent != "" {
-			// Create new metadata item with cleaned content
-			cleanedItem := item
-			cleanedItem.Content = cleanedContent
-			finalMetadataItems = append(finalMetadataItems, cleanedItem)
-		}
-		if documentContent != "" {
-			// Add document content to document body
-			if documentBody.Len() > 0 {
-				documentBody.WriteString("\n\n") // Add extra newline to preserve spacing
-			}
-			documentBody.WriteString(documentContent)
-		}
-	}
-
-	return strings.TrimSpace(documentBody.String()), finalMetadataItems, nil
-}
-
-// cleanMetadataContent separates metadata content from document content
-func (cr *ContentRouter) cleanMetadataContent(content string) (string, string) {
-	lines := strings.Split(content, "\n")
-	var metadataLines []string
-	var documentLines []string
-
-	// Find the last metadata line by going backwards
-	lastMetadataIndex := -1
-	for i := len(lines) - 1; i >= 0; i-- {
-		line := lines[i]
-		lineTrimmed := strings.TrimSpace(line)
-
-		// Skip empty lines at the end
-		if lineTrimmed == "" {
+		// Skip a section with nothing in it rather than emitting an empty
+		// metadata item, matching what the previous path did.
+		if strings.TrimSpace(section.Text) == "" {
 			continue
 		}
 
-		// If this line looks like document content, everything from here to the end is document content
-		if !strings.HasPrefix(lineTrimmed, "---") && cr.isMetadataSectionEnd(line) {
-			// This line and all following lines are document content
-			documentLines = lines[i:]
-			lastMetadataIndex = i - 1
-			break
+		metaType := section.Type
+		if metaType == "" {
+			metaType = PreprocessorTypeDocumentMetadata
 		}
+		sourceFile := section.SourceFile
+		if sourceFile == "" {
+			sourceFile = processedContent.OriginalPath
+		}
+
+		metadataItems = append(metadataItems, MetadataContent{
+			Content:          section.Text,
+			PreprocessorType: metaType,
+			PreprocessorName: cr.getPreprocessorName(metaType),
+			SourceFile:       sourceFile,
+			Metadata: map[string]interface{}{
+				"processor_type": processedContent.ProcessorType,
+				"format":         processedContent.Format,
+				"success":        processedContent.Success,
+				"declared":       true,
+				"section_name":   section.Name,
+				"section_line":   section.LineOffset,
+			},
+		})
 	}
 
-	// If we found document content, separate it
-	if lastMetadataIndex >= 0 {
-		metadataLines = lines[:lastMetadataIndex+1]
-	} else {
-		// No document content found, all lines are metadata
-		metadataLines = lines
+	// Join body sections with a blank line, mirroring the "\n\n" the file router
+	// puts between concatenated preprocessor outputs. Without a separator the last
+	// line of one section and the first of the next would land on a single logical
+	// line, fusing two adjacent values or splitting one, and every line-based
+	// validator would see the wrong line at each seam.
+	documentBody := strings.Join(bodySections, "\n\n")
+
+	// No body section at all (a pure-metadata file: every media type has exactly
+	// one capable preprocessor, and it is a metadata one). Hand the metadata text
+	// to the document path as well, because dual_path_bridge gates that path on
+	// having text to scan, and the METADATA validator alone reports nothing for an
+	// SSN or a card number sitting inside a metadata VALUE.
+	if documentBody == "" {
+		documentBody = processedContent.Text
 	}
 
-	metadataContent := strings.TrimSpace(strings.Join(metadataLines, "\n"))
-	documentContent := strings.TrimSpace(strings.Join(documentLines, "\n"))
-
-	return metadataContent, documentContent
+	return documentBody, metadataItems
 }
 
-// Helper methods for content analysis
-
-// containsMetadataSections checks if content contains metadata section markers
-func (cr *ContentRouter) containsMetadataSections(content string) bool {
-	metadataMarkers := []string{
-		"--- image_metadata ---",
-		"--- document_metadata ---",
-		"--- audio_metadata ---",
-		"--- video_metadata ---",
-		"--- Embedded Media",
-		"=== METADATA ===",
-		"=== IMAGE METADATA ===",
-		"=== DOCUMENT METADATA ===",
-	}
-
-	contentLower := strings.ToLower(content)
-	for _, marker := range metadataMarkers {
-		if strings.Contains(contentLower, strings.ToLower(marker)) {
-			return true
-		}
-	}
-	return false
-}
-
-// containsImageMetadataPatterns checks for image-specific metadata patterns
-func (cr *ContentRouter) containsImageMetadataPatterns(content string) bool {
-	imagePatterns := []string{
-		"gpslatitude", "gpslongitude", "gpsaltitude",
-		"camera_make", "camera_model", "exif",
-		"image_width", "image_height", "orientation",
-		"flash", "focal_length", "iso_speed",
-	}
-
-	contentLower := strings.ToLower(content)
-	patternCount := 0
-	for _, pattern := range imagePatterns {
-		if strings.Contains(contentLower, pattern) {
-			patternCount++
-		}
-	}
-
-	// Require at least 2 image-specific patterns to classify as image metadata
-	return patternCount >= 2
-}
-
-// containsAudioMetadataPatterns checks for audio-specific metadata patterns
-func (cr *ContentRouter) containsAudioMetadataPatterns(content string) bool {
-	audioPatterns := []string{
-		"artist:", "album:", "track:", "genre:",
-		"duration:", "bitrate:", "sample_rate:",
-		"tpe1:", "tpe2:", "tpe3:", "tpe4:",
-		"composer:", "performer:", "conductor:",
-	}
-
-	contentLower := strings.ToLower(content)
-	patternCount := 0
-	for _, pattern := range audioPatterns {
-		if strings.Contains(contentLower, pattern) {
-			patternCount++
-		}
-	}
-
-	// Require at least 2 audio-specific patterns
-	return patternCount >= 2
-}
-
-// containsVideoMetadataPatterns checks for video-specific metadata patterns
-func (cr *ContentRouter) containsVideoMetadataPatterns(content string) bool {
-	videoPatterns := []string{
-		"video_codec:", "audio_codec:", "frame_rate:",
-		"resolution:", "duration:", "recording_device:",
-		"xyz:", "creation_time:", "encoder:",
-		"major_brand:", "minor_version:",
-	}
-
-	contentLower := strings.ToLower(content)
-	patternCount := 0
-	for _, pattern := range videoPatterns {
-		if strings.Contains(contentLower, pattern) {
-			patternCount++
-		}
-	}
-
-	// Require at least 2 video-specific patterns
-	return patternCount >= 2
-}
-
-// containsDocumentMetadataPatterns checks for document-specific metadata patterns
-func (cr *ContentRouter) containsDocumentMetadataPatterns(content string) bool {
-	documentPatterns := []string{
-		"author:", "creator:", "title:", "subject:",
-		"keywords:", "comments:", "description:",
-		"lastmodifiedby:", "manager:", "company:",
-		"creation_date:", "modification_date:",
-	}
-
-	contentLower := strings.ToLower(content)
-	patternCount := 0
-	for _, pattern := range documentPatterns {
-		if strings.Contains(contentLower, pattern) {
-			patternCount++
-		}
-	}
-
-	// Require at least 2 document-specific patterns
-	return patternCount >= 2
-}
-
-// detectMetadataSection detects the start of a metadata section and returns its type
-func (cr *ContentRouter) detectMetadataSection(line string) string {
-	lineLower := strings.ToLower(strings.TrimSpace(line))
-
-	// Check for explicit metadata section markers
-	if strings.Contains(lineLower, "--- image_metadata ---") {
+// metadataTypeForProcessorType maps a SINGLE preprocessor's ProcessorType to the
+// metadata type whose validation rules apply, or "" when the content is not
+// wholly metadata (document text, plain text, an unknown producer, or a
+// multi-preprocessor "a+b" join whose structure was not declared).
+//
+// Only used on the undeclared-structure path; a declared section carries its type
+// directly. The input is our own GetName()-derived constant, so this is an exact
+// match rather than the substring test the deleted text-scanning path used.
+func metadataTypeForProcessorType(processorType string) string {
+	switch strings.ToLower(strings.TrimSpace(processorType)) {
+	case "image_metadata", "image-metadata", "imagemetadata":
 		return PreprocessorTypeImageMetadata
-	}
-	if strings.Contains(lineLower, "--- document_metadata ---") {
+	case "document_metadata", "document-metadata", "documentmetadata",
+		"pdf_metadata", "pdf-metadata", "pdfmetadata":
 		return PreprocessorTypeDocumentMetadata
-	}
-	if strings.Contains(lineLower, "--- office_metadata ---") {
+	case "office_metadata", "office-metadata", "officemetadata":
 		return PreprocessorTypeOfficeMetadata
-	}
-	if strings.Contains(lineLower, "--- audio_metadata ---") {
+	case "audio_metadata", "audio-metadata", "audiometadata":
 		return PreprocessorTypeAudioMetadata
-	}
-	if strings.Contains(lineLower, "--- video_metadata ---") {
+	case "video_metadata", "video-metadata", "videometadata":
 		return PreprocessorTypeVideoMetadata
-	}
-	if strings.Contains(lineLower, "--- embedded media") {
-		// Determine type based on file extension in the line
-		if strings.Contains(lineLower, ".jpg") || strings.Contains(lineLower, ".png") ||
-			strings.Contains(lineLower, ".gif") || strings.Contains(lineLower, ".jpeg") {
-			return PreprocessorTypeImageMetadata
-		}
-		if strings.Contains(lineLower, ".mp3") || strings.Contains(lineLower, ".wav") ||
-			strings.Contains(lineLower, ".flac") || strings.Contains(lineLower, ".m4a") {
-			return PreprocessorTypeAudioMetadata
-		}
-		if strings.Contains(lineLower, ".mp4") || strings.Contains(lineLower, ".mov") ||
-			strings.Contains(lineLower, ".avi") || strings.Contains(lineLower, ".m4v") {
-			return PreprocessorTypeVideoMetadata
-		}
-		// Default to image for embedded media
-		return PreprocessorTypeImageMetadata
-	}
-
-	return ""
-}
-
-// extractEmbeddedMediaPath extracts the embedded media file path from a section header
-func (cr *ContentRouter) extractEmbeddedMediaPath(line, originalPath string) string {
-	// Look for patterns like "--- Embedded Media 1 (image1.jpg) ---"
-	lineTrimmed := strings.TrimSpace(line)
-
-	// Find the filename in parentheses
-	start := strings.Index(lineTrimmed, "(")
-	end := strings.Index(lineTrimmed, ")")
-
-	if start != -1 && end != -1 && end > start {
-		mediaName := lineTrimmed[start+1 : end]
-		// Extract just the filename from the media path (remove word/media/ etc.)
-		justFilename := filepath.Base(mediaName)
-		// Create the embedded path format: "originalfile.docx -> image1.jpg"
-		return fmt.Sprintf("%s -> %s", filepath.Base(originalPath), justFilename)
-	}
-
-	// Fallback to original path if we can't extract the media name
-	return originalPath
-}
-
-// isMetadataSectionEnd checks if a line marks the end of a metadata section
-func (cr *ContentRouter) isMetadataSectionEnd(line string) bool {
-	lineTrimmed := strings.TrimSpace(line)
-
-	// Don't end on empty lines - metadata sections can have empty lines between fields
-	if lineTrimmed == "" {
-		return false
-	}
-
-	// Check for new section separators (but let the main loop handle them)
-	if strings.HasPrefix(lineTrimmed, "---") {
-		// This is a new section header - let the main loop detect it
-		return false
-	}
-
-	// Check if this line looks like a metadata field (key: value format)
-	if cr.looksLikeMetadataField(lineTrimmed) {
-		return false // Continue metadata section
-	}
-
-	// Check for start of document content (common patterns)
-	lineLower := strings.ToLower(lineTrimmed)
-	documentStartPatterns := []string{
-		"chapter", "section", "introduction", "abstract",
-		"summary", "overview", "content", "body",
-	}
-
-	for _, pattern := range documentStartPatterns {
-		if strings.HasPrefix(lineLower, pattern) {
-			return true
-		}
-	}
-
-	// If the line doesn't look like metadata and contains multiple words, it's likely document content
-	// This handles cases where document content follows metadata without clear markers
-	words := strings.Fields(lineTrimmed)
-	if len(words) >= 3 && !cr.looksLikeMetadataField(lineTrimmed) {
-		return true
-	}
-
-	return false
-}
-
-// looksLikeMetadataField checks if a line looks like a metadata field (key: value format)
-func (cr *ContentRouter) looksLikeMetadataField(line string) bool {
-	// Check for key: value pattern
-	if strings.Contains(line, ":") && !strings.HasPrefix(line, "http") {
-		parts := strings.SplitN(line, ":", 2)
-		if len(parts) == 2 {
-			key := strings.TrimSpace(parts[0])
-			value := strings.TrimSpace(parts[1])
-
-			// Key should be reasonably short and not contain spaces (or very few)
-			keyWords := strings.Fields(key)
-			if len(keyWords) <= 3 && len(key) <= 50 && value != "" {
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
-// createMetadataFromLines creates a MetadataContent from collected lines
-func (cr *ContentRouter) createMetadataFromLines(lines []string, sectionType, sourceFile string) *MetadataContent {
-	if len(lines) == 0 {
-		return nil
-	}
-
-	content := strings.Join(lines, "\n")
-	preprocessorName := cr.getPreprocessorName(sectionType)
-
-	return &MetadataContent{
-		Content:          content,
-		PreprocessorType: sectionType,
-		PreprocessorName: preprocessorName,
-		SourceFile:       sourceFile,
-		Metadata: map[string]interface{}{
-			"section_lines":  len(lines),
-			"extracted_from": "mixed_content",
-		},
+	default:
+		return ""
 	}
 }
 
@@ -828,251 +353,5 @@ func (cr *ContentRouter) getPreprocessorName(preprocessorType string) string {
 		return "Document Text Extractor"
 	default:
 		return "Unknown Preprocessor"
-	}
-}
-
-// isCombinedPreprocessorOutput checks if the content is from multiple preprocessors combined by file router
-func (cr *ContentRouter) isCombinedPreprocessorOutput(processedContent *preprocessors.ProcessedContent) bool {
-	// Check if ProcessorType contains multiple processors (e.g., "pdf_metadata+text")
-	if strings.Contains(processedContent.ProcessorType, "+") {
-		return true
-	}
-
-	// Check if content contains preprocessor separator markers
-	return strings.Contains(processedContent.Text, "--- ") &&
-		(strings.Contains(processedContent.Text, " ---") || strings.Contains(processedContent.Text, "---\n"))
-}
-
-// separateCombinedPreprocessorOutput separates combined preprocessor output into document body and metadata
-func (cr *ContentRouter) separateCombinedPreprocessorOutput(processedContent *preprocessors.ProcessedContent) (string, []MetadataContent, error) {
-	content := processedContent.Text
-	var bodySections []string
-	var metadataItems []MetadataContent
-
-	// Split by preprocessor separators (e.g., "--- pdf_metadata ---", "--- text ---")
-	sections := cr.splitByPreprocessorSeparators(content)
-
-	for _, section := range sections {
-		if section.preprocessorName == "" {
-			// Content before any separator - likely metadata
-			if cr.looksLikeMetadata(section.content) {
-				metadataContent := cr.createMetadataContentFromSection(section.content, "document_metadata", processedContent.OriginalPath)
-				if metadataContent != nil {
-					metadataItems = append(metadataItems, *metadataContent)
-				}
-			} else {
-				bodySections = append(bodySections, section.content)
-			}
-		} else if cr.isMetadataPreprocessor(section.preprocessorName) {
-			// This is metadata content - determine the correct preprocessor type
-			preprocessorType := cr.determinePreprocessorTypeFromName(section.preprocessorName)
-			sourceFile := processedContent.OriginalPath
-
-			// For embedded media, extract the media file path for better source tracking
-			if strings.Contains(strings.ToLower(section.preprocessorName), "embedded media") {
-				sourceFile = cr.extractEmbeddedMediaPath("--- "+section.preprocessorName+" ---", processedContent.OriginalPath)
-			}
-
-			metadataContent := cr.createMetadataContentFromSection(section.content, preprocessorType, sourceFile)
-			if metadataContent != nil {
-				metadataItems = append(metadataItems, *metadataContent)
-			}
-		} else {
-			// This is document body content
-			bodySections = append(bodySections, section.content)
-		}
-	}
-
-	// Join body sections with a blank line between them. splitByPreprocessorSeparators
-	// TrimSpace-es each section, so concatenating them directly would run the last
-	// line of one section into the first line of the next on a single logical line —
-	// fusing two adjacent values (or splitting one) and breaking line-based detection
-	// at every section seam. A blank-line separator keeps each section's lines intact
-	// and mirrors the paragraph spacing the other combine path already uses.
-	return strings.TrimSpace(strings.Join(bodySections, "\n\n")), metadataItems, nil
-}
-
-// preprocessorSection represents a section of content from a specific preprocessor
-type preprocessorSection struct {
-	preprocessorName string
-	content          string
-}
-
-// splitByPreprocessorSeparators splits content by preprocessor separator markers
-func (cr *ContentRouter) splitByPreprocessorSeparators(content string) []preprocessorSection {
-	var sections []preprocessorSection
-	lines := strings.Split(content, "\n")
-
-	var currentSection strings.Builder
-	currentPreprocessor := ""
-
-	for _, line := range lines {
-		// Check for preprocessor separator (e.g., "--- pdf_metadata ---", "--- text ---")
-		if strings.HasPrefix(line, "--- ") && strings.HasSuffix(line, " ---") {
-			// Save previous section
-			if currentSection.Len() > 0 {
-				sections = append(sections, preprocessorSection{
-					preprocessorName: currentPreprocessor,
-					content:          strings.TrimSpace(currentSection.String()),
-				})
-				currentSection.Reset()
-			}
-
-			// Extract preprocessor name
-			preprocessorName := strings.TrimSpace(line[4 : len(line)-4])
-			currentPreprocessor = preprocessorName
-		} else {
-			// Add line to current section
-			if currentSection.Len() > 0 {
-				currentSection.WriteString("\n")
-			}
-			currentSection.WriteString(line)
-		}
-	}
-
-	// Add final section
-	if currentSection.Len() > 0 {
-		sections = append(sections, preprocessorSection{
-			preprocessorName: currentPreprocessor,
-			content:          strings.TrimSpace(currentSection.String()),
-		})
-	}
-
-	return sections
-}
-
-// isMetadataPreprocessor checks if a preprocessor name indicates metadata extraction
-func (cr *ContentRouter) isMetadataPreprocessor(preprocessorName string) bool {
-	metadataPreprocessors := []string{
-		"pdf_metadata", "image_metadata", "audio_metadata", "video_metadata",
-		"office_metadata", "document_metadata", "metadata",
-	}
-
-	preprocessorLower := strings.ToLower(preprocessorName)
-
-	// Check for embedded media sections (e.g., "Embedded Media 3 (word/media/image18.jpeg)")
-	if strings.Contains(preprocessorLower, "embedded media") {
-		return true
-	}
-
-	for _, metaProcessor := range metadataPreprocessors {
-		if strings.Contains(preprocessorLower, metaProcessor) {
-			return true
-		}
-	}
-
-	return false
-}
-
-// looksLikeMetadata checks if content appears to be metadata rather than document text
-func (cr *ContentRouter) looksLikeMetadata(content string) bool {
-	lines := strings.Split(content, "\n")
-	metadataFieldCount := 0
-	totalLines := 0
-
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		totalLines++
-
-		// Check for metadata field patterns (key: value)
-		if strings.Contains(line, ":") && !strings.HasPrefix(line, "http") {
-			parts := strings.SplitN(line, ":", 2)
-			if len(parts) == 2 {
-				key := strings.TrimSpace(parts[0])
-				// Check if key looks like a metadata field name
-				if cr.isMetadataFieldName(key) {
-					metadataFieldCount++
-				}
-			}
-		}
-	}
-
-	// Consider it metadata if more than 50% of lines are metadata fields
-	return totalLines > 0 && float64(metadataFieldCount)/float64(totalLines) > 0.5
-}
-
-// isMetadataFieldName checks if a string looks like a metadata field name
-func (cr *ContentRouter) isMetadataFieldName(fieldName string) bool {
-	fieldLower := strings.ToLower(fieldName)
-	metadataFields := []string{
-		"title", "author", "creator", "producer", "subject", "keywords",
-		"creationdate", "modificationdate", "pagecount", "encrypted",
-		"pdfversion", "application", "company", "lastmodifiedby",
-		"camera", "device", "gps", "latitude", "longitude", "altitude",
-		"artist", "album", "genre", "year", "track", "duration",
-	}
-
-	for _, field := range metadataFields {
-		if strings.Contains(fieldLower, field) {
-			return true
-		}
-	}
-
-	return false
-}
-
-// determinePreprocessorTypeFromName determines the preprocessor type from the section name
-func (cr *ContentRouter) determinePreprocessorTypeFromName(sectionName string) string {
-	sectionLower := strings.ToLower(sectionName)
-
-	// Check for embedded media sections
-	if strings.Contains(sectionLower, "embedded media") {
-		// Determine type based on file extension in the section name
-		if strings.Contains(sectionLower, ".jpg") || strings.Contains(sectionLower, ".jpeg") ||
-			strings.Contains(sectionLower, ".png") || strings.Contains(sectionLower, ".gif") ||
-			strings.Contains(sectionLower, ".bmp") || strings.Contains(sectionLower, ".tiff") ||
-			strings.Contains(sectionLower, ".webp") {
-			return PreprocessorTypeImageMetadata
-		}
-		if strings.Contains(sectionLower, ".mp3") || strings.Contains(sectionLower, ".wav") ||
-			strings.Contains(sectionLower, ".flac") || strings.Contains(sectionLower, ".m4a") {
-			return PreprocessorTypeAudioMetadata
-		}
-		if strings.Contains(sectionLower, ".mp4") || strings.Contains(sectionLower, ".mov") ||
-			strings.Contains(sectionLower, ".avi") || strings.Contains(sectionLower, ".m4v") {
-			return PreprocessorTypeVideoMetadata
-		}
-		// Default to image for embedded media
-		return PreprocessorTypeImageMetadata
-	}
-
-	// Check for specific preprocessor types
-	if strings.Contains(sectionLower, "office_metadata") {
-		return PreprocessorTypeOfficeMetadata
-	}
-	if strings.Contains(sectionLower, "pdf_metadata") {
-		return PreprocessorTypeDocumentMetadata
-	}
-	if strings.Contains(sectionLower, "image_metadata") {
-		return PreprocessorTypeImageMetadata
-	}
-	if strings.Contains(sectionLower, "audio_metadata") {
-		return PreprocessorTypeAudioMetadata
-	}
-	if strings.Contains(sectionLower, "video_metadata") {
-		return PreprocessorTypeVideoMetadata
-	}
-
-	// Default to document metadata
-	return PreprocessorTypeDocumentMetadata
-}
-
-// createMetadataContentFromSection creates MetadataContent from a content section
-func (cr *ContentRouter) createMetadataContentFromSection(content, preprocessorType, sourceFile string) *MetadataContent {
-	if strings.TrimSpace(content) == "" {
-		return nil
-	}
-
-	return &MetadataContent{
-		Content:          content,
-		PreprocessorType: preprocessorType,
-		PreprocessorName: cr.getPreprocessorName(preprocessorType),
-		SourceFile:       sourceFile,
-		Metadata: map[string]interface{}{
-			"separated_from_combined": true,
-		},
 	}
 }

--- a/internal/router/content_router.go
+++ b/internal/router/content_router.go
@@ -23,6 +23,26 @@ type RoutedContent struct {
 	DocumentBody string            // Combined plain text + document text
 	Metadata     []MetadataContent // Separated metadata by preprocessor
 	OriginalPath string
+
+	// FullText is every byte the preprocessors extracted, captured BEFORE any
+	// routing decision is made.
+	//
+	// It exists because routing is decided by inspecting the extracted text itself
+	// — section headers of the form "--- name ---" — and document authors control
+	// that text. DocumentBody is therefore an attacker-influenced SUBSET, while the
+	// document validator set is the larger of the two (the metadata path runs a
+	// single field-name scanner that has no SSN, card, phone or email logic). So
+	// whenever the split moved content from the document path to the metadata path,
+	// it moved it from ~19 validators to 1 that cannot detect it, and the finding
+	// vanished. Since only reported findings reach the redactor, a vanished finding
+	// is a value left in cleartext.
+	//
+	// Keeping the pre-routing text lets the document path scan the union, which
+	// makes routing a LABELLING decision rather than a COVERAGE decision: a forged
+	// or merely unlucky section header can still change how a finding is described,
+	// but it can no longer delete one. That property holds for section names nobody
+	// has thought of yet, which a per-marker fix would not.
+	FullText string
 }
 
 // MetadataContent represents metadata content with preprocessor context
@@ -102,10 +122,18 @@ func (cr *ContentRouter) RouteContent(processedContent *preprocessors.ProcessedC
 		finishTiming = cr.observer.StartTiming("content_router", "route_content", processedContent.OriginalPath)
 	}
 
-	// Initialize routed content
+	// Initialize routed content.
+	//
+	// FullText is populated HERE, in the struct literal, deliberately: this is above
+	// the CanContainMetadata early return below and above the whole
+	// `switch preprocessorType`, including its graceful-degradation arms. Assigning
+	// it inside any branch would leave some path emitting an empty FullText, and an
+	// empty FullText silently disables the coverage guarantee for exactly the inputs
+	// that took the unusual path.
 	routedContent := &RoutedContent{
 		OriginalPath: processedContent.OriginalPath,
 		Metadata:     make([]MetadataContent, 0),
+		FullText:     processedContent.Text,
 	}
 
 	// Check if file can contain metadata using FileRouter

--- a/internal/router/empty_extraction_visibility_test.go
+++ b/internal/router/empty_extraction_visibility_test.go
@@ -1,0 +1,202 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package router
+
+import (
+	"archive/zip"
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/observability"
+	"github.com/awslabs/ferret-scan/v2/internal/preprocessors"
+)
+
+// A container that yields no document text must say so.
+//
+// Selecting the body part by name means an unrecognized name yields zero text, and
+// zero text used to be indistinguishable from an empty document: Success=true,
+// exit 0, no message. That made the failure the part-selection fix addresses silent
+// by construction — a 40-page document could contribute nothing to a scan and the
+// operator would have no signal.
+//
+// The subtle half is that the warning must survive an ERROR return. When the archive
+// has no recognizable body part at all, the extractor both sets the warning and
+// returns an error, and the file usually still has a successful metadata sibling — so
+// any code path that only propagates warnings from non-error results drops the note
+// exactly when it matters most.
+
+// TestExtractionWarningSurvivesAnExtractorError is the regression. It routes a
+// container in which one preprocessor errored while carrying a warning, and one
+// succeeded, which is the real shape of a .docx with a missing body part.
+func TestExtractionWarningSurvivesAnExtractorError(t *testing.T) {
+	fr := NewFileRouter(false)
+	fr.preprocessors = []preprocessors.Preprocessor{
+		// Mirrors the text extractor: no body part found, so both an error and the
+		// note that explains what the user lost.
+		&stubPreprocessor{
+			name:    "Text Extractor",
+			warning: "no text extracted from .docx: no document body part was found in the archive",
+			err:     errNoBodyPart,
+		},
+		// Mirrors office_metadata, which succeeds from docProps and would otherwise
+		// make the whole file look fine.
+		&stubPreprocessor{
+			name: "office_metadata",
+			text: "Author: Jane Analyst\n",
+		},
+	}
+
+	got, err := fr.ProcessFileWithContext("report.docx", &ProcessingContext{FilePath: "report.docx"})
+	if err != nil {
+		t.Fatalf("routing failed outright: %v", err)
+	}
+	if got.ExtractionWarning == "" {
+		t.Fatalf("no ExtractionWarning survived.\n"+
+			"The extractor that found no body part returned an error alongside its warning, and "+
+			"the successful metadata sibling made the file look healthy — so the scan would "+
+			"report metadata-only findings at exit 0 with nothing said about the unread "+
+			"document body.\n  ProcessorType=%q Text=%q", got.ProcessorType, got.Text)
+	}
+	if !strings.Contains(got.ExtractionWarning, "no document body part") {
+		t.Errorf("ExtractionWarning = %q, want it to name the missing body part", got.ExtractionWarning)
+	}
+	if !strings.Contains(got.ExtractionWarning, "Text Extractor") {
+		t.Errorf("ExtractionWarning = %q, want it to name which preprocessor reported it, since a "+
+			"combined result has several", got.ExtractionWarning)
+	}
+}
+
+// TestNoExtractionWarningOnAHealthyContainer is the non-vacuity floor. If the warning
+// were emitted unconditionally the test above would pass while every ordinary scan
+// gained a spurious message and, with --fail-on-incomplete, a spurious exit 3.
+func TestNoExtractionWarningOnAHealthyContainer(t *testing.T) {
+	fr := NewFileRouter(false)
+	fr.preprocessors = []preprocessors.Preprocessor{
+		&stubPreprocessor{name: "Text Extractor", text: "Employee SSN 449-87-4100 on file.\n"},
+		&stubPreprocessor{name: "office_metadata", text: "Author: Jane Analyst\n"},
+	}
+
+	got, err := fr.ProcessFileWithContext("report.docx", &ProcessingContext{FilePath: "report.docx"})
+	if err != nil {
+		t.Fatalf("routing failed: %v", err)
+	}
+	if got.ExtractionWarning != "" {
+		t.Errorf("ExtractionWarning = %q on a container that extracted normally; every ordinary "+
+			"scan would carry this message", got.ExtractionWarning)
+	}
+}
+
+// TestDocxWithNoBodyPartIsFlagged drives the real extractor rather than a stub, so the
+// two halves (the extractor setting the note, the router carrying it) are proven to fit
+// together. Built in a repo-relative directory: t.TempDir() would work for the text
+// extractor but not for the metadata one, and the point is the combined result.
+func TestDocxWithNoBodyPartIsFlagged(t *testing.T) {
+	dir, err := os.MkdirTemp(".", "empty-extraction-")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	path := filepath.Join(dir, "nobody.docx")
+	if err := os.WriteFile(path, docxWithoutBodyPart(), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	// Use the real text preprocessor rather than the registry: NewFileRouter starts
+	// with an empty preprocessor list and InitializePreprocessors registers only what
+	// a caller has previously supplied a factory for, so relying on it would make this
+	// test silently skip — which is how the gap being fixed stayed invisible.
+	fr := NewFileRouter(false)
+	fr.preprocessors = []preprocessors.Preprocessor{preprocessors.NewTextPreprocessor()}
+
+	got, err := fr.ProcessFileWithContext(path, &ProcessingContext{FilePath: path})
+
+	// A degenerate container may legitimately fail outright. What must not happen is a
+	// result that looks fine and says nothing, so assert on whichever came back.
+	switch {
+	case err != nil:
+		if !strings.Contains(err.Error(), "no preprocessor") && !strings.Contains(err.Error(), "failed") {
+			t.Fatalf("unexpected routing error shape: %v", err)
+		}
+	case got == nil:
+		t.Fatal("no result and no error")
+	case got.ExtractionWarning == "":
+		t.Errorf("a .docx with no document body part produced no ExtractionWarning "+
+			"(ProcessorType=%q, textLen=%d); its unread body would be invisible to the operator",
+			got.ProcessorType, len(got.Text))
+	}
+}
+
+// --- helpers ---------------------------------------------------------------
+
+var errNoBodyPart = io.ErrUnexpectedEOF // any non-nil error; the value is not asserted
+
+type stubPreprocessor struct {
+	name    string
+	text    string
+	warning string
+	err     error
+}
+
+func (s *stubPreprocessor) GetName() string                    { return s.name }
+func (s *stubPreprocessor) CanProcess(string) bool             { return true }
+func (s *stubPreprocessor) GetSupportedExtensions() []string   { return []string{".docx"} }
+func (s *stubPreprocessor) SetObserver(observability.Observer) {}
+
+func (s *stubPreprocessor) Process(filePath string) (*preprocessors.ProcessedContent, error) {
+	c := &preprocessors.ProcessedContent{
+		OriginalPath:      filePath,
+		Filename:          filepath.Base(filePath),
+		Text:              s.text,
+		ProcessorType:     s.name,
+		Success:           s.err == nil,
+		ExtractionWarning: s.warning,
+	}
+	return c, s.err
+}
+
+// docxWithoutBodyPart builds a .docx whose relationships name a document part that is
+// not in the archive, while docProps/core.xml is present — so the metadata extractor
+// succeeds and the text extractor cannot find a body.
+func docxWithoutBodyPart() []byte {
+	const decl = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>`
+	parts := []struct{ name, body string }{
+		{"[Content_Types].xml", decl +
+			`<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+			`<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+			`<Default Extension="xml" ContentType="application/xml"/>` +
+			`<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>` +
+			`<Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/>` +
+			`</Types>`},
+		{"_rels/.rels", decl +
+			`<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+			`<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>` +
+			`<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" Target="docProps/core.xml"/>` +
+			`</Relationships>`},
+		{"docProps/core.xml", decl +
+			`<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/">` +
+			`<dc:creator>Jane Analyst</dc:creator></cp:coreProperties>`},
+		// word/document.xml is deliberately absent.
+	}
+
+	out := new(bytes.Buffer)
+	zw := zip.NewWriter(out)
+	for _, p := range parts {
+		w, err := zw.Create(p.name)
+		if err != nil {
+			panic(err)
+		}
+		if _, err := io.WriteString(w, p.body); err != nil {
+			panic(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		panic(err)
+	}
+	return out.Bytes()
+}

--- a/internal/router/file_router.go
+++ b/internal/router/file_router.go
@@ -79,6 +79,32 @@ func (fr *FileRouter) CanProcessFile(filePath string, enablePreprocessors bool) 
 	if err != nil {
 		return false, fmt.Sprintf("%s: %v", ReasonUnreadable, err)
 	}
+
+	// Refuse anything that is not a regular file.
+	//
+	// This is an operational bound, not a security boundary: a character device, a
+	// FIFO, a socket or a kernel pseudo-file has no meaningful size, so the size
+	// gate below cannot bound it. Opening /dev/zero or a FIFO with no writer means
+	// reading forever, and the extractors downstream read the whole file into memory.
+	//
+	// It replaces a prefix denylist that used to live in the Office metadata
+	// extractor and refused /proc/, /sys/, /dev/ by name. A mode check is both wider
+	// and narrower in the right directions: it covers block and character devices,
+	// FIFOs and sockets on every platform, including the Windows device namespace
+	// (\\.\PhysicalDrive0) and reserved DOS names that a Unix-shaped path denylist
+	// never matched — while it does NOT reject the ordinary files that happen to sit
+	// under one of those prefixes. /dev/shm is the case that matters: it is
+	// world-writable tmpfs, routinely used for temporary files by scripts and CI, and
+	// the files in it are regular files. A path denylist rejected them; this does not.
+	//
+	// It lives here because the router is where "can this file be processed" is
+	// decided, and it already has the stat. The extractors get a path this function
+	// has already vetted, so each of the seven no longer needs its own copy of the
+	// rule — only one of them ever had one.
+	if !info.Mode().IsRegular() {
+		return false, fmt.Sprintf("%s: not a regular file (%s)", ReasonUnreadable, describeFileMode(info.Mode()))
+	}
+
 	if info.Size() > MaxFileSize {
 		return false, fmt.Sprintf("File too large (max: %dMB)", MaxFileSize/(1024*1024))
 	}
@@ -104,6 +130,31 @@ func (fr *FileRouter) CanProcessFile(filePath string, enablePreprocessors bool) 
 	}
 
 	return false, "Unsupported file type"
+}
+
+// describeFileMode names the non-regular kind a path turned out to be, so the skip
+// reason tells the user what they actually pointed at rather than only that it was
+// rejected. Directories are included because a caller can hand a directory path to a
+// single-file scan.
+func describeFileMode(m os.FileMode) string {
+	switch {
+	case m.IsDir():
+		return "directory"
+	case m&os.ModeSymlink != 0:
+		return "symlink"
+	case m&os.ModeNamedPipe != 0:
+		return "named pipe"
+	case m&os.ModeSocket != 0:
+		return "socket"
+	case m&os.ModeCharDevice != 0:
+		return "character device"
+	case m&os.ModeDevice != 0:
+		return "block device"
+	case m&os.ModeIrregular != 0:
+		return "irregular file"
+	default:
+		return m.String()
+	}
 }
 
 // ProcessFileWithContext processes a file through the routing system with full context
@@ -225,8 +276,25 @@ func (fr *FileRouter) processFileInternal(filePath string, config *ProcessingCon
 	var combinedMetadata = make(map[string]interface{})
 	var totalWordCount, totalCharCount, totalLineCount int
 	var successfulProcessors []string
+	// extractionWarnings collects each preprocessor's "read the file but got no
+	// document text" note, in launch order so the message is stable.
+	//
+	// Deliberately gathered regardless of pResult.err. The note is set by the
+	// extractor that produced no text, and for the most important case — the body
+	// part is absent from the archive entirely — that extractor ALSO returns an
+	// error ("document.xml not found in the archive"). Requiring err == nil dropped
+	// the warning exactly when it mattered: a .docx with no recognizable body part
+	// still had a successful office_metadata sibling, so the file reported Success
+	// with metadata-only findings, exit 0, and nothing said the document body had
+	// never been read. Measured before this: such a file produced
+	// {PERSON_NAME, AUTHOR_INFO} and no warning at all.
+	var extractionWarnings []string
 
 	for _, pResult := range ordered {
+		if pResult.result != nil && pResult.result.ExtractionWarning != "" {
+			extractionWarnings = append(extractionWarnings,
+				pResult.name+": "+pResult.result.ExtractionWarning)
+		}
 		if pResult.err == nil && pResult.result != nil && pResult.result.Success && pResult.result.Text != "" {
 			if len(successfulProcessors) == 0 {
 				// First success: reference its text directly (no copy).
@@ -276,6 +344,11 @@ func (fr *FileRouter) processFileInternal(filePath string, config *ProcessingCon
 			ProcessorType: strings.Join(successfulProcessors, "+"),
 			Success:       true,
 			Metadata:      combinedMetadata,
+			// Carry the warnings up. Without this the combine step swallowed them:
+			// a .docx whose body part was never found still had a successful
+			// office_metadata result, so the file reported Success with only
+			// metadata findings and nothing said the document body was missing.
+			ExtractionWarning: strings.Join(extractionWarnings, "; "),
 		}
 
 		return result, nil

--- a/internal/router/file_router.go
+++ b/internal/router/file_router.go
@@ -289,6 +289,21 @@ func (fr *FileRouter) processFileInternal(filePath string, config *ProcessingCon
 	// never been read. Measured before this: such a file produced
 	// {PERSON_NAME, AUTHOR_INFO} and no warning at all.
 	var extractionWarnings []string
+	// sections records the structure of the concatenation OUT OF BAND, one entry
+	// per successful preprocessor, built in this same loop so it cannot drift from
+	// the text it describes.
+	//
+	// The name comes from Preprocessor.GetName(), which is our own code's constant
+	// — not a byte from the scanned document. That is what makes a boundary here
+	// unforgeable, and it is the whole reason for this field: the content router
+	// used to recover this same structure by scanning the assembled text for
+	// "--- name ---" lines, which a document author can simply type.
+	//
+	// sectionLine tracks where the next section starts, as a line index into the
+	// text assembled so far, so it is maintained incrementally rather than by
+	// re-scanning the (potentially multi-megabyte) result.
+	var sections []preprocessors.ContentSection
+	sectionLine := 0
 
 	for _, pResult := range ordered {
 		if pResult.result != nil && pResult.result.ExtractionWarning != "" {
@@ -308,7 +323,42 @@ func (fr *FileRouter) processFileInternal(filePath string, config *ProcessingCon
 				}
 				combinedContent.WriteString("\n\n--- " + pResult.name + " ---\n")
 				combinedContent.WriteString(pResult.result.Text)
+				// The separator "\n\n--- name ---\n" advances the line cursor by 3
+				// (it closes the previous section's last line, adds a blank line,
+				// and adds the header line itself).
+				sectionLine += 3
 			}
+
+			// Prefer the preprocessor's OWN declared sections. A metadata
+			// extractor can carry sub-structure the router cannot see: the Office
+			// extractor appends each embedded media item's text to its own, and
+			// those items route to a DIFFERENT metadata rule set (a .wav inside a
+			// .docx has an "Artist:" field, which is on the audio field list but
+			// not the office one). Only that extractor knows where the split is,
+			// so re-anchor what it declared instead of overwriting it with one
+			// coarse section.
+			if declared := pResult.result.Sections; len(declared) > 0 {
+				for _, s := range declared {
+					if s.SourceFile == "" {
+						s.SourceFile = filePath
+					}
+					s.LineOffset += sectionLine
+					sections = append(sections, s)
+				}
+			} else {
+				kind, metaType := preprocessors.ClassifySection(pResult.name)
+				sections = append(sections, preprocessors.ContentSection{
+					Name:       pResult.name,
+					Kind:       kind,
+					Type:       metaType,
+					SourceFile: filePath,
+					// A substring reference, not a copy: Go strings share backing
+					// storage, so recording every section costs pointers, not bytes.
+					Text:       pResult.result.Text,
+					LineOffset: sectionLine,
+				})
+			}
+			sectionLine += strings.Count(pResult.result.Text, "\n")
 
 			// Accumulate metadata
 			for k, v := range pResult.result.Metadata {
@@ -349,6 +399,10 @@ func (fr *FileRouter) processFileInternal(filePath string, config *ProcessingCon
 			// office_metadata result, so the file reported Success with only
 			// metadata findings and nothing said the document body was missing.
 			ExtractionWarning: strings.Join(extractionWarnings, "; "),
+			// The out-of-band structure of Text. Set unconditionally on this
+			// success path so the content router never has to fall back to
+			// re-parsing the text for separators.
+			Sections: sections,
 		}
 
 		return result, nil

--- a/internal/router/irregular_file_test.go
+++ b/internal/router/irregular_file_test.go
@@ -1,0 +1,95 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package router
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// CanProcessFile refuses anything that is not a regular file. The reason is
+// operational rather than security: a FIFO, socket or character device has no
+// meaningful size, so the MaxFileSize gate cannot bound it, and the extractors
+// downstream read the whole file into memory — a FIFO with no writer blocks forever
+// and /dev/zero never ends.
+//
+// This check replaced a path-prefix denylist that lived in the Office metadata
+// extractor and named /proc/, /sys/ and /dev/. The tests below pin the reasons a mode
+// check is the right shape: it catches kinds the name-based list missed (and would
+// have had to enumerate per platform), and it accepts the ordinary files that merely
+// happen to live under one of those prefixes.
+//
+// The FIFO case lives in irregular_file_unix_test.go. It cannot be guarded by a
+// runtime GOOS check in this file: syscall.Mkfifo does not exist on Windows, so the
+// reference fails to COMPILE there long before any skip could run — which is exactly
+// how it broke windows-latest.
+
+// TestDirectoryIsRejectedWithItsOwnReason covers the mistake a user is most likely to
+// make — pointing --file at a directory.
+func TestDirectoryIsRejectedWithItsOwnReason(t *testing.T) {
+	fr := NewFileRouter(false)
+	ok, reason := fr.CanProcessFile(t.TempDir(), true)
+
+	if ok {
+		t.Fatalf("a directory was accepted for processing (reason %q)", reason)
+	}
+	if !strings.Contains(reason, "directory") {
+		t.Errorf("reason = %q, want it to say the path is a directory", reason)
+	}
+}
+
+// TestRegularFileUnderDeviceLikePathIsAccepted is the non-vacuity floor and the
+// regression for the denylist this replaced.
+//
+// The rejected version of this rule was a name-based list containing /dev/. On Linux
+// /dev/shm is world-writable tmpfs that scripts and CI routinely use for temporary
+// files, and its contents are ordinary regular files, so that list refused real
+// documents. A mode check cannot make that mistake: the discriminator is what the
+// file IS, not where it sits. Simulated here with a directory literally named "dev"
+// so the test is portable.
+func TestRegularFileUnderDeviceLikePathIsAccepted(t *testing.T) {
+	base := t.TempDir()
+	for _, dirName := range []string{"dev", "proc", "sys"} {
+		dir := filepath.Join(base, dirName, "shm")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		p := filepath.Join(dir, "notes.txt")
+		if err := os.WriteFile(p, []byte("ssn 449-87-4100\n"), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+
+		t.Run(dirName, func(t *testing.T) {
+			fr := NewFileRouter(false)
+			ok, reason := fr.CanProcessFile(p, true)
+			if !ok {
+				t.Errorf("a regular file under a directory named %q was rejected: %q.\n"+
+					"The predecessor path denylist rejected these; the mode check must not, "+
+					"or ordinary files in /dev/shm silently go unscanned.", dirName, reason)
+			}
+		})
+	}
+}
+
+// TestOrdinaryFileStillAccepted is the broader floor: if the mode check were inverted
+// or too aggressive it would reject everything, and the assertions above would pass
+// for the wrong reason.
+func TestOrdinaryFileStillAccepted(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "plain.txt")
+	if err := os.WriteFile(p, []byte("ssn 449-87-4100\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	fr := NewFileRouter(false)
+	ok, reason := fr.CanProcessFile(p, true)
+	if !ok {
+		t.Fatalf("an ordinary readable .txt was rejected: %q", reason)
+	}
+	if reason != "Text file" {
+		t.Errorf("reason = %q, want %q", reason, "Text file")
+	}
+}

--- a/internal/router/irregular_file_unix_test.go
+++ b/internal/router/irregular_file_unix_test.go
@@ -1,0 +1,57 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows && !plan9
+
+package router
+
+import (
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// A build tag, not a runtime GOOS check.
+//
+// syscall.Mkfifo is not defined on Windows, so a `if runtime.GOOS == "windows" { t.Skip() }`
+// guard inside a portable test file does not help: the compiler still has to resolve the
+// symbol, and `go vet` fails on windows-latest before any test body runs. Constraining
+// the whole file is the only thing that works.
+//
+// The behavior under test is not Unix-specific — the mode check rejects Windows device
+// paths through the same os.FileMode bits — only the cheapest way to CREATE a
+// non-regular file is. The portable half of the coverage (directories, and regular
+// files under device-like paths) lives in irregular_file_test.go and runs everywhere.
+
+// TestFifoIsRejectedAsIrregular is the positive case for the mode check. A named pipe
+// is the cheapest non-regular file to create portably, and it is the one that would
+// actually hang a scan.
+func TestFifoIsRejectedAsIrregular(t *testing.T) {
+	dir := t.TempDir()
+	fifo := filepath.Join(dir, "pipe.txt")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Skipf("cannot create a FIFO here: %v", err)
+	}
+
+	fr := NewFileRouter(false)
+
+	// Deliberately named .txt: without the mode check this would be routed as a text
+	// file and isTextFile would then block on the open, since a FIFO with no writer
+	// never returns.
+	ok, reason := fr.CanProcessFile(fifo, true)
+
+	if ok {
+		t.Fatalf("a FIFO was accepted for processing (reason %q); reading it would block "+
+			"the scan indefinitely", reason)
+	}
+	if !strings.HasPrefix(reason, ReasonUnreadable) {
+		t.Errorf("reason = %q, want the %q prefix: the file exists but could not be examined, "+
+			"which is the same class as a permission error rather than an unsupported type",
+			reason, ReasonUnreadable)
+	}
+	if !strings.Contains(reason, "named pipe") {
+		t.Errorf("reason = %q, want it to name what the path actually was, so the user can tell "+
+			"a mistyped path from a rejected format", reason)
+	}
+}

--- a/internal/router/pure_metadata_routing_test.go
+++ b/internal/router/pure_metadata_routing_test.go
@@ -71,10 +71,12 @@ func TestPureMetadataKeepsDocumentBody(t *testing.T) {
 
 // TestCombinedPreprocessorsUnaffected pins the boundary of the change.
 //
-// .pdf/.docx/.xlsx have TWO capable preprocessors, so ProcessorType contains "+",
-// identifyPreprocessorType returns "combined_preprocessors", and they route down a
-// different branch that always preserved a body. Those file types must be
-// byte-identical before and after.
+// .pdf/.docx/.xlsx have TWO capable preprocessors, so ProcessorType contains "+".
+// They used to be classified "combined_preprocessors" and routed down a separate
+// branch that always preserved a body; that branch, and the classifier that
+// selected it, are gone — structure now comes from the declared sections, and a
+// caller that declares none keeps the whole text as body. Either way these file
+// types must still have a document body.
 func TestCombinedPreprocessorsUnaffected(t *testing.T) {
 	cr := NewContentRouter()
 	routed, err := cr.RouteContent(&preprocessors.ProcessedContent{

--- a/internal/router/section_join_test.go
+++ b/internal/router/section_join_test.go
@@ -10,40 +10,40 @@ import (
 	"github.com/awslabs/ferret-scan/v2/internal/preprocessors"
 )
 
-// TestSeparateCombinedOutput_BodySectionsAreNotFused is the regression test for
-// the section-join defect.
+// TestRouteSections_BodySectionsAreNotFused is the regression test for the
+// section-join defect, carried over to the out-of-band routing path.
 //
-// splitByPreprocessorSeparators TrimSpace-es each section, so a section carries
-// no trailing newline. separateCombinedPreprocessorOutput then wrote consecutive
-// document-body sections back to back with nothing between them, so the last line
-// of one section and the first line of the next collapsed onto a single logical
-// line. A validator that scans line by line then sees one fused line instead of
-// two — which can merge two adjacent values into one unrecognized token or split
-// a boundary value, i.e. a recall bug at every body-section seam.
-func TestSeparateCombinedOutput_BodySectionsAreNotFused(t *testing.T) {
+// The defect: consecutive document-body sections were concatenated with nothing
+// between them, so the last line of one and the first line of the next collapsed
+// onto a single logical line. A validator that scans line by line then sees one
+// fused line instead of two, which can merge two adjacent values into one
+// unrecognized token or split a boundary value — a recall bug at every seam.
+//
+// The property is unchanged by the switch to declared sections, and so is the way
+// to get it wrong (strings.Join with "" instead of "\n\n"), which is why the test
+// survives its original subject: it now drives routeSections through the exported
+// RouteContent with two declared body sections.
+func TestRouteSections_BodySectionsAreNotFused(t *testing.T) {
 	cr := NewContentRouter()
 
-	// Two document-body sections (a non-metadata preprocessor name). The last line
-	// of the first and the first line of the second must stay on separate lines.
-	content := strings.Join([]string{
-		"--- text ---",
-		"first body line",
-		"LAST-LINE-OF-SECTION-A",
-		"--- text ---",
-		"FIRST-LINE-OF-SECTION-B",
-		"second body line",
-	}, "\n")
+	sectionA := "first body line\nLAST-LINE-OF-SECTION-A"
+	sectionB := "FIRST-LINE-OF-SECTION-B\nsecond body line"
 
 	pc := &preprocessors.ProcessedContent{
-		Text:          content,
+		Text:          sectionA + "\n\n--- text ---\n" + sectionB,
 		OriginalPath:  "combined.txt",
 		ProcessorType: "text+text",
+		Sections: []preprocessors.ContentSection{
+			{Name: "text", Kind: preprocessors.SectionKindBody, Text: sectionA, LineOffset: 0},
+			{Name: "text", Kind: preprocessors.SectionKindBody, Text: sectionB, LineOffset: 4},
+		},
 	}
 
-	body, _, err := cr.separateCombinedPreprocessorOutput(pc)
+	routed, err := cr.RouteContent(pc)
 	if err != nil {
-		t.Fatalf("separateCombinedPreprocessorOutput: %v", err)
+		t.Fatalf("RouteContent: %v", err)
 	}
+	body := routed.DocumentBody
 
 	// The fusion signature: the two boundary tokens adjacent with no newline.
 	fused := "LAST-LINE-OF-SECTION-AFIRST-LINE-OF-SECTION-B"

--- a/internal/router/structured_sections_test.go
+++ b/internal/router/structured_sections_test.go
@@ -1,0 +1,379 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package router
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unsafe"
+
+	"github.com/awslabs/ferret-scan/v2/internal/preprocessors"
+)
+
+// These tests cover the structural fix: routing reads the producer-declared
+// ProcessedContent.Sections and never re-derives structure by scanning the
+// extracted text for "--- name ---" markers.
+//
+// The previous design was in-band signalling. A document author types the body
+// text, so a paragraph reading "--- office_metadata ---" became a section
+// boundary, and everything after it moved from the full validator set to the
+// single field-name METADATA scanner — which deletes findings rather than
+// relabelling them, and an unreported finding is never redacted.
+//
+// Where a test asserts a property that ALSO holds under the old code (because
+// PR1's FullText union already prevented the deletion), it says so, so nobody
+// mistakes a defence-in-depth check for the load-bearing one.
+
+// TestDeclaredSectionsDecideRouting_NotTheText is the load-bearing assertion, and
+// it is the one that fails on the parent code.
+//
+// Two inputs carry IDENTICAL declared sections and identical text EXCEPT that one
+// has a forged "--- office_metadata ---" paragraph in the body. Since routing is
+// supposed to come from the declaration, the metadata item list must be identical:
+// exactly one item, holding the real property block and NOT the body text.
+//
+// On the parent code the forged line splits the body, so the SSN paragraph is
+// emitted as an extra metadata item — the routing decision was taken from the
+// document's own bytes.
+func TestDeclaredSectionsDecideRouting_NotTheText(t *testing.T) {
+	const props = "Author: Jane Analyst\nLastModifiedBy: Ops Reviewer"
+	const ssnLine = "Employee SSN 449-87-4100 on file."
+
+	build := func(body string) *preprocessors.ProcessedContent {
+		flat := body + "\n\n--- office_metadata ---\n" + props
+		return &preprocessors.ProcessedContent{
+			Text:          flat,
+			OriginalPath:  "report.docx",
+			ProcessorType: "Text Extractor+office_metadata",
+			Success:       true,
+			Sections: []preprocessors.ContentSection{
+				{
+					Name: "Text Extractor", Kind: preprocessors.SectionKindBody,
+					SourceFile: "report.docx", Text: body, LineOffset: 0,
+				},
+				{
+					Name: "office_metadata", Kind: preprocessors.SectionKindMetadata,
+					Type: PreprocessorTypeOfficeMetadata, SourceFile: "report.docx",
+					Text: props, LineOffset: strings.Count(body, "\n") + 3,
+				},
+			},
+		}
+	}
+
+	cr := NewContentRouter()
+
+	clean, err := cr.RouteContent(build("Quarterly summary follows.\n" + ssnLine))
+	if err != nil {
+		t.Fatalf("RouteContent(clean): %v", err)
+	}
+	forged, err := cr.RouteContent(build("Quarterly summary follows.\n--- office_metadata ---\n" + ssnLine))
+	if err != nil {
+		t.Fatalf("RouteContent(forged): %v", err)
+	}
+
+	if len(clean.Metadata) != 1 {
+		t.Fatalf("control produced %d metadata items, want 1: %s",
+			len(clean.Metadata), describeItems(clean.Metadata))
+	}
+	if got, want := len(forged.Metadata), len(clean.Metadata); got != want {
+		t.Errorf("a forged section header in the BODY changed the metadata split: "+
+			"%d items with the header vs %d without.\n  with header: %s\n"+
+			"Routing must come from the declared sections, which are identical here, "+
+			"not from the document's own text.", got, want, describeItems(forged.Metadata))
+	}
+
+	// The forged header must not have pushed body text onto the metadata path,
+	// where only the field-name scanner would see it.
+	for _, item := range forged.Metadata {
+		if strings.Contains(item.Content, "449-87-4100") {
+			t.Errorf("body text reached the metadata path because the document "+
+				"forged a header; metadata item content:\n%s", item.Content)
+		}
+	}
+}
+
+// TestNoDeclaredSections_FailsClosedToDocumentBody covers the other half of the
+// contract: an older caller, or one that builds ProcessedContent by hand (the pkg
+// and ScanContent entry points do), declares nothing. That must route the WHOLE
+// text to the document path, because the document path runs every validator and
+// the metadata path runs one field-name scanner. Guessing structure from the text
+// is exactly what was removed, and guessing "it is all metadata" would be the
+// fail-OPEN direction: an SSN in the text would go unreported and unredacted.
+func TestNoDeclaredSections_FailsClosedToDocumentBody(t *testing.T) {
+	// The text deliberately contains a marker the deleted parser recognized, to
+	// prove no residual parsing happens on this path.
+	const text = "Quarterly summary follows.\n--- office_metadata ---\nEmployee SSN 449-87-4100 on file.\n"
+
+	for _, processorType := range []string{
+		"Text Extractor+office_metadata", // a combined join, undeclared
+		"plaintext",
+		"office_metadata",
+		"audio_metadata",
+		"",                  // unknown
+		"mystery_extractor", // a producer this switch has never heard of
+	} {
+		t.Run(processorType, func(t *testing.T) {
+			cr := NewContentRouter()
+			routed, err := cr.RouteContent(&preprocessors.ProcessedContent{
+				Text: text, ProcessorType: processorType,
+				OriginalPath: "hand.docx", Success: true,
+			})
+			if err != nil {
+				t.Fatalf("RouteContent: %v", err)
+			}
+			if routed.DocumentBody != text {
+				t.Errorf("DocumentBody is not the whole extraction.\n got: %q\nwant: %q\n"+
+					"With no declared structure the router must not guess one: every "+
+					"byte goes to the document path, which is the only path that "+
+					"detects an SSN.", routed.DocumentBody, text)
+			}
+		})
+	}
+}
+
+// TestSingleMetadataPreprocessorStillLabelled is the non-vacuity floor for the
+// fail-closed path above: routing everything to the body must not be achieved by
+// abandoning metadata labelling. A media file has exactly one capable
+// preprocessor, and it is a metadata one, so if this stopped producing a metadata
+// item the METADATA validator would report nothing for the whole file type.
+//
+// This also pins that the classifier reads ProcessorType — our own GetName()
+// string — rather than the content.
+func TestSingleMetadataPreprocessorStillLabelled(t *testing.T) {
+	cases := map[string]string{
+		"image_metadata":  PreprocessorTypeImageMetadata,
+		"pdf_metadata":    PreprocessorTypeDocumentMetadata, // remapped, see ClassifySection
+		"office_metadata": PreprocessorTypeOfficeMetadata,
+		"audio_metadata":  PreprocessorTypeAudioMetadata,
+		"video_metadata":  PreprocessorTypeVideoMetadata,
+	}
+	for processorType, wantType := range cases {
+		t.Run(processorType, func(t *testing.T) {
+			cr := NewContentRouter()
+			routed, err := cr.RouteContent(&preprocessors.ProcessedContent{
+				Text:          "Artist: john.doe@example.com\n",
+				ProcessorType: processorType, OriginalPath: "asset.bin", Success: true,
+			})
+			if err != nil {
+				t.Fatalf("RouteContent: %v", err)
+			}
+			if len(routed.Metadata) != 1 {
+				t.Fatalf("got %d metadata items, want 1 — the metadata path lost a "+
+					"whole file type's labelling", len(routed.Metadata))
+			}
+			if got := routed.Metadata[0].PreprocessorType; got != wantType {
+				t.Errorf("metadata item type = %q, want %q; the wrong rule set selects "+
+					"the wrong sensitive-field list, so real fields report nothing",
+					got, wantType)
+			}
+		})
+	}
+}
+
+// TestSectionKindMetadataRoutesOnlyItsOwnText states the labelling invariant as an
+// equality on content. A metadata section's item must hold exactly that section's
+// text — not the whole extraction, and not a slice decided by scanning for markers.
+func TestSectionKindMetadataRoutesOnlyItsOwnText(t *testing.T) {
+	const body = "Employee SSN 449-87-4100 on file."
+	const props = "Author: Jane Analyst"
+
+	cr := NewContentRouter()
+	routed, err := cr.RouteContent(&preprocessors.ProcessedContent{
+		Text:          body + "\n\n--- office_metadata ---\n" + props,
+		OriginalPath:  "report.docx",
+		ProcessorType: "Text Extractor+office_metadata",
+		Success:       true,
+		Sections: []preprocessors.ContentSection{
+			{Name: "Text Extractor", Kind: preprocessors.SectionKindBody, Text: body, LineOffset: 0},
+			{
+				Name: "office_metadata", Kind: preprocessors.SectionKindMetadata,
+				Type: PreprocessorTypeOfficeMetadata, Text: props, LineOffset: 3,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("RouteContent: %v", err)
+	}
+
+	if len(routed.Metadata) != 1 {
+		t.Fatalf("got %d metadata items, want 1: %s", len(routed.Metadata), describeItems(routed.Metadata))
+	}
+	if routed.Metadata[0].Content != props {
+		t.Errorf("metadata item content = %q, want exactly the declared section %q",
+			routed.Metadata[0].Content, props)
+	}
+	if routed.DocumentBody != body {
+		t.Errorf("DocumentBody = %q, want the declared body section %q",
+			routed.DocumentBody, body)
+	}
+	// Defence in depth (PR1): even if the split above were wrong, the union must
+	// still carry everything.
+	if !strings.Contains(routed.FullText, "449-87-4100") {
+		t.Error("FullText lost the SSN; the PR1 coverage union must survive this change")
+	}
+}
+
+// TestFileRouterDeclaresSectionsMatchingItsOwnText checks the producer side against
+// the text it produced, rather than against the arithmetic that built it: every
+// declared section's Text must be a substring of the flat Text, and its LineOffset
+// must be the line index where that text actually begins. A wrong LineOffset would
+// misreport line numbers in every finding from that section.
+func TestFileRouterDeclaresSectionsMatchingItsOwnText(t *testing.T) {
+	// A .docx has two capable preprocessors, so this exercises the multi-section
+	// concatenation where the offsets can actually be wrong.
+	//
+	// Repo-relative, not t.TempDir(): the Office metadata extractor's path guard
+	// rejects /var, /tmp and /home, which is where t.TempDir() lives on all three
+	// CI platforms. A fixture there would silently lose that extractor, leave one
+	// section, and pass this test for the wrong reason.
+	dir, err := os.MkdirTemp(".", "structured-sections-")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	path := filepath.Join(dir, "report.docx")
+	if err := os.WriteFile(path, minimalSectionedDOCX(), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	fr := NewFileRouter(false)
+	RegisterDefaultPreprocessors(fr)
+	fr.InitializePreprocessors(CreateRouterConfig(false))
+
+	pc, err := fr.ProcessFile(path, nil)
+	if err != nil {
+		t.Fatalf("ProcessFile: %v", err)
+	}
+	if len(pc.Sections) < 2 {
+		t.Fatalf("got %d declared sections, want >= 2 — a .docx must declare both a "+
+			"body and a metadata section, or this test is vacuous", len(pc.Sections))
+	}
+
+	flatLines := strings.Split(pc.Text, "\n")
+	for i, s := range pc.Sections {
+		if !strings.Contains(pc.Text, s.Text) {
+			t.Errorf("section %d (%s): Text is not a substring of the flat Text", i, s.Name)
+			continue
+		}
+		if s.LineOffset < 0 || s.LineOffset >= len(flatLines) {
+			t.Errorf("section %d (%s): LineOffset %d out of range for %d flat lines",
+				i, s.Name, s.LineOffset, len(flatLines))
+			continue
+		}
+		firstLine := strings.SplitN(s.Text, "\n", 2)[0]
+		if flatLines[s.LineOffset] != firstLine {
+			t.Errorf("section %d (%s): LineOffset %d points at %q but the section starts "+
+				"with %q — every finding in this section would report the wrong line",
+				i, s.Name, s.LineOffset, flatLines[s.LineOffset], firstLine)
+		}
+	}
+}
+
+// TestSectionTextAliasesNotCopies guards the hot path. processFileInternal keeps a
+// direct reference to the sole preprocessor's text (firstText) specifically so a
+// large extracted document is not duplicated into a strings.Builder, and recording
+// a ContentSection per preprocessor must not undo that: a section's Text has to be
+// a reference to the same backing array, not a copy of it.
+//
+// Asserted on the string data pointer rather than on a benchmark, so it cannot pass
+// by being merely fast on a small input.
+func TestSectionTextAliasesNotCopies(t *testing.T) {
+	big := make([]byte, 1<<20)
+	for i := range big {
+		big[i] = 'a'
+	}
+	text := string(big)
+	src := unsafe.StringData(text)
+
+	fr := NewFileRouter(false)
+	fr.preprocessors = []preprocessors.Preprocessor{
+		&stubPreprocessor{name: "Text Extractor", text: text},
+	}
+
+	got, err := fr.ProcessFileWithContext("x.txt", &ProcessingContext{FilePath: "x.txt"})
+	if err != nil {
+		t.Fatalf("ProcessFileWithContext: %v", err)
+	}
+	if unsafe.StringData(got.Text) != src {
+		t.Error("ProcessedContent.Text copied the payload; the zero-copy " +
+			"single-preprocessor path regressed")
+	}
+	if len(got.Sections) != 1 {
+		t.Fatalf("got %d sections, want 1", len(got.Sections))
+	}
+	if unsafe.StringData(got.Sections[0].Text) != src {
+		t.Error("ContentSection.Text copied the payload instead of referencing it, " +
+			"so every scan now holds a second copy of the whole extracted document")
+	}
+}
+
+func describeItems(items []MetadataContent) string {
+	var b strings.Builder
+	for i, it := range items {
+		fmt.Fprintf(&b, "\n  [%d] type=%s content=%q", i, it.PreprocessorType, it.Content)
+	}
+	return b.String()
+}
+
+// minimalSectionedDOCX builds a .docx carrying BOTH a document body and core
+// properties, so the text extractor and the office metadata extractor are both
+// capable and the router assembles a two-section concatenation. A .docx with only
+// word/document.xml takes the single-preprocessor fast path, where the section
+// offsets are trivially 0 and the arithmetic under test never runs.
+func minimalSectionedDOCX() []byte {
+	const decl = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>`
+	body := ""
+	for _, p := range []string{
+		"Quarterly summary follows.",
+		"Employee SSN 449-87-4100 on file.",
+		"Card 4532-0151-1283-0366 expires soon.",
+	} {
+		body += `<w:p><w:r><w:t xml:space="preserve">` + p + `</w:t></w:r></w:p>`
+	}
+
+	parts := []struct{ name, body string }{
+		{"[Content_Types].xml", decl +
+			`<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+			`<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+			`<Default Extension="xml" ContentType="application/xml"/>` +
+			`<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>` +
+			`<Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/>` +
+			`</Types>`},
+		{"_rels/.rels", decl +
+			`<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+			`<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>` +
+			`<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" Target="docProps/core.xml"/>` +
+			`</Relationships>`},
+		{"docProps/core.xml", decl +
+			`<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/">` +
+			`<dc:creator>Jane Analyst</dc:creator><cp:lastModifiedBy>Ops Reviewer</cp:lastModifiedBy>` +
+			`</cp:coreProperties>`},
+		{"word/document.xml", decl +
+			`<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>` +
+			body + `</w:body></w:document>`},
+	}
+
+	out := new(bytes.Buffer)
+	zw := zip.NewWriter(out)
+	for _, p := range parts {
+		w, err := zw.Create(p.name)
+		if err != nil {
+			panic(err)
+		}
+		if _, err := io.WriteString(w, p.body); err != nil {
+			panic(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		panic(err)
+	}
+	return out.Bytes()
+}

--- a/internal/validators/dual_path_bridge.go
+++ b/internal/validators/dual_path_bridge.go
@@ -372,13 +372,42 @@ func (evb *EnhancedValidatorBridge) processDualPath(ctx stdctx.Context, routedCo
 	var documentErr, metadataErr error
 	var documentProcessingTime, metadataProcessingTime time.Duration
 
+	// The document path scans every extracted byte, not the routed subset.
+	//
+	// Routing decides which content is called "metadata", and it decides it by
+	// reading section headers out of the extracted text — which document authors
+	// supply. The two paths do not run the same validators: this one runs the full
+	// set, while the metadata path runs a single field-name scanner with no SSN,
+	// card, phone or email logic. Feeding it the subset therefore let a section
+	// header delete findings rather than relabel them, and a finding that is never
+	// reported is never redacted, so the value stayed in the output in cleartext.
+	//
+	// Two details here are load-bearing and were both wrong in the obvious version
+	// of this fix:
+	//
+	//   - the INPUT is FullText, so content classified as metadata is still seen by
+	//     the document validators;
+	//   - the GATE is on documentText, not on routedContent.DocumentBody. When a
+	//     section header is the FIRST line of extracted text, the pre-header body is
+	//     empty, so a `DocumentBody != ""` gate skips this goroutine entirely and
+	//     FullText is never read. Gating on the text actually being scanned is what
+	//     makes the guarantee hold for that placement.
+	//
+	// Fall back to DocumentBody when FullText is empty so an older caller that
+	// constructs RoutedContent directly (without going through RouteContent) keeps
+	// its previous behavior rather than silently scanning nothing.
+	documentText := routedContent.FullText
+	if documentText == "" {
+		documentText = routedContent.DocumentBody
+	}
+
 	// Process document body content in parallel
-	if routedContent.DocumentBody != "" {
+	if documentText != "" {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			docStartTime := time.Now()
-			matches, err := evb.documentBridge.ProcessDocumentContentCtx(ctx, routedContent.DocumentBody, routedContent.OriginalPath, contextInsights)
+			matches, err := evb.documentBridge.ProcessDocumentContentCtx(ctx, documentText, routedContent.OriginalPath, contextInsights)
 			documentProcessingTime = time.Since(docStartTime)
 
 			if err != nil {


### PR DESCRIPTION
**Stacked on #238.** The structural fix — removes the attacker's capability rather than containing its consequence. Verified **SOUND** by an independent adversarial pass.

## The mechanism

`file_router.go` flattened every extractor's output into one `ProcessedContent.Text` using literal `\n\n--- name ---\n` separators, and `content_router.go` then **re-parsed that text** to recover the structure. Document authors control the text, so they controlled the "structure". This is in-band signaling — the same class as SQL injection — and the answer is the same: carry structure out of band.

**Producer:** `Sections []ContentSection` (plus `SectionKind`, `ClassifySection`) on `ProcessedContent`, appended in the same loop that already builds the flat concatenation, so the description cannot drift from what it describes. `Kind`/`Type` come from `Preprocessor.GetName()` — our own constant, never a document byte. `Text` stays the byte-identical flat concatenation, so the field is purely additive.

**Consumer:** `RouteContent` reads only `ContentSection` fields via a new `routeSections`, never the section text. With no declared structure it **fails closed** — the whole extraction becomes `DocumentBody`, so the document path runs all validators and the worst case is a lost metadata *label*, never lost coverage.

**Deletions:** `content_router.go` goes **1129 → 349 lines**. 24 symbols removed, including `separateCombinedPreprocessorOutput`, `splitByPreprocessorSeparators`, `detectMetadataSection`, `isMetadataSectionEnd`, `containsMetadataSections`, `looksLikeMetadata`, `extractEmbeddedMediaPath`, the four `contains*MetadataPatterns` sniffers, the `preprocessorSection` type, and `PreprocessorTypeMixedContent` (a category only the deleted classifier returned).

## Two things not in the original plan

**Embedded media is a sub-section inside one preprocessor's text**, and it routes to a *different* rule set — a `.wav` in a `.docx` has `Artist:`, on the audio sensitive-field list but not the office one. The first cut regressed `embedded.docx` from 7 findings to 6, losing `AUTHOR_INFO` for the clip's artist address. Fixed by having `ProcessEmbeddedMedia` return sections with its text and the router re-anchor rather than overwrite them. Caught by measurement, not by a test written to pass.

**`identifyPreprocessorType` also had to go**, though it wasn't on the list. It survived only as a timing label — but it sniffs document text, so reporting an attacker-derived label would have kept the in-band read path alive. Replaced with `processedContent.ProcessorType` in the observability payload.

**Docs:** both content-routing docs instructed maintainers to fix routing by regex-matching `--- image_metadata ---` against section text — i.e. to reintroduce this exact vulnerability — against an API (`ContentSection.Header`) that never existed. Rewritten to describe the declared-section mechanism.

## Testing

**Golden: ZERO change.** `git diff sec/pr2-extraction-part-names -- internal/goldencorpus/testdata/golden/` is empty. No regeneration, `UPDATE_GOLDEN` never used. That is the load-bearing result: the mechanism for determining structure was replaced wholesale and nothing about what gets detected moved.

Beyond the corpus, base-vs-fix equivalence on **14 fixtures × 7 formats**, identical modulo timestamps — with one disclosed exception: `forged_embed.docx` differs by one *removed* forged-attribution false positive, which is an improvement. The second commit here exists specifically to disclose that rather than let it hide inside "identical".

**Non-vacuity, isolated properly.** Reverting all production files gives only a compile error, which proves nothing about routing. So the type and producer were restored and **only the consumer** reverted:

```
--- FAIL: TestDeclaredSectionsDecideRouting_NotTheText
    a forged section header in the BODY changed the metadata split:
    2 items with the header vs 1 without.
--- FAIL: TestNoDeclaredSections_FailsClosedToDocumentBody
    DocumentBody is not the whole extraction.
```

Separately, replacing `Text: pResult.result.Text` with a copy fails `TestSectionTextAliasesNotCopies` — *"every scan now holds a second copy of the whole extracted document"*.

Note **5 of 7 new tests pass on a consumer-only revert**, because PR1's union already prevents the deletion. That is defence-in-depth working, not vacuity, and the test file documents it in a header comment rather than presenting seven independent proofs.

**PR1's union is intact and deliberately kept**, with a comment warning against "simplifying" it away now that sections are trustworthy — removing the capability and containing the consequence are different jobs. A forged first-line header still yields the SSN.

**Adversarial verify: no bypass survives.** Forged headers at first-line / mid-body / interleaved, odd casing and internal whitespace, the legacy `=== METADATA ===` form, all five metadata names forged at once, an `.xlsx` member named literally `xl/worksheets/--- office_metadata ---.xml`, and an embedded `.wav` named `a --- office_metadata --- b.wav` — none change section structure.

61 packages pass · `-race` clean on all five touched packages · cross-platform vet clean · timing flat within noise (0.96–1.02× over 12 points, linear on all three fixture families).