### PR TITLE
fix(secrets): stop document context promoting a bare hex identifier to a secret

### DIFF
--- a/internal/validators/confidence_ceiling_test.go
+++ b/internal/validators/confidence_ceiling_test.go
@@ -1,0 +1,96 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package validators
+
+import (
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/validators/secrets"
+)
+
+// A validator can declare a hard ceiling on a finding's confidence, and the bridge
+// must honour it after every adjustment that raises confidence.
+//
+// The mechanism exists because confidence is raised in three places AFTER a validator
+// returns — a document-context adjustment on each path, and a cross-path correlation
+// boost — so a validator that clamps its own return value cannot make the bound stick.
+// Measured: a value the secrets validator scored 55 was reported at 80 in a real
+// document once +20 context and +5 correlation had been applied.
+//
+// It is generic on purpose. Any validator with a value-intrinsic reason to say "no
+// amount of surrounding context should promote this" can set the key; the bridge needs
+// no knowledge of which validator or which shape.
+
+func TestClampToCeilingHonoursADeclaredCeiling(t *testing.T) {
+	m := detector.Match{
+		Confidence: 80,
+		Metadata:   map[string]any{ConfidenceCeilingKey: 55.0},
+	}
+	clampToCeiling(&m)
+
+	if m.Confidence != 55 {
+		t.Errorf("Confidence = %v, want 55.\nA declared ceiling must survive the "+
+			"document-context and cross-path boosts, which is the whole reason the clamp "+
+			"lives in the bridge rather than in the validator.", m.Confidence)
+	}
+}
+
+func TestClampToCeilingLeavesLowerConfidenceAlone(t *testing.T) {
+	m := detector.Match{
+		Confidence: 40,
+		Metadata:   map[string]any{ConfidenceCeilingKey: 55.0},
+	}
+	clampToCeiling(&m)
+
+	if m.Confidence != 40 {
+		t.Errorf("Confidence = %v, want 40 unchanged: a ceiling is an upper bound, "+
+			"not a target to raise toward", m.Confidence)
+	}
+}
+
+// TestClampToCeilingIgnoresMalformedCeilings is the safety floor. A ceiling that is
+// absent, the wrong type, or non-positive must be ignored rather than treated as zero:
+// clamping to 0 would erase a finding's confidence and, depending on the band filter,
+// remove it from the report entirely — which per the sink rule means it stops being
+// redacted.
+func TestClampToCeilingIgnoresMalformedCeilings(t *testing.T) {
+	cases := []struct {
+		name string
+		meta map[string]any
+	}{
+		{"nil metadata", nil},
+		{"key absent", map[string]any{"other": 1.0}},
+		{"wrong type int", map[string]any{ConfidenceCeilingKey: 55}},
+		{"wrong type string", map[string]any{ConfidenceCeilingKey: "55"}},
+		{"zero", map[string]any{ConfidenceCeilingKey: 0.0}},
+		{"negative", map[string]any{ConfidenceCeilingKey: -10.0}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := detector.Match{Confidence: 90, Metadata: tc.meta}
+			clampToCeiling(&m)
+			if m.Confidence != 90 {
+				t.Errorf("Confidence = %v, want 90 unchanged. A malformed ceiling must be "+
+					"ignored; clamping to 0 would erase the finding's confidence and could "+
+					"drop it from the report, which stops it being redacted.", m.Confidence)
+			}
+		})
+	}
+}
+
+// TestCeilingKeyMatchesTheSecretsValidator guards the one duplicated literal. The
+// bridge declares the key rather than importing it from a validator package, so the
+// dependency points one way; this test is what keeps the two spellings from drifting
+// apart silently, which would turn every ceiling into a no-op.
+func TestCeilingKeyMatchesTheSecretsValidator(t *testing.T) {
+	if ConfidenceCeilingKey != secrets.ConfidenceCeilingKey {
+		t.Errorf("ceiling key drift: bridge has %q, secrets validator has %q.\n"+
+			"The literal is duplicated to keep the bridge from depending on a validator "+
+			"package. If they diverge, every declared ceiling is silently ignored and the "+
+			"findings it protects go back to being promoted by document context.",
+			ConfidenceCeilingKey, secrets.ConfidenceCeilingKey)
+	}
+}

