### PR TITLE
fix(router): take document structure from the extractor, not from the document

### DIFF
--- a/docs/development/content-routing-troubleshooting.md
+++ b/docs/development/content-routing-troubleshooting.md
@@ -141,35 +141,27 @@ ferret-scan --file document.pdf --debug-content-routing --dry-run
 
 **Solutions:**
 
-1. **Update Preprocessor Configuration:**
-```yaml
-# Ensure preprocessors include proper section markers
-preprocessors:
-  metadata_extractor:
-    include_section_markers: true
-    marker_format: "--- {type}_metadata ---"
-```
+> **Do not fix this by matching section markers in the extracted text.** Section
+> boundaries are *declared* by the producing preprocessor in
+> `ProcessedContent.Sections`, not recovered from the text. Matching
+> `--- image_metadata ---` in content lets a document author choose the routing,
+> because the author writes the text — and because the metadata path runs one
+> field-name scanner rather than the full validator set, a forged marker deletes
+> findings instead of relabelling them. A finding that is never reported is never
+> redacted.
 
-2. **Fix Section Pattern Matching:**
-```go
-// Update pattern matching logic if needed
-func (cr *ContentRouter) identifyPreprocessorType(section ContentSection) string {
-    patterns := map[string]string{
-        "image_metadata":    `(?i)---\s*image_metadata\s*---`,
-        "document_metadata": `(?i)---\s*document_metadata\s*---`,
-        "audio_metadata":    `(?i)---\s*audio_metadata\s*---`,
-        "video_metadata":    `(?i)---\s*video_metadata\s*---`,
-    }
+1. **Check that the preprocessor populates `Sections`:**
+   A preprocessor that returns text but no sections is treated as *all document
+   body* (fail-closed). Coverage is intact, but metadata labelling is lost, which
+   is what "missing preprocessor type information" looks like. The fix belongs in
+   the preprocessor: return one `ContentSection` per distinct run of its output,
+   as `office_metadata` does for its property block and each embedded media item.
 
-    for preprocessorType, pattern := range patterns {
-        if matched, _ := regexp.MatchString(pattern, section.Header); matched {
-            return preprocessorType
-        }
-    }
-
-    return "unknown"
-}
-```
+2. **Check that the section's `Name` is in the classifier:**
+   `preprocessors.ClassifySection` switches on the preprocessor's `GetName()`.
+   An unrecognized name classifies as body, so a newly added metadata
+   preprocessor needs a case there — and a corresponding rule set in the METADATA
+   validator's table, keyed by the type the classifier returns.
 
 ### Issue: Content Router Performance Degradation
 
@@ -408,42 +400,38 @@ ferret-scan --file document.pdf --debug-content-routing --preprocess-only
 
 **Solutions:**
 
-1. **Improve Type Detection Logic:**
+1. **Set the type at the producer, where it is known:**
+
+A `ContentSection` carries its own `Type`, and the producing preprocessor fills it
+in. There is no detection step to improve — and adding one that reads the section
+header or the content would reintroduce the in-band signalling this design exists
+to remove (see the boxed warning above).
+
 ```go
-func (cr *ContentRouter) identifyPreprocessorType(section ContentSection) string {
-    // Check explicit type markers first
-    if section.Metadata != nil {
-        if pType, exists := section.Metadata["preprocessor_type"]; exists {
-            return pType.(string)
-        }
-    }
-
-    // Check section headers
-    headerLower := strings.ToLower(section.Header)
-    switch {
-    case strings.Contains(headerLower, "image") && strings.Contains(headerLower, "metadata"):
-        return PreprocessorTypeImageMetadata
-    case strings.Contains(headerLower, "document") && strings.Contains(headerLower, "metadata"):
-        return PreprocessorTypeDocumentMetadata
-    case strings.Contains(headerLower, "audio") && strings.Contains(headerLower, "metadata"):
-        return PreprocessorTypeAudioMetadata
-    case strings.Contains(headerLower, "video") && strings.Contains(headerLower, "metadata"):
-        return PreprocessorTypeVideoMetadata
-    }
-
-    // Fallback to content analysis
-    return cr.analyzeContentForType(section.Content)
-}
+// internal/preprocessors/office_metadata_preprocessor.go
+sections := []ContentSection{{
+    Name:       omp.GetName(), // our own constant, not document bytes
+    Kind:       SectionKindMetadata,
+    Type:       ProcessorTypeOfficeMetadata,
+    SourceFile: filePath,
+    Text:       text,
+    LineOffset: 0,
+}}
 ```
 
-2. **Update Preprocessor Output Format:**
+2. **For nested content, carry the inner producer's type:**
+
+An embedded item routes to a *different* rule set than its container: a `.wav`
+inside a `.docx` has an `Artist:` field, which is on the audio sensitive-field list
+but not the office one. Label the sub-section with the extractor that actually read
+it, or that field reports nothing.
+
 ```go
-// Ensure preprocessors include type information
-type PreprocessorOutput struct {
-    Content          string
-    PreprocessorType string
-    SectionMarker    string
-    Metadata         map[string]interface{}
+// The sub-result's own sections are re-anchored, not overwritten.
+for _, sub := range processed.Sections {
+    sub.SourceFile = sectionSource // "container.docx -> audio1.wav"
+    sub.LineOffset += contentLine
+    sections = append(sections, sub)
 }
 ```
 

