### PR TITLE
fix(metadata): take a finding's reported source from the package, not from the text

### DIFF
--- a/internal/preprocessors/shared_utilities.go
+++ b/internal/preprocessors/shared_utilities.go
@@ -270,7 +270,21 @@ func (rih *RouterIntegrationHelper) CreateEmbeddedMediaPath(originalFilePath, em
 	return fmt.Sprintf("%s -> %s", filepath.Base(originalFilePath), embeddedFileName)
 }
 
-// FormatEmbeddedMediaSection formats embedded media content for inclusion in metadata text
+// FormatEmbeddedMediaSection formats embedded media content for inclusion in
+// metadata text.
+//
+// The "--- Embedded Media N (name) ---" line is now DISPLAY ONLY: it tells a
+// human reading the extracted text where an embedded item begins, and nothing
+// parses it back. Two readers used to, and both let a document author choose the
+// reported source of a finding just by typing this line as body text — the
+// content router's extractEmbeddedMediaPath (deleted with the rest of the
+// text-sniffing read side) and the METADATA validator's line loop. The real
+// provenance travels out of band in ContentSection.SourceFile, set by the
+// preprocessor that actually opened the archive member.
+//
+// So do not reintroduce a parser for this text, and do not "fix" a wrong
+// attribution by escaping the parentheses or the name: an author still controls
+// whatever a parser would read, and the structure carries the answer already.
 func (rih *RouterIntegrationHelper) FormatEmbeddedMediaSection(index int, mediaName, content string) string {
 	var result strings.Builder
 	result.WriteString(fmt.Sprintf("\n--- Embedded Media %d (%s) ---\n", index+1, mediaName))

--- a/internal/router/attribution_provenance_test.go
+++ b/internal/router/attribution_provenance_test.go
@@ -1,0 +1,252 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package router
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/binary"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestEmbeddedMediaProvenanceComesFromTheArchive is the producer-side half of the
+// attribution fix, and the reason the METADATA validator's parse site could simply
+// be deleted rather than replaced.
+//
+// The reported source of an embedded item's findings must be derived from the zip
+// entry the extractor actually opened, and it must arrive at the validator as
+// STRUCTURE — MetadataContent.SourceFile, from ContentSection.SourceFile — not as
+// text for the validator to re-parse. Two properties are asserted:
+//
+//  1. a genuine embedded member produces a section attributed to that member, so
+//     deleting the parser did not cost real provenance (which would be worse than
+//     the bug: an embedded item's findings blamed on the container);
+//  2. a forged "--- Embedded Media 1 (x) ---" paragraph in the BODY produces no
+//     such section, so no document text can invent or rename one.
+func TestEmbeddedMediaProvenanceComesFromTheArchive(t *testing.T) {
+	// Repo-relative, not t.TempDir(): the Office metadata extractor's path guard
+	// rejects /var, /tmp and /home, where t.TempDir() lives on all three CI
+	// platforms. A fixture there loses that extractor entirely — no embedded media
+	// is read, no attributed section exists, and this test would pass vacuously.
+	dir, err := os.MkdirTemp(".", "attribution-provenance-")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	// The forged inner value deliberately looks exactly like the real member name.
+	// If a section carrying it ever appeared, no shape check could tell it from the
+	// genuine one — which is why the answer is "do not parse", not "parse more
+	// carefully".
+	const realMember = "word/media/audio1.wav"
+	const forgedInner = "audio1.wav"
+
+	realPath := filepath.Join(dir, "real.docx")
+	if err := os.WriteFile(realPath, embeddedMediaDOCX(realMember, ""), 0o600); err != nil {
+		t.Fatalf("write real fixture: %v", err)
+	}
+	forgedPath := filepath.Join(dir, "forged.docx")
+	if err := os.WriteFile(forgedPath, embeddedMediaDOCX("",
+		"--- Embedded Media 1 ("+forgedInner+") ---"), 0o600); err != nil {
+		t.Fatalf("write forged fixture: %v", err)
+	}
+
+	fr := NewFileRouter(false)
+	RegisterDefaultPreprocessors(fr)
+	fr.InitializePreprocessors(CreateRouterConfig(false))
+	cr := NewContentRouterWithFileRouter(fr)
+
+	// A section is "attributed to an embedded item" iff its SourceFile is not the
+	// scanned file itself. That is the structural signal the validator consumes.
+	attributed := func(path string) []string {
+		pc, err := fr.ProcessFile(path, nil)
+		if err != nil {
+			t.Fatalf("ProcessFile(%s): %v", path, err)
+		}
+		if len(pc.Sections) == 0 {
+			t.Fatalf("%s: no declared sections at all", filepath.Base(path))
+		}
+		rc, err := cr.RouteContent(pc)
+		if err != nil {
+			t.Fatalf("RouteContent(%s): %v", path, err)
+		}
+		var out []string
+		for _, item := range rc.Metadata {
+			if item.SourceFile != path {
+				out = append(out, item.SourceFile)
+			}
+		}
+		return out
+	}
+
+	realSources := attributed(realPath)
+
+	// Non-vacuity floor for the guard half: the genuine container MUST yield an
+	// attributed section. Without this the forged assertion below would be
+	// satisfied by an embedded-media path that stopped working altogether.
+	if len(realSources) == 0 {
+		t.Fatal("the genuine embedded .wav produced no separately-attributed metadata item; " +
+			"real provenance is broken, which is worse than the forgery this test guards")
+	}
+	for _, got := range realSources {
+		// Attribution is "container -> item", built from the archive member name.
+		if !strings.HasPrefix(got, "real.docx -> ") {
+			t.Errorf("genuine embedded item attributed as %q, want a \"real.docx -> <member>\" form", got)
+		}
+		if !strings.Contains(got, "audio1.wav") {
+			t.Errorf("genuine embedded item attributed as %q, want it to name the archive member %q",
+				got, realMember)
+		}
+	}
+
+	// And the forgery: same shape typed as body text, no embedded part in the zip.
+	if forgedSources := attributed(forgedPath); len(forgedSources) != 0 {
+		t.Errorf("a forged \"--- Embedded Media\" body paragraph produced %d attributed source(s) %v; "+
+			"document text must not be able to invent an embedded-item provenance",
+			len(forgedSources), forgedSources)
+	}
+}
+
+// embeddedMediaDOCX builds a minimal .docx. A non-empty member adds a real .wav at
+// that archive path; a non-empty extraPara adds one more body paragraph (used to
+// type the forged header as document content).
+func embeddedMediaDOCX(member, extraPara string) []byte {
+	const decl = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>`
+
+	paras := []string{
+		"Quarterly summary follows.",
+		"Employee SSN 449-87-4100 on file.",
+	}
+	if extraPara != "" {
+		paras = append(paras, extraPara)
+	}
+	body := ""
+	for _, p := range paras {
+		body += `<w:p><w:r><w:t xml:space="preserve">` + p + `</w:t></w:r></w:p>`
+	}
+
+	// The .wav's INFO chunk carries fields on the AUDIO sensitive-field list, which
+	// is what makes the embedded item's own findings distinguishable from the
+	// container's.
+	wav := wavWithInfo(map[string]string{
+		"INAM": "Quarterly Review Recording",
+		"IART": "john.doe@example.com",
+		"ICMT": "contact 212-555-0142",
+	})
+
+	out := new(bytes.Buffer)
+	zw := zip.NewWriter(out)
+	put := func(name, content string) {
+		w, err := zw.Create(name)
+		if err != nil {
+			panic(err)
+		}
+		if _, err := io.WriteString(w, content); err != nil {
+			panic(err)
+		}
+	}
+
+	ctOverrides := `<Default Extension="wav" ContentType="audio/wav"/>`
+	put("[Content_Types].xml", decl+
+		`<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">`+
+		`<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>`+
+		`<Default Extension="xml" ContentType="application/xml"/>`+ctOverrides+
+		`<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>`+
+		`<Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/>`+
+		`</Types>`)
+	put("_rels/.rels", decl+
+		`<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">`+
+		`<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>`+
+		`<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" Target="docProps/core.xml"/>`+
+		`</Relationships>`)
+	put("docProps/core.xml", decl+
+		`<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/">`+
+		`<dc:creator>Jane Analyst</dc:creator><cp:lastModifiedBy>Ops Reviewer</cp:lastModifiedBy>`+
+		`</cp:coreProperties>`)
+	put("word/document.xml", decl+
+		`<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>`+
+		body+`</w:body></w:document>`)
+
+	if member != "" {
+		w, err := zw.Create(member)
+		if err != nil {
+			panic(err)
+		}
+		if _, err := w.Write(wav); err != nil {
+			panic(err)
+		}
+	}
+
+	if err := zw.Close(); err != nil {
+		panic(err)
+	}
+	return out.Bytes()
+}
+
+// wavWithInfo builds a minimal PCM WAV carrying a RIFF INFO LIST chunk, whose
+// fields are what the AUDIO metadata rule set reads.
+//
+// Duplicated from goldencorpus.BuildWAVWithInfo rather than imported: goldencorpus
+// reaches pkg/redact -> internal/core -> internal/router, so importing it from a
+// test in THIS package is an import cycle.
+func wavWithInfo(info map[string]string) []byte {
+	le := func(w io.Writer, vals ...any) {
+		for _, v := range vals {
+			if err := binary.Write(w, binary.LittleEndian, v); err != nil {
+				panic(err)
+			}
+		}
+	}
+
+	fmtChunk := new(bytes.Buffer)
+	le(fmtChunk, uint16(1), uint16(1), uint32(8000), uint32(8000), uint16(1), uint16(8))
+
+	// Sorted ids so the fixture bytes are identical run to run.
+	ids := make([]string, 0, len(info))
+	for id := range info {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	infoBody := new(bytes.Buffer)
+	infoBody.WriteString("INFO")
+	for _, id := range ids {
+		v := info[id]
+		field := append([]byte(v), 0) // null-terminated
+		if len(field)%2 == 1 {
+			field = append(field, 0) // pad to an even boundary
+		}
+		infoBody.WriteString(id)
+		le(infoBody, uint32(len(v)+1))
+		infoBody.Write(field)
+	}
+
+	list := new(bytes.Buffer)
+	list.WriteString("LIST")
+	le(list, uint32(infoBody.Len()))
+	list.Write(infoBody.Bytes())
+
+	data := []byte{0, 0, 0, 0} // 4 bytes of silence
+
+	body := new(bytes.Buffer)
+	body.WriteString("WAVE")
+	body.WriteString("fmt ")
+	le(body, uint32(fmtChunk.Len()))
+	body.Write(fmtChunk.Bytes())
+	body.Write(list.Bytes())
+	body.WriteString("data")
+	le(body, uint32(len(data)))
+	body.Write(data)
+
+	out := new(bytes.Buffer)
+	out.WriteString("RIFF")
+	le(out, uint32(body.Len()))
+	out.Write(body.Bytes())
+	return out.Bytes()
+}

--- a/internal/validators/dual_path_bridge.go
+++ b/internal/validators/dual_path_bridge.go
@@ -609,6 +609,56 @@ func (evb *EnhancedValidatorBridge) routeContentWithRetry(content *preprocessors
 
 // processContentLegacy provides fallback to legacy aggregation behavior. ctx is
 // threaded to the document-path dispatch chokepoint.
+// legacyMetadataUnit is one chunk of text to validate together with the path a
+// finding in it should be attributed to, and where the chunk starts in the whole
+// extraction.
+type legacyMetadataUnit struct {
+	text       string
+	sourceFile string
+	// lineOffset is the 0-based line index at which text begins within the full
+	// concatenation. A validator handed only a section counts lines from 1 inside
+	// it, so the offset is added back to keep reported line numbers file-relative.
+	lineOffset int
+}
+
+// legacyMetadataUnits splits a ProcessedContent into the units the legacy fallback
+// should validate separately.
+//
+// The units come from the DECLARED sections, so provenance is whatever the
+// preprocessor recorded when it opened the archive member — not something parsed back
+// out of the extracted text, which a document author writes and can therefore choose.
+//
+// Fails closed in the shape this path needs: with no declared sections (an older
+// preprocessor, or a caller that built ProcessedContent by hand) it returns the whole
+// text attributed to the container, which is exactly the previous behavior. Losing a
+// precise label is acceptable; losing the scan is not.
+func legacyMetadataUnits(content *preprocessors.ProcessedContent) []legacyMetadataUnit {
+	if content == nil {
+		return nil
+	}
+
+	units := make([]legacyMetadataUnit, 0, len(content.Sections))
+	for _, section := range content.Sections {
+		if strings.TrimSpace(section.Text) == "" {
+			continue
+		}
+		source := section.SourceFile
+		if source == "" {
+			source = content.OriginalPath
+		}
+		units = append(units, legacyMetadataUnit{
+			text:       section.Text,
+			sourceFile: source,
+			lineOffset: section.LineOffset,
+		})
+	}
+
+	if len(units) == 0 {
+		return []legacyMetadataUnit{{text: content.Text, sourceFile: content.OriginalPath}}
+	}
+	return units
+}
+
 func (evb *EnhancedValidatorBridge) processContentLegacy(ctx stdctx.Context, content *preprocessors.ProcessedContent, contextInsights context.ContextInsights) ([]detector.Match, error) {
 	if evb.observer != nil && evb.observer.Debug() != nil {
 		evb.observer.Debug().LogDetail("fallback", "Using legacy content aggregation")
@@ -638,21 +688,52 @@ func (evb *EnhancedValidatorBridge) processContentLegacy(ctx stdctx.Context, con
 	// Process with metadata validator if available. Dispatch through execguard
 	// so a panic in the metadata validator is recovered rather than crashing
 	// the process (v2 gap 1.3), matching the document path.
+	//
+	// Validate each DECLARED SECTION separately rather than handing over the whole
+	// concatenation, so a finding inside an embedded archive member is attributed to
+	// that member instead of to the container.
+	//
+	// This path has no ContentRouter to consult, and it used to get embedded-media
+	// provenance from the "--- Embedded Media N (name) ---" line the extractor writes
+	// into the text — which is precisely the forgeable channel this change removes.
+	// Deleting the reader without giving this path the structural equivalent silently
+	// re-attributed real embedded findings to the container: on a .docx carrying an
+	// embedded .wav, AUDIO_ARTIST_IDENTITY, EMAIL and IMAGE_AUTHOR moved from
+	// "real_embed.docx -> audio1.wav" to the container path, and because
+	// generateFindingHash folds filepath.Base(Filename), three suppression rules
+	// written against the old attribution stopped matching.
+	//
+	// Sections are produced by the file router before any routing decision, so they
+	// are available here even though this arm is only reached when routing failed.
 	if evb.metadataBridge.metadataValidator != nil {
 		mv := evb.metadataBridge.metadataValidator
-		metadataMatches, err := execguard.ValidateContent(ctx, fmt.Sprintf("%T", mv), mv, content.Text, content.OriginalPath)
-		if err != nil {
-			processingErrors = append(processingErrors, fmt.Errorf("metadata validation failed: %w", err))
-			if evb.observer != nil {
-				evb.observer.LogOperation(observability.StandardObservabilityData{
-					Component: "enhanced_validator_bridge",
-					Operation: "legacy_metadata_error",
-					FilePath:  content.OriginalPath,
-					Success:   false,
-					Error:     err.Error(),
-				})
+		name := fmt.Sprintf("%T", mv)
+
+		for _, unit := range legacyMetadataUnits(content) {
+			metadataMatches, err := execguard.ValidateContent(ctx, name, mv, unit.text, unit.sourceFile)
+			if err != nil {
+				processingErrors = append(processingErrors, fmt.Errorf("metadata validation failed: %w", err))
+				if evb.observer != nil {
+					evb.observer.LogOperation(observability.StandardObservabilityData{
+						Component: "enhanced_validator_bridge",
+						Operation: "legacy_metadata_error",
+						FilePath:  unit.sourceFile,
+						Success:   false,
+						Error:     err.Error(),
+					})
+				}
+				continue
 			}
-		} else {
+
+			// Rebase to file-relative lines. The validator saw only this section, so
+			// it counted from the section's first line; the suppression hash embeds
+			// the line number, so leaving them section-relative would invalidate
+			// every saved rule for a container with more than one section.
+			if unit.lineOffset > 0 {
+				for i := range metadataMatches {
+					metadataMatches[i].LineNumber += unit.lineOffset
+				}
+			}
 			allMatches = append(allMatches, metadataMatches...)
 		}
 	}

--- a/internal/validators/legacy_provenance_test.go
+++ b/internal/validators/legacy_provenance_test.go
@@ -1,0 +1,124 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package validators
+
+import (
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/preprocessors"
+)
+
+// The legacy fallback must carry provenance structurally, like the routed path.
+//
+// It is reached whenever routing or dual-path processing fails, and EnableFallbackMode
+// defaults to true, so it is live rather than theoretical. It used to learn where an
+// embedded archive member began by reading the "--- Embedded Media N (name) ---" line
+// out of the extracted text — the same forgeable channel this change removes elsewhere.
+// Deleting that reader without giving this path the structural equivalent silently
+// re-attributed real embedded findings to the container: measured on a .docx carrying an
+// embedded .wav, AUDIO_ARTIST_IDENTITY, EMAIL and IMAGE_AUTHOR moved from
+// "real_embed.docx -> audio1.wav" to the container path, and because
+// generateFindingHash folds filepath.Base(Filename), 3 of 11 suppression rules written
+// against the old attribution stopped matching.
+//
+// Two properties have to hold together, and fixing only the first breaks the second:
+// each unit is attributed to the member it came from, AND its line numbers stay
+// file-relative. A validator handed one section counts lines from 1 inside it, so
+// without rebasing by LineOffset the reported lines shift (21 -> 6, 8 -> 1) and the
+// suppression hash — which embeds the line number — invalidates every saved rule for
+// any container with more than one section.
+
+// TestLegacyMetadataUnitsUseDeclaredProvenance pins the first property.
+func TestLegacyMetadataUnitsUseDeclaredProvenance(t *testing.T) {
+	content := &preprocessors.ProcessedContent{
+		OriginalPath: "report.docx",
+		Text:         "Author: Jane Analyst\n\n--- Embedded Media 1 (audio1.wav) ---\nArtist: john.doe@example.com\n",
+		Sections: []preprocessors.ContentSection{
+			{
+				Name:       "office_metadata",
+				Kind:       preprocessors.SectionKindMetadata,
+				Text:       "Author: Jane Analyst",
+				SourceFile: "report.docx",
+				LineOffset: 0,
+			},
+			{
+				Name:       "embedded",
+				Kind:       preprocessors.SectionKindMetadata,
+				Text:       "Artist: john.doe@example.com",
+				SourceFile: "report.docx -> audio1.wav",
+				LineOffset: 3,
+			},
+		},
+	}
+
+	units := legacyMetadataUnits(content)
+	if len(units) != 2 {
+		t.Fatalf("got %d units, want one per declared section (2)", len(units))
+	}
+
+	if units[1].sourceFile != "report.docx -> audio1.wav" {
+		t.Errorf("embedded section attributed to %q, want the archive member it came from.\n"+
+			"Attributing it to the container loses real provenance and, because the "+
+			"suppression hash folds the filename, invalidates rules written against it.",
+			units[1].sourceFile)
+	}
+	if units[1].lineOffset != 3 {
+		t.Errorf("lineOffset = %d, want 3: without it the validator's section-relative "+
+			"lines are reported as file-relative and every saved suppression rule for "+
+			"this file stops matching", units[1].lineOffset)
+	}
+}
+
+// TestLegacyMetadataUnitsFailClosedWithoutSections is the floor. A caller that builds
+// ProcessedContent by hand, or an older preprocessor that does not declare sections,
+// must still get its text scanned — losing a precise label is acceptable, losing the
+// scan is not.
+func TestLegacyMetadataUnitsFailClosedWithoutSections(t *testing.T) {
+	content := &preprocessors.ProcessedContent{
+		OriginalPath: "report.docx",
+		Text:         "Author: Jane Analyst\nssn 449-87-4100\n",
+	}
+
+	units := legacyMetadataUnits(content)
+	if len(units) != 1 {
+		t.Fatalf("got %d units, want exactly 1 covering the whole text", len(units))
+	}
+	if units[0].text != content.Text {
+		t.Errorf("unit text = %q, want the whole extraction %q — a narrowed unit would "+
+			"leave part of the file unscanned on this path", units[0].text, content.Text)
+	}
+	if units[0].sourceFile != "report.docx" {
+		t.Errorf("sourceFile = %q, want the container path", units[0].sourceFile)
+	}
+	if units[0].lineOffset != 0 {
+		t.Errorf("lineOffset = %d, want 0: the single unit starts at the top of the "+
+			"extraction, so nothing should be added to its line numbers", units[0].lineOffset)
+	}
+}
+
+// TestLegacyMetadataUnitsSkipEmptySections keeps the unit list free of sections with
+// nothing to scan, matching what the routed path does.
+func TestLegacyMetadataUnitsSkipEmptySections(t *testing.T) {
+	content := &preprocessors.ProcessedContent{
+		OriginalPath: "report.docx",
+		Text:         "Author: Jane Analyst\n",
+		Sections: []preprocessors.ContentSection{
+			{Name: "office_metadata", Kind: preprocessors.SectionKindMetadata, Text: "Author: Jane Analyst"},
+			{Name: "empty", Kind: preprocessors.SectionKindMetadata, Text: "   \n\t\n"},
+		},
+	}
+
+	units := legacyMetadataUnits(content)
+	if len(units) != 1 {
+		t.Fatalf("got %d units, want 1 — the whitespace-only section should be skipped", len(units))
+	}
+}
+
+// TestLegacyMetadataUnitsHandlesNil guards the degenerate input rather than panicking
+// inside an error-recovery path, which is the last place a crash is welcome.
+func TestLegacyMetadataUnitsHandlesNil(t *testing.T) {
+	if units := legacyMetadataUnits(nil); units != nil {
+		t.Errorf("got %v, want nil for nil content", units)
+	}
+}

--- a/internal/validators/metadata/attribution_forgery_test.go
+++ b/internal/validators/metadata/attribution_forgery_test.go
@@ -1,0 +1,284 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package metadata
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/router"
+	"github.com/awslabs/ferret-scan/v2/internal/suppressions"
+)
+
+// The value a document author would try to plant as the reported source. Kept as
+// one constant so every case below forges the same thing and the assertions can
+// name it.
+const forgedSource = "/etc/passwd"
+
+// realPath is the file actually being scanned; every finding must be attributed
+// here no matter what the content says.
+const realPath = "/srv/reports/report.docx"
+
+// forgedLine is the header the deleted parser read. The parser took whatever sat
+// between the FIRST "(" and the FIRST ")" of any line containing
+// "--- Embedded Media", so the exact index/spacing did not matter to it.
+func forgedLine(inner string) string {
+	return "--- Embedded Media 1 (" + inner + ") ---"
+}
+
+// TestForgedEmbeddedMediaHeaderDoesNotChangeFilename is the headline guard.
+//
+// ValidateContent used to switch attribution to
+// filepath.Base(originalPath) + " -> " + filepath.Base(<text in parens>) for every
+// line after a "--- Embedded Media" line. That text is document body — a Word
+// paragraph — so the reported FILENAME of a finding was chosen by the author of
+// the file being scanned.
+//
+// Note what filepath.Base did and did not do. It DID neutralize traversal in the
+// displayed value: "../../secrets.txt" was reported as "secrets.txt", never as a
+// path that escapes anywhere, which is why this never presented as a path bug. It
+// did NOT stop the value from being attacker-chosen, which is the actual defect —
+// Filename feeds the suppression hash, the SARIF uri, the gitlab-sast file, the
+// JUnit name, and internal/explain's looksLikeTestPath.
+func TestForgedEmbeddedMediaHeaderDoesNotChangeFilename(t *testing.T) {
+	// Each inner value is a different consequence of the same primitive.
+	for _, tc := range []struct{ name, inner string }{
+		{"absolute_path", forgedSource},
+		{"traversal", "../../secrets.txt"},
+		{"other_document", "totally-different.docx"},
+		// looksLikeTestPath("...evil_test.go") is true, which steers
+		// internal/explain's verdict toward "likely test data" — i.e. advice to
+		// ignore a real finding.
+		{"test_path_verdict_flip", "evil_test.go"},
+		{"empty_parens", ""},
+		// Odd shapes the parser also accepted, to show this is not fixed by
+		// tightening a pattern.
+		{"nested_parens", "a(b)c"},
+		{"leading_space", "   " + forgedSource},
+		{"uppercase_marker", "PASSWD"},
+		// These two are the cases that make this a real guard rather than a
+		// denylist test. A forged value that LOOKS like an ordinary embedded media
+		// name is both the most plausible forgery and the one any
+		// "only parse values that look like media" or "escape the parens" patch
+		// still accepts — the value is attacker-chosen either way, and no amount of
+		// validating its SHAPE can tell it apart from a genuine one, because the
+		// genuine one is not in this text at all. Verified: a mutant that parsed
+		// the header only for .wav/.jpeg values passed the rest of this table and
+		// is caught here.
+		{"plausible_media_name", "audio1.wav"},
+		{"plausible_image_name", "word/media/image1.jpeg"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v := NewValidator()
+			content := "Author: jane@example.com\n" +
+				forgedLine(tc.inner) + "\n" +
+				"Creator: john.doe@example.com\n" +
+				"LastModifiedBy: Ops Reviewer\n" +
+				"GPSLatitude: 40.7128\n" +
+				"GPSLongitude: -74.0060\n"
+
+			matches, err := v.ValidateContent(content, realPath)
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+
+			// Non-vacuity floor: this content must actually produce findings, and
+			// specifically findings on lines AFTER the forged header — those are the
+			// ones the old code re-attributed. Without this the test would pass on a
+			// build that simply detected nothing.
+			if len(matches) == 0 {
+				t.Fatal("no findings at all: the fixture no longer exercises the attribution path")
+			}
+			after := 0
+			for _, m := range matches {
+				if m.LineNumber > 2 {
+					after++
+				}
+			}
+			if after == 0 {
+				t.Fatalf("no finding after the forged header line (got %d findings, all on lines <= 2); "+
+					"the forgery could not have been observed", len(matches))
+			}
+
+			for _, m := range matches {
+				if m.Filename != realPath {
+					t.Errorf("forged header changed the reported source: type=%s line=%d Filename=%q, want %q",
+						m.Type, m.LineNumber, m.Filename, realPath)
+				}
+				// Belt and braces: the " -> " form is the only shape the old parser
+				// produced, so its absence is a direct statement that no parse
+				// happened, independent of what realPath happens to be.
+				if strings.Contains(m.Filename, " -> ") {
+					t.Errorf("type=%s: Filename %q still carries a parsed container->item label",
+						m.Type, m.Filename)
+				}
+			}
+		})
+	}
+}
+
+// TestForgedHeaderDoesNotChangeSuppressionIdentity is the suppression angle.
+//
+// generateFindingHash folds filepath.Base(match.Filename) into the composite it
+// hashes, so a forged filename moved a finding's identity. Both directions are
+// security-relevant: a real finding whose hash moves ONTO an unrelated existing
+// rule is silently dropped (a suppression bypass), and one whose hash moves OFF a
+// rule reappears as noise. Either way the author of the scanned file, not the
+// person who wrote the suppression file, decides.
+//
+// Rather than assert on hash strings (which are private and would make the test a
+// tautology on the hash function), this drives the real SuppressionManager: write
+// a rule against the CONTROL finding, then check the forged run is suppressed by
+// exactly the same rule.
+func TestForgedHeaderDoesNotChangeSuppressionIdentity(t *testing.T) {
+	// Same metadata fields in both; the only difference is the forged header line,
+	// inserted at the top so the line numbers of the metadata fields still agree
+	// (LineNumber is also a hash component, so a shifted line would change the
+	// hash for a legitimate reason and mask the thing under test).
+	fields := "Creator: john.doe@example.com\n" +
+		"LastModifiedBy: Ops Reviewer\n"
+	control := forgedLine("") + "\n" + fields
+	forged := forgedLine(forgedSource) + "\n" + fields
+
+	v := NewValidator()
+	controlMatches, err := v.ValidateContent(control, realPath)
+	if err != nil {
+		t.Fatalf("control ValidateContent: %v", err)
+	}
+	forgedMatches, err := v.ValidateContent(forged, realPath)
+	if err != nil {
+		t.Fatalf("forged ValidateContent: %v", err)
+	}
+	if len(controlMatches) == 0 {
+		t.Fatal("control produced no findings: nothing to build a suppression identity from")
+	}
+	if len(forgedMatches) != len(controlMatches) {
+		t.Fatalf("forged run produced %d findings, control %d: the fixtures are not comparable",
+			len(forgedMatches), len(controlMatches))
+	}
+
+	// Build a manager holding a rule for every control finding, then confirm the
+	// forged run's findings hit those same rules.
+	dir := t.TempDir()
+	sm := suppressions.NewSuppressionManager(dir + "/suppressions.yaml")
+	for _, m := range controlMatches {
+		// AddSuppression rejects a hash it already holds. Two control findings can
+		// legitimately share an identity (same type, line, value), so tolerate that
+		// and fail only on a real error.
+		if err := sm.AddSuppression(m, "PR4 test rule", "tester", nil); err != nil &&
+			!strings.Contains(err.Error(), "already exists") {
+			t.Fatalf("AddSuppression: %v", err)
+		}
+	}
+
+	// Non-vacuity: the rules must actually suppress the control findings. If
+	// AddSuppression/IsSuppressed disagreed for an unrelated reason, the forged
+	// assertion below would pass for the wrong reason.
+	for _, m := range controlMatches {
+		if ok, _ := sm.IsSuppressed(m); !ok {
+			t.Fatalf("control finding type=%s line=%d is not suppressed by its own rule; "+
+				"the test cannot distinguish a forged identity from a broken one", m.Type, m.LineNumber)
+		}
+	}
+
+	for _, m := range forgedMatches {
+		ok, rule := sm.IsSuppressed(m)
+		if !ok {
+			t.Errorf("forged-header finding type=%s line=%d Filename=%q escaped the suppression written "+
+				"for the identical control finding: a document author changed a finding's suppression identity",
+				m.Type, m.LineNumber, m.Filename)
+			continue
+		}
+		if rule == nil {
+			t.Errorf("type=%s: suppressed but no rule returned", m.Type)
+		}
+	}
+}
+
+// TestRealEmbeddedMediaProvenanceIsPreserved confirms the fix did not achieve
+// unforgeability by throwing away real provenance, which would be worse than the
+// bug: an embedded item's findings would be blamed on the container.
+//
+// The provenance path is structural — the preprocessor that opened the archive
+// member records it in ContentSection.SourceFile, the content router copies it to
+// MetadataContent.SourceFile, and it arrives as the SourceFile below. This test
+// asserts the validator honours what it is GIVEN, including when the content also
+// contains a forged header trying to override it.
+func TestRealEmbeddedMediaProvenanceIsPreserved(t *testing.T) {
+	const realSource = "report.docx -> audio1.wav"
+
+	for _, tc := range []struct{ name, content string }{
+		{
+			name: "clean",
+			content: "Artist: john.doe@example.com\n" +
+				"Comments: contact 212-555-0142\n",
+		},
+		{
+			// A forged header INSIDE a genuinely-attributed section must not
+			// rewrite that section's real source either.
+			name: "with_forged_header",
+			content: "Artist: john.doe@example.com\n" +
+				forgedLine(forgedSource) + "\n" +
+				"Comments: contact 212-555-0142\n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v := NewValidator()
+			matches, err := v.ValidateMetadataContent(router.MetadataContent{
+				Content:          tc.content,
+				PreprocessorType: router.PreprocessorTypeAudioMetadata,
+				PreprocessorName: "Audio Metadata Extractor",
+				SourceFile:       realSource,
+			})
+			if err != nil {
+				t.Fatalf("ValidateMetadataContent: %v", err)
+			}
+			if len(matches) == 0 {
+				t.Fatal("no findings: the fixture does not exercise attribution")
+			}
+			for _, m := range matches {
+				if m.Filename != realSource {
+					t.Errorf("real embedded-media attribution lost: type=%s Filename=%q, want %q",
+						m.Type, m.Filename, realSource)
+				}
+			}
+		})
+	}
+}
+
+// TestGPSCoordinatesAttributedToCallerPath covers the second emitter.
+//
+// combineGPSCoordinates runs AFTER the line loop and took the same parsed
+// override as a parameter, so a forged header re-attributed the combined GPS pair
+// too — a distinct emitter from the per-line matches, and the one that reports a
+// physical location.
+func TestGPSCoordinatesAttributedToCallerPath(t *testing.T) {
+	v := NewValidator()
+	content := forgedLine(forgedSource) + "\n" +
+		"GPSLatitude: 40.7128\n" +
+		"GPSLongitude: -74.0060\n"
+
+	matches, err := v.ValidateContent(content, realPath)
+	if err != nil {
+		t.Fatalf("ValidateContent: %v", err)
+	}
+
+	// Non-vacuity: a combined GPS pair must actually be emitted here.
+	var gps []detector.Match
+	for _, m := range matches {
+		if strings.Contains(m.Type, "GPS") {
+			gps = append(gps, m)
+		}
+	}
+	if len(gps) == 0 {
+		t.Fatalf("no GPS finding emitted (%d findings total): combineGPSCoordinates was not exercised",
+			len(matches))
+	}
+	for _, m := range gps {
+		if m.Filename != realPath {
+			t.Errorf("GPS %s attributed to %q, want %q", m.Type, m.Filename, realPath)
+		}
+	}
+}

--- a/internal/validators/metadata/metadata_validator.go
+++ b/internal/validators/metadata/metadata_validator.go
@@ -5,7 +5,6 @@ package metadata
 
 import (
 	"fmt"
-	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
@@ -680,32 +679,42 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 	seenGPSFields := make(map[string]bool)
 	// Track if we've seen author/creator info to avoid duplicate matches
 	seenAuthor := false
-	// Track current embedded media context
-	currentEmbeddedMedia := ""
 	// Track GPS coordinate components for combining
 	gpsCoordinates := make(map[string]string) // field -> value
 	gpsLineNumbers := make(map[string]int)    // field -> line number
 
+	// Every match this function emits is attributed to originalPath, the path the
+	// CALLER supplied.
+	//
+	// This used to be conditional. A line containing "--- Embedded Media" switched
+	// attribution for every subsequent line to filepath.Base(originalPath) + " -> " +
+	// filepath.Base(text between the first "(" and the first ")"), so the reported
+	// source of a finding was read out of the content being scanned. A document
+	// author writes that content, so the author chose the filename: typing
+	// "--- Embedded Media 1 (/etc/passwd) ---" in a Word paragraph produced
+	// "report.docx -> passwd", and "(evil_test.go)" produced a name that
+	// internal/explain's looksLikeTestPath reads as fixture data and downgrades the
+	// verdict toward "likely test data" — advice to ignore a real finding.
+	// filepath.Base did neutralize traversal in the DISPLAYED string
+	// ("../../secrets.txt" showed as "secrets.txt", not as an escaping path), which
+	// is why this never looked like a path-handling bug; what it did not do is stop
+	// the value from being attacker-chosen in the first place.
+	//
+	// Filename is also an input to the suppression identity: generateFindingHash
+	// folds in filepath.Base(match.Filename), so a forged name moved a finding's
+	// hash — either off an existing rule (a genuinely suppressed finding reappears)
+	// or onto one (a real finding is silently dropped by a rule written for
+	// something else).
+	//
+	// The provenance is real structure, not text: the preprocessor that actually
+	// read the archive member records it in ContentSection.SourceFile, the content
+	// router copies that into MetadataContent.SourceFile, and it arrives here as the
+	// originalPath argument. So the correct value is already in hand on the routed
+	// path, and re-deriving it from the text could only ever produce a WORSE answer
+	// than the one the caller passed in.
+	filename := originalPath
+
 	for lineNumber, line := range lines {
-		// Check if we're entering an embedded media section
-		if strings.Contains(line, "--- Embedded Media") {
-			if idx := strings.Index(line, "("); idx != -1 {
-				if endIdx := strings.Index(line[idx:], ")"); endIdx != -1 {
-					embeddedName := line[idx+1 : idx+endIdx]
-					// Extract just the image filename from the path
-					imageName := filepath.Base(embeddedName)
-					currentEmbeddedMedia = fmt.Sprintf("%s -> %s", filepath.Base(originalPath), imageName)
-				}
-			}
-			continue
-		}
-
-		// Determine filename based on context
-		filename := originalPath
-		if currentEmbeddedMedia != "" {
-			filename = currentEmbeddedMedia
-		}
-
 		// Skip empty lines
 		if strings.TrimSpace(line) == "" {
 			continue
@@ -1091,7 +1100,7 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 	}
 
 	// After processing all lines, combine GPS coordinate components
-	combinedMatches := v.combineGPSCoordinates(gpsCoordinates, gpsLineNumbers, originalPath, currentEmbeddedMedia)
+	combinedMatches := v.combineGPSCoordinates(gpsCoordinates, gpsLineNumbers, originalPath)
 	matches = append(matches, combinedMatches...)
 
 	return matches, nil
@@ -2367,15 +2376,16 @@ func sortedGPSFields(gpsCoordinates map[string]string) []string {
 	return fields
 }
 
-// combineGPSCoordinates combines latitude and longitude into coordinate pairs
-func (v *Validator) combineGPSCoordinates(gpsCoordinates map[string]string, gpsLineNumbers map[string]int, originalPath, currentEmbeddedMedia string) []detector.Match {
+// combineGPSCoordinates combines latitude and longitude into coordinate pairs.
+//
+// It took a currentEmbeddedMedia override that the caller derived by parsing
+// "--- Embedded Media N (name) ---" out of the scanned text; see ValidateContent
+// for why that made the reported source attacker-chosen. Coordinates are
+// attributed to originalPath, which the caller already receives as real structure.
+func (v *Validator) combineGPSCoordinates(gpsCoordinates map[string]string, gpsLineNumbers map[string]int, originalPath string) []detector.Match {
 	var matches []detector.Match
 
-	// Determine filename based on context
 	filename := originalPath
-	if currentEmbeddedMedia != "" {
-		filename = currentEmbeddedMedia
-	}
 
 	// Look for latitude/longitude pairs
 	var latitude, longitude, latRef, longRef string

--- a/internal/validators/metadata/metadata_validator_test.go
+++ b/internal/validators/metadata/metadata_validator_test.go
@@ -102,7 +102,7 @@ func TestMetadata_CombineGPSNoEarlyReturn(t *testing.T) {
 	v := NewValidator()
 	gps := map[string]string{"coordinates": "N/A", "gpslatitude": "40.7128", "gpslongitude": "-74.0060"}
 	lines := map[string]int{"coordinates": 1, "gpslatitude": 2, "gpslongitude": 3}
-	res := v.combineGPSCoordinates(gps, lines, "f.jpg", "")
+	res := v.combineGPSCoordinates(gps, lines, "f.jpg")
 
 	pairFound := false
 	for _, r := range res {
@@ -133,7 +133,7 @@ func TestMetadata_GPSPairValidation(t *testing.T) {
 	} {
 		res := v.combineGPSCoordinates(
 			map[string]string{"gpslatitude": tc.lat, "gpslongitude": tc.long},
-			map[string]int{"gpslatitude": 1, "gpslongitude": 2}, "f.jpg", "")
+			map[string]int{"gpslatitude": 1, "gpslongitude": 2}, "f.jpg")
 		if len(res) > 0 {
 			t.Errorf("L17: invalid pair (%s,%s) should not be emitted, got %d", tc.lat, tc.long, len(res))
 		}
@@ -141,7 +141,7 @@ func TestMetadata_GPSPairValidation(t *testing.T) {
 	// A valid in-range pair is still HIGH.
 	res := v.combineGPSCoordinates(
 		map[string]string{"gpslatitude": "40.7128", "gpslongitude": "-74.0060"},
-		map[string]int{"gpslatitude": 1, "gpslongitude": 2}, "f.jpg", "")
+		map[string]int{"gpslatitude": 1, "gpslongitude": 2}, "f.jpg")
 	if len(res) != 1 || res[0].Confidence < 90 {
 		t.Errorf("L17: valid pair should be one HIGH GPS match, got %d", len(res))
 	}


### PR DESCRIPTION
_Supersedes #240. GitHub blocks retargeting a PR's base while it is linked in a stack, and #240's old base branch (`sec/pr3-structured-sections`) predates the rebase onto `main` (merged via #244). Same head branch, same two commits, rebased onto `main`._

**Stacked on #239.** Last of the sequence. Closes the attribution half that no earlier PR reaches.

## The defect

`extractEmbeddedMediaPath` parsed whatever sat between the first `(` and the first `)` of an `--- Embedded Media N (name) ---` line and built `MetadataContent.SourceFile` from it. That becomes `Match.Filename`. A document author can type that line as body text or supply the media part name, so **the reported source of a finding was attacker-chosen**:

| typed in a Word paragraph | reported as |
|---|---|
| `--- Embedded Media 1 (/etc/passwd) ---` | `report.docx -> passwd` |
| `--- Embedded Media 1 (../../secrets.txt) ---` | `report.docx -> secrets.txt` |
| `--- Embedded Media 1 (totally-different.docx) ---` | `report.docx -> totally-different.docx` |

`Match.Filename` feeds the suppression hash (`generateFindingHash` folds `filepath.Base(Filename)`), the SARIF `uri`, the gitlab-sast `file`, the JUnit name, and `internal/explain`'s `looksLikeTestPath` — where a name like `evil_test.go` flips the verdict toward "likely test data", i.e. advice to ignore a real finding.

`filepath.Base` neutralised traversal in the *displayed* value; it did nothing about the value being attacker-chosen at all.

Provenance now travels out of band in `ContentSection.SourceFile`, set by the preprocessor that actually opened the archive member. Both parse sites are gone — `extractEmbeddedMediaPath` (with #239's read side) and the METADATA validator's line loop. The `--- Embedded Media N (name) ---` line is now **display only**, with a comment saying so and saying not to reintroduce a parser or "fix" a wrong attribution by escaping the parens: an author still controls whatever a parser would read.

## What the adversarial pass caught

The verify agent returned **DEFECTIVE** on the first cut, with two regressions confined to the bridge's legacy fallback (`processContentLegacy`; `EnableFallbackMode` defaults **true**, and the arm runs whenever routing or dual-path processing fails). The final commit here fixes both.

That path hands the whole concatenation to the metadata validator with only the container path and has no `ContentRouter` to consult — so the emitted header was its **only** provenance carrier. Deleting the reader while leaving the emitter in place silently re-attributed real embedded findings to the container:

| binary | `real_embed.docx` (embedded `.wav`) |
|---|---|
| parent | `AUDIO_ARTIST_IDENTITY`, `EMAIL`, `IMAGE_AUTHOR` → `real_embed.docx -> audio1.wav` |
| first cut | all three → the container path ❌ |
| final | all three → `real_embed.docx -> audio1.wav` ✅ |

And because the suppression hash folds the filename, rules generated with the **parent** binary (11 enabled) suppressed only **8**; three legitimate findings escaped. Now **11/11**.

The fix validates each *declared section* separately, so each finding inherits the `SourceFile` its preprocessor recorded. Sections are produced before any routing decision, so they are available even though this arm only runs when routing failed. With no declared sections it falls closed to the previous behaviour — whole text, container path — because losing a precise label is acceptable and losing the scan is not.

**Fixing attribution alone was not enough**, and the second half is easy to miss. A validator handed one section counts lines from 1 inside it, so per-section validation made reported lines section-relative (21 → 6, 8 → 1, 9 → 2). The suppression hash embeds the line number, so that traded one hash invalidation for another — suppression went **8/11 → 6/11** before rebasing by `ContentSection.LineOffset`. Line numbers are now byte-identical to the parent.

## Testing

**Non-vacuity.** The three forgery tests: 10/10 subcases plus the suppression and GPS tests fail on the parent with the exact quoted output, and both new tests carry explicit floors (fatal if no finding lands after the forged header; fatal if no GPS pair is found). The legacy fix is mutation-proven in **both** halves separately — forcing `lineOffset` to 0 fails on the line-number assertion; replacing `section.SourceFile` with the container path fails on the attribution assertion.

**Forgery closed on every reachable path.** 15 shapes across the direct validator, the adapter fallback, and all 8 preprocessor arms all report the caller's path.

**Honest residual, stated rather than claimed away:** the replacement provenance is a zip member name, which the same document author also writes. So the specific harms are *narrowed*, not eliminated — a member at `word/media/evil_test.go` still reaches `looksLikeTestPath`. What is gone is forging attribution from **body text**, which needed no control of the archive at all.

61 packages pass · gofmt clean · vet clean for darwin/linux/windows · goldens unchanged vs #239 · SSN/PAN removal identical base-vs-fix on all 5 containers.
