### PR TITLE
fix(secrets): stop document context promoting a bare hex identifier to a secret

### DIFF
--- a/internal/preprocessors/shared_utilities.go
+++ b/internal/preprocessors/shared_utilities.go
@@ -270,7 +270,21 @@ func (rih *RouterIntegrationHelper) CreateEmbeddedMediaPath(originalFilePath, em
 	return fmt.Sprintf("%s -> %s", filepath.Base(originalFilePath), embeddedFileName)
 }
 
-// FormatEmbeddedMediaSection formats embedded media content for inclusion in metadata text
+// FormatEmbeddedMediaSection formats embedded media content for inclusion in
+// metadata text.
+//
+// The "--- Embedded Media N (name) ---" line is now DISPLAY ONLY: it tells a
+// human reading the extracted text where an embedded item begins, and nothing
+// parses it back. Two readers used to, and both let a document author choose the
+// reported source of a finding just by typing this line as body text — the
+// content router's extractEmbeddedMediaPath (deleted with the rest of the
+// text-sniffing read side) and the METADATA validator's line loop. The real
+// provenance travels out of band in ContentSection.SourceFile, set by the
+// preprocessor that actually opened the archive member.
+//
+// So do not reintroduce a parser for this text, and do not "fix" a wrong
+// attribution by escaping the parentheses or the name: an author still controls
+// whatever a parser would read, and the structure carries the answer already.
 func (rih *RouterIntegrationHelper) FormatEmbeddedMediaSection(index int, mediaName, content string) string {
 	var result strings.Builder
 	result.WriteString(fmt.Sprintf("\n--- Embedded Media %d (%s) ---\n", index+1, mediaName))

--- a/internal/router/attribution_provenance_test.go
+++ b/internal/router/attribution_provenance_test.go
@@ -1,0 +1,252 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package router
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/binary"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestEmbeddedMediaProvenanceComesFromTheArchive is the producer-side half of the
+// attribution fix, and the reason the METADATA validator's parse site could simply
+// be deleted rather than replaced.
+//
+// The reported source of an embedded item's findings must be derived from the zip
+// entry the extractor actually opened, and it must arrive at the validator as
+// STRUCTURE — MetadataContent.SourceFile, from ContentSection.SourceFile — not as
+// text for the validator to re-parse. Two properties are asserted:
+//
+//  1. a genuine embedded member produces a section attributed to that member, so
+//     deleting the parser did not cost real provenance (which would be worse than
+//     the bug: an embedded item's findings blamed on the container);
+//  2. a forged "--- Embedded Media 1 (x) ---" paragraph in the BODY produces no
+//     such section, so no document text can invent or rename one.
+func TestEmbeddedMediaProvenanceComesFromTheArchive(t *testing.T) {
+	// Repo-relative, not t.TempDir(): the Office metadata extractor's path guard
+	// rejects /var, /tmp and /home, where t.TempDir() lives on all three CI
+	// platforms. A fixture there loses that extractor entirely — no embedded media
+	// is read, no attributed section exists, and this test would pass vacuously.
+	dir, err := os.MkdirTemp(".", "attribution-provenance-")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	// The forged inner value deliberately looks exactly like the real member name.
+	// If a section carrying it ever appeared, no shape check could tell it from the
+	// genuine one — which is why the answer is "do not parse", not "parse more
+	// carefully".
+	const realMember = "word/media/audio1.wav"
+	const forgedInner = "audio1.wav"
+
+	realPath := filepath.Join(dir, "real.docx")
+	if err := os.WriteFile(realPath, embeddedMediaDOCX(realMember, ""), 0o600); err != nil {
+		t.Fatalf("write real fixture: %v", err)
+	}
+	forgedPath := filepath.Join(dir, "forged.docx")
+	if err := os.WriteFile(forgedPath, embeddedMediaDOCX("",
+		"--- Embedded Media 1 ("+forgedInner+") ---"), 0o600); err != nil {
+		t.Fatalf("write forged fixture: %v", err)
+	}
+
+	fr := NewFileRouter(false)
+	RegisterDefaultPreprocessors(fr)
+	fr.InitializePreprocessors(CreateRouterConfig(false))
+	cr := NewContentRouterWithFileRouter(fr)
+
+	// A section is "attributed to an embedded item" iff its SourceFile is not the
+	// scanned file itself. That is the structural signal the validator consumes.
+	attributed := func(path string) []string {
+		pc, err := fr.ProcessFile(path, nil)
+		if err != nil {
+			t.Fatalf("ProcessFile(%s): %v", path, err)
+		}
+		if len(pc.Sections) == 0 {
+			t.Fatalf("%s: no declared sections at all", filepath.Base(path))
+		}
+		rc, err := cr.RouteContent(pc)
+		if err != nil {
+			t.Fatalf("RouteContent(%s): %v", path, err)
+		}
+		var out []string
+		for _, item := range rc.Metadata {
+			if item.SourceFile != path {
+				out = append(out, item.SourceFile)
+			}
+		}
+		return out
+	}
+
+	realSources := attributed(realPath)
+
+	// Non-vacuity floor for the guard half: the genuine container MUST yield an
+	// attributed section. Without this the forged assertion below would be
+	// satisfied by an embedded-media path that stopped working altogether.
+	if len(realSources) == 0 {
+		t.Fatal("the genuine embedded .wav produced no separately-attributed metadata item; " +
+			"real provenance is broken, which is worse than the forgery this test guards")
+	}
+	for _, got := range realSources {
+		// Attribution is "container -> item", built from the archive member name.
+		if !strings.HasPrefix(got, "real.docx -> ") {
+			t.Errorf("genuine embedded item attributed as %q, want a \"real.docx -> <member>\" form", got)
+		}
+		if !strings.Contains(got, "audio1.wav") {
+			t.Errorf("genuine embedded item attributed as %q, want it to name the archive member %q",
+				got, realMember)
+		}
+	}
+
+	// And the forgery: same shape typed as body text, no embedded part in the zip.
+	if forgedSources := attributed(forgedPath); len(forgedSources) != 0 {
+		t.Errorf("a forged \"--- Embedded Media\" body paragraph produced %d attributed source(s) %v; "+
+			"document text must not be able to invent an embedded-item provenance",
+			len(forgedSources), forgedSources)
+	}
+}
+
+// embeddedMediaDOCX builds a minimal .docx. A non-empty member adds a real .wav at
+// that archive path; a non-empty extraPara adds one more body paragraph (used to
+// type the forged header as document content).
+func embeddedMediaDOCX(member, extraPara string) []byte {
+	const decl = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>`
+
+	paras := []string{
+		"Quarterly summary follows.",
+		"Employee SSN 449-87-4100 on file.",
+	}
+	if extraPara != "" {
+		paras = append(paras, extraPara)
+	}
+	body := ""
+	for _, p := range paras {
+		body += `<w:p><w:r><w:t xml:space="preserve">` + p + `</w:t></w:r></w:p>`
+	}
+
+	// The .wav's INFO chunk carries fields on the AUDIO sensitive-field list, which
+	// is what makes the embedded item's own findings distinguishable from the
+	// container's.
+	wav := wavWithInfo(map[string]string{
+		"INAM": "Quarterly Review Recording",
+		"IART": "john.doe@example.com",
+		"ICMT": "contact 212-555-0142",
+	})
+
+	out := new(bytes.Buffer)
+	zw := zip.NewWriter(out)
+	put := func(name, content string) {
+		w, err := zw.Create(name)
+		if err != nil {
+			panic(err)
+		}
+		if _, err := io.WriteString(w, content); err != nil {
+			panic(err)
+		}
+	}
+
+	ctOverrides := `<Default Extension="wav" ContentType="audio/wav"/>`
+	put("[Content_Types].xml", decl+
+		`<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">`+
+		`<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>`+
+		`<Default Extension="xml" ContentType="application/xml"/>`+ctOverrides+
+		`<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>`+
+		`<Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/>`+
+		`</Types>`)
+	put("_rels/.rels", decl+
+		`<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">`+
+		`<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>`+
+		`<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" Target="docProps/core.xml"/>`+
+		`</Relationships>`)
+	put("docProps/core.xml", decl+
+		`<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/">`+
+		`<dc:creator>Jane Analyst</dc:creator><cp:lastModifiedBy>Ops Reviewer</cp:lastModifiedBy>`+
+		`</cp:coreProperties>`)
+	put("word/document.xml", decl+
+		`<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>`+
+		body+`</w:body></w:document>`)
+
+	if member != "" {
+		w, err := zw.Create(member)
+		if err != nil {
+			panic(err)
+		}
+		if _, err := w.Write(wav); err != nil {
+			panic(err)
+		}
+	}
+
+	if err := zw.Close(); err != nil {
+		panic(err)
+	}
+	return out.Bytes()
+}
+
+// wavWithInfo builds a minimal PCM WAV carrying a RIFF INFO LIST chunk, whose
+// fields are what the AUDIO metadata rule set reads.
+//
+// Duplicated from goldencorpus.BuildWAVWithInfo rather than imported: goldencorpus
+// reaches pkg/redact -> internal/core -> internal/router, so importing it from a
+// test in THIS package is an import cycle.
+func wavWithInfo(info map[string]string) []byte {
+	le := func(w io.Writer, vals ...any) {
+		for _, v := range vals {
+			if err := binary.Write(w, binary.LittleEndian, v); err != nil {
+				panic(err)
+			}
+		}
+	}
+
+	fmtChunk := new(bytes.Buffer)
+	le(fmtChunk, uint16(1), uint16(1), uint32(8000), uint32(8000), uint16(1), uint16(8))
+
+	// Sorted ids so the fixture bytes are identical run to run.
+	ids := make([]string, 0, len(info))
+	for id := range info {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	infoBody := new(bytes.Buffer)
+	infoBody.WriteString("INFO")
+	for _, id := range ids {
+		v := info[id]
+		field := append([]byte(v), 0) // null-terminated
+		if len(field)%2 == 1 {
+			field = append(field, 0) // pad to an even boundary
+		}
+		infoBody.WriteString(id)
+		le(infoBody, uint32(len(v)+1))
+		infoBody.Write(field)
+	}
+
+	list := new(bytes.Buffer)
+	list.WriteString("LIST")
+	le(list, uint32(infoBody.Len()))
+	list.Write(infoBody.Bytes())
+
+	data := []byte{0, 0, 0, 0} // 4 bytes of silence
+
+	body := new(bytes.Buffer)
+	body.WriteString("WAVE")
+	body.WriteString("fmt ")
+	le(body, uint32(fmtChunk.Len()))
+	body.Write(fmtChunk.Bytes())
+	body.Write(list.Bytes())
+	body.WriteString("data")
+	le(body, uint32(len(data)))
+	body.Write(data)
+
+	out := new(bytes.Buffer)
+	out.WriteString("RIFF")
+	le(out, uint32(body.Len()))
+	out.Write(body.Bytes())
+	return out.Bytes()
+}

--- a/internal/validators/confidence_ceiling_test.go
+++ b/internal/validators/confidence_ceiling_test.go
@@ -1,0 +1,96 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package validators
+
+import (
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/validators/secrets"
+)
+
+// A validator can declare a hard ceiling on a finding's confidence, and the bridge
+// must honour it after every adjustment that raises confidence.
+//
+// The mechanism exists because confidence is raised in three places AFTER a validator
+// returns — a document-context adjustment on each path, and a cross-path correlation
+// boost — so a validator that clamps its own return value cannot make the bound stick.
+// Measured: a value the secrets validator scored 55 was reported at 80 in a real
+// document once +20 context and +5 correlation had been applied.
+//
+// It is generic on purpose. Any validator with a value-intrinsic reason to say "no
+// amount of surrounding context should promote this" can set the key; the bridge needs
+// no knowledge of which validator or which shape.
+
+func TestClampToCeilingHonoursADeclaredCeiling(t *testing.T) {
+	m := detector.Match{
+		Confidence: 80,
+		Metadata:   map[string]any{ConfidenceCeilingKey: 55.0},
+	}
+	clampToCeiling(&m)
+
+	if m.Confidence != 55 {
+		t.Errorf("Confidence = %v, want 55.\nA declared ceiling must survive the "+
+			"document-context and cross-path boosts, which is the whole reason the clamp "+
+			"lives in the bridge rather than in the validator.", m.Confidence)
+	}
+}
+
+func TestClampToCeilingLeavesLowerConfidenceAlone(t *testing.T) {
+	m := detector.Match{
+		Confidence: 40,
+		Metadata:   map[string]any{ConfidenceCeilingKey: 55.0},
+	}
+	clampToCeiling(&m)
+
+	if m.Confidence != 40 {
+		t.Errorf("Confidence = %v, want 40 unchanged: a ceiling is an upper bound, "+
+			"not a target to raise toward", m.Confidence)
+	}
+}
+
+// TestClampToCeilingIgnoresMalformedCeilings is the safety floor. A ceiling that is
+// absent, the wrong type, or non-positive must be ignored rather than treated as zero:
+// clamping to 0 would erase a finding's confidence and, depending on the band filter,
+// remove it from the report entirely — which per the sink rule means it stops being
+// redacted.
+func TestClampToCeilingIgnoresMalformedCeilings(t *testing.T) {
+	cases := []struct {
+		name string
+		meta map[string]any
+	}{
+		{"nil metadata", nil},
+		{"key absent", map[string]any{"other": 1.0}},
+		{"wrong type int", map[string]any{ConfidenceCeilingKey: 55}},
+		{"wrong type string", map[string]any{ConfidenceCeilingKey: "55"}},
+		{"zero", map[string]any{ConfidenceCeilingKey: 0.0}},
+		{"negative", map[string]any{ConfidenceCeilingKey: -10.0}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := detector.Match{Confidence: 90, Metadata: tc.meta}
+			clampToCeiling(&m)
+			if m.Confidence != 90 {
+				t.Errorf("Confidence = %v, want 90 unchanged. A malformed ceiling must be "+
+					"ignored; clamping to 0 would erase the finding's confidence and could "+
+					"drop it from the report, which stops it being redacted.", m.Confidence)
+			}
+		})
+	}
+}
+
+// TestCeilingKeyMatchesTheSecretsValidator guards the one duplicated literal. The
+// bridge declares the key rather than importing it from a validator package, so the
+// dependency points one way; this test is what keeps the two spellings from drifting
+// apart silently, which would turn every ceiling into a no-op.
+func TestCeilingKeyMatchesTheSecretsValidator(t *testing.T) {
+	if ConfidenceCeilingKey != secrets.ConfidenceCeilingKey {
+		t.Errorf("ceiling key drift: bridge has %q, secrets validator has %q.\n"+
+			"The literal is duplicated to keep the bridge from depending on a validator "+
+			"package. If they diverge, every declared ceiling is silently ignored and the "+
+			"findings it protects go back to being promoted by document context.",
+			ConfidenceCeilingKey, secrets.ConfidenceCeilingKey)
+	}
+}