--- a/docs/development/enhanced-processing-sequence.md
+++ b/docs/development/enhanced-processing-sequence.md
@@ -238,26 +238,40 @@ func (cr *ContentRouter) RouteContent(content *ProcessedContent) (*RoutedContent
 ```
 
 #### 3.3 Preprocessor Type Identification
-```go
-func (cr *ContentRouter) identifyPreprocessorType(section ContentSection) string {
-    // Check section markers
-    if strings.Contains(section.Header, "image_metadata") {
-        return PreprocessorTypeImageMetadata
-    }
-    if strings.Contains(section.Header, "document_metadata") {
-        return PreprocessorTypeDocumentMetadata
-    }
-    if strings.Contains(section.Header, "audio_metadata") {
-        return PreprocessorTypeAudioMetadata
-    }
-    if strings.Contains(section.Header, "video_metadata") {
-        return PreprocessorTypeVideoMetadata
-    }
 
-    // Fallback to content analysis
-    return cr.analyzeContentType(section.Content)
+A section's type is **declared by the producer, not detected from the content**. The
+file router builds `ProcessedContent.Sections` in the same loop that concatenates
+the extractors' output, and classifies each one from the preprocessor's
+`GetName()` — a constant in our own code:
+
+```go
+// internal/preprocessors/preprocessor.go
+func ClassifySection(preprocessorName string) (SectionKind, string) {
+    switch preprocessorName {
+    case ProcessorTypeImageMetadata:
+        return SectionKindMetadata, ProcessorTypeImageMetadata
+    case ProcessorTypePDFMetadata:
+        return SectionKindMetadata, "document_metadata"
+    // ... one case per preprocessor ...
+    default:
+        // "Text Extractor", "Plain Text Preprocessor", anything unknown.
+        return SectionKindBody, ""
+    }
 }
 ```
+
+Two properties are deliberate and must not be "improved" away:
+
+- **Exact match on a closed set, never a substring or regex over section text.**
+  Deriving the type by matching markers such as `--- image_metadata ---` in the
+  extracted text means a document author decides the type, because the author
+  writes the text. A paragraph typed as `--- office_metadata ---` used to move the
+  rest of the document onto the metadata path, which runs a single field-name
+  scanner instead of the full validator set — so findings were deleted, not
+  relabelled, and an unreported finding is never redacted.
+- **Unknown names classify as body, not metadata.** That is the fail-closed
+  direction: the document path runs every validator, so a preprocessor added
+  without updating the switch loses a metadata *label*, never coverage.
 
 ### 4. Dual-Path Validation (NEW)
 

--- a/internal/preprocessors/base_metadata_preprocessor.go
+++ b/internal/preprocessors/base_metadata_preprocessor.go
@@ -6,6 +6,8 @@ package preprocessors
 import (
 	"context"
 	"fmt"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/awslabs/ferret-scan/v2/internal/observability"
@@ -177,13 +179,29 @@ func (bmp *BaseMetadataPreprocessor) processWithRetryInternal(filePath string, p
 	return content, err
 }
 
-// ProcessEmbeddedMedia processes embedded media through the router if available
-func (bmp *BaseMetadataPreprocessor) ProcessEmbeddedMedia(originalFilePath string, embeddedMedia []EmbeddedMedia) string {
+// ProcessEmbeddedMedia processes embedded media through the router if available.
+//
+// It returns the text to append to the container's own metadata text, AND one
+// ContentSection per embedded item describing that text out of band. The sections'
+// LineOffset values are relative to the START OF THE RETURNED TEXT; the caller
+// shifts them by the length of whatever it puts in front.
+//
+// The sections matter because an embedded item is a section INSIDE one
+// preprocessor's output, and it routes to a DIFFERENT metadata rule set than its
+// container: a .wav inside a .docx carries an "Artist:" field, which is on the
+// audio rule list but not the office one. Without a declared sub-section the whole
+// blob would be labelled office_metadata and that field would report nothing.
+// Measured: the AUTHOR_INFO finding for an embedded clip's artist address
+// disappeared until these sections were carried.
+func (bmp *BaseMetadataPreprocessor) ProcessEmbeddedMedia(originalFilePath string, embeddedMedia []EmbeddedMedia) (string, []ContentSection) {
 	if bmp.router == nil || len(embeddedMedia) == 0 {
-		return ""
+		return "", nil
 	}
 
 	var result string
+	var sections []ContentSection
+	// Line cursor into `result`, maintained incrementally.
+	line := 0
 
 	for i, media := range embeddedMedia {
 		// Create context showing original file relationship
@@ -196,11 +214,49 @@ func (bmp *BaseMetadataPreprocessor) ProcessEmbeddedMedia(originalFilePath strin
 			processed.Filename = embeddedPath
 
 			// Format and append embedded media section
-			result += bmp.utilities.RouterHelper.FormatEmbeddedMediaSection(i, media.OriginalName, processed.Text)
+			block := bmp.utilities.RouterHelper.FormatEmbeddedMediaSection(i, media.OriginalName, processed.Text)
+			result += block
+
+			// FormatEmbeddedMediaSection prefixes "\n--- ... ---\n", so the
+			// item's own text starts two lines further on.
+			contentLine := line + 2
+
+			// Attribute findings to "container.docx -> audio1.wav", i.e. the BARE
+			// media filename. CreateEmbeddedMediaPath keeps the full archive member
+			// name ("word/media/audio1.wav"); the label the deleted text-parsing
+			// path produced was the basename, and it is what appears in the FILE
+			// column of every report, so keep it identical.
+			sectionSource := bmp.utilities.RouterHelper.CreateEmbeddedMediaPath(
+				originalFilePath, filepath.Base(media.OriginalName))
+
+			// Prefer the sub-result's OWN declared sections — the router built
+			// them from that file's preprocessor names — and just re-anchor them
+			// onto this text and onto the "container -> item" source label. This
+			// composes: a section nested two levels deep still carries the rule
+			// set of the extractor that actually produced it.
+			if len(processed.Sections) > 0 {
+				for _, sub := range processed.Sections {
+					sub.SourceFile = sectionSource
+					sub.LineOffset += contentLine
+					sections = append(sections, sub)
+				}
+			} else {
+				kind, metaType := ClassifySection(processed.ProcessorType)
+				sections = append(sections, ContentSection{
+					Name:       processed.ProcessorType,
+					Kind:       kind,
+					Type:       metaType,
+					SourceFile: embeddedPath,
+					Text:       processed.Text,
+					LineOffset: contentLine,
+				})
+			}
+
+			line += strings.Count(block, "\n")
 		}
 	}
 
-	return result
+	return result, sections
 }
 
 // EmbeddedMedia represents embedded media extracted from documents

--- a/internal/preprocessors/office_metadata_preprocessor.go
+++ b/internal/preprocessors/office_metadata_preprocessor.go
@@ -52,15 +52,40 @@ func (omp *OfficeMetadataPreprocessor) processOfficeMetadata(filePath string) (*
 	text := omp.formatOfficeMetadata(meta)
 
 	// Process embedded media through router if available
-	embeddedText := omp.processEmbeddedMedia(filePath)
+	embeddedText, embeddedSections := omp.processEmbeddedMedia(filePath)
+
+	// Declare this extractor's own structure out of band. The container's own
+	// property block is one office_metadata section; each embedded item is its own
+	// section carrying the rule set of whichever extractor read it (a .wav's
+	// "Artist:" field is on the audio list, not the office one).
+	//
+	// Built here rather than in the router because only this function knows the
+	// split point: the router sees one opaque string from this preprocessor.
+	sections := []ContentSection{{
+		Name:       omp.GetName(),
+		Kind:       SectionKindMetadata,
+		Type:       ProcessorTypeOfficeMetadata,
+		SourceFile: filePath,
+		Text:       text,
+		LineOffset: 0,
+	}}
 	if embeddedText != "" {
+		// The embedded sections were anchored relative to embeddedText, which is
+		// appended after the property block.
+		shift := strings.Count(text, "\n")
+		for _, s := range embeddedSections {
+			s.LineOffset += shift
+			sections = append(sections, s)
+		}
 		text += embeddedText
 	}
 
 	// Log successful processing
 	omp.LogSuccessfulProcessing(meta.Filename, meta.FileSize, meta.MimeType)
 
-	return omp.BuildSuccessContent(filePath, text, "office_metadata", meta.PageCount), nil
+	content := omp.BuildSuccessContent(filePath, text, "office_metadata", meta.PageCount)
+	content.Sections = sections
+	return content, nil
 }
 
 // formatOfficeMetadata formats Office metadata into text format for validation
@@ -141,12 +166,13 @@ func (omp *OfficeMetadataPreprocessor) formatOfficeMetadata(meta *meta_extract_o
 	return result.String()
 }
 
-// processEmbeddedMedia processes embedded media through router integration
-func (omp *OfficeMetadataPreprocessor) processEmbeddedMedia(filePath string) string {
+// processEmbeddedMedia processes embedded media through router integration,
+// returning the text to append and the out-of-band sections describing it.
+func (omp *OfficeMetadataPreprocessor) processEmbeddedMedia(filePath string) (string, []ContentSection) {
 	// Extract embedded media for processing
 	embeddedMedia, err := meta_extract_officelib.ExtractEmbeddedMediaForProcessing(filePath)
 	if err != nil || len(embeddedMedia) == 0 {
-		return ""
+		return "", nil
 	}
 
 	// Ensure cleanup of temporary files

--- a/internal/preprocessors/preprocessor.go
+++ b/internal/preprocessors/preprocessor.go
@@ -50,6 +50,107 @@ type ProcessedContent struct {
 
 	// Additional metadata for embedded media and other extensions
 	Metadata map[string]interface{}
+
+	// Sections carries the structure of Text OUT OF BAND: one entry per
+	// preprocessor whose output was concatenated into Text, in the same order.
+	//
+	// It exists because the structure used to be carried IN BAND. The file router
+	// flattens every extractor's output into Text with literal "\n\n--- name ---\n"
+	// separators, and the content router then re-parsed that text to recover which
+	// bytes came from which extractor. Document authors control the text, so they
+	// controlled the recovered "structure": a paragraph typed as
+	// "--- office_metadata ---" became a section boundary. That is in-band
+	// signalling, the same class of defect as SQL injection, and it has the same
+	// answer — carry the structure alongside the data instead of re-deriving it
+	// from the data.
+	//
+	// Text stays the flat concatenation, byte for byte, so every existing consumer
+	// is unaffected; this field is purely additive. A nil/empty Sections means "no
+	// structure was declared", which consumers must treat as "all of Text is
+	// document body" — the safe direction, since the document path runs the full
+	// validator set and the metadata path runs one field-name scanner.
+	Sections []ContentSection
+}
+
+// ContentSection describes one contiguous run of ProcessedContent.Text and where
+// it came from. Every field is derived from OUR OWN code — the preprocessor's
+// GetName() and the router's classification of it — never from the scanned
+// document's bytes. That provenance is the entire point: it is what makes a
+// section boundary unforgeable by a document author.
+type ContentSection struct {
+	// Name is the producing preprocessor's GetName(), e.g. "Text Extractor" or
+	// "office_metadata". This is the string the flat separator used to spell out.
+	Name string
+
+	// Kind is the routing decision: SectionKindBody or SectionKindMetadata.
+	Kind SectionKind
+
+	// Type is the metadata preprocessor type ("office_metadata",
+	// "image_metadata", ...) for a metadata section, and empty for a body
+	// section. It is what the METADATA validator keys its per-preprocessor
+	// field rules off.
+	Type string
+
+	// SourceFile is the path to attribute findings in this section to. It is the
+	// scanned file for a normal section, and the "container.docx -> image1.jpg"
+	// form for a section extracted from embedded media.
+	SourceFile string
+
+	// Text is this section's bytes. It is a substring of ProcessedContent.Text
+	// (Go strings share backing storage, so this is a reference, not a copy).
+	Text string
+
+	// LineOffset is the 0-based line index at which Text begins within
+	// ProcessedContent.Text, so a finding's line number inside a section can be
+	// reported against the whole extracted document.
+	LineOffset int
+}
+
+// SectionKind is the routing classification of a ContentSection.
+type SectionKind int
+
+const (
+	// SectionKindBody is document body text: the full validator set applies.
+	SectionKindBody SectionKind = iota
+	// SectionKindMetadata is extracted metadata fields: the METADATA validator's
+	// per-preprocessor field rules apply. Note this is about LABELLING, not
+	// coverage — the document path scans the union of all sections regardless.
+	SectionKindMetadata
+)
+
+// ClassifySection maps a preprocessor's GetName() to a section Kind and metadata
+// Type. It lives next to the metadata_constants.go names it matches, and it is a
+// CLOSED switch on the seven names this repo's preprocessors actually return
+// (verified against every GetName() implementation) rather than a substring
+// search.
+//
+// A closed switch is the security-relevant part. The name it classifies is our
+// own code's constant, so an exact match is always possible; substring matching
+// was how the old text-parsing path turned a document paragraph named
+// "--- Employee Metadata ---" into a metadata section. Anything unrecognized
+// classifies as BODY, which is the fail-closed direction: the document path runs
+// the full validator set, so a preprocessor added later without updating this
+// switch loses a label, not coverage.
+func ClassifySection(preprocessorName string) (SectionKind, string) {
+	switch preprocessorName {
+	case ProcessorTypeImageMetadata:
+		return SectionKindMetadata, ProcessorTypeImageMetadata
+	case ProcessorTypePDFMetadata:
+		// The METADATA validator keys PDF metadata rules under
+		// "document_metadata", not "pdf_metadata" — see the content router's
+		// PreprocessorTypeDocumentMetadata. Preserving that remap here keeps the
+		// same rule set (and therefore the same findings) selected.
+		return SectionKindMetadata, "document_metadata"
+	case ProcessorTypeOfficeMetadata:
+		return SectionKindMetadata, ProcessorTypeOfficeMetadata
+	case ProcessorTypeAudioMetadata:
+		return SectionKindMetadata, ProcessorTypeAudioMetadata
+	case ProcessorTypeVideoMetadata:
+		return SectionKindMetadata, ProcessorTypeVideoMetadata
+	default:
+		// "Text Extractor", "Plain Text Preprocessor", and anything unknown.
+		return SectionKindBody, ""
+	}
 }
 
 // PositionMapping represents a mapping between extracted text positions and original document positions

--- a/internal/router/content_router.go
+++ b/internal/router/content_router.go
@@ -27,21 +27,26 @@ type RoutedContent struct {
 	// FullText is every byte the preprocessors extracted, captured BEFORE any
 	// routing decision is made.
 	//
-	// It exists because routing is decided by inspecting the extracted text itself
-	// — section headers of the form "--- name ---" — and document authors control
-	// that text. DocumentBody is therefore an attacker-influenced SUBSET, while the
-	// document validator set is the larger of the two (the metadata path runs a
-	// single field-name scanner that has no SSN, card, phone or email logic). So
-	// whenever the split moved content from the document path to the metadata path,
-	// it moved it from ~19 validators to 1 that cannot detect it, and the finding
-	// vanished. Since only reported findings reach the redactor, a vanished finding
-	// is a value left in cleartext.
+	// It is the SECOND of two independent controls, and it is deliberately kept now
+	// that structure is declared out of band rather than parsed out of the text.
+	// The first control removes the capability: routing reads
+	// ProcessedContent.Sections, built from our own preprocessor names, so a
+	// document author can no longer forge a section boundary. This one contains the
+	// consequence if the first is ever wrong — a bug in a producer, a preprocessor
+	// that populates Sections incorrectly, a caller that declares nothing.
 	//
-	// Keeping the pre-routing text lets the document path scan the union, which
-	// makes routing a LABELLING decision rather than a COVERAGE decision: a forged
-	// or merely unlucky section header can still change how a finding is described,
-	// but it can no longer delete one. That property holds for section names nobody
-	// has thought of yet, which a per-marker fix would not.
+	// It matters because the two paths do not run the same validators. The document
+	// path runs the full set; the metadata path runs a single field-name scanner
+	// with no SSN, card, phone or email logic. So any split that moves content from
+	// the document path to the metadata path moves it from ~19 validators to 1 that
+	// cannot detect it, and the finding does not get relabelled, it vanishes. Since
+	// only reported findings reach the redactor, a vanished finding is a value left
+	// in cleartext.
+	//
+	// Letting the document path scan the union makes routing a LABELLING decision
+	// rather than a COVERAGE decision, for section names nobody has thought of yet.
+	// Do not "simplify" this away on the grounds that the declared sections are now
+	// trustworthy: defence in depth is the point.
 	FullText string
 }
 
@@ -65,7 +70,14 @@ func (e *ContentRouterError) Error() string {
 	return fmt.Sprintf("content router %s failed for %s: %v", e.Operation, e.FilePath, e.Cause)
 }
 
-// Preprocessor type constants for identification
+// Preprocessor type constants. These are the keys the METADATA validator's
+// per-preprocessor rule table is indexed by, so a MetadataContent must carry one
+// of them or the wrong sensitive-field list is applied.
+//
+// "mixed_content" used to live here too. It was a category the deleted
+// text-sniffing classifier returned when it found metadata-looking markers in the
+// document text; nothing keys a rule set off it, and with structure now declared
+// out of band there is no way to reach it.
 const (
 	PreprocessorTypeImageMetadata    = "image_metadata"
 	PreprocessorTypeDocumentMetadata = "document_metadata"
@@ -74,7 +86,6 @@ const (
 	PreprocessorTypeVideoMetadata    = "video_metadata"
 	PreprocessorTypePlainText        = "plain_text"
 	PreprocessorTypeDocumentText     = "document_text"
-	PreprocessorTypeMixedContent     = "mixed_content"
 )
 
 // NewContentRouter creates a new content router
@@ -162,650 +173,164 @@ func (cr *ContentRouter) RouteContent(processedContent *preprocessors.ProcessedC
 		return routedContent, nil
 	}
 
-	// Determine preprocessor type and route accordingly
-	preprocessorType := cr.identifyPreprocessorType(processedContent)
-
-	switch preprocessorType {
-	case PreprocessorTypeImageMetadata, PreprocessorTypeDocumentMetadata, PreprocessorTypeOfficeMetadata,
-		PreprocessorTypeAudioMetadata, PreprocessorTypeVideoMetadata:
-		// This is metadata content - extract and route to metadata validator
-		metadataContent, err := cr.extractMetadataContent(processedContent, preprocessorType)
-		if err != nil {
-			// Graceful degradation - log error but continue
-			if cr.observer != nil {
-				cr.observer.LogOperation(observability.StandardObservabilityData{
-					Component: "content_router",
-					Operation: "extract_metadata",
-					FilePath:  processedContent.OriginalPath,
-					Success:   false,
-					Error:     err.Error(),
-				})
-			}
-		} else {
-			routedContent.Metadata = append(routedContent.Metadata, *metadataContent)
-		}
-
-		// The metadata text is ALSO the document body, so the text validators see it.
+	// Route from the OUT-OF-BAND structure when the producer declared one.
+	//
+	// This is the whole point of the change. The router previously recovered the
+	// structure by scanning processedContent.Text for "--- name ---" lines — and a
+	// document author types the text, so the author decided where the sections
+	// were. A paragraph reading "--- office_metadata ---" moved everything after it
+	// onto the metadata path, which runs ONE field-name scanner instead of the full
+	// validator set, so the finding was not relabelled but deleted. In-band
+	// signalling, same class as SQL injection, same answer: carry the structure
+	// beside the data instead of re-deriving it from the data.
+	//
+	// ProcessedContent.Sections is built by the file router in the same loop that
+	// builds the concatenation, from each Preprocessor's GetName(). That name is
+	// our own code's constant, never a byte of the scanned file, so a boundary here
+	// cannot be forged.
+	if len(processedContent.Sections) > 0 {
+		routedContent.DocumentBody, routedContent.Metadata = cr.routeSections(processedContent)
+	} else {
+		// FAIL CLOSED. No declared structure means we do not guess one from the
+		// text — the whole extraction is document body, which is the safe
+		// direction: the document path runs every validator, so the worst case is
+		// a missing metadata LABEL, never missing coverage. (Reversing it would
+		// hand the whole file to the single-field-name metadata scanner.)
 		//
-		// This used to be set to "", and dual_path_bridge.go gates the entire
-		// document path on `DocumentBody != ""` — so for a file whose only text is
-		// its metadata, exactly 1 of the 19 validators ran: METADATA. That is the
-		// routing outcome for every media type (.jpg/.png/.gif/.tiff/.webp,
-		// .wav/.mp3/.flac/.m4a, .mp4/.mov), because only one preprocessor is capable
-		// for those extensions, so ProcessorType has no "+" and lands in this arm.
-		// (.pdf/.docx/.xlsx are unaffected: two preprocessors are capable, so they
-		// route through "combined_preprocessors", which keeps a body.)
-		//
-		// The METADATA validator cannot cover for that. It is a field-NAME allowlist
-		// scanner: validateWithPreprocessorRules skips any line whose key is not in
-		// the per-preprocessor SensitiveFields list, and for a line that does match
-		// it emits ONE coarse type for the whole field value. So an SSN, a PAN or an
-		// AWS key sitting inside a metadata value is either skipped outright or
-		// reported as a single AUTHOR_INFO/DOCUMENT_COMMENTS row — never typed, and
-		// never individually redactable.
-		//
-		// Measured: an EXIF ImageDescription carrying an SSN, an email and a phone
-		// number produced ZERO findings at any confidence, and because there were no
-		// findings the redaction pipeline wrote no output file at all — the tool
-		// affirmatively reported the file clean while the PII sat in it. The
-		// byte-identical text saved as .txt yielded SSN 83 / PHONE 47 / EMAIL 33.
-		//
-		// This is also what the golden corpus was locking in: the file_wav_metadata_pii
-		// case declares Checks EMAIL, PHONE and SECRETS, and its committed snapshot
-		// contained none of them — an AKIA-prefixed access key went undetected inside
-		// a DOCUMENT_COMMENTS blob.
+		// ProcessorType is still consulted, and that is not a hole: it is
+		// strings.Join of the preprocessors' GetName() values, i.e. our own
+		// constants, not document content. It is the one trustworthy classifier
+		// available to a caller that builds ProcessedContent by hand (the pkg and
+		// ScanContent entry points, and older callers) rather than through the file
+		// router.
 		routedContent.DocumentBody = processedContent.Text
 
-	case PreprocessorTypePlainText, PreprocessorTypeDocumentText:
-		// This is document body content - route to document validators
-		routedContent.DocumentBody = processedContent.Text
-
-	case "combined_preprocessors":
-		// This is combined output from multiple preprocessors - separate them
-		documentBody, metadataItems, err := cr.separateMixedContent(processedContent)
-		if err != nil {
-			// Graceful degradation - treat as document body content
-			if cr.observer != nil {
-				cr.observer.LogOperation(observability.StandardObservabilityData{
-					Component: "content_router",
-					Operation: "separate_combined_preprocessors",
-					FilePath:  processedContent.OriginalPath,
-					Success:   false,
-					Error:     err.Error(),
-				})
-			}
-			routedContent.DocumentBody = processedContent.Text
-		} else {
-			routedContent.DocumentBody = documentBody
-			routedContent.Metadata = metadataItems
-		}
-
-	default:
-		// Mixed content or unknown type - attempt to separate
-		documentBody, metadataItems, err := cr.separateMixedContent(processedContent)
-		if err != nil {
-			// Graceful degradation - treat as document body content
-			if cr.observer != nil {
-				cr.observer.LogOperation(observability.StandardObservabilityData{
-					Component: "content_router",
-					Operation: "separate_mixed_content",
-					FilePath:  processedContent.OriginalPath,
-					Success:   false,
-					Error:     err.Error(),
-				})
-			}
-			routedContent.DocumentBody = processedContent.Text
-		} else {
-			routedContent.DocumentBody = documentBody
-			routedContent.Metadata = metadataItems
+		// A single metadata preprocessor's output is metadata as a whole, so it can
+		// still be labelled without inspecting the text. DocumentBody above already
+		// carries the same bytes to the document path: for a media file that is the
+		// only thing that detects an SSN inside an EXIF field, because the METADATA
+		// validator is a field-NAME allowlist that reports one coarse type per
+		// matching line and never an SSN, a PAN or a key inside the value.
+		if metaType := metadataTypeForProcessorType(processedContent.ProcessorType); metaType != "" &&
+			strings.TrimSpace(processedContent.Text) != "" {
+			routedContent.Metadata = append(routedContent.Metadata, MetadataContent{
+				Content:          processedContent.Text,
+				PreprocessorType: metaType,
+				PreprocessorName: cr.getPreprocessorName(metaType),
+				SourceFile:       processedContent.OriginalPath,
+				Metadata: map[string]interface{}{
+					"processor_type": processedContent.ProcessorType,
+					"format":         processedContent.Format,
+					"success":        processedContent.Success,
+					"declared":       false,
+				},
+			})
 		}
 	}
 
 	if finishTiming != nil {
+		// processor_type is the preprocessors' own joined GetName() string now,
+		// rather than a category inferred by sniffing the document text. The
+		// sniffing classifier is gone: it was the read half of the in-band
+		// signalling, and reporting a label derived from attacker-supplied text
+		// would have kept a use for it alive.
 		finishTiming(true, map[string]interface{}{
-			"preprocessor_type":    preprocessorType,
+			"processor_type":       processedContent.ProcessorType,
 			"document_body_length": len(routedContent.DocumentBody),
 			"metadata_items":       len(routedContent.Metadata),
+			"declared_sections":    len(processedContent.Sections),
 		})
 	}
 
 	return routedContent, nil
 }
 
-// identifyPreprocessorType determines the type of preprocessor that generated the content
-func (cr *ContentRouter) identifyPreprocessorType(processedContent *preprocessors.ProcessedContent) string {
-	// Check ProcessorType field first
-	if processedContent.ProcessorType != "" {
-		// Handle combined processor types (e.g., "pdf_metadata+text")
-		if strings.Contains(processedContent.ProcessorType, "+") {
-			return "combined_preprocessors"
-		}
+// routeSections turns the producer-declared sections into the routed body and
+// metadata items. It reads only ContentSection fields — never the section text —
+// so nothing in the scanned document influences the split.
+func (cr *ContentRouter) routeSections(processedContent *preprocessors.ProcessedContent) (string, []MetadataContent) {
+	var bodySections []string
+	metadataItems := make([]MetadataContent, 0, len(processedContent.Sections))
 
-		switch strings.ToLower(processedContent.ProcessorType) {
-		case "image_metadata", "image-metadata", "imagemetadata":
-			return PreprocessorTypeImageMetadata
-		case "document_metadata", "document-metadata", "documentmetadata":
-			return PreprocessorTypeDocumentMetadata
-		case "pdf_metadata", "pdf-metadata", "pdfmetadata":
-			return PreprocessorTypeDocumentMetadata
-		case "office_metadata", "office-metadata", "officemetadata":
-			return PreprocessorTypeOfficeMetadata
-		case "audio_metadata", "audio-metadata", "audiometadata":
-			return PreprocessorTypeAudioMetadata
-		case "video_metadata", "video-metadata", "videometadata":
-			return PreprocessorTypeVideoMetadata
-		case "plain_text", "plain-text", "plaintext":
-			return PreprocessorTypePlainText
-		case "document_text", "document-text", "documenttext":
-			return PreprocessorTypeDocumentText
-		case "mixed":
-			return PreprocessorTypeMixedContent
-		}
-	}
-
-	// Analyze content patterns to identify type
-	content := processedContent.Text
-	if content == "" {
-		return PreprocessorTypePlainText
-	}
-
-	// Check for metadata section markers
-	if cr.containsMetadataSections(content) {
-		return PreprocessorTypeMixedContent
-	}
-
-	// Check for specific metadata patterns
-	if cr.containsImageMetadataPatterns(content) {
-		return PreprocessorTypeImageMetadata
-	}
-
-	if cr.containsAudioMetadataPatterns(content) {
-		return PreprocessorTypeAudioMetadata
-	}
-
-	if cr.containsVideoMetadataPatterns(content) {
-		return PreprocessorTypeVideoMetadata
-	}
-
-	if cr.containsDocumentMetadataPatterns(content) {
-		return PreprocessorTypeDocumentMetadata
-	}
-
-	// Default to plain text if no specific patterns found
-	return PreprocessorTypePlainText
-}
-
-// extractMetadataContent creates a MetadataContent struct from processed content
-func (cr *ContentRouter) extractMetadataContent(processedContent *preprocessors.ProcessedContent, preprocessorType string) (*MetadataContent, error) {
-	if processedContent.Text == "" {
-		return nil, fmt.Errorf("no content to extract")
-	}
-
-	// Create human-readable preprocessor name
-	preprocessorName := cr.getPreprocessorName(preprocessorType)
-
-	metadataContent := &MetadataContent{
-		Content:          processedContent.Text,
-		PreprocessorType: preprocessorType,
-		PreprocessorName: preprocessorName,
-		SourceFile:       processedContent.OriginalPath,
-		Metadata: map[string]interface{}{
-			"processor_type": processedContent.ProcessorType,
-			"format":         processedContent.Format,
-			"success":        processedContent.Success,
-		},
-	}
-
-	// Add additional metadata if available
-	if processedContent.Metadata != nil {
-		for key, value := range processedContent.Metadata {
-			metadataContent.Metadata[key] = value
-		}
-	}
-
-	return metadataContent, nil
-}
-
-// separateMixedContent separates mixed content into document body and metadata sections
-func (cr *ContentRouter) separateMixedContent(processedContent *preprocessors.ProcessedContent) (string, []MetadataContent, error) {
-	content := processedContent.Text
-
-	// First, check if this is combined preprocessor output from file router
-	if cr.isCombinedPreprocessorOutput(processedContent) {
-		return cr.separateCombinedPreprocessorOutput(processedContent)
-	}
-
-	var documentBody strings.Builder
-	var metadataItems []MetadataContent
-
-	// Split content by lines for processing
-	lines := strings.Split(content, "\n")
-	currentSection := ""
-	var currentMetadataLines []string
-	inMetadataSection := false
-
-	for _, line := range lines {
-		// Check for metadata section markers
-		if metadataSection := cr.detectMetadataSection(line); metadataSection != "" {
-			// Save previous section if it was metadata
-			if inMetadataSection && currentSection != "" && len(currentMetadataLines) > 0 {
-				// Extract embedded media path from the first line of the previous section
-				sourceFile := processedContent.OriginalPath
-				if len(currentMetadataLines) > 0 {
-					sourceFile = cr.extractEmbeddedMediaPath(currentMetadataLines[0], processedContent.OriginalPath)
-				}
-				metadataContent := cr.createMetadataFromLines(currentMetadataLines, currentSection, sourceFile)
-				if metadataContent != nil {
-					metadataItems = append(metadataItems, *metadataContent)
-				}
-			}
-
-			// Start new metadata section
-			currentSection = metadataSection
-			currentMetadataLines = []string{line}
-			inMetadataSection = true
+	for _, section := range processedContent.Sections {
+		if section.Kind != preprocessors.SectionKindMetadata {
+			bodySections = append(bodySections, section.Text)
 			continue
 		}
 
-		// Determine if this line should be added to document body or metadata
-		addToDocumentBody := false
-
-		if inMetadataSection {
-			// Check if this line ends the metadata section BEFORE adding it to metadata
-			isEndMarker := cr.isMetadataSectionEnd(line)
-			if isEndMarker {
-				// End the current metadata section
-				sourceFile := processedContent.OriginalPath
-				if len(currentMetadataLines) > 0 {
-					sourceFile = cr.extractEmbeddedMediaPath(currentMetadataLines[0], processedContent.OriginalPath)
-				}
-				metadataContent := cr.createMetadataFromLines(currentMetadataLines, currentSection, sourceFile)
-				if metadataContent != nil {
-					metadataItems = append(metadataItems, *metadataContent)
-				}
-				inMetadataSection = false
-				currentSection = ""
-				currentMetadataLines = nil
-				addToDocumentBody = true
-			} else {
-				// Continue collecting metadata lines
-				currentMetadataLines = append(currentMetadataLines, line)
-			}
-		} else {
-			// This is document body content
-			addToDocumentBody = true
-		}
-
-		// Add line to document body if determined above
-		if addToDocumentBody {
-			documentBody.WriteString(line)
-			documentBody.WriteString("\n")
-		}
-	}
-
-	// Handle any remaining metadata section
-	if inMetadataSection && currentSection != "" && len(currentMetadataLines) > 0 {
-		// Check if the last few lines should be treated as document content
-		var finalMetadataLines []string
-		var documentLines []string
-
-		// Go through the metadata lines from the end and check if they should be document content
-		for i := len(currentMetadataLines) - 1; i >= 0; i-- {
-			line := currentMetadataLines[i]
-			if cr.isMetadataSectionEnd(line) {
-				// This line and all following lines should be document content
-				documentLines = append([]string{line}, documentLines...)
-			} else {
-				// This line and all previous lines are metadata
-				finalMetadataLines = currentMetadataLines[:i+1]
-				break
-			}
-		}
-
-		// If we found document lines at the end, add them to document body
-		if len(documentLines) > 0 {
-			for _, line := range documentLines {
-				documentBody.WriteString(line)
-				documentBody.WriteString("\n")
-			}
-		}
-
-		// Save the remaining metadata if any
-		if len(finalMetadataLines) > 0 {
-			sourceFile := processedContent.OriginalPath
-			if len(finalMetadataLines) > 0 {
-				sourceFile = cr.extractEmbeddedMediaPath(finalMetadataLines[0], processedContent.OriginalPath)
-			}
-			metadataContent := cr.createMetadataFromLines(finalMetadataLines, currentSection, sourceFile)
-			if metadataContent != nil {
-				metadataItems = append(metadataItems, *metadataContent)
-			}
-		} else if len(documentLines) == 0 {
-			// No document lines found, save all as metadata (original behavior)
-			sourceFile := processedContent.OriginalPath
-			if len(currentMetadataLines) > 0 {
-				sourceFile = cr.extractEmbeddedMediaPath(currentMetadataLines[0], processedContent.OriginalPath)
-			}
-			metadataContent := cr.createMetadataFromLines(currentMetadataLines, currentSection, sourceFile)
-			if metadataContent != nil {
-				metadataItems = append(metadataItems, *metadataContent)
-			}
-		}
-	}
-
-	// Post-process metadata items to move obvious document content to document body
-	var finalMetadataItems []MetadataContent
-	for _, item := range metadataItems {
-		cleanedContent, documentContent := cr.cleanMetadataContent(item.Content)
-		if cleanedContent != "" {
-			// Create new metadata item with cleaned content
-			cleanedItem := item
-			cleanedItem.Content = cleanedContent
-			finalMetadataItems = append(finalMetadataItems, cleanedItem)
-		}
-		if documentContent != "" {
-			// Add document content to document body
-			if documentBody.Len() > 0 {
-				documentBody.WriteString("\n\n") // Add extra newline to preserve spacing
-			}
-			documentBody.WriteString(documentContent)
-		}
-	}
-
-	return strings.TrimSpace(documentBody.String()), finalMetadataItems, nil
-}
-
-// cleanMetadataContent separates metadata content from document content
-func (cr *ContentRouter) cleanMetadataContent(content string) (string, string) {
-	lines := strings.Split(content, "\n")
-	var metadataLines []string
-	var documentLines []string
-
-	// Find the last metadata line by going backwards
-	lastMetadataIndex := -1
-	for i := len(lines) - 1; i >= 0; i-- {
-		line := lines[i]
-		lineTrimmed := strings.TrimSpace(line)
-
-		// Skip empty lines at the end
-		if lineTrimmed == "" {
+		// Skip a section with nothing in it rather than emitting an empty
+		// metadata item, matching what the previous path did.
+		if strings.TrimSpace(section.Text) == "" {
 			continue
 		}
 
-		// If this line looks like document content, everything from here to the end is document content
-		if !strings.HasPrefix(lineTrimmed, "---") && cr.isMetadataSectionEnd(line) {
-			// This line and all following lines are document content
-			documentLines = lines[i:]
-			lastMetadataIndex = i - 1
-			break
+		metaType := section.Type
+		if metaType == "" {
+			metaType = PreprocessorTypeDocumentMetadata
 		}
+		sourceFile := section.SourceFile
+		if sourceFile == "" {
+			sourceFile = processedContent.OriginalPath
+		}
+
+		metadataItems = append(metadataItems, MetadataContent{
+			Content:          section.Text,
+			PreprocessorType: metaType,
+			PreprocessorName: cr.getPreprocessorName(metaType),
+			SourceFile:       sourceFile,
+			Metadata: map[string]interface{}{
+				"processor_type": processedContent.ProcessorType,
+				"format":         processedContent.Format,
+				"success":        processedContent.Success,
+				"declared":       true,
+				"section_name":   section.Name,
+				"section_line":   section.LineOffset,
+			},
+		})
 	}
 
-	// If we found document content, separate it
-	if lastMetadataIndex >= 0 {
-		metadataLines = lines[:lastMetadataIndex+1]
-	} else {
-		// No document content found, all lines are metadata
-		metadataLines = lines
+	// Join body sections with a blank line, mirroring the "\n\n" the file router
+	// puts between concatenated preprocessor outputs. Without a separator the last
+	// line of one section and the first of the next would land on a single logical
+	// line, fusing two adjacent values or splitting one, and every line-based
+	// validator would see the wrong line at each seam.
+	documentBody := strings.Join(bodySections, "\n\n")
+
+	// No body section at all (a pure-metadata file: every media type has exactly
+	// one capable preprocessor, and it is a metadata one). Hand the metadata text
+	// to the document path as well, because dual_path_bridge gates that path on
+	// having text to scan, and the METADATA validator alone reports nothing for an
+	// SSN or a card number sitting inside a metadata VALUE.
+	if documentBody == "" {
+		documentBody = processedContent.Text
 	}
 
-	metadataContent := strings.TrimSpace(strings.Join(metadataLines, "\n"))
-	documentContent := strings.TrimSpace(strings.Join(documentLines, "\n"))
-
-	return metadataContent, documentContent
+	return documentBody, metadataItems
 }
 
-// Helper methods for content analysis
-
-// containsMetadataSections checks if content contains metadata section markers
-func (cr *ContentRouter) containsMetadataSections(content string) bool {
-	metadataMarkers := []string{
-		"--- image_metadata ---",
-		"--- document_metadata ---",
-		"--- audio_metadata ---",
-		"--- video_metadata ---",
-		"--- Embedded Media",
-		"=== METADATA ===",
-		"=== IMAGE METADATA ===",
-		"=== DOCUMENT METADATA ===",
-	}
-
-	contentLower := strings.ToLower(content)
-	for _, marker := range metadataMarkers {
-		if strings.Contains(contentLower, strings.ToLower(marker)) {
-			return true
-		}
-	}
-	return false
-}
-
-// containsImageMetadataPatterns checks for image-specific metadata patterns
-func (cr *ContentRouter) containsImageMetadataPatterns(content string) bool {
-	imagePatterns := []string{
-		"gpslatitude", "gpslongitude", "gpsaltitude",
-		"camera_make", "camera_model", "exif",
-		"image_width", "image_height", "orientation",
-		"flash", "focal_length", "iso_speed",
-	}
-
-	contentLower := strings.ToLower(content)
-	patternCount := 0
-	for _, pattern := range imagePatterns {
-		if strings.Contains(contentLower, pattern) {
-			patternCount++
-		}
-	}
-
-	// Require at least 2 image-specific patterns to classify as image metadata
-	return patternCount >= 2
-}
-
-// containsAudioMetadataPatterns checks for audio-specific metadata patterns
-func (cr *ContentRouter) containsAudioMetadataPatterns(content string) bool {
-	audioPatterns := []string{
-		"artist:", "album:", "track:", "genre:",
-		"duration:", "bitrate:", "sample_rate:",
-		"tpe1:", "tpe2:", "tpe3:", "tpe4:",
-		"composer:", "performer:", "conductor:",
-	}
-
-	contentLower := strings.ToLower(content)
-	patternCount := 0
-	for _, pattern := range audioPatterns {
-		if strings.Contains(contentLower, pattern) {
-			patternCount++
-		}
-	}
-
-	// Require at least 2 audio-specific patterns
-	return patternCount >= 2
-}
-
-// containsVideoMetadataPatterns checks for video-specific metadata patterns
-func (cr *ContentRouter) containsVideoMetadataPatterns(content string) bool {
-	videoPatterns := []string{
-		"video_codec:", "audio_codec:", "frame_rate:",
-		"resolution:", "duration:", "recording_device:",
-		"xyz:", "creation_time:", "encoder:",
-		"major_brand:", "minor_version:",
-	}
-
-	contentLower := strings.ToLower(content)
-	patternCount := 0
-	for _, pattern := range videoPatterns {
-		if strings.Contains(contentLower, pattern) {
-			patternCount++
-		}
-	}
-
-	// Require at least 2 video-specific patterns
-	return patternCount >= 2
-}
-
-// containsDocumentMetadataPatterns checks for document-specific metadata patterns
-func (cr *ContentRouter) containsDocumentMetadataPatterns(content string) bool {
-	documentPatterns := []string{
-		"author:", "creator:", "title:", "subject:",
-		"keywords:", "comments:", "description:",
-		"lastmodifiedby:", "manager:", "company:",
-		"creation_date:", "modification_date:",
-	}
-
-	contentLower := strings.ToLower(content)
-	patternCount := 0
-	for _, pattern := range documentPatterns {
-		if strings.Contains(contentLower, pattern) {
-			patternCount++
-		}
-	}
-
-	// Require at least 2 document-specific patterns
-	return patternCount >= 2
-}
-
-// detectMetadataSection detects the start of a metadata section and returns its type
-func (cr *ContentRouter) detectMetadataSection(line string) string {
-	lineLower := strings.ToLower(strings.TrimSpace(line))
-
-	// Check for explicit metadata section markers
-	if strings.Contains(lineLower, "--- image_metadata ---") {
+// metadataTypeForProcessorType maps a SINGLE preprocessor's ProcessorType to the
+// metadata type whose validation rules apply, or "" when the content is not
+// wholly metadata (document text, plain text, an unknown producer, or a
+// multi-preprocessor "a+b" join whose structure was not declared).
+//
+// Only used on the undeclared-structure path; a declared section carries its type
+// directly. The input is our own GetName()-derived constant, so this is an exact
+// match rather than the substring test the deleted text-scanning path used.
+func metadataTypeForProcessorType(processorType string) string {
+	switch strings.ToLower(strings.TrimSpace(processorType)) {
+	case "image_metadata", "image-metadata", "imagemetadata":
 		return PreprocessorTypeImageMetadata
-	}
-	if strings.Contains(lineLower, "--- document_metadata ---") {
+	case "document_metadata", "document-metadata", "documentmetadata",
+		"pdf_metadata", "pdf-metadata", "pdfmetadata":
 		return PreprocessorTypeDocumentMetadata
-	}
-	if strings.Contains(lineLower, "--- office_metadata ---") {
+	case "office_metadata", "office-metadata", "officemetadata":
 		return PreprocessorTypeOfficeMetadata
-	}
-	if strings.Contains(lineLower, "--- audio_metadata ---") {
+	case "audio_metadata", "audio-metadata", "audiometadata":
 		return PreprocessorTypeAudioMetadata
-	}
-	if strings.Contains(lineLower, "--- video_metadata ---") {
+	case "video_metadata", "video-metadata", "videometadata":
 		return PreprocessorTypeVideoMetadata
-	}
-	if strings.Contains(lineLower, "--- embedded media") {
-		// Determine type based on file extension in the line
-		if strings.Contains(lineLower, ".jpg") || strings.Contains(lineLower, ".png") ||
-			strings.Contains(lineLower, ".gif") || strings.Contains(lineLower, ".jpeg") {
-			return PreprocessorTypeImageMetadata
-		}
-		if strings.Contains(lineLower, ".mp3") || strings.Contains(lineLower, ".wav") ||
-			strings.Contains(lineLower, ".flac") || strings.Contains(lineLower, ".m4a") {
-			return PreprocessorTypeAudioMetadata
-		}
-		if strings.Contains(lineLower, ".mp4") || strings.Contains(lineLower, ".mov") ||
-			strings.Contains(lineLower, ".avi") || strings.Contains(lineLower, ".m4v") {
-			return PreprocessorTypeVideoMetadata
-		}
-		// Default to image for embedded media
-		return PreprocessorTypeImageMetadata
-	}
-
-	return ""
-}
-
-// extractEmbeddedMediaPath extracts the embedded media file path from a section header
-func (cr *ContentRouter) extractEmbeddedMediaPath(line, originalPath string) string {
-	// Look for patterns like "--- Embedded Media 1 (image1.jpg) ---"
-	lineTrimmed := strings.TrimSpace(line)
-
-	// Find the filename in parentheses
-	start := strings.Index(lineTrimmed, "(")
-	end := strings.Index(lineTrimmed, ")")
-
-	if start != -1 && end != -1 && end > start {
-		mediaName := lineTrimmed[start+1 : end]
-		// Extract just the filename from the media path (remove word/media/ etc.)
-		justFilename := filepath.Base(mediaName)
-		// Create the embedded path format: "originalfile.docx -> image1.jpg"
-		return fmt.Sprintf("%s -> %s", filepath.Base(originalPath), justFilename)
-	}
-
-	// Fallback to original path if we can't extract the media name
-	return originalPath
-}
-
-// isMetadataSectionEnd checks if a line marks the end of a metadata section
-func (cr *ContentRouter) isMetadataSectionEnd(line string) bool {
-	lineTrimmed := strings.TrimSpace(line)
-
-	// Don't end on empty lines - metadata sections can have empty lines between fields
-	if lineTrimmed == "" {
-		return false
-	}
-
-	// Check for new section separators (but let the main loop handle them)
-	if strings.HasPrefix(lineTrimmed, "---") {
-		// This is a new section header - let the main loop detect it
-		return false
-	}
-
-	// Check if this line looks like a metadata field (key: value format)
-	if cr.looksLikeMetadataField(lineTrimmed) {
-		return false // Continue metadata section
-	}
-
-	// Check for start of document content (common patterns)
-	lineLower := strings.ToLower(lineTrimmed)
-	documentStartPatterns := []string{
-		"chapter", "section", "introduction", "abstract",
-		"summary", "overview", "content", "body",
-	}
-
-	for _, pattern := range documentStartPatterns {
-		if strings.HasPrefix(lineLower, pattern) {
-			return true
-		}
-	}
-
-	// If the line doesn't look like metadata and contains multiple words, it's likely document content
-	// This handles cases where document content follows metadata without clear markers
-	words := strings.Fields(lineTrimmed)
-	if len(words) >= 3 && !cr.looksLikeMetadataField(lineTrimmed) {
-		return true
-	}
-
-	return false
-}
-
-// looksLikeMetadataField checks if a line looks like a metadata field (key: value format)
-func (cr *ContentRouter) looksLikeMetadataField(line string) bool {
-	// Check for key: value pattern
-	if strings.Contains(line, ":") && !strings.HasPrefix(line, "http") {
-		parts := strings.SplitN(line, ":", 2)
-		if len(parts) == 2 {
-			key := strings.TrimSpace(parts[0])
-			value := strings.TrimSpace(parts[1])
-
-			// Key should be reasonably short and not contain spaces (or very few)
-			keyWords := strings.Fields(key)
-			if len(keyWords) <= 3 && len(key) <= 50 && value != "" {
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
-// createMetadataFromLines creates a MetadataContent from collected lines
-func (cr *ContentRouter) createMetadataFromLines(lines []string, sectionType, sourceFile string) *MetadataContent {
-	if len(lines) == 0 {
-		return nil
-	}
-
-	content := strings.Join(lines, "\n")
-	preprocessorName := cr.getPreprocessorName(sectionType)
-
-	return &MetadataContent{
-		Content:          content,
-		PreprocessorType: sectionType,
-		PreprocessorName: preprocessorName,
-		SourceFile:       sourceFile,
-		Metadata: map[string]interface{}{
-			"section_lines":  len(lines),
-			"extracted_from": "mixed_content",
-		},
+	default:
+		return ""
 	}
 }
 
@@ -828,251 +353,5 @@ func (cr *ContentRouter) getPreprocessorName(preprocessorType string) string {
 		return "Document Text Extractor"
 	default:
 		return "Unknown Preprocessor"
-	}
-}
-
-// isCombinedPreprocessorOutput checks if the content is from multiple preprocessors combined by file router
-func (cr *ContentRouter) isCombinedPreprocessorOutput(processedContent *preprocessors.ProcessedContent) bool {
-	// Check if ProcessorType contains multiple processors (e.g., "pdf_metadata+text")
-	if strings.Contains(processedContent.ProcessorType, "+") {
-		return true
-	}
-
-	// Check if content contains preprocessor separator markers
-	return strings.Contains(processedContent.Text, "--- ") &&
-		(strings.Contains(processedContent.Text, " ---") || strings.Contains(processedContent.Text, "---\n"))
-}
-
-// separateCombinedPreprocessorOutput separates combined preprocessor output into document body and metadata
-func (cr *ContentRouter) separateCombinedPreprocessorOutput(processedContent *preprocessors.ProcessedContent) (string, []MetadataContent, error) {
-	content := processedContent.Text
-	var bodySections []string
-	var metadataItems []MetadataContent
-
-	// Split by preprocessor separators (e.g., "--- pdf_metadata ---", "--- text ---")
-	sections := cr.splitByPreprocessorSeparators(content)
-
-	for _, section := range sections {
-		if section.preprocessorName == "" {
-			// Content before any separator - likely metadata
-			if cr.looksLikeMetadata(section.content) {
-				metadataContent := cr.createMetadataContentFromSection(section.content, "document_metadata", processedContent.OriginalPath)
-				if metadataContent != nil {
-					metadataItems = append(metadataItems, *metadataContent)
-				}
-			} else {
-				bodySections = append(bodySections, section.content)
-			}
-		} else if cr.isMetadataPreprocessor(section.preprocessorName) {
-			// This is metadata content - determine the correct preprocessor type
-			preprocessorType := cr.determinePreprocessorTypeFromName(section.preprocessorName)
-			sourceFile := processedContent.OriginalPath
-
-			// For embedded media, extract the media file path for better source tracking
-			if strings.Contains(strings.ToLower(section.preprocessorName), "embedded media") {
-				sourceFile = cr.extractEmbeddedMediaPath("--- "+section.preprocessorName+" ---", processedContent.OriginalPath)
-			}
-
-			metadataContent := cr.createMetadataContentFromSection(section.content, preprocessorType, sourceFile)
-			if metadataContent != nil {
-				metadataItems = append(metadataItems, *metadataContent)
-			}
-		} else {
-			// This is document body content
-			bodySections = append(bodySections, section.content)
-		}
-	}
-
-	// Join body sections with a blank line between them. splitByPreprocessorSeparators
-	// TrimSpace-es each section, so concatenating them directly would run the last
-	// line of one section into the first line of the next on a single logical line —
-	// fusing two adjacent values (or splitting one) and breaking line-based detection
-	// at every section seam. A blank-line separator keeps each section's lines intact
-	// and mirrors the paragraph spacing the other combine path already uses.
-	return strings.TrimSpace(strings.Join(bodySections, "\n\n")), metadataItems, nil
-}
-
-// preprocessorSection represents a section of content from a specific preprocessor
-type preprocessorSection struct {
-	preprocessorName string
-	content          string
-}
-
-// splitByPreprocessorSeparators splits content by preprocessor separator markers
-func (cr *ContentRouter) splitByPreprocessorSeparators(content string) []preprocessorSection {
-	var sections []preprocessorSection
-	lines := strings.Split(content, "\n")
-
-	var currentSection strings.Builder
-	currentPreprocessor := ""
-
-	for _, line := range lines {
-		// Check for preprocessor separator (e.g., "--- pdf_metadata ---", "--- text ---")
-		if strings.HasPrefix(line, "--- ") && strings.HasSuffix(line, " ---") {
-			// Save previous section
-			if currentSection.Len() > 0 {
-				sections = append(sections, preprocessorSection{
-					preprocessorName: currentPreprocessor,
-					content:          strings.TrimSpace(currentSection.String()),
-				})
-				currentSection.Reset()
-			}
-
-			// Extract preprocessor name
-			preprocessorName := strings.TrimSpace(line[4 : len(line)-4])
-			currentPreprocessor = preprocessorName
-		} else {
-			// Add line to current section
-			if currentSection.Len() > 0 {
-				currentSection.WriteString("\n")
-			}
-			currentSection.WriteString(line)
-		}
-	}
-
-	// Add final section
-	if currentSection.Len() > 0 {
-		sections = append(sections, preprocessorSection{
-			preprocessorName: currentPreprocessor,
-			content:          strings.TrimSpace(currentSection.String()),
-		})
-	}
-
-	return sections
-}
-
-// isMetadataPreprocessor checks if a preprocessor name indicates metadata extraction
-func (cr *ContentRouter) isMetadataPreprocessor(preprocessorName string) bool {
-	metadataPreprocessors := []string{
-		"pdf_metadata", "image_metadata", "audio_metadata", "video_metadata",
-		"office_metadata", "document_metadata", "metadata",
-	}
-
-	preprocessorLower := strings.ToLower(preprocessorName)
-
-	// Check for embedded media sections (e.g., "Embedded Media 3 (word/media/image18.jpeg)")
-	if strings.Contains(preprocessorLower, "embedded media") {
-		return true
-	}
-
-	for _, metaProcessor := range metadataPreprocessors {
-		if strings.Contains(preprocessorLower, metaProcessor) {
-			return true
-		}
-	}
-
-	return false
-}
-
-// looksLikeMetadata checks if content appears to be metadata rather than document text
-func (cr *ContentRouter) looksLikeMetadata(content string) bool {
-	lines := strings.Split(content, "\n")
-	metadataFieldCount := 0
-	totalLines := 0
-
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		totalLines++
-
-		// Check for metadata field patterns (key: value)
-		if strings.Contains(line, ":") && !strings.HasPrefix(line, "http") {
-			parts := strings.SplitN(line, ":", 2)
-			if len(parts) == 2 {
-				key := strings.TrimSpace(parts[0])
-				// Check if key looks like a metadata field name
-				if cr.isMetadataFieldName(key) {
-					metadataFieldCount++
-				}
-			}
-		}
-	}
-
-	// Consider it metadata if more than 50% of lines are metadata fields
-	return totalLines > 0 && float64(metadataFieldCount)/float64(totalLines) > 0.5
-}
-
-// isMetadataFieldName checks if a string looks like a metadata field name
-func (cr *ContentRouter) isMetadataFieldName(fieldName string) bool {
-	fieldLower := strings.ToLower(fieldName)
-	metadataFields := []string{
-		"title", "author", "creator", "producer", "subject", "keywords",
-		"creationdate", "modificationdate", "pagecount", "encrypted",
-		"pdfversion", "application", "company", "lastmodifiedby",
-		"camera", "device", "gps", "latitude", "longitude", "altitude",
-		"artist", "album", "genre", "year", "track", "duration",
-	}
-
-	for _, field := range metadataFields {
-		if strings.Contains(fieldLower, field) {
-			return true
-		}
-	}
-
-	return false
-}
-
-// determinePreprocessorTypeFromName determines the preprocessor type from the section name
-func (cr *ContentRouter) determinePreprocessorTypeFromName(sectionName string) string {
-	sectionLower := strings.ToLower(sectionName)
-
-	// Check for embedded media sections
-	if strings.Contains(sectionLower, "embedded media") {
-		// Determine type based on file extension in the section name
-		if strings.Contains(sectionLower, ".jpg") || strings.Contains(sectionLower, ".jpeg") ||
-			strings.Contains(sectionLower, ".png") || strings.Contains(sectionLower, ".gif") ||
-			strings.Contains(sectionLower, ".bmp") || strings.Contains(sectionLower, ".tiff") ||
-			strings.Contains(sectionLower, ".webp") {
-			return PreprocessorTypeImageMetadata
-		}
-		if strings.Contains(sectionLower, ".mp3") || strings.Contains(sectionLower, ".wav") ||
-			strings.Contains(sectionLower, ".flac") || strings.Contains(sectionLower, ".m4a") {
-			return PreprocessorTypeAudioMetadata
-		}
-		if strings.Contains(sectionLower, ".mp4") || strings.Contains(sectionLower, ".mov") ||
-			strings.Contains(sectionLower, ".avi") || strings.Contains(sectionLower, ".m4v") {
-			return PreprocessorTypeVideoMetadata
-		}
-		// Default to image for embedded media
-		return PreprocessorTypeImageMetadata
-	}
-
-	// Check for specific preprocessor types
-	if strings.Contains(sectionLower, "office_metadata") {
-		return PreprocessorTypeOfficeMetadata
-	}
-	if strings.Contains(sectionLower, "pdf_metadata") {
-		return PreprocessorTypeDocumentMetadata
-	}
-	if strings.Contains(sectionLower, "image_metadata") {
-		return PreprocessorTypeImageMetadata
-	}
-	if strings.Contains(sectionLower, "audio_metadata") {
-		return PreprocessorTypeAudioMetadata
-	}
-	if strings.Contains(sectionLower, "video_metadata") {
-		return PreprocessorTypeVideoMetadata
-	}
-
-	// Default to document metadata
-	return PreprocessorTypeDocumentMetadata
-}
-
-// createMetadataContentFromSection creates MetadataContent from a content section
-func (cr *ContentRouter) createMetadataContentFromSection(content, preprocessorType, sourceFile string) *MetadataContent {
-	if strings.TrimSpace(content) == "" {
-		return nil
-	}
-
-	return &MetadataContent{
-		Content:          content,
-		PreprocessorType: preprocessorType,
-		PreprocessorName: cr.getPreprocessorName(preprocessorType),
-		SourceFile:       sourceFile,
-		Metadata: map[string]interface{}{
-			"separated_from_combined": true,
-		},
 	}
 }

--- a/internal/router/file_router.go
+++ b/internal/router/file_router.go
@@ -289,6 +289,21 @@ func (fr *FileRouter) processFileInternal(filePath string, config *ProcessingCon
 	// never been read. Measured before this: such a file produced
 	// {PERSON_NAME, AUTHOR_INFO} and no warning at all.
 	var extractionWarnings []string
+	// sections records the structure of the concatenation OUT OF BAND, one entry
+	// per successful preprocessor, built in this same loop so it cannot drift from
+	// the text it describes.
+	//
+	// The name comes from Preprocessor.GetName(), which is our own code's constant
+	// — not a byte from the scanned document. That is what makes a boundary here
+	// unforgeable, and it is the whole reason for this field: the content router
+	// used to recover this same structure by scanning the assembled text for
+	// "--- name ---" lines, which a document author can simply type.
+	//
+	// sectionLine tracks where the next section starts, as a line index into the
+	// text assembled so far, so it is maintained incrementally rather than by
+	// re-scanning the (potentially multi-megabyte) result.
+	var sections []preprocessors.ContentSection
+	sectionLine := 0
 
 	for _, pResult := range ordered {
 		if pResult.result != nil && pResult.result.ExtractionWarning != "" {
@@ -308,7 +323,42 @@ func (fr *FileRouter) processFileInternal(filePath string, config *ProcessingCon
 				}
 				combinedContent.WriteString("\n\n--- " + pResult.name + " ---\n")
 				combinedContent.WriteString(pResult.result.Text)
+				// The separator "\n\n--- name ---\n" advances the line cursor by 3
+				// (it closes the previous section's last line, adds a blank line,
+				// and adds the header line itself).
+				sectionLine += 3
 			}
+
+			// Prefer the preprocessor's OWN declared sections. A metadata
+			// extractor can carry sub-structure the router cannot see: the Office
+			// extractor appends each embedded media item's text to its own, and
+			// those items route to a DIFFERENT metadata rule set (a .wav inside a
+			// .docx has an "Artist:" field, which is on the audio field list but
+			// not the office one). Only that extractor knows where the split is,
+			// so re-anchor what it declared instead of overwriting it with one
+			// coarse section.
+			if declared := pResult.result.Sections; len(declared) > 0 {
+				for _, s := range declared {
+					if s.SourceFile == "" {
+						s.SourceFile = filePath
+					}
+					s.LineOffset += sectionLine
+					sections = append(sections, s)
+				}
+			} else {
+				kind, metaType := preprocessors.ClassifySection(pResult.name)
+				sections = append(sections, preprocessors.ContentSection{
+					Name:       pResult.name,
+					Kind:       kind,
+					Type:       metaType,
+					SourceFile: filePath,
+					// A substring reference, not a copy: Go strings share backing
+					// storage, so recording every section costs pointers, not bytes.
+					Text:       pResult.result.Text,
+					LineOffset: sectionLine,
+				})
+			}
+			sectionLine += strings.Count(pResult.result.Text, "\n")
 
 			// Accumulate metadata
 			for k, v := range pResult.result.Metadata {
@@ -349,6 +399,10 @@ func (fr *FileRouter) processFileInternal(filePath string, config *ProcessingCon
 			// office_metadata result, so the file reported Success with only
 			// metadata findings and nothing said the document body was missing.
 			ExtractionWarning: strings.Join(extractionWarnings, "; "),
+			// The out-of-band structure of Text. Set unconditionally on this
+			// success path so the content router never has to fall back to
+			// re-parsing the text for separators.
+			Sections: sections,
 		}
 
 		return result, nil

--- a/internal/router/pure_metadata_routing_test.go
+++ b/internal/router/pure_metadata_routing_test.go
@@ -71,10 +71,12 @@ func TestPureMetadataKeepsDocumentBody(t *testing.T) {
 
 // TestCombinedPreprocessorsUnaffected pins the boundary of the change.
 //
-// .pdf/.docx/.xlsx have TWO capable preprocessors, so ProcessorType contains "+",
-// identifyPreprocessorType returns "combined_preprocessors", and they route down a
-// different branch that always preserved a body. Those file types must be
-// byte-identical before and after.
+// .pdf/.docx/.xlsx have TWO capable preprocessors, so ProcessorType contains "+".
+// They used to be classified "combined_preprocessors" and routed down a separate
+// branch that always preserved a body; that branch, and the classifier that
+// selected it, are gone — structure now comes from the declared sections, and a
+// caller that declares none keeps the whole text as body. Either way these file
+// types must still have a document body.
 func TestCombinedPreprocessorsUnaffected(t *testing.T) {
 	cr := NewContentRouter()
 	routed, err := cr.RouteContent(&preprocessors.ProcessedContent{

--- a/internal/router/section_join_test.go
+++ b/internal/router/section_join_test.go
@@ -10,40 +10,40 @@ import (
 	"github.com/awslabs/ferret-scan/v2/internal/preprocessors"
 )
 
-// TestSeparateCombinedOutput_BodySectionsAreNotFused is the regression test for
-// the section-join defect.
+// TestRouteSections_BodySectionsAreNotFused is the regression test for the
+// section-join defect, carried over to the out-of-band routing path.
 //
-// splitByPreprocessorSeparators TrimSpace-es each section, so a section carries
-// no trailing newline. separateCombinedPreprocessorOutput then wrote consecutive
-// document-body sections back to back with nothing between them, so the last line
-// of one section and the first line of the next collapsed onto a single logical
-// line. A validator that scans line by line then sees one fused line instead of
-// two — which can merge two adjacent values into one unrecognized token or split
-// a boundary value, i.e. a recall bug at every body-section seam.
-func TestSeparateCombinedOutput_BodySectionsAreNotFused(t *testing.T) {
+// The defect: consecutive document-body sections were concatenated with nothing
+// between them, so the last line of one and the first line of the next collapsed
+// onto a single logical line. A validator that scans line by line then sees one
+// fused line instead of two, which can merge two adjacent values into one
+// unrecognized token or split a boundary value — a recall bug at every seam.
+//
+// The property is unchanged by the switch to declared sections, and so is the way
+// to get it wrong (strings.Join with "" instead of "\n\n"), which is why the test
+// survives its original subject: it now drives routeSections through the exported
+// RouteContent with two declared body sections.
+func TestRouteSections_BodySectionsAreNotFused(t *testing.T) {
 	cr := NewContentRouter()
 
-	// Two document-body sections (a non-metadata preprocessor name). The last line
-	// of the first and the first line of the second must stay on separate lines.
-	content := strings.Join([]string{
-		"--- text ---",
-		"first body line",
-		"LAST-LINE-OF-SECTION-A",
-		"--- text ---",
-		"FIRST-LINE-OF-SECTION-B",
-		"second body line",
-	}, "\n")
+	sectionA := "first body line\nLAST-LINE-OF-SECTION-A"
+	sectionB := "FIRST-LINE-OF-SECTION-B\nsecond body line"
 
 	pc := &preprocessors.ProcessedContent{
-		Text:          content,
+		Text:          sectionA + "\n\n--- text ---\n" + sectionB,
 		OriginalPath:  "combined.txt",
 		ProcessorType: "text+text",
+		Sections: []preprocessors.ContentSection{
+			{Name: "text", Kind: preprocessors.SectionKindBody, Text: sectionA, LineOffset: 0},
+			{Name: "text", Kind: preprocessors.SectionKindBody, Text: sectionB, LineOffset: 4},
+		},
 	}
 
-	body, _, err := cr.separateCombinedPreprocessorOutput(pc)
+	routed, err := cr.RouteContent(pc)
 	if err != nil {
-		t.Fatalf("separateCombinedPreprocessorOutput: %v", err)
+		t.Fatalf("RouteContent: %v", err)
 	}
+	body := routed.DocumentBody
 
 	// The fusion signature: the two boundary tokens adjacent with no newline.
 	fused := "LAST-LINE-OF-SECTION-AFIRST-LINE-OF-SECTION-B"

--- a/internal/router/structured_sections_test.go
+++ b/internal/router/structured_sections_test.go
@@ -1,0 +1,379 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package router
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unsafe"
+
+	"github.com/awslabs/ferret-scan/v2/internal/preprocessors"
+)
+
+// These tests cover the structural fix: routing reads the producer-declared
+// ProcessedContent.Sections and never re-derives structure by scanning the
+// extracted text for "--- name ---" markers.
+//
+// The previous design was in-band signalling. A document author types the body
+// text, so a paragraph reading "--- office_metadata ---" became a section
+// boundary, and everything after it moved from the full validator set to the
+// single field-name METADATA scanner — which deletes findings rather than
+// relabelling them, and an unreported finding is never redacted.
+//
+// Where a test asserts a property that ALSO holds under the old code (because
+// PR1's FullText union already prevented the deletion), it says so, so nobody
+// mistakes a defence-in-depth check for the load-bearing one.
+
+// TestDeclaredSectionsDecideRouting_NotTheText is the load-bearing assertion, and
+// it is the one that fails on the parent code.
+//
+// Two inputs carry IDENTICAL declared sections and identical text EXCEPT that one
+// has a forged "--- office_metadata ---" paragraph in the body. Since routing is
+// supposed to come from the declaration, the metadata item list must be identical:
+// exactly one item, holding the real property block and NOT the body text.
+//
+// On the parent code the forged line splits the body, so the SSN paragraph is
+// emitted as an extra metadata item — the routing decision was taken from the
+// document's own bytes.
+func TestDeclaredSectionsDecideRouting_NotTheText(t *testing.T) {
+	const props = "Author: Jane Analyst\nLastModifiedBy: Ops Reviewer"
+	const ssnLine = "Employee SSN 449-87-4100 on file."
+
+	build := func(body string) *preprocessors.ProcessedContent {
+		flat := body + "\n\n--- office_metadata ---\n" + props
+		return &preprocessors.ProcessedContent{
+			Text:          flat,
+			OriginalPath:  "report.docx",
+			ProcessorType: "Text Extractor+office_metadata",
+			Success:       true,
+			Sections: []preprocessors.ContentSection{
+				{
+					Name: "Text Extractor", Kind: preprocessors.SectionKindBody,
+					SourceFile: "report.docx", Text: body, LineOffset: 0,
+				},
+				{
+					Name: "office_metadata", Kind: preprocessors.SectionKindMetadata,
+					Type: PreprocessorTypeOfficeMetadata, SourceFile: "report.docx",
+					Text: props, LineOffset: strings.Count(body, "\n") + 3,
+				},
+			},
+		}
+	}
+
+	cr := NewContentRouter()
+
+	clean, err := cr.RouteContent(build("Quarterly summary follows.\n" + ssnLine))
+	if err != nil {
+		t.Fatalf("RouteContent(clean): %v", err)
+	}
+	forged, err := cr.RouteContent(build("Quarterly summary follows.\n--- office_metadata ---\n" + ssnLine))
+	if err != nil {
+		t.Fatalf("RouteContent(forged): %v", err)
+	}
+
+	if len(clean.Metadata) != 1 {
+		t.Fatalf("control produced %d metadata items, want 1: %s",
+			len(clean.Metadata), describeItems(clean.Metadata))
+	}
+	if got, want := len(forged.Metadata), len(clean.Metadata); got != want {
+		t.Errorf("a forged section header in the BODY changed the metadata split: "+
+			"%d items with the header vs %d without.\n  with header: %s\n"+
+			"Routing must come from the declared sections, which are identical here, "+
+			"not from the document's own text.", got, want, describeItems(forged.Metadata))
+	}
+
+	// The forged header must not have pushed body text onto the metadata path,
+	// where only the field-name scanner would see it.
+	for _, item := range forged.Metadata {
+		if strings.Contains(item.Content, "449-87-4100") {
+			t.Errorf("body text reached the metadata path because the document "+
+				"forged a header; metadata item content:\n%s", item.Content)
+		}
+	}
+}
+
+// TestNoDeclaredSections_FailsClosedToDocumentBody covers the other half of the
+// contract: an older caller, or one that builds ProcessedContent by hand (the pkg
+// and ScanContent entry points do), declares nothing. That must route the WHOLE
+// text to the document path, because the document path runs every validator and
+// the metadata path runs one field-name scanner. Guessing structure from the text
+// is exactly what was removed, and guessing "it is all metadata" would be the
+// fail-OPEN direction: an SSN in the text would go unreported and unredacted.
+func TestNoDeclaredSections_FailsClosedToDocumentBody(t *testing.T) {
+	// The text deliberately contains a marker the deleted parser recognized, to
+	// prove no residual parsing happens on this path.
+	const text = "Quarterly summary follows.\n--- office_metadata ---\nEmployee SSN 449-87-4100 on file.\n"
+
+	for _, processorType := range []string{
+		"Text Extractor+office_metadata", // a combined join, undeclared
+		"plaintext",
+		"office_metadata",
+		"audio_metadata",
+		"",                  // unknown
+		"mystery_extractor", // a producer this switch has never heard of
+	} {
+		t.Run(processorType, func(t *testing.T) {
+			cr := NewContentRouter()
+			routed, err := cr.RouteContent(&preprocessors.ProcessedContent{
+				Text: text, ProcessorType: processorType,
+				OriginalPath: "hand.docx", Success: true,
+			})
+			if err != nil {
+				t.Fatalf("RouteContent: %v", err)
+			}
+			if routed.DocumentBody != text {
+				t.Errorf("DocumentBody is not the whole extraction.\n got: %q\nwant: %q\n"+
+					"With no declared structure the router must not guess one: every "+
+					"byte goes to the document path, which is the only path that "+
+					"detects an SSN.", routed.DocumentBody, text)
+			}
+		})
+	}
+}
+
+// TestSingleMetadataPreprocessorStillLabelled is the non-vacuity floor for the
+// fail-closed path above: routing everything to the body must not be achieved by
+// abandoning metadata labelling. A media file has exactly one capable
+// preprocessor, and it is a metadata one, so if this stopped producing a metadata
+// item the METADATA validator would report nothing for the whole file type.
+//
+// This also pins that the classifier reads ProcessorType — our own GetName()
+// string — rather than the content.
+func TestSingleMetadataPreprocessorStillLabelled(t *testing.T) {
+	cases := map[string]string{
+		"image_metadata":  PreprocessorTypeImageMetadata,
+		"pdf_metadata":    PreprocessorTypeDocumentMetadata, // remapped, see ClassifySection
+		"office_metadata": PreprocessorTypeOfficeMetadata,
+		"audio_metadata":  PreprocessorTypeAudioMetadata,
+		"video_metadata":  PreprocessorTypeVideoMetadata,
+	}
+	for processorType, wantType := range cases {
+		t.Run(processorType, func(t *testing.T) {
+			cr := NewContentRouter()
+			routed, err := cr.RouteContent(&preprocessors.ProcessedContent{
+				Text:          "Artist: john.doe@example.com\n",
+				ProcessorType: processorType, OriginalPath: "asset.bin", Success: true,
+			})
+			if err != nil {
+				t.Fatalf("RouteContent: %v", err)
+			}
+			if len(routed.Metadata) != 1 {
+				t.Fatalf("got %d metadata items, want 1 — the metadata path lost a "+
+					"whole file type's labelling", len(routed.Metadata))
+			}
+			if got := routed.Metadata[0].PreprocessorType; got != wantType {
+				t.Errorf("metadata item type = %q, want %q; the wrong rule set selects "+
+					"the wrong sensitive-field list, so real fields report nothing",
+					got, wantType)
+			}
+		})
+	}
+}
+
+// TestSectionKindMetadataRoutesOnlyItsOwnText states the labelling invariant as an
+// equality on content. A metadata section's item must hold exactly that section's
+// text — not the whole extraction, and not a slice decided by scanning for markers.
+func TestSectionKindMetadataRoutesOnlyItsOwnText(t *testing.T) {
+	const body = "Employee SSN 449-87-4100 on file."
+	const props = "Author: Jane Analyst"
+
+	cr := NewContentRouter()
+	routed, err := cr.RouteContent(&preprocessors.ProcessedContent{
+		Text:          body + "\n\n--- office_metadata ---\n" + props,
+		OriginalPath:  "report.docx",
+		ProcessorType: "Text Extractor+office_metadata",
+		Success:       true,
+		Sections: []preprocessors.ContentSection{
+			{Name: "Text Extractor", Kind: preprocessors.SectionKindBody, Text: body, LineOffset: 0},
+			{
+				Name: "office_metadata", Kind: preprocessors.SectionKindMetadata,
+				Type: PreprocessorTypeOfficeMetadata, Text: props, LineOffset: 3,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("RouteContent: %v", err)
+	}
+
+	if len(routed.Metadata) != 1 {
+		t.Fatalf("got %d metadata items, want 1: %s", len(routed.Metadata), describeItems(routed.Metadata))
+	}
+	if routed.Metadata[0].Content != props {
+		t.Errorf("metadata item content = %q, want exactly the declared section %q",
+			routed.Metadata[0].Content, props)
+	}
+	if routed.DocumentBody != body {
+		t.Errorf("DocumentBody = %q, want the declared body section %q",
+			routed.DocumentBody, body)
+	}
+	// Defence in depth (PR1): even if the split above were wrong, the union must
+	// still carry everything.
+	if !strings.Contains(routed.FullText, "449-87-4100") {
+		t.Error("FullText lost the SSN; the PR1 coverage union must survive this change")
+	}
+}
+
+// TestFileRouterDeclaresSectionsMatchingItsOwnText checks the producer side against
+// the text it produced, rather than against the arithmetic that built it: every
+// declared section's Text must be a substring of the flat Text, and its LineOffset
+// must be the line index where that text actually begins. A wrong LineOffset would
+// misreport line numbers in every finding from that section.
+func TestFileRouterDeclaresSectionsMatchingItsOwnText(t *testing.T) {
+	// A .docx has two capable preprocessors, so this exercises the multi-section
+	// concatenation where the offsets can actually be wrong.
+	//
+	// Repo-relative, not t.TempDir(): the Office metadata extractor's path guard
+	// rejects /var, /tmp and /home, which is where t.TempDir() lives on all three
+	// CI platforms. A fixture there would silently lose that extractor, leave one
+	// section, and pass this test for the wrong reason.
+	dir, err := os.MkdirTemp(".", "structured-sections-")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	path := filepath.Join(dir, "report.docx")
+	if err := os.WriteFile(path, minimalSectionedDOCX(), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	fr := NewFileRouter(false)
+	RegisterDefaultPreprocessors(fr)
+	fr.InitializePreprocessors(CreateRouterConfig(false))
+
+	pc, err := fr.ProcessFile(path, nil)
+	if err != nil {
+		t.Fatalf("ProcessFile: %v", err)
+	}
+	if len(pc.Sections) < 2 {
+		t.Fatalf("got %d declared sections, want >= 2 — a .docx must declare both a "+
+			"body and a metadata section, or this test is vacuous", len(pc.Sections))
+	}
+
+	flatLines := strings.Split(pc.Text, "\n")
+	for i, s := range pc.Sections {
+		if !strings.Contains(pc.Text, s.Text) {
+			t.Errorf("section %d (%s): Text is not a substring of the flat Text", i, s.Name)
+			continue
+		}
+		if s.LineOffset < 0 || s.LineOffset >= len(flatLines) {
+			t.Errorf("section %d (%s): LineOffset %d out of range for %d flat lines",
+				i, s.Name, s.LineOffset, len(flatLines))
+			continue
+		}
+		firstLine := strings.SplitN(s.Text, "\n", 2)[0]
+		if flatLines[s.LineOffset] != firstLine {
+			t.Errorf("section %d (%s): LineOffset %d points at %q but the section starts "+
+				"with %q — every finding in this section would report the wrong line",
+				i, s.Name, s.LineOffset, flatLines[s.LineOffset], firstLine)
+		}
+	}
+}
+
+// TestSectionTextAliasesNotCopies guards the hot path. processFileInternal keeps a
+// direct reference to the sole preprocessor's text (firstText) specifically so a
+// large extracted document is not duplicated into a strings.Builder, and recording
+// a ContentSection per preprocessor must not undo that: a section's Text has to be
+// a reference to the same backing array, not a copy of it.
+//
+// Asserted on the string data pointer rather than on a benchmark, so it cannot pass
+// by being merely fast on a small input.
+func TestSectionTextAliasesNotCopies(t *testing.T) {
+	big := make([]byte, 1<<20)
+	for i := range big {
+		big[i] = 'a'
+	}
+	text := string(big)
+	src := unsafe.StringData(text)
+
+	fr := NewFileRouter(false)
+	fr.preprocessors = []preprocessors.Preprocessor{
+		&stubPreprocessor{name: "Text Extractor", text: text},
+	}
+
+	got, err := fr.ProcessFileWithContext("x.txt", &ProcessingContext{FilePath: "x.txt"})
+	if err != nil {
+		t.Fatalf("ProcessFileWithContext: %v", err)
+	}
+	if unsafe.StringData(got.Text) != src {
+		t.Error("ProcessedContent.Text copied the payload; the zero-copy " +
+			"single-preprocessor path regressed")
+	}
+	if len(got.Sections) != 1 {
+		t.Fatalf("got %d sections, want 1", len(got.Sections))
+	}
+	if unsafe.StringData(got.Sections[0].Text) != src {
+		t.Error("ContentSection.Text copied the payload instead of referencing it, " +
+			"so every scan now holds a second copy of the whole extracted document")
+	}
+}
+
+func describeItems(items []MetadataContent) string {
+	var b strings.Builder
+	for i, it := range items {
+		fmt.Fprintf(&b, "\n  [%d] type=%s content=%q", i, it.PreprocessorType, it.Content)
+	}
+	return b.String()
+}
+
+// minimalSectionedDOCX builds a .docx carrying BOTH a document body and core
+// properties, so the text extractor and the office metadata extractor are both
+// capable and the router assembles a two-section concatenation. A .docx with only
+// word/document.xml takes the single-preprocessor fast path, where the section
+// offsets are trivially 0 and the arithmetic under test never runs.
+func minimalSectionedDOCX() []byte {
+	const decl = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>`
+	body := ""
+	for _, p := range []string{
+		"Quarterly summary follows.",
+		"Employee SSN 449-87-4100 on file.",
+		"Card 4532-0151-1283-0366 expires soon.",
+	} {
+		body += `<w:p><w:r><w:t xml:space="preserve">` + p + `</w:t></w:r></w:p>`
+	}
+
+	parts := []struct{ name, body string }{
+		{"[Content_Types].xml", decl +
+			`<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+			`<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+			`<Default Extension="xml" ContentType="application/xml"/>` +
+			`<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>` +
+			`<Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/>` +
+			`</Types>`},
+		{"_rels/.rels", decl +
+			`<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+			`<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>` +
+			`<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" Target="docProps/core.xml"/>` +
+			`</Relationships>`},
+		{"docProps/core.xml", decl +
+			`<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/">` +
+			`<dc:creator>Jane Analyst</dc:creator><cp:lastModifiedBy>Ops Reviewer</cp:lastModifiedBy>` +
+			`</cp:coreProperties>`},
+		{"word/document.xml", decl +
+			`<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>` +
+			body + `</w:body></w:document>`},
+	}
+
+	out := new(bytes.Buffer)
+	zw := zip.NewWriter(out)
+	for _, p := range parts {
+		w, err := zw.Create(p.name)
+		if err != nil {
+			panic(err)
+		}
+		if _, err := io.WriteString(w, p.body); err != nil {
+			panic(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		panic(err)
+	}
+	return out.Bytes()
+}


### PR DESCRIPTION
_Supersedes #239, which was auto-closed when its now-merged base branch (`sec/pr0-office-golden-fixtures`, landed via #243) was deleted. Same head branch, same commits, rebased onto `main`._

**Stacked on #238.** The structural fix — removes the attacker's capability rather than containing its consequence. Verified **SOUND** by an independent adversarial pass.

## The mechanism

`file_router.go` flattened every extractor's output into one `ProcessedContent.Text` using literal `\n\n--- name ---\n` separators, and `content_router.go` then **re-parsed that text** to recover the structure. Document authors control the text, so they controlled the "structure". This is in-band signaling — the same class as SQL injection — and the answer is the same: carry structure out of band.

**Producer:** `Sections []ContentSection` (plus `SectionKind`, `ClassifySection`) on `ProcessedContent`, appended in the same loop that already builds the flat concatenation, so the description cannot drift from what it describes. `Kind`/`Type` come from `Preprocessor.GetName()` — our own constant, never a document byte. `Text` stays the byte-identical flat concatenation, so the field is purely additive.

**Consumer:** `RouteContent` reads only `ContentSection` fields via a new `routeSections`, never the section text. With no declared structure it **fails closed** — the whole extraction becomes `DocumentBody`, so the document path runs all validators and the worst case is a lost metadata *label*, never lost coverage.

**Deletions:** `content_router.go` goes **1129 → 349 lines**. 24 symbols removed, including `separateCombinedPreprocessorOutput`, `splitByPreprocessorSeparators`, `detectMetadataSection`, `isMetadataSectionEnd`, `containsMetadataSections`, `looksLikeMetadata`, `extractEmbeddedMediaPath`, the four `contains*MetadataPatterns` sniffers, the `preprocessorSection` type, and `PreprocessorTypeMixedContent` (a category only the deleted classifier returned).

## Two things not in the original plan

**Embedded media is a sub-section inside one preprocessor's text**, and it routes to a *different* rule set — a `.wav` in a `.docx` has `Artist:`, on the audio sensitive-field list but not the office one. The first cut regressed `embedded.docx` from 7 findings to 6, losing `AUTHOR_INFO` for the clip's artist address. Fixed by having `ProcessEmbeddedMedia` return sections with its text and the router re-anchor rather than overwrite them. Caught by measurement, not by a test written to pass.

**`identifyPreprocessorType` also had to go**, though it wasn't on the list. It survived only as a timing label — but it sniffs document text, so reporting an attacker-derived label would have kept the in-band read path alive. Replaced with `processedContent.ProcessorType` in the observability payload.

**Docs:** both content-routing docs instructed maintainers to fix routing by regex-matching `--- image_metadata ---` against section text — i.e. to reintroduce this exact vulnerability — against an API (`ContentSection.Header`) that never existed. Rewritten to describe the declared-section mechanism.

## Testing

**Golden: ZERO change.** `git diff sec/pr2-extraction-part-names -- internal/goldencorpus/testdata/golden/` is empty. No regeneration, `UPDATE_GOLDEN` never used. That is the load-bearing result: the mechanism for determining structure was replaced wholesale and nothing about what gets detected moved.

Beyond the corpus, base-vs-fix equivalence on **14 fixtures × 7 formats**, identical modulo timestamps — with one disclosed exception: `forged_embed.docx` differs by one *removed* forged-attribution false positive, which is an improvement. The second commit here exists specifically to disclose that rather than let it hide inside "identical".

**Non-vacuity, isolated properly.** Reverting all production files gives only a compile error, which proves nothing about routing. So the type and producer were restored and **only the consumer** reverted:

```
--- FAIL: TestDeclaredSectionsDecideRouting_NotTheText
    a forged section header in the BODY changed the metadata split:
    2 items with the header vs 1 without.
--- FAIL: TestNoDeclaredSections_FailsClosedToDocumentBody
    DocumentBody is not the whole extraction.
```

Separately, replacing `Text: pResult.result.Text` with a copy fails `TestSectionTextAliasesNotCopies` — *"every scan now holds a second copy of the whole extracted document"*.

Note **5 of 7 new tests pass on a consumer-only revert**, because PR1's union already prevents the deletion. That is defence-in-depth working, not vacuity, and the test file documents it in a header comment rather than presenting seven independent proofs.

**PR1's union is intact and deliberately kept**, with a comment warning against "simplifying" it away now that sections are trustworthy — removing the capability and containing the consequence are different jobs. A forged first-line header still yields the SSN.

**Adversarial verify: no bypass survives.** Forged headers at first-line / mid-body / interleaved, odd casing and internal whitespace, the legacy `=== METADATA ===` form, all five metadata names forged at once, an `.xlsx` member named literally `xl/worksheets/--- office_metadata ---.xml`, and an embedded `.wav` named `a --- office_metadata --- b.wav` — none change section structure.

61 packages pass · `-race` clean on all five touched packages · cross-platform vet clean · timing flat within noise (0.96–1.02× over 12 points, linear on all three fixture families).