--- a/internal/validators/dual_path_bridge.go
+++ b/internal/validators/dual_path_bridge.go
@@ -524,6 +524,47 @@ func (evb *EnhancedValidatorBridge) processDualPath(ctx stdctx.Context, routedCo
 	return result, nil
 }
 
+// ConfidenceCeilingKey is the Match.Metadata key a validator sets to declare a hard
+// upper bound on a finding's confidence. It is read here, in the bridge, because this
+// is where confidence is RAISED after a validator has finished: a document-context
+// adjustment and a cross-path correlation boost are both added downstream, so a
+// validator that clamps its own return value has no way to make the bound stick.
+// Measured case: a value the secrets validator scored 55 was reported at 80 once +20
+// context and +5 correlation had been applied.
+//
+// The key is a plain string rather than an import from one validator package so any
+// validator can use the mechanism without the bridge depending on it. Value must be a
+// float64; anything else is ignored rather than treated as zero, since a
+// misinterpreted ceiling of 0 would silently erase a finding's confidence.
+const ConfidenceCeilingKey = "confidence_ceiling"
+
+// clampToCeiling applies a match's declared confidence ceiling, if it has one.
+//
+// Call this after every adjustment that can raise Confidence. A ceiling means "this
+// value is shaped like something benign and no amount of surrounding context should
+// promote it", which is exactly the claim that document-level boosts would otherwise
+// override — they know nothing about the individual value.
+//
+// Deliberately a clamp and not a drop: only reported findings reach the redactor, so
+// removing a finding would leave its value in the redacted output. A demoted finding
+// is still reported and still redacted.
+func clampToCeiling(match *detector.Match) {
+	if match.Metadata == nil {
+		return
+	}
+	raw, ok := match.Metadata[ConfidenceCeilingKey]
+	if !ok {
+		return
+	}
+	ceiling, ok := raw.(float64)
+	if !ok || ceiling <= 0 {
+		return
+	}
+	if match.Confidence > ceiling {
+		match.Confidence = ceiling
+	}
+}
+
 // applyCrossPathConfidenceAdjustments applies confidence adjustments based on cross-path analysis
 func (evb *EnhancedValidatorBridge) applyCrossPathConfidenceAdjustments(matches []detector.Match, contextInsights context.ContextInsights) []detector.Match {
 	if len(matches) == 0 {
@@ -554,6 +595,7 @@ func (evb *EnhancedValidatorBridge) applyCrossPathConfidenceAdjustments(matches 
 		for i := range matches {
 			originalConfidence := matches[i].Confidence
 			matches[i].Confidence += correlationBoost
+			clampToCeiling(&matches[i])
 
 			// Ensure confidence stays within bounds
 			if matches[i].Confidence > 100 {
@@ -911,6 +953,7 @@ func (dvb *DocumentValidatorBridge) ProcessDocumentContentCtx(ctx stdctx.Context
 					adjustment := dvb.contextAnalyzer.GetConfidenceAdjustment(contextInsights, validatorName)
 					originalConfidence := matches[i].Confidence
 					matches[i].Confidence += adjustment
+					clampToCeiling(&matches[i])
 
 					// Ensure confidence stays within bounds
 					if matches[i].Confidence > 100 {
@@ -1179,6 +1222,7 @@ func (mvb *MetadataValidatorBridge) ProcessMetadataContentCtx(ctx stdctx.Context
 
 				originalConfidence := matches[i].Confidence
 				matches[i].Confidence += totalAdjustment
+				clampToCeiling(&matches[i])
 
 				// Ensure confidence stays within bounds
 				if matches[i].Confidence > 100 {

--- a/internal/validators/secrets/hex_identifier_test.go
+++ b/internal/validators/secrets/hex_identifier_test.go
@@ -1,0 +1,126 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package secrets
+
+import "testing"
+
+// A bare hex value on a line that names nothing secret is an identifier shape, not a
+// credential, and gets a confidence ceiling below the MEDIUM band.
+//
+// The case that prompted it: an EXIF ImageUniqueID — an image GUID — was reported as
+// API_KEY_OR_SECRET at 80 inside a real 10 MB .docx. It reaches the entropy path at all
+// only because containsSecretIndicators admits any quoted value of 20+ bytes; no secret
+// keyword is involved. Digests, ETags, commit ids and content hashes share the shape.
+//
+// The discriminator is the LINE'S LABEL read as a POSITIVE signal — the ceiling applies
+// when nothing says "secret" — and the direction is the point. A negative list of
+// identifier field names would let a document author suppress a REAL secret by writing
+// `ImageUniqueID: "AKIA..."`. That is attacker-controlled suppression, the same class of
+// defect the surrounding work has been removing. Here relabelling can only REMOVE the
+// ceiling, never trigger it.
+
+func TestUnlabelledHexIdentifierCap(t *testing.T) {
+	const guid = "14f6364997257b9170c016a13d1f1127" // 32 hex, the measured EXIF value
+
+	cases := []struct {
+		name    string
+		value   string
+		line    string
+		capped  bool
+		comment string
+	}{
+		// Capped: identifier shapes with no credential label.
+		{"exif image guid", guid, `ImageUniqueID: "` + guid + `"`, true, "the reported false positive"},
+		{"md5 digest", "d41d8cd98f00b204e9800998ecf8427e", `checksum: "d41d8cd98f00b204e9800998ecf8427e"`, true, ""},
+		{"sha1 commit", "9f8e7d6c5b4a39281706f5e4d3c2b1a0f9e8d7c6", `commit "9f8e7d6c5b4a39281706f5e4d3c2b1a0f9e8d7c6"`, true, ""},
+		{"sha256", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", `digest "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"`, true, ""},
+		{"uppercase hex", "14F6364997257B9170C016A13D1F1127", `SerialNumber: "14F6364997257B9170C016A13D1F1127"`, true, "case must not matter"},
+
+		// NOT capped: the line labels the value as a credential. This is the direction
+		// that makes the rule safe — an author cannot demote a real secret by renaming
+		// its field, because any secret-ish word removes the ceiling.
+		{"api_key label", guid, `api_key = "` + guid + `"`, false, "SAME VALUE as the FP, must keep full score"},
+		{"secret label", guid, `client_secret: "` + guid + `"`, false, ""},
+		{"token label", guid, `token "` + guid + `"`, false, ""},
+		{"password label", guid, `password: "` + guid + `"`, false, ""},
+		{"auth label", guid, `authorization: "` + guid + `"`, false, ""},
+		{"private label", guid, `private_value: "` + guid + `"`, false, ""},
+		{"hmac label", guid, `hmac: "` + guid + `"`, false, ""},
+		{"session label", guid, `session: "` + guid + `"`, false, ""},
+
+		// NOT capped: wrong shape. Anything that is not pure hex at an identifier
+		// length keeps its score, so the rule cannot quietly demote real secrets that
+		// merely contain hex.
+		{"base64ish", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", `value = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"`, false, ""},
+		{"hex with dashes", "14f63649-9725-7b91-70c0-16a13d1f1127", `id: "14f63649-9725-7b91-70c0-16a13d1f1127"`, false, "a dashed GUID is not bare hex"},
+		{"too short", "14f6364997257b91", `id: "14f6364997257b91"`, false, "16 hex is not an identifier length we claim"},
+		{"48 hex is not a known length", "14f6364997257b9170c016a13d1f112714f6364997257b91", `id: "x"`, false, ""},
+		{"hex plus suffix", guid + "z", `id: "` + guid + `z"`, false, ""},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := unlabelledHexIdentifierCap(genericSecretType, tc.value, tc.line)
+			capped := got > 0
+
+			if capped != tc.capped {
+				verb := "was not capped but should be"
+				if !tc.capped {
+					verb = "was capped but should not be"
+				}
+				extra := ""
+				if tc.comment != "" {
+					extra = " (" + tc.comment + ")"
+				}
+				t.Errorf("%s%s\n  value: %q\n  line:  %q\n  ceiling returned: %v",
+					verb, extra, tc.value, tc.line, got)
+			}
+			if capped && got != unlabelledHexIdentifierCeiling {
+				t.Errorf("ceiling = %v, want %v (below the MEDIUM band so the finding "+
+					"reports as LOW)", got, unlabelledHexIdentifierCeiling)
+			}
+		})
+	}
+}
+
+// TestUnlabelledHexIdentifierCapOnlyAppliesToGenericFindings keeps the rule away from
+// provider-identified secrets. A value that matched a provider signature has been
+// identified by its own shape, and no line-label heuristic should second-guess it.
+func TestUnlabelledHexIdentifierCapOnlyAppliesToGenericFindings(t *testing.T) {
+	const guid = "14f6364997257b9170c016a13d1f1127"
+	line := `ImageUniqueID: "` + guid + `"`
+
+	if got := unlabelledHexIdentifierCap("AWS_SECRET_ACCESS_KEY", guid, line); got != 0 {
+		t.Errorf("ceiling = %v for a provider-identified type, want 0: a value that "+
+			"matched a provider signature must not be demoted by a label heuristic", got)
+	}
+	if got := unlabelledHexIdentifierCap(genericSecretType, guid, line); got == 0 {
+		t.Error("the generic type should be capped on this line; the test above would " +
+			"otherwise pass for the wrong reason")
+	}
+}
+
+// TestSecretLabelWordsCoverTheIndicatorKeywords is the consistency floor between the
+// two lists. containsSecretIndicators decides whether a line is scanned at all; the
+// ceiling must never fire on a line that check would have called secret-labelled, or
+// the two would disagree about the same line.
+func TestSecretLabelWordsCoverTheIndicatorKeywords(t *testing.T) {
+	indicatorKeywords := []string{
+		"key", "secret", "token", "password", "pass", "pwd", "auth",
+		"credential", "private", "bearer", "jwt", "api",
+	}
+
+	have := make(map[string]bool, len(secretLabelWords))
+	for _, w := range secretLabelWords {
+		have[w] = true
+	}
+	for _, kw := range indicatorKeywords {
+		if !have[kw] {
+			t.Errorf("secretLabelWords is missing %q, which containsSecretIndicators "+
+				"treats as a secret label. The ceiling could then demote a line the "+
+				"indicator check considers credential-labelled.", kw)
+		}
+	}
+}

--- a/internal/validators/secrets/validator.go
+++ b/internal/validators/secrets/validator.go
@@ -75,6 +75,78 @@ type spannedMatch struct {
 // what the secret actually is, which is strictly more useful to a reviewer.
 const genericSecretType = "API_KEY_OR_SECRET"
 
+// ConfidenceCeilingKey is the Match.Metadata key carrying a hard upper bound on a
+// finding's confidence. The dual-path bridge reads it and clamps AFTER its context and
+// cross-path adjustments — a ceiling applied only here would be undone by them, since a
+// value scored 55 by this validator was reported at 80 in a real document once +20
+// document context and +5 cross-path correlation had been added downstream.
+//
+// The literal is duplicated rather than imported to keep the dependency pointing one
+// way (the bridge must not depend on a validator package). It is covered by a test that
+// fails if the two drift apart.
+const ConfidenceCeilingKey = "confidence_ceiling"
+
+// unlabelledHexIdentifierCeiling keeps a bare hexadecimal value on a line that names
+// nothing secret below the MEDIUM band, so it is reported as LOW.
+//
+// A ceiling and not a veto, deliberately. A 32-hex string genuinely can be a secret,
+// and only reported findings reach the redactor — dropping one would leave the value
+// in the "redacted" output, which is the failure mode this area keeps producing.
+// Demoting keeps the row, keeps the redaction, and keeps it out of the band that
+// drives blocking decisions.
+const unlabelledHexIdentifierCeiling = 55.0
+
+// bareHexIdentifier matches a value that is nothing but hex digits, at the lengths
+// where identifiers live: 32 (GUID, MD5), 40 (SHA-1, git object), 64 (SHA-256).
+// Shorter runs are too common to reason about; longer ones are rarer than the noise
+// they would add.
+var bareHexIdentifier = regexp.MustCompile(`^(?:[0-9a-f]{32}|[0-9a-f]{40}|[0-9a-f]{64})$`)
+
+// secretLabelWords are the words whose presence on a line means the value is being
+// presented as a credential. Matched as substrings, and kept a superset of what
+// containsSecretIndicators looks for, so the ceiling can never fire on a line that
+// the indicator check would have called secret-labelled.
+var secretLabelWords = []string{
+	"key", "secret", "token", "password", "pass", "pwd", "auth",
+	"credential", "private", "bearer", "jwt", "api", "signature", "hmac",
+	"session", "cookie", "access", "refresh", "client_id", "clientid",
+}
+
+// unlabelledHexIdentifierCap returns the ceiling for a generic high-entropy finding
+// whose value is a bare hex identifier on a line carrying no secret-ish label, or 0
+// when no ceiling applies.
+//
+// The case that prompted it: an EXIF ImageUniqueID — `ImageUniqueID:
+// "14f6364997257b9170c016a13d1f1127"` — is an image GUID, and it was reported as
+// API_KEY_OR_SECRET at 80 in a real 10 MB .docx. It reaches the entropy path at all
+// only because containsSecretIndicators admits any quoted value of 20+ bytes; no
+// secret keyword is involved. Digests, ETags, commit ids and content hashes share the
+// shape.
+//
+// The discriminator is the LINE'S LABEL read as a positive signal — the ceiling
+// applies when nothing says "secret" — rather than a negative list of identifier
+// field names. That direction is the point. A negative list would let an author
+// suppress a REAL secret by writing `ImageUniqueID: "AKIA..."`, which is
+// attacker-controlled suppression: the exact class of defect the surrounding changes
+// have been removing. Here an author cannot trigger the ceiling by relabelling, since
+// adding any secret-ish word only removes it. Measured on one 32-hex value:
+// `api_key = "14f6..."` keeps 75, `ImageUniqueID: "14f6..."` becomes 55.
+func unlabelledHexIdentifierCap(secretType, match, line string) float64 {
+	if secretType != genericSecretType {
+		return 0
+	}
+	if !bareHexIdentifier.MatchString(strings.ToLower(strings.Trim(match, `"'`))) {
+		return 0
+	}
+	lower := strings.ToLower(line)
+	for _, keyword := range secretLabelWords {
+		if strings.Contains(lower, keyword) {
+			return 0
+		}
+	}
+	return unlabelledHexIdentifierCeiling
+}
+
 // mergeBySpanKeepStrongest folds src into dst, treating findings that cover the
 // identical byte span as one secret discovered twice: a quoted 40-char AWS
 // secret is matched both by the context-gated AWS path (AWS_SECRET_ACCESS_KEY)
@@ -1476,6 +1548,25 @@ func (v *Validator) processScopedCandidates(matches []scopedCandidate, line stri
 
 		if confidence > confidenceThreshold {
 			secretType := v.getSecretType(match)
+			meta := map[string]any{
+				"validation_checks": checks,
+				"detection_method":  detectionMethod,
+				"source":            "preprocessed_content",
+				"context_domain":    contextInsights.Domain,
+				"context_doc_type":  contextInsights.DocumentType,
+				"environment_type":  envType,
+				"secret_type":       secretType,
+			}
+			// A bare hex identifier on an unlabelled line gets a hard ceiling that the
+			// bridge's downstream context and cross-path adjustments must respect.
+			// Clamping here alone would not hold: those adjustments are applied after
+			// the validator returns and took one such value from 55 to 80.
+			if ceiling := unlabelledHexIdentifierCap(secretType, match, line); ceiling > 0 {
+				meta[ConfidenceCeilingKey] = ceiling
+				if confidence > ceiling {
+					confidence = ceiling
+				}
+			}
 			results = append(results, spannedMatch{
 				start: cand.start,
 				end:   cand.end,
@@ -1486,15 +1577,7 @@ func (v *Validator) processScopedCandidates(matches []scopedCandidate, line stri
 					Confidence: confidence,
 					Filename:   originalPath,
 					Validator:  "secrets",
-					Metadata: map[string]any{
-						"validation_checks": checks,
-						"detection_method":  detectionMethod,
-						"source":            "preprocessed_content",
-						"context_domain":    contextInsights.Domain,
-						"context_doc_type":  contextInsights.DocumentType,
-						"environment_type":  envType,
-						"secret_type":       secretType,
-					},
+					Metadata:   meta,
 				},
 			})
 		}


### PR DESCRIPTION
_Supersedes #241, rebased onto `main`. GitHub blocks retargeting a stacked PR's base, and #241's old base branch predates the rest of the stack landing on `main` (#243, #244, #245). Same head branch, same commit._

**Stacked on #240.** Fixes the false positive surfaced (not caused) by #237, and adds a small generic mechanism other validators can reuse.

## The finding

An EXIF `ImageUniqueID` reported as `API_KEY_OR_SECRET` at **80 (MEDIUM)** in a real 10 MB `.docx`:

```
ImageUniqueID: "14f6364997257b9170c016a13d1f1127"
```

That's an image GUID. It reaches the generic entropy path only because `containsSecretIndicators` admits *any* quoted value of 20+ bytes — no secret keyword is involved. Digests, ETags, commit ids and content hashes share the shape.

## Why the obvious fix doesn't work

The secrets validator scores this value **55**. The 80 is:

```
55 (validator) + 20 (document-context adjustment) + 5 (cross-path correlation boost)
```

Both applied **after** the validator returns, at three separate sites in the bridge. So a validator clamping its own output has no way to make a bound stick — I tried that first and the reported score stayed at 80.

## The mechanism

A small generic contract instead: a validator sets `Match.Metadata["confidence_ceiling"]`, and the bridge clamps to it after **every** adjustment that can raise confidence.

The key is declared in the bridge rather than imported from a validator package, so the dependency keeps pointing one way. A test fails if the two literals drift, since a silent mismatch would turn every ceiling into a no-op.

Any validator with a value-intrinsic reason to say *"no amount of surrounding context should promote this"* can now use it without new plumbing. The secrets validator declares a ceiling of 55 for a value that is bare hex at an identifier length (32/40/64) on a line carrying no secret-ish word.

## Two decisions worth reviewing

**It is a ceiling, not a veto.** A 32-hex string genuinely can be a secret, and only reported findings reach the redactor — dropping one would leave the value in the "redacted" output, which is the failure mode this whole area keeps producing. Verified: the demoted finding is still redacted, output reads `ImageUniqueID: "[API_KEY_OR_SECRET-REDACTED]"` with zero cleartext occurrences.

**The discriminator is the line's label as a POSITIVE signal** — the ceiling applies when nothing says "secret" — rather than a negative list of identifier field names like `ImageUniqueID` or `SerialNumber`. That direction is the point. A negative list would let a document author suppress a **real** secret by writing `ImageUniqueID: "AKIA..."`: attacker-controlled suppression, the same class of defect #237–#240 have been removing. Here relabelling can only *remove* the ceiling.

Measured on one identical value:

| line | confidence |
|---|---|
| `api_key = "14f6364997257b9170c016a13d1f1127"` | **75** (untouched) |
| `ImageUniqueID: "14f6364997257b9170c016a13d1f1127"` | **55** (capped) |

## Result

| | before | after |
|---|---|---|
| the reported row | `[MEDIUM] 80.00%` | `[LOW] 55.00%` |
| total findings | 78 | **78** — count deliberately unchanged |

## Testing

Per `docs/testing/TEST_PLAN.md`.

**D10 non-vacuity, both halves separately:** removing the clamp calls restores 80 on the real document; dropping the label check fails **8 of 20** shape subtests.

**D3** goldens 0 changed — the corpus has no `API_KEY_OR_SECRET` row at all, so this moves nothing. **D4** linear on all four fixture families (1.70–1.88× per doubling), within 1.03× of base. **D5** sink verified above. **D11** 10 runs stable at 78 findings / 55 confidence. **D1/D2/D12/D13** 61 packages pass, gofmt clean, vet clean *and* test binaries compile for darwin/linux/windows, `-race` clean on both touched packages.

## One accepted cost

The suppression hash embeds `%.2f` confidence, so demoting a finding invalidates a rule written against it. Of 78 rules generated by the parent binary on that document, **77 still match and 1 escapes** — the demoted row, and nothing else. Any confidence change has this property; this is the minimum blast radius for it.

## Not addressed here

The **+5 cross-path correlation boost** applies to *every* finding whenever both validation paths hit — so adding one finding to a document can shift an unrelated finding's confidence and invalidate its suppression rule. That touches every finding in every container and doesn't belong in a one-row fix. Its own issue.