--- a/internal/validators/dual_path_bridge.go
+++ b/internal/validators/dual_path_bridge.go
@@ -609,6 +609,56 @@ func (evb *EnhancedValidatorBridge) routeContentWithRetry(content *preprocessors
 
 // processContentLegacy provides fallback to legacy aggregation behavior. ctx is
 // threaded to the document-path dispatch chokepoint.
+// legacyMetadataUnit is one chunk of text to validate together with the path a
+// finding in it should be attributed to, and where the chunk starts in the whole
+// extraction.
+type legacyMetadataUnit struct {
+	text       string
+	sourceFile string
+	// lineOffset is the 0-based line index at which text begins within the full
+	// concatenation. A validator handed only a section counts lines from 1 inside
+	// it, so the offset is added back to keep reported line numbers file-relative.
+	lineOffset int
+}
+
+// legacyMetadataUnits splits a ProcessedContent into the units the legacy fallback
+// should validate separately.
+//
+// The units come from the DECLARED sections, so provenance is whatever the
+// preprocessor recorded when it opened the archive member — not something parsed back
+// out of the extracted text, which a document author writes and can therefore choose.
+//
+// Fails closed in the shape this path needs: with no declared sections (an older
+// preprocessor, or a caller that built ProcessedContent by hand) it returns the whole
+// text attributed to the container, which is exactly the previous behavior. Losing a
+// precise label is acceptable; losing the scan is not.
+func legacyMetadataUnits(content *preprocessors.ProcessedContent) []legacyMetadataUnit {
+	if content == nil {
+		return nil
+	}
+
+	units := make([]legacyMetadataUnit, 0, len(content.Sections))
+	for _, section := range content.Sections {
+		if strings.TrimSpace(section.Text) == "" {
+			continue
+		}
+		source := section.SourceFile
+		if source == "" {
+			source = content.OriginalPath
+		}
+		units = append(units, legacyMetadataUnit{
+			text:       section.Text,
+			sourceFile: source,
+			lineOffset: section.LineOffset,
+		})
+	}
+
+	if len(units) == 0 {
+		return []legacyMetadataUnit{{text: content.Text, sourceFile: content.OriginalPath}}
+	}
+	return units
+}
+
 func (evb *EnhancedValidatorBridge) processContentLegacy(ctx stdctx.Context, content *preprocessors.ProcessedContent, contextInsights context.ContextInsights) ([]detector.Match, error) {
 	if evb.observer != nil && evb.observer.Debug() != nil {
 		evb.observer.Debug().LogDetail("fallback", "Using legacy content aggregation")
@@ -638,21 +688,52 @@ func (evb *EnhancedValidatorBridge) processContentLegacy(ctx stdctx.Context, con
 	// Process with metadata validator if available. Dispatch through execguard
 	// so a panic in the metadata validator is recovered rather than crashing
 	// the process (v2 gap 1.3), matching the document path.
+	//
+	// Validate each DECLARED SECTION separately rather than handing over the whole
+	// concatenation, so a finding inside an embedded archive member is attributed to
+	// that member instead of to the container.
+	//
+	// This path has no ContentRouter to consult, and it used to get embedded-media
+	// provenance from the "--- Embedded Media N (name) ---" line the extractor writes
+	// into the text — which is precisely the forgeable channel this change removes.
+	// Deleting the reader without giving this path the structural equivalent silently
+	// re-attributed real embedded findings to the container: on a .docx carrying an
+	// embedded .wav, AUDIO_ARTIST_IDENTITY, EMAIL and IMAGE_AUTHOR moved from
+	// "real_embed.docx -> audio1.wav" to the container path, and because
+	// generateFindingHash folds filepath.Base(Filename), three suppression rules
+	// written against the old attribution stopped matching.
+	//
+	// Sections are produced by the file router before any routing decision, so they
+	// are available here even though this arm is only reached when routing failed.
 	if evb.metadataBridge.metadataValidator != nil {
 		mv := evb.metadataBridge.metadataValidator
-		metadataMatches, err := execguard.ValidateContent(ctx, fmt.Sprintf("%T", mv), mv, content.Text, content.OriginalPath)
-		if err != nil {
-			processingErrors = append(processingErrors, fmt.Errorf("metadata validation failed: %w", err))
-			if evb.observer != nil {
-				evb.observer.LogOperation(observability.StandardObservabilityData{
-					Component: "enhanced_validator_bridge",
-					Operation: "legacy_metadata_error",
-					FilePath:  content.OriginalPath,
-					Success:   false,
-					Error:     err.Error(),
-				})
+		name := fmt.Sprintf("%T", mv)
+
+		for _, unit := range legacyMetadataUnits(content) {
+			metadataMatches, err := execguard.ValidateContent(ctx, name, mv, unit.text, unit.sourceFile)
+			if err != nil {
+				processingErrors = append(processingErrors, fmt.Errorf("metadata validation failed: %w", err))
+				if evb.observer != nil {
+					evb.observer.LogOperation(observability.StandardObservabilityData{
+						Component: "enhanced_validator_bridge",
+						Operation: "legacy_metadata_error",
+						FilePath:  unit.sourceFile,
+						Success:   false,
+						Error:     err.Error(),
+					})
+				}
+				continue
 			}
-		} else {
+
+			// Rebase to file-relative lines. The validator saw only this section, so
+			// it counted from the section's first line; the suppression hash embeds
+			// the line number, so leaving them section-relative would invalidate
+			// every saved rule for a container with more than one section.
+			if unit.lineOffset > 0 {
+				for i := range metadataMatches {
+					metadataMatches[i].LineNumber += unit.lineOffset
+				}
+			}
 			allMatches = append(allMatches, metadataMatches...)
 		}
 	}

--- a/internal/validators/dual_path_bridge.go
+++ b/internal/validators/dual_path_bridge.go
@@ -524,6 +524,47 @@ func (evb *EnhancedValidatorBridge) processDualPath(ctx stdctx.Context, routedCo
 	return result, nil
 }
 
+// ConfidenceCeilingKey is the Match.Metadata key a validator sets to declare a hard
+// upper bound on a finding's confidence. It is read here, in the bridge, because this
+// is where confidence is RAISED after a validator has finished: a document-context
+// adjustment and a cross-path correlation boost are both added downstream, so a
+// validator that clamps its own return value has no way to make the bound stick.
+// Measured case: a value the secrets validator scored 55 was reported at 80 once +20
+// context and +5 correlation had been applied.
+//
+// The key is a plain string rather than an import from one validator package so any
+// validator can use the mechanism without the bridge depending on it. Value must be a
+// float64; anything else is ignored rather than treated as zero, since a
+// misinterpreted ceiling of 0 would silently erase a finding's confidence.
+const ConfidenceCeilingKey = "confidence_ceiling"
+
+// clampToCeiling applies a match's declared confidence ceiling, if it has one.
+//
+// Call this after every adjustment that can raise Confidence. A ceiling means "this
+// value is shaped like something benign and no amount of surrounding context should
+// promote it", which is exactly the claim that document-level boosts would otherwise
+// override — they know nothing about the individual value.
+//
+// Deliberately a clamp and not a drop: only reported findings reach the redactor, so
+// removing a finding would leave its value in the redacted output. A demoted finding
+// is still reported and still redacted.
+func clampToCeiling(match *detector.Match) {
+	if match.Metadata == nil {
+		return
+	}
+	raw, ok := match.Metadata[ConfidenceCeilingKey]
+	if !ok {
+		return
+	}
+	ceiling, ok := raw.(float64)
+	if !ok || ceiling <= 0 {
+		return
+	}
+	if match.Confidence > ceiling {
+		match.Confidence = ceiling
+	}
+}
+
 // applyCrossPathConfidenceAdjustments applies confidence adjustments based on cross-path analysis
 func (evb *EnhancedValidatorBridge) applyCrossPathConfidenceAdjustments(matches []detector.Match, contextInsights context.ContextInsights) []detector.Match {
 	if len(matches) == 0 {
@@ -554,6 +595,7 @@ func (evb *EnhancedValidatorBridge) applyCrossPathConfidenceAdjustments(matches 
 		for i := range matches {
 			originalConfidence := matches[i].Confidence
 			matches[i].Confidence += correlationBoost
+			clampToCeiling(&matches[i])
 
 			// Ensure confidence stays within bounds
 			if matches[i].Confidence > 100 {
@@ -911,6 +953,7 @@ func (dvb *DocumentValidatorBridge) ProcessDocumentContentCtx(ctx stdctx.Context
 					adjustment := dvb.contextAnalyzer.GetConfidenceAdjustment(contextInsights, validatorName)
 					originalConfidence := matches[i].Confidence
 					matches[i].Confidence += adjustment
+					clampToCeiling(&matches[i])
 
 					// Ensure confidence stays within bounds
 					if matches[i].Confidence > 100 {
@@ -1179,6 +1222,7 @@ func (mvb *MetadataValidatorBridge) ProcessMetadataContentCtx(ctx stdctx.Context
 
 				originalConfidence := matches[i].Confidence
 				matches[i].Confidence += totalAdjustment
+				clampToCeiling(&matches[i])
 
 				// Ensure confidence stays within bounds
 				if matches[i].Confidence > 100 {

--- a/internal/validators/legacy_provenance_test.go
+++ b/internal/validators/legacy_provenance_test.go
@@ -1,0 +1,124 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package validators
+
+import (
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/preprocessors"
+)
+
+// The legacy fallback must carry provenance structurally, like the routed path.
+//
+// It is reached whenever routing or dual-path processing fails, and EnableFallbackMode
+// defaults to true, so it is live rather than theoretical. It used to learn where an
+// embedded archive member began by reading the "--- Embedded Media N (name) ---" line
+// out of the extracted text — the same forgeable channel this change removes elsewhere.
+// Deleting that reader without giving this path the structural equivalent silently
+// re-attributed real embedded findings to the container: measured on a .docx carrying an
+// embedded .wav, AUDIO_ARTIST_IDENTITY, EMAIL and IMAGE_AUTHOR moved from
+// "real_embed.docx -> audio1.wav" to the container path, and because
+// generateFindingHash folds filepath.Base(Filename), 3 of 11 suppression rules written
+// against the old attribution stopped matching.
+//
+// Two properties have to hold together, and fixing only the first breaks the second:
+// each unit is attributed to the member it came from, AND its line numbers stay
+// file-relative. A validator handed one section counts lines from 1 inside it, so
+// without rebasing by LineOffset the reported lines shift (21 -> 6, 8 -> 1) and the
+// suppression hash — which embeds the line number — invalidates every saved rule for
+// any container with more than one section.
+
+// TestLegacyMetadataUnitsUseDeclaredProvenance pins the first property.
+func TestLegacyMetadataUnitsUseDeclaredProvenance(t *testing.T) {
+	content := &preprocessors.ProcessedContent{
+		OriginalPath: "report.docx",
+		Text:         "Author: Jane Analyst\n\n--- Embedded Media 1 (audio1.wav) ---\nArtist: john.doe@example.com\n",
+		Sections: []preprocessors.ContentSection{
+			{
+				Name:       "office_metadata",
+				Kind:       preprocessors.SectionKindMetadata,
+				Text:       "Author: Jane Analyst",
+				SourceFile: "report.docx",
+				LineOffset: 0,
+			},
+			{
+				Name:       "embedded",
+				Kind:       preprocessors.SectionKindMetadata,
+				Text:       "Artist: john.doe@example.com",
+				SourceFile: "report.docx -> audio1.wav",
+				LineOffset: 3,
+			},
+		},
+	}
+
+	units := legacyMetadataUnits(content)
+	if len(units) != 2 {
+		t.Fatalf("got %d units, want one per declared section (2)", len(units))
+	}
+
+	if units[1].sourceFile != "report.docx -> audio1.wav" {
+		t.Errorf("embedded section attributed to %q, want the archive member it came from.\n"+
+			"Attributing it to the container loses real provenance and, because the "+
+			"suppression hash folds the filename, invalidates rules written against it.",
+			units[1].sourceFile)
+	}
+	if units[1].lineOffset != 3 {
+		t.Errorf("lineOffset = %d, want 3: without it the validator's section-relative "+
+			"lines are reported as file-relative and every saved suppression rule for "+
+			"this file stops matching", units[1].lineOffset)
+	}
+}
+
+// TestLegacyMetadataUnitsFailClosedWithoutSections is the floor. A caller that builds
+// ProcessedContent by hand, or an older preprocessor that does not declare sections,
+// must still get its text scanned — losing a precise label is acceptable, losing the
+// scan is not.
+func TestLegacyMetadataUnitsFailClosedWithoutSections(t *testing.T) {
+	content := &preprocessors.ProcessedContent{
+		OriginalPath: "report.docx",
+		Text:         "Author: Jane Analyst\nssn 449-87-4100\n",
+	}
+
+	units := legacyMetadataUnits(content)
+	if len(units) != 1 {
+		t.Fatalf("got %d units, want exactly 1 covering the whole text", len(units))
+	}
+	if units[0].text != content.Text {
+		t.Errorf("unit text = %q, want the whole extraction %q — a narrowed unit would "+
+			"leave part of the file unscanned on this path", units[0].text, content.Text)
+	}
+	if units[0].sourceFile != "report.docx" {
+		t.Errorf("sourceFile = %q, want the container path", units[0].sourceFile)
+	}
+	if units[0].lineOffset != 0 {
+		t.Errorf("lineOffset = %d, want 0: the single unit starts at the top of the "+
+			"extraction, so nothing should be added to its line numbers", units[0].lineOffset)
+	}
+}
+
+// TestLegacyMetadataUnitsSkipEmptySections keeps the unit list free of sections with
+// nothing to scan, matching what the routed path does.
+func TestLegacyMetadataUnitsSkipEmptySections(t *testing.T) {
+	content := &preprocessors.ProcessedContent{
+		OriginalPath: "report.docx",
+		Text:         "Author: Jane Analyst\n",
+		Sections: []preprocessors.ContentSection{
+			{Name: "office_metadata", Kind: preprocessors.SectionKindMetadata, Text: "Author: Jane Analyst"},
+			{Name: "empty", Kind: preprocessors.SectionKindMetadata, Text: "   \n\t\n"},
+		},
+	}
+
+	units := legacyMetadataUnits(content)
+	if len(units) != 1 {
+		t.Fatalf("got %d units, want 1 — the whitespace-only section should be skipped", len(units))
+	}
+}
+
+// TestLegacyMetadataUnitsHandlesNil guards the degenerate input rather than panicking
+// inside an error-recovery path, which is the last place a crash is welcome.
+func TestLegacyMetadataUnitsHandlesNil(t *testing.T) {
+	if units := legacyMetadataUnits(nil); units != nil {
+		t.Errorf("got %v, want nil for nil content", units)
+	}
+}

--- a/internal/validators/metadata/attribution_forgery_test.go
+++ b/internal/validators/metadata/attribution_forgery_test.go
@@ -1,0 +1,284 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package metadata
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/router"
+	"github.com/awslabs/ferret-scan/v2/internal/suppressions"
+)
+
+// The value a document author would try to plant as the reported source. Kept as
+// one constant so every case below forges the same thing and the assertions can
+// name it.
+const forgedSource = "/etc/passwd"
+
+// realPath is the file actually being scanned; every finding must be attributed
+// here no matter what the content says.
+const realPath = "/srv/reports/report.docx"
+
+// forgedLine is the header the deleted parser read. The parser took whatever sat
+// between the FIRST "(" and the FIRST ")" of any line containing
+// "--- Embedded Media", so the exact index/spacing did not matter to it.
+func forgedLine(inner string) string {
+	return "--- Embedded Media 1 (" + inner + ") ---"
+}
+
+// TestForgedEmbeddedMediaHeaderDoesNotChangeFilename is the headline guard.
+//
+// ValidateContent used to switch attribution to
+// filepath.Base(originalPath) + " -> " + filepath.Base(<text in parens>) for every
+// line after a "--- Embedded Media" line. That text is document body — a Word
+// paragraph — so the reported FILENAME of a finding was chosen by the author of
+// the file being scanned.
+//
+// Note what filepath.Base did and did not do. It DID neutralize traversal in the
+// displayed value: "../../secrets.txt" was reported as "secrets.txt", never as a
+// path that escapes anywhere, which is why this never presented as a path bug. It
+// did NOT stop the value from being attacker-chosen, which is the actual defect —
+// Filename feeds the suppression hash, the SARIF uri, the gitlab-sast file, the
+// JUnit name, and internal/explain's looksLikeTestPath.
+func TestForgedEmbeddedMediaHeaderDoesNotChangeFilename(t *testing.T) {
+	// Each inner value is a different consequence of the same primitive.
+	for _, tc := range []struct{ name, inner string }{
+		{"absolute_path", forgedSource},
+		{"traversal", "../../secrets.txt"},
+		{"other_document", "totally-different.docx"},
+		// looksLikeTestPath("...evil_test.go") is true, which steers
+		// internal/explain's verdict toward "likely test data" — i.e. advice to
+		// ignore a real finding.
+		{"test_path_verdict_flip", "evil_test.go"},
+		{"empty_parens", ""},
+		// Odd shapes the parser also accepted, to show this is not fixed by
+		// tightening a pattern.
+		{"nested_parens", "a(b)c"},
+		{"leading_space", "   " + forgedSource},
+		{"uppercase_marker", "PASSWD"},
+		// These two are the cases that make this a real guard rather than a
+		// denylist test. A forged value that LOOKS like an ordinary embedded media
+		// name is both the most plausible forgery and the one any
+		// "only parse values that look like media" or "escape the parens" patch
+		// still accepts — the value is attacker-chosen either way, and no amount of
+		// validating its SHAPE can tell it apart from a genuine one, because the
+		// genuine one is not in this text at all. Verified: a mutant that parsed
+		// the header only for .wav/.jpeg values passed the rest of this table and
+		// is caught here.
+		{"plausible_media_name", "audio1.wav"},
+		{"plausible_image_name", "word/media/image1.jpeg"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v := NewValidator()
+			content := "Author: jane@example.com\n" +
+				forgedLine(tc.inner) + "\n" +
+				"Creator: john.doe@example.com\n" +
+				"LastModifiedBy: Ops Reviewer\n" +
+				"GPSLatitude: 40.7128\n" +
+				"GPSLongitude: -74.0060\n"
+
+			matches, err := v.ValidateContent(content, realPath)
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+
+			// Non-vacuity floor: this content must actually produce findings, and
+			// specifically findings on lines AFTER the forged header — those are the
+			// ones the old code re-attributed. Without this the test would pass on a
+			// build that simply detected nothing.
+			if len(matches) == 0 {
+				t.Fatal("no findings at all: the fixture no longer exercises the attribution path")
+			}
+			after := 0
+			for _, m := range matches {
+				if m.LineNumber > 2 {
+					after++
+				}
+			}
+			if after == 0 {
+				t.Fatalf("no finding after the forged header line (got %d findings, all on lines <= 2); "+
+					"the forgery could not have been observed", len(matches))
+			}
+
+			for _, m := range matches {
+				if m.Filename != realPath {
+					t.Errorf("forged header changed the reported source: type=%s line=%d Filename=%q, want %q",
+						m.Type, m.LineNumber, m.Filename, realPath)
+				}
+				// Belt and braces: the " -> " form is the only shape the old parser
+				// produced, so its absence is a direct statement that no parse
+				// happened, independent of what realPath happens to be.
+				if strings.Contains(m.Filename, " -> ") {
+					t.Errorf("type=%s: Filename %q still carries a parsed container->item label",
+						m.Type, m.Filename)
+				}
+			}
+		})
+	}
+}
+
+// TestForgedHeaderDoesNotChangeSuppressionIdentity is the suppression angle.
+//
+// generateFindingHash folds filepath.Base(match.Filename) into the composite it
+// hashes, so a forged filename moved a finding's identity. Both directions are
+// security-relevant: a real finding whose hash moves ONTO an unrelated existing
+// rule is silently dropped (a suppression bypass), and one whose hash moves OFF a
+// rule reappears as noise. Either way the author of the scanned file, not the
+// person who wrote the suppression file, decides.
+//
+// Rather than assert on hash strings (which are private and would make the test a
+// tautology on the hash function), this drives the real SuppressionManager: write
+// a rule against the CONTROL finding, then check the forged run is suppressed by
+// exactly the same rule.
+func TestForgedHeaderDoesNotChangeSuppressionIdentity(t *testing.T) {
+	// Same metadata fields in both; the only difference is the forged header line,
+	// inserted at the top so the line numbers of the metadata fields still agree
+	// (LineNumber is also a hash component, so a shifted line would change the
+	// hash for a legitimate reason and mask the thing under test).
+	fields := "Creator: john.doe@example.com\n" +
+		"LastModifiedBy: Ops Reviewer\n"
+	control := forgedLine("") + "\n" + fields
+	forged := forgedLine(forgedSource) + "\n" + fields
+
+	v := NewValidator()
+	controlMatches, err := v.ValidateContent(control, realPath)
+	if err != nil {
+		t.Fatalf("control ValidateContent: %v", err)
+	}
+	forgedMatches, err := v.ValidateContent(forged, realPath)
+	if err != nil {
+		t.Fatalf("forged ValidateContent: %v", err)
+	}
+	if len(controlMatches) == 0 {
+		t.Fatal("control produced no findings: nothing to build a suppression identity from")
+	}
+	if len(forgedMatches) != len(controlMatches) {
+		t.Fatalf("forged run produced %d findings, control %d: the fixtures are not comparable",
+			len(forgedMatches), len(controlMatches))
+	}
+
+	// Build a manager holding a rule for every control finding, then confirm the
+	// forged run's findings hit those same rules.
+	dir := t.TempDir()
+	sm := suppressions.NewSuppressionManager(dir + "/suppressions.yaml")
+	for _, m := range controlMatches {
+		// AddSuppression rejects a hash it already holds. Two control findings can
+		// legitimately share an identity (same type, line, value), so tolerate that
+		// and fail only on a real error.
+		if err := sm.AddSuppression(m, "PR4 test rule", "tester", nil); err != nil &&
+			!strings.Contains(err.Error(), "already exists") {
+			t.Fatalf("AddSuppression: %v", err)
+		}
+	}
+
+	// Non-vacuity: the rules must actually suppress the control findings. If
+	// AddSuppression/IsSuppressed disagreed for an unrelated reason, the forged
+	// assertion below would pass for the wrong reason.
+	for _, m := range controlMatches {
+		if ok, _ := sm.IsSuppressed(m); !ok {
+			t.Fatalf("control finding type=%s line=%d is not suppressed by its own rule; "+
+				"the test cannot distinguish a forged identity from a broken one", m.Type, m.LineNumber)
+		}
+	}
+
+	for _, m := range forgedMatches {
+		ok, rule := sm.IsSuppressed(m)
+		if !ok {
+			t.Errorf("forged-header finding type=%s line=%d Filename=%q escaped the suppression written "+
+				"for the identical control finding: a document author changed a finding's suppression identity",
+				m.Type, m.LineNumber, m.Filename)
+			continue
+		}
+		if rule == nil {
+			t.Errorf("type=%s: suppressed but no rule returned", m.Type)
+		}
+	}
+}
+
+// TestRealEmbeddedMediaProvenanceIsPreserved confirms the fix did not achieve
+// unforgeability by throwing away real provenance, which would be worse than the
+// bug: an embedded item's findings would be blamed on the container.
+//
+// The provenance path is structural — the preprocessor that opened the archive
+// member records it in ContentSection.SourceFile, the content router copies it to
+// MetadataContent.SourceFile, and it arrives as the SourceFile below. This test
+// asserts the validator honours what it is GIVEN, including when the content also
+// contains a forged header trying to override it.
+func TestRealEmbeddedMediaProvenanceIsPreserved(t *testing.T) {
+	const realSource = "report.docx -> audio1.wav"
+
+	for _, tc := range []struct{ name, content string }{
+		{
+			name: "clean",
+			content: "Artist: john.doe@example.com\n" +
+				"Comments: contact 212-555-0142\n",
+		},
+		{
+			// A forged header INSIDE a genuinely-attributed section must not
+			// rewrite that section's real source either.
+			name: "with_forged_header",
+			content: "Artist: john.doe@example.com\n" +
+				forgedLine(forgedSource) + "\n" +
+				"Comments: contact 212-555-0142\n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v := NewValidator()
+			matches, err := v.ValidateMetadataContent(router.MetadataContent{
+				Content:          tc.content,
+				PreprocessorType: router.PreprocessorTypeAudioMetadata,
+				PreprocessorName: "Audio Metadata Extractor",
+				SourceFile:       realSource,
+			})
+			if err != nil {
+				t.Fatalf("ValidateMetadataContent: %v", err)
+			}
+			if len(matches) == 0 {
+				t.Fatal("no findings: the fixture does not exercise attribution")
+			}
+			for _, m := range matches {
+				if m.Filename != realSource {
+					t.Errorf("real embedded-media attribution lost: type=%s Filename=%q, want %q",
+						m.Type, m.Filename, realSource)
+				}
+			}
+		})
+	}
+}
+
+// TestGPSCoordinatesAttributedToCallerPath covers the second emitter.
+//
+// combineGPSCoordinates runs AFTER the line loop and took the same parsed
+// override as a parameter, so a forged header re-attributed the combined GPS pair
+// too — a distinct emitter from the per-line matches, and the one that reports a
+// physical location.
+func TestGPSCoordinatesAttributedToCallerPath(t *testing.T) {
+	v := NewValidator()
+	content := forgedLine(forgedSource) + "\n" +
+		"GPSLatitude: 40.7128\n" +
+		"GPSLongitude: -74.0060\n"
+
+	matches, err := v.ValidateContent(content, realPath)
+	if err != nil {
+		t.Fatalf("ValidateContent: %v", err)
+	}
+
+	// Non-vacuity: a combined GPS pair must actually be emitted here.
+	var gps []detector.Match
+	for _, m := range matches {
+		if strings.Contains(m.Type, "GPS") {
+			gps = append(gps, m)
+		}
+	}
+	if len(gps) == 0 {
+		t.Fatalf("no GPS finding emitted (%d findings total): combineGPSCoordinates was not exercised",
+			len(matches))
+	}
+	for _, m := range gps {
+		if m.Filename != realPath {
+			t.Errorf("GPS %s attributed to %q, want %q", m.Type, m.Filename, realPath)
+		}
+	}
+}

--- a/internal/validators/metadata/metadata_validator.go
+++ b/internal/validators/metadata/metadata_validator.go
@@ -5,7 +5,6 @@ package metadata
 
 import (
 	"fmt"
-	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
@@ -680,32 +679,42 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 	seenGPSFields := make(map[string]bool)
 	// Track if we've seen author/creator info to avoid duplicate matches
 	seenAuthor := false
-	// Track current embedded media context
-	currentEmbeddedMedia := ""
 	// Track GPS coordinate components for combining
 	gpsCoordinates := make(map[string]string) // field -> value
 	gpsLineNumbers := make(map[string]int)    // field -> line number
 
+	// Every match this function emits is attributed to originalPath, the path the
+	// CALLER supplied.
+	//
+	// This used to be conditional. A line containing "--- Embedded Media" switched
+	// attribution for every subsequent line to filepath.Base(originalPath) + " -> " +
+	// filepath.Base(text between the first "(" and the first ")"), so the reported
+	// source of a finding was read out of the content being scanned. A document
+	// author writes that content, so the author chose the filename: typing
+	// "--- Embedded Media 1 (/etc/passwd) ---" in a Word paragraph produced
+	// "report.docx -> passwd", and "(evil_test.go)" produced a name that
+	// internal/explain's looksLikeTestPath reads as fixture data and downgrades the
+	// verdict toward "likely test data" — advice to ignore a real finding.
+	// filepath.Base did neutralize traversal in the DISPLAYED string
+	// ("../../secrets.txt" showed as "secrets.txt", not as an escaping path), which
+	// is why this never looked like a path-handling bug; what it did not do is stop
+	// the value from being attacker-chosen in the first place.
+	//
+	// Filename is also an input to the suppression identity: generateFindingHash
+	// folds in filepath.Base(match.Filename), so a forged name moved a finding's
+	// hash — either off an existing rule (a genuinely suppressed finding reappears)
+	// or onto one (a real finding is silently dropped by a rule written for
+	// something else).
+	//
+	// The provenance is real structure, not text: the preprocessor that actually
+	// read the archive member records it in ContentSection.SourceFile, the content
+	// router copies that into MetadataContent.SourceFile, and it arrives here as the
+	// originalPath argument. So the correct value is already in hand on the routed
+	// path, and re-deriving it from the text could only ever produce a WORSE answer
+	// than the one the caller passed in.
+	filename := originalPath
+
 	for lineNumber, line := range lines {
-		// Check if we're entering an embedded media section
-		if strings.Contains(line, "--- Embedded Media") {
-			if idx := strings.Index(line, "("); idx != -1 {
-				if endIdx := strings.Index(line[idx:], ")"); endIdx != -1 {
-					embeddedName := line[idx+1 : idx+endIdx]
-					// Extract just the image filename from the path
-					imageName := filepath.Base(embeddedName)
-					currentEmbeddedMedia = fmt.Sprintf("%s -> %s", filepath.Base(originalPath), imageName)
-				}
-			}
-			continue
-		}
-
-		// Determine filename based on context
-		filename := originalPath
-		if currentEmbeddedMedia != "" {
-			filename = currentEmbeddedMedia
-		}
-
 		// Skip empty lines
 		if strings.TrimSpace(line) == "" {
 			continue
@@ -1091,7 +1100,7 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 	}
 
 	// After processing all lines, combine GPS coordinate components
-	combinedMatches := v.combineGPSCoordinates(gpsCoordinates, gpsLineNumbers, originalPath, currentEmbeddedMedia)
+	combinedMatches := v.combineGPSCoordinates(gpsCoordinates, gpsLineNumbers, originalPath)
 	matches = append(matches, combinedMatches...)
 
 	return matches, nil
@@ -2367,15 +2376,16 @@ func sortedGPSFields(gpsCoordinates map[string]string) []string {
 	return fields
 }
 
-// combineGPSCoordinates combines latitude and longitude into coordinate pairs
-func (v *Validator) combineGPSCoordinates(gpsCoordinates map[string]string, gpsLineNumbers map[string]int, originalPath, currentEmbeddedMedia string) []detector.Match {
+// combineGPSCoordinates combines latitude and longitude into coordinate pairs.
+//
+// It took a currentEmbeddedMedia override that the caller derived by parsing
+// "--- Embedded Media N (name) ---" out of the scanned text; see ValidateContent
+// for why that made the reported source attacker-chosen. Coordinates are
+// attributed to originalPath, which the caller already receives as real structure.
+func (v *Validator) combineGPSCoordinates(gpsCoordinates map[string]string, gpsLineNumbers map[string]int, originalPath string) []detector.Match {
 	var matches []detector.Match
 
-	// Determine filename based on context
 	filename := originalPath
-	if currentEmbeddedMedia != "" {
-		filename = currentEmbeddedMedia
-	}
 
 	// Look for latitude/longitude pairs
 	var latitude, longitude, latRef, longRef string

--- a/internal/validators/metadata/metadata_validator_test.go
+++ b/internal/validators/metadata/metadata_validator_test.go
@@ -102,7 +102,7 @@ func TestMetadata_CombineGPSNoEarlyReturn(t *testing.T) {
 	v := NewValidator()
 	gps := map[string]string{"coordinates": "N/A", "gpslatitude": "40.7128", "gpslongitude": "-74.0060"}
 	lines := map[string]int{"coordinates": 1, "gpslatitude": 2, "gpslongitude": 3}
-	res := v.combineGPSCoordinates(gps, lines, "f.jpg", "")
+	res := v.combineGPSCoordinates(gps, lines, "f.jpg")
 
 	pairFound := false
 	for _, r := range res {
@@ -133,7 +133,7 @@ func TestMetadata_GPSPairValidation(t *testing.T) {
 	} {
 		res := v.combineGPSCoordinates(
 			map[string]string{"gpslatitude": tc.lat, "gpslongitude": tc.long},
-			map[string]int{"gpslatitude": 1, "gpslongitude": 2}, "f.jpg", "")
+			map[string]int{"gpslatitude": 1, "gpslongitude": 2}, "f.jpg")
 		if len(res) > 0 {
 			t.Errorf("L17: invalid pair (%s,%s) should not be emitted, got %d", tc.lat, tc.long, len(res))
 		}
@@ -141,7 +141,7 @@ func TestMetadata_GPSPairValidation(t *testing.T) {
 	// A valid in-range pair is still HIGH.
 	res := v.combineGPSCoordinates(
 		map[string]string{"gpslatitude": "40.7128", "gpslongitude": "-74.0060"},
-		map[string]int{"gpslatitude": 1, "gpslongitude": 2}, "f.jpg", "")
+		map[string]int{"gpslatitude": 1, "gpslongitude": 2}, "f.jpg")
 	if len(res) != 1 || res[0].Confidence < 90 {
 		t.Errorf("L17: valid pair should be one HIGH GPS match, got %d", len(res))
 	}

--- a/internal/validators/secrets/hex_identifier_test.go
+++ b/internal/validators/secrets/hex_identifier_test.go
@@ -1,0 +1,126 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package secrets
+
+import "testing"
+
+// A bare hex value on a line that names nothing secret is an identifier shape, not a
+// credential, and gets a confidence ceiling below the MEDIUM band.
+//
+// The case that prompted it: an EXIF ImageUniqueID — an image GUID — was reported as
+// API_KEY_OR_SECRET at 80 inside a real 10 MB .docx. It reaches the entropy path at all
+// only because containsSecretIndicators admits any quoted value of 20+ bytes; no secret
+// keyword is involved. Digests, ETags, commit ids and content hashes share the shape.
+//
+// The discriminator is the LINE'S LABEL read as a POSITIVE signal — the ceiling applies
+// when nothing says "secret" — and the direction is the point. A negative list of
+// identifier field names would let a document author suppress a REAL secret by writing
+// `ImageUniqueID: "AKIA..."`. That is attacker-controlled suppression, the same class of
+// defect the surrounding work has been removing. Here relabelling can only REMOVE the
+// ceiling, never trigger it.
+
+func TestUnlabelledHexIdentifierCap(t *testing.T) {
+	const guid = "14f6364997257b9170c016a13d1f1127" // 32 hex, the measured EXIF value
+
+	cases := []struct {
+		name    string
+		value   string
+		line    string
+		capped  bool
+		comment string
+	}{
+		// Capped: identifier shapes with no credential label.
+		{"exif image guid", guid, `ImageUniqueID: "` + guid + `"`, true, "the reported false positive"},
+		{"md5 digest", "d41d8cd98f00b204e9800998ecf8427e", `checksum: "d41d8cd98f00b204e9800998ecf8427e"`, true, ""},
+		{"sha1 commit", "9f8e7d6c5b4a39281706f5e4d3c2b1a0f9e8d7c6", `commit "9f8e7d6c5b4a39281706f5e4d3c2b1a0f9e8d7c6"`, true, ""},
+		{"sha256", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", `digest "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"`, true, ""},
+		{"uppercase hex", "14F6364997257B9170C016A13D1F1127", `SerialNumber: "14F6364997257B9170C016A13D1F1127"`, true, "case must not matter"},
+
+		// NOT capped: the line labels the value as a credential. This is the direction
+		// that makes the rule safe — an author cannot demote a real secret by renaming
+		// its field, because any secret-ish word removes the ceiling.
+		{"api_key label", guid, `api_key = "` + guid + `"`, false, "SAME VALUE as the FP, must keep full score"},
+		{"secret label", guid, `client_secret: "` + guid + `"`, false, ""},
+		{"token label", guid, `token "` + guid + `"`, false, ""},
+		{"password label", guid, `password: "` + guid + `"`, false, ""},
+		{"auth label", guid, `authorization: "` + guid + `"`, false, ""},
+		{"private label", guid, `private_value: "` + guid + `"`, false, ""},
+		{"hmac label", guid, `hmac: "` + guid + `"`, false, ""},
+		{"session label", guid, `session: "` + guid + `"`, false, ""},
+
+		// NOT capped: wrong shape. Anything that is not pure hex at an identifier
+		// length keeps its score, so the rule cannot quietly demote real secrets that
+		// merely contain hex.
+		{"base64ish", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", `value = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"`, false, ""},
+		{"hex with dashes", "14f63649-9725-7b91-70c0-16a13d1f1127", `id: "14f63649-9725-7b91-70c0-16a13d1f1127"`, false, "a dashed GUID is not bare hex"},
+		{"too short", "14f6364997257b91", `id: "14f6364997257b91"`, false, "16 hex is not an identifier length we claim"},
+		{"48 hex is not a known length", "14f6364997257b9170c016a13d1f112714f6364997257b91", `id: "x"`, false, ""},
+		{"hex plus suffix", guid + "z", `id: "` + guid + `z"`, false, ""},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := unlabelledHexIdentifierCap(genericSecretType, tc.value, tc.line)
+			capped := got > 0
+
+			if capped != tc.capped {
+				verb := "was not capped but should be"
+				if !tc.capped {
+					verb = "was capped but should not be"
+				}
+				extra := ""
+				if tc.comment != "" {
+					extra = " (" + tc.comment + ")"
+				}
+				t.Errorf("%s%s\n  value: %q\n  line:  %q\n  ceiling returned: %v",
+					verb, extra, tc.value, tc.line, got)
+			}
+			if capped && got != unlabelledHexIdentifierCeiling {
+				t.Errorf("ceiling = %v, want %v (below the MEDIUM band so the finding "+
+					"reports as LOW)", got, unlabelledHexIdentifierCeiling)
+			}
+		})
+	}
+}
+
+// TestUnlabelledHexIdentifierCapOnlyAppliesToGenericFindings keeps the rule away from
+// provider-identified secrets. A value that matched a provider signature has been
+// identified by its own shape, and no line-label heuristic should second-guess it.
+func TestUnlabelledHexIdentifierCapOnlyAppliesToGenericFindings(t *testing.T) {
+	const guid = "14f6364997257b9170c016a13d1f1127"
+	line := `ImageUniqueID: "` + guid + `"`
+
+	if got := unlabelledHexIdentifierCap("AWS_SECRET_ACCESS_KEY", guid, line); got != 0 {
+		t.Errorf("ceiling = %v for a provider-identified type, want 0: a value that "+
+			"matched a provider signature must not be demoted by a label heuristic", got)
+	}
+	if got := unlabelledHexIdentifierCap(genericSecretType, guid, line); got == 0 {
+		t.Error("the generic type should be capped on this line; the test above would " +
+			"otherwise pass for the wrong reason")
+	}
+}
+
+// TestSecretLabelWordsCoverTheIndicatorKeywords is the consistency floor between the
+// two lists. containsSecretIndicators decides whether a line is scanned at all; the
+// ceiling must never fire on a line that check would have called secret-labelled, or
+// the two would disagree about the same line.
+func TestSecretLabelWordsCoverTheIndicatorKeywords(t *testing.T) {
+	indicatorKeywords := []string{
+		"key", "secret", "token", "password", "pass", "pwd", "auth",
+		"credential", "private", "bearer", "jwt", "api",
+	}
+
+	have := make(map[string]bool, len(secretLabelWords))
+	for _, w := range secretLabelWords {
+		have[w] = true
+	}
+	for _, kw := range indicatorKeywords {
+		if !have[kw] {
+			t.Errorf("secretLabelWords is missing %q, which containsSecretIndicators "+
+				"treats as a secret label. The ceiling could then demote a line the "+
+				"indicator check considers credential-labelled.", kw)
+		}
+	}
+}

--- a/internal/validators/secrets/validator.go
+++ b/internal/validators/secrets/validator.go
@@ -75,6 +75,78 @@ type spannedMatch struct {
 // what the secret actually is, which is strictly more useful to a reviewer.
 const genericSecretType = "API_KEY_OR_SECRET"
 
+// ConfidenceCeilingKey is the Match.Metadata key carrying a hard upper bound on a
+// finding's confidence. The dual-path bridge reads it and clamps AFTER its context and
+// cross-path adjustments — a ceiling applied only here would be undone by them, since a
+// value scored 55 by this validator was reported at 80 in a real document once +20
+// document context and +5 cross-path correlation had been added downstream.
+//
+// The literal is duplicated rather than imported to keep the dependency pointing one
+// way (the bridge must not depend on a validator package). It is covered by a test that
+// fails if the two drift apart.
+const ConfidenceCeilingKey = "confidence_ceiling"
+
+// unlabelledHexIdentifierCeiling keeps a bare hexadecimal value on a line that names
+// nothing secret below the MEDIUM band, so it is reported as LOW.
+//
+// A ceiling and not a veto, deliberately. A 32-hex string genuinely can be a secret,
+// and only reported findings reach the redactor — dropping one would leave the value
+// in the "redacted" output, which is the failure mode this area keeps producing.
+// Demoting keeps the row, keeps the redaction, and keeps it out of the band that
+// drives blocking decisions.
+const unlabelledHexIdentifierCeiling = 55.0
+
+// bareHexIdentifier matches a value that is nothing but hex digits, at the lengths
+// where identifiers live: 32 (GUID, MD5), 40 (SHA-1, git object), 64 (SHA-256).
+// Shorter runs are too common to reason about; longer ones are rarer than the noise
+// they would add.
+var bareHexIdentifier = regexp.MustCompile(`^(?:[0-9a-f]{32}|[0-9a-f]{40}|[0-9a-f]{64})$`)
+
+// secretLabelWords are the words whose presence on a line means the value is being
+// presented as a credential. Matched as substrings, and kept a superset of what
+// containsSecretIndicators looks for, so the ceiling can never fire on a line that
+// the indicator check would have called secret-labelled.
+var secretLabelWords = []string{
+	"key", "secret", "token", "password", "pass", "pwd", "auth",
+	"credential", "private", "bearer", "jwt", "api", "signature", "hmac",
+	"session", "cookie", "access", "refresh", "client_id", "clientid",
+}
+
+// unlabelledHexIdentifierCap returns the ceiling for a generic high-entropy finding
+// whose value is a bare hex identifier on a line carrying no secret-ish label, or 0
+// when no ceiling applies.
+//
+// The case that prompted it: an EXIF ImageUniqueID — `ImageUniqueID:
+// "14f6364997257b9170c016a13d1f1127"` — is an image GUID, and it was reported as
+// API_KEY_OR_SECRET at 80 in a real 10 MB .docx. It reaches the entropy path at all
+// only because containsSecretIndicators admits any quoted value of 20+ bytes; no
+// secret keyword is involved. Digests, ETags, commit ids and content hashes share the
+// shape.
+//
+// The discriminator is the LINE'S LABEL read as a positive signal — the ceiling
+// applies when nothing says "secret" — rather than a negative list of identifier
+// field names. That direction is the point. A negative list would let an author
+// suppress a REAL secret by writing `ImageUniqueID: "AKIA..."`, which is
+// attacker-controlled suppression: the exact class of defect the surrounding changes
+// have been removing. Here an author cannot trigger the ceiling by relabelling, since
+// adding any secret-ish word only removes it. Measured on one 32-hex value:
+// `api_key = "14f6..."` keeps 75, `ImageUniqueID: "14f6..."` becomes 55.
+func unlabelledHexIdentifierCap(secretType, match, line string) float64 {
+	if secretType != genericSecretType {
+		return 0
+	}
+	if !bareHexIdentifier.MatchString(strings.ToLower(strings.Trim(match, `"'`))) {
+		return 0
+	}
+	lower := strings.ToLower(line)
+	for _, keyword := range secretLabelWords {
+		if strings.Contains(lower, keyword) {
+			return 0
+		}
+	}
+	return unlabelledHexIdentifierCeiling
+}
+
 // mergeBySpanKeepStrongest folds src into dst, treating findings that cover the
 // identical byte span as one secret discovered twice: a quoted 40-char AWS
 // secret is matched both by the context-gated AWS path (AWS_SECRET_ACCESS_KEY)
@@ -1476,6 +1548,25 @@ func (v *Validator) processScopedCandidates(matches []scopedCandidate, line stri
 
 		if confidence > confidenceThreshold {
 			secretType := v.getSecretType(match)
+			meta := map[string]any{
+				"validation_checks": checks,
+				"detection_method":  detectionMethod,
+				"source":            "preprocessed_content",
+				"context_domain":    contextInsights.Domain,
+				"context_doc_type":  contextInsights.DocumentType,
+				"environment_type":  envType,
+				"secret_type":       secretType,
+			}
+			// A bare hex identifier on an unlabelled line gets a hard ceiling that the
+			// bridge's downstream context and cross-path adjustments must respect.
+			// Clamping here alone would not hold: those adjustments are applied after
+			// the validator returns and took one such value from 55 to 80.
+			if ceiling := unlabelledHexIdentifierCap(secretType, match, line); ceiling > 0 {
+				meta[ConfidenceCeilingKey] = ceiling
+				if confidence > ceiling {
+					confidence = ceiling
+				}
+			}
 			results = append(results, spannedMatch{
 				start: cand.start,
 				end:   cand.end,
@@ -1486,15 +1577,7 @@ func (v *Validator) processScopedCandidates(matches []scopedCandidate, line stri
 					Confidence: confidence,
 					Filename:   originalPath,
 					Validator:  "secrets",
-					Metadata: map[string]any{
-						"validation_checks": checks,
-						"detection_method":  detectionMethod,
-						"source":            "preprocessed_content",
-						"context_domain":    contextInsights.Domain,
-						"context_doc_type":  contextInsights.DocumentType,
-						"environment_type":  envType,
-						"secret_type":       secretType,
-					},
+					Metadata:   meta,
 				},
 			})
 		}


### PR DESCRIPTION
**Stacked on #240.** Fixes the false positive surfaced (not caused) by #237, and adds a small generic mechanism other validators can reuse.

## The finding

An EXIF `ImageUniqueID` reported as `API_KEY_OR_SECRET` at **80 (MEDIUM)** in a real 10 MB `.docx`:

```
ImageUniqueID: "14f6364997257b9170c016a13d1f1127"
```

That's an image GUID. It reaches the generic entropy path only because `containsSecretIndicators` admits *any* quoted value of 20+ bytes — no secret keyword is involved. Digests, ETags, commit ids and content hashes share the shape.

## Why the obvious fix doesn't work

The secrets validator scores this value **55**. The 80 is:

```
55 (validator) + 20 (document-context adjustment) + 5 (cross-path correlation boost)
```

Both applied **after** the validator returns, at three separate sites in the bridge. So a validator clamping its own output has no way to make a bound stick — I tried that first and the reported score stayed at 80.

## The mechanism

A small generic contract instead: a validator sets `Match.Metadata["confidence_ceiling"]`, and the bridge clamps to it after **every** adjustment that can raise confidence.

The key is declared in the bridge rather than imported from a validator package, so the dependency keeps pointing one way. A test fails if the two literals drift, since a silent mismatch would turn every ceiling into a no-op.

Any validator with a value-intrinsic reason to say *"no amount of surrounding context should promote this"* can now use it without new plumbing. The secrets validator declares a ceiling of 55 for a value that is bare hex at an identifier length (32/40/64) on a line carrying no secret-ish word.

## Two decisions worth reviewing

**It is a ceiling, not a veto.** A 32-hex string genuinely can be a secret, and only reported findings reach the redactor — dropping one would leave the value in the "redacted" output, which is the failure mode this whole area keeps producing. Verified: the demoted finding is still redacted, output reads `ImageUniqueID: "[API_KEY_OR_SECRET-REDACTED]"` with zero cleartext occurrences.

**The discriminator is the line's label as a POSITIVE signal** — the ceiling applies when nothing says "secret" — rather than a negative list of identifier field names like `ImageUniqueID` or `SerialNumber`. That direction is the point. A negative list would let a document author suppress a **real** secret by writing `ImageUniqueID: "AKIA..."`: attacker-controlled suppression, the same class of defect #237–#240 have been removing. Here relabelling can only *remove* the ceiling.

Measured on one identical value:

| line | confidence |
|---|---|
| `api_key = "14f6364997257b9170c016a13d1f1127"` | **75** (untouched) |
| `ImageUniqueID: "14f6364997257b9170c016a13d1f1127"` | **55** (capped) |

## Result

| | before | after |
|---|---|---|
| the reported row | `[MEDIUM] 80.00%` | `[LOW] 55.00%` |
| total findings | 78 | **78** — count deliberately unchanged |

## Testing

Per `docs/testing/TEST_PLAN.md`.

**D10 non-vacuity, both halves separately:** removing the clamp calls restores 80 on the real document; dropping the label check fails **8 of 20** shape subtests.

**D3** goldens 0 changed — the corpus has no `API_KEY_OR_SECRET` row at all, so this moves nothing. **D4** linear on all four fixture families (1.70–1.88× per doubling), within 1.03× of base. **D5** sink verified above. **D11** 10 runs stable at 78 findings / 55 confidence. **D1/D2/D12/D13** 61 packages pass, gofmt clean, vet clean *and* test binaries compile for darwin/linux/windows, `-race` clean on both touched packages.

## One accepted cost

The suppression hash embeds `%.2f` confidence, so demoting a finding invalidates a rule written against it. Of 78 rules generated by the parent binary on that document, **77 still match and 1 escapes** — the demoted row, and nothing else. Any confidence change has this property; this is the minimum blast radius for it.

## Not addressed here

The **+5 cross-path correlation boost** applies to *every* finding whenever both validation paths hit — so adding one finding to a document can shift an unrelated finding's confidence and invalidate its suppression rule. That touches every finding in every container and doesn't belong in a one-row fix. Its own issue.