### PR TITLE
fix(suppressions): stop a finding's identity depending on its confidence score

### DIFF
--- a/internal/suppressions/hash_version_test.go
+++ b/internal/suppressions/hash_version_test.go
@@ -1,0 +1,174 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package suppressions
+
+import (
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+)
+
+// A finding's suppression identity must not depend on its confidence score.
+//
+// It used to. Confidence was the second component of the hash, so a saved rule stopped
+// matching whenever the score moved — including for reasons unrelated to the finding.
+// Measured on two .docx files with identical content and identical basenames, differing
+// only by an unrelated author name in the metadata: the same API_KEY_OR_SECRET scored 55
+// in one and 60 in the other, because the bridge adds a cross-path correlation boost
+// when both validation paths report. A rule written against the first file left the
+// finding unsuppressed in the second. The same mechanism broke 1 of 78 rules when one
+// EXIF finding was demoted from 80 to 55.
+//
+// Confidence is a SCORE, not an identity — it is precisely the field the tool keeps
+// tuning. Hashing it meant every scoring improvement silently invalidated operators'
+// files, turning findings they had reviewed and accepted back into noise, and in a
+// pre-commit gate back into a block.
+//
+// Existing rule files must keep working regardless, so matching accepts the legacy
+// formula too. A file migrates as it is regenerated; an operator who never regenerates
+// loses nothing.
+
+func testMatch(confidence float64) detector.Match {
+	return detector.Match{
+		Type:       "API_KEY_OR_SECRET",
+		Text:       "14f6364997257b9170c016a13d1f1127",
+		Filename:   "report.docx",
+		LineNumber: 12,
+		Confidence: confidence,
+		Context: detector.ContextInfo{
+			FullLine:   `value "14f6364997257b9170c016a13d1f1127"`,
+			BeforeText: "before",
+			AfterText:  "after",
+		},
+	}
+}
+
+// TestHashIsStableAcrossConfidenceChange is the regression. Two findings identical in
+// every respect except score must share one identity.
+func TestHashIsStableAcrossConfidenceChange(t *testing.T) {
+	sm := &SuppressionManager{}
+
+	low := sm.generateFindingHash(testMatch(55))
+	high := sm.generateFindingHash(testMatch(60))
+
+	if low != high {
+		t.Errorf("the same finding hashed differently at confidence 55 vs 60:\n"+
+			"  55 -> %s\n  60 -> %s\n"+
+			"A saved rule would stop matching after any scoring change — including one "+
+			"caused by an unrelated finding elsewhere in the same document.", low, high)
+	}
+}
+
+// TestLegacyHashStillMatches is the compatibility half. A rule file written before this
+// change records the confidence-sensitive hash, and it must keep suppressing.
+func TestLegacyHashStillMatches(t *testing.T) {
+	sm := &SuppressionManager{}
+	match := testMatch(55)
+
+	legacy := sm.findingHashVersion(match, hashVersionLegacyConfidence)
+	current := sm.findingHashVersion(match, hashVersionNoConfidence)
+
+	if legacy == current {
+		t.Fatal("legacy and current hashes are identical, so this test proves nothing — " +
+			"the version switch is not actually changing the composite")
+	}
+	if !sm.hashMatchesFinding(legacy, match) {
+		t.Error("a rule recorded under the legacy formula no longer matches its own " +
+			"finding; every pre-existing suppression file would stop working")
+	}
+	if !sm.hashMatchesFinding(current, match) {
+		t.Error("a rule recorded under the current formula does not match its own finding")
+	}
+}
+
+// TestLegacyHashRemainsConfidenceBound documents the honest limit of the compatibility
+// shim, so nobody later mistakes it for a broader guarantee. A v1 hash encodes the score
+// it was written with, so it can only ever match a finding at that score. The fix is
+// that NEW rules are score-free — not that old rules become so.
+func TestLegacyHashRemainsConfidenceBound(t *testing.T) {
+	sm := &SuppressionManager{}
+
+	legacyAt55 := sm.findingHashVersion(testMatch(55), hashVersionLegacyConfidence)
+
+	if sm.hashMatchesFinding(legacyAt55, testMatch(60)) {
+		t.Error("a legacy hash written at confidence 55 matched a finding at 60; that " +
+			"would mean the legacy formula is not being reproduced faithfully")
+	}
+	if !sm.hashMatchesFinding(legacyAt55, testMatch(55)) {
+		t.Error("a legacy hash written at confidence 55 no longer matches at 55")
+	}
+}
+
+// TestNewRulesAreWrittenWithTheCurrentFormula pins which version AddSuppression records.
+// If new rules were still written with the legacy hash the change would be inert.
+func TestNewRulesAreWrittenWithTheCurrentFormula(t *testing.T) {
+	sm := &SuppressionManager{
+		config:  &SuppressionConfig{Version: "1.0"},
+		enabled: true,
+	}
+	match := testMatch(55)
+
+	if err := sm.AddSuppression(match, "reviewed", "tester", nil); err != nil {
+		t.Fatalf("AddSuppression: %v", err)
+	}
+	if len(sm.config.Rules) != 1 {
+		t.Fatalf("got %d rules, want 1", len(sm.config.Rules))
+	}
+
+	want := sm.findingHashVersion(match, hashVersionNoConfidence)
+	if got := sm.config.Rules[0].Hash; got != want {
+		t.Errorf("new rule hash = %s, want the current (confidence-free) formula %s", got, want)
+	}
+}
+
+// TestDuplicateDetectionSpansBothFormulas guards the regeneration path. A file holding a
+// legacy rule must not gain a second rule for the same finding, or it would grow one
+// duplicate per finding on every regeneration.
+func TestDuplicateDetectionSpansBothFormulas(t *testing.T) {
+	sm := &SuppressionManager{
+		config:  &SuppressionConfig{Version: "1.0"},
+		enabled: true,
+	}
+	match := testMatch(55)
+
+	// Seed a rule as an older binary would have written it.
+	sm.config.Rules = append(sm.config.Rules, SuppressionRule{
+		ID:      "SUP-00000001",
+		Hash:    sm.findingHashVersion(match, hashVersionLegacyConfidence),
+		Enabled: true,
+	})
+	sm.rebuildHashIndex()
+
+	err := sm.AddSuppression(match, "reviewed", "tester", nil)
+	if err == nil {
+		t.Errorf("AddSuppression accepted a finding already covered by a legacy rule; the "+
+			"file now holds %d rules for one decision", len(sm.config.Rules))
+	}
+}
+
+// TestSuppressionSurvivesAConfidenceShift is the end-to-end property, expressed through
+// IsSuppressed rather than the hash helpers: a rule written when a finding scored 55
+// still suppresses it at 60.
+func TestSuppressionSurvivesAConfidenceShift(t *testing.T) {
+	sm := &SuppressionManager{
+		config:  &SuppressionConfig{Version: "1.0"},
+		enabled: true,
+	}
+
+	if err := sm.AddSuppression(testMatch(55), "reviewed", "tester", nil); err != nil {
+		t.Fatalf("AddSuppression: %v", err)
+	}
+	sm.config.Rules[0].Enabled = true
+	sm.rebuildHashIndex()
+
+	if ok, _ := sm.IsSuppressed(testMatch(55)); !ok {
+		t.Fatal("the rule does not suppress the finding it was written against; the rest " +
+			"of this test would pass for the wrong reason")
+	}
+	if ok, _ := sm.IsSuppressed(testMatch(60)); !ok {
+		t.Error("a rule written at confidence 55 stopped suppressing the same finding at " +
+			"60. That is the defect: an unrelated finding elsewhere in the document can " +
+			"move this score, and the operator's reviewed-and-accepted finding comes back.")
+	}
+}

--- a/internal/suppressions/suppression.go
+++ b/internal/suppressions/suppression.go
@@ -192,7 +192,51 @@ func (sm *SuppressionManager) rebuildHashIndexLocked() {
 // a suppression rule against) are truncated.
 const maxHashLineLen = 8192
 
+// generateFindingHash returns the current-version identity of a finding, used when
+// WRITING a new rule.
+//
+// Confidence is deliberately NOT an input. It used to be, and that made a saved rule
+// stop matching whenever a finding's score moved — including for reasons that have
+// nothing to do with the finding. Measured on two .docx files with identical content
+// and identical basenames, differing only by an unrelated author name in the metadata:
+// the same API_KEY_OR_SECRET scored 55 in one and 60 in the other (the bridge adds a
+// cross-path correlation boost when both validation paths report), so a rule written
+// against the first file left the finding unsuppressed in the second. The same
+// mechanism broke 1 of 78 rules when a single EXIF finding was demoted from 80 to 55.
+//
+// Confidence is a SCORE, not an identity: it is exactly the field the tool is expected
+// to keep tuning. Hashing it meant every scoring improvement silently invalidated
+// operators' suppression files, which is both surprising and unsafe — a rule that stops
+// matching turns a finding an operator had reviewed and accepted back into noise, and
+// in a pre-commit gate back into a block.
+//
+// What identifies a finding is what it is and where it is: type, the line it sits on,
+// the file's basename, the line number, its surrounding context and the matched value.
+// All of those still participate.
 func (sm *SuppressionManager) generateFindingHash(match detector.Match) string {
+	return sm.findingHashVersion(match, hashVersionCurrent)
+}
+
+// hashVersion identifies a finding-hash formula. Old rule files carry hashes computed
+// by an older formula, and they have to keep working: an operator's suppression file is
+// a record of decisions they already made, not a cache we may invalidate.
+type hashVersion int
+
+const (
+	// hashVersionLegacyConfidence is the original formula, which included
+	// fmt.Sprintf("%.2f", Confidence) as the second component. Still computed when
+	// MATCHING so pre-existing rule files keep suppressing, never when writing.
+	hashVersionLegacyConfidence hashVersion = 1
+
+	// hashVersionNoConfidence drops confidence from the identity.
+	hashVersionNoConfidence hashVersion = 2
+
+	// hashVersionCurrent is what new rules are written with.
+	hashVersionCurrent = hashVersionNoConfidence
+)
+
+// findingHashVersion computes a finding's hash under a specific formula version.
+func (sm *SuppressionManager) findingHashVersion(match detector.Match, version hashVersion) string {
 	// Bound the FullLine contribution (see maxHashLineLen). TrimSpace first so a
 	// short line padded with whitespace still hashes identically; the cap only
 	// engages for genuinely long lines.
@@ -201,14 +245,19 @@ func (sm *SuppressionManager) generateFindingHash(match detector.Match) string {
 		fullLine = fullLine[:maxHashLineLen]
 	}
 
-	// Create a composite string with all relevant identifying information
-	components := []string{
-		match.Type,
-		fmt.Sprintf("%.2f", match.Confidence),
+	// Create a composite string with all relevant identifying information. The v1
+	// ordering is preserved exactly — confidence second — because any change to the
+	// component order or separator would alter every v1 hash and defeat the
+	// compatibility this version switch exists to provide.
+	components := []string{match.Type}
+	if version == hashVersionLegacyConfidence {
+		components = append(components, fmt.Sprintf("%.2f", match.Confidence))
+	}
+	components = append(components,
 		fullLine,
 		filepath.Base(match.Filename), // Use basename to avoid path sensitivity
 		fmt.Sprintf("%d", match.LineNumber),
-	}
+	)
 
 	// Add context for uniqueness but hash it for privacy
 	contextHash := sm.hashSensitiveData(match.Context.BeforeText + match.Context.AfterText)
@@ -222,6 +271,34 @@ func (sm *SuppressionManager) generateFindingHash(match detector.Match) string {
 	composite := strings.Join(components, "|")
 	hash := sha256.Sum256([]byte(composite))
 	return fmt.Sprintf("%x", hash)
+}
+
+// findingHashCandidates returns every hash a finding could legitimately be recorded
+// under, current formula first.
+//
+// Matching accepts any of them so an existing rule file keeps working untouched, while
+// newly written rules use only the current formula and stop being confidence-sensitive.
+// A rule file therefore migrates as it is regenerated rather than needing a conversion
+// step, and an operator who never regenerates loses nothing.
+func (sm *SuppressionManager) findingHashCandidates(match detector.Match) []string {
+	return []string{
+		sm.findingHashVersion(match, hashVersionNoConfidence),
+		sm.findingHashVersion(match, hashVersionLegacyConfidence),
+	}
+}
+
+// hashMatchesFinding reports whether a stored rule hash identifies this finding under
+// any supported formula version.
+func (sm *SuppressionManager) hashMatchesFinding(ruleHash string, match detector.Match) bool {
+	if ruleHash == "" {
+		return false
+	}
+	for _, candidate := range sm.findingHashCandidates(match) {
+		if ruleHash == candidate {
+			return true
+		}
+	}
+	return false
 }
 
 // hashSensitiveData creates a hash of sensitive data
@@ -240,21 +317,26 @@ func (sm *SuppressionManager) IsSuppressed(match detector.Match) (bool, *Suppres
 		return false, nil
 	}
 
-	findingHash := sm.generateFindingHash(match)
+	// Every hash this finding could be recorded under: the current formula, plus the
+	// legacy confidence-sensitive one so an existing rule file keeps suppressing
+	// without being regenerated.
+	candidates := sm.findingHashCandidates(match)
 
 	// Fast read-locked path: index is already built.
 	sm.indexMu.RLock()
 	if sm.rulesByHash != nil {
-		for _, ruleIdx := range sm.rulesByHash[findingHash] {
-			rule := &sm.config.Rules[ruleIdx]
-			if !rule.Enabled {
-				continue
+		for _, findingHash := range candidates {
+			for _, ruleIdx := range sm.rulesByHash[findingHash] {
+				rule := &sm.config.Rules[ruleIdx]
+				if !rule.Enabled {
+					continue
+				}
+				if rule.ExpiresAt != nil && time.Now().After(*rule.ExpiresAt) {
+					continue
+				}
+				sm.indexMu.RUnlock()
+				return true, rule
 			}
-			if rule.ExpiresAt != nil && time.Now().After(*rule.ExpiresAt) {
-				continue
-			}
-			sm.indexMu.RUnlock()
-			return true, rule
 		}
 		sm.indexMu.RUnlock()
 		return false, nil
@@ -268,16 +350,18 @@ func (sm *SuppressionManager) IsSuppressed(match detector.Match) (bool, *Suppres
 	if sm.rulesByHash == nil {
 		sm.rebuildHashIndexLocked()
 	}
-	for _, ruleIdx := range sm.rulesByHash[findingHash] {
-		rule := &sm.config.Rules[ruleIdx]
-		if !rule.Enabled {
-			continue
+	for _, findingHash := range candidates {
+		for _, ruleIdx := range sm.rulesByHash[findingHash] {
+			rule := &sm.config.Rules[ruleIdx]
+			if !rule.Enabled {
+				continue
+			}
+			if rule.ExpiresAt != nil && time.Now().After(*rule.ExpiresAt) {
+				continue
+			}
+			sm.indexMu.Unlock()
+			return true, rule
 		}
-		if rule.ExpiresAt != nil && time.Now().After(*rule.ExpiresAt) {
-			continue
-		}
-		sm.indexMu.Unlock()
-		return true, rule
 	}
 	sm.indexMu.Unlock()
 	return false, nil
@@ -294,9 +378,11 @@ func (sm *SuppressionManager) AddSuppression(match detector.Match, reason, creat
 
 	findingHash := sm.generateFindingHash(match)
 
-	// Check if already exists
+	// Check if already exists, under EITHER formula: a rule recorded with the legacy
+	// confidence-sensitive hash already covers this finding, so adding a second one
+	// would leave the operator with two rules for one decision.
 	for _, rule := range sm.config.Rules {
-		if rule.Hash == findingHash {
+		if sm.hashMatchesFinding(rule.Hash, match) {
 			return fmt.Errorf("suppression rule already exists for this finding")
 		}
 	}
@@ -453,10 +539,8 @@ func (sm *SuppressionManager) GetExpiredRule(match detector.Match) *SuppressionR
 		return nil
 	}
 
-	findingHash := sm.generateFindingHash(match)
-
 	for _, rule := range sm.config.Rules {
-		if rule.Hash == findingHash && rule.Enabled {
+		if sm.hashMatchesFinding(rule.Hash, match) && rule.Enabled {
 			// Check if rule has expired
 			if rule.ExpiresAt != nil && time.Now().After(*rule.ExpiresAt) {
 				return &rule
@@ -520,8 +604,20 @@ func (sm *SuppressionManager) GenerateSuppressionRules(matches []detector.Match,
 	for _, match := range matches {
 		findingHash := sm.generateFindingHash(match)
 
-		// Check if already exists
-		if idx, exists := existingHashes[findingHash]; exists {
+		// Check if already exists under EITHER formula. A rule file written before
+		// confidence left the hash records the legacy hash, and treating that as
+		// absent would append a duplicate rule for a finding the operator has already
+		// ruled on — the file would grow a second entry per finding on every
+		// regeneration. Refreshing last_seen_at on the legacy rule instead lets the
+		// file carry forward untouched; it migrates only when a rule is genuinely new.
+		matchedIdx := -1
+		for _, candidate := range sm.findingHashCandidates(match) {
+			if idx, exists := existingHashes[candidate]; exists {
+				matchedIdx = idx
+				break
+			}
+		}
+		if idx := matchedIdx; idx >= 0 {
 			// Update last_seen_at for existing rule. Written through the live
 			// slice so it survives any reallocation caused by the appends below.
 			sm.config.Rules[idx].LastSeenAt = &now


### PR DESCRIPTION
**1 of 3 confidence-integrity fixes.** Root cause of the other two, so it lands first. Merge order: this → correlation boost → same-span arbitration.

## The defect

A suppression rule stopped matching whenever the finding's score moved, because confidence was the second component of the finding hash. Every scoring change — including ones with nothing to do with the finding — silently invalidated operators' suppression files.

Measured on two `.docx` files with **identical content and identical basenames**, differing only by an unrelated author name in the metadata:

| fixture | `API_KEY_OR_SECRET` |
|---|---|
| `m/a` (no metadata) | **55** |
| `m/b` (unrelated metadata) | **60** |

The bridge adds a cross-path correlation boost when both validation paths report, so merely having a metadata finding *elsewhere in the document* moved this unrelated score. A rule generated from `m/a` then left the finding unsuppressed in `m/b` — `suppressed=0`, and the reviewed-and-accepted finding reappears. The same mechanism broke **1 of 78** rules when a single EXIF finding was demoted from 80 to 55 in #241.

## Why confidence doesn't belong in an identity

Confidence is a **score**, not an identity. It's precisely the field the tool keeps tuning, so hashing it guaranteed that improving detection quality would break saved suppressions — surprising on its own, and unsafe in a pre-commit gate where a rule that stops matching turns an accepted finding back into a block.

What identifies a finding is *what it is and where it is*: type, the line it sits on, the file's basename, the line number, the surrounding context, and the matched value. All of those still participate.

## Compatibility

A version switch, not a replacement. Rules are **written** with the confidence-free formula; **matching accepts either**, so a pre-existing file keeps suppressing untouched and migrates only as rules are regenerated. An operator who never regenerates loses nothing.

Duplicate detection spans both formulas too — otherwise a regeneration would append a second rule for every finding a legacy rule already covered, growing the file on each run.

The v1 composite is reproduced exactly (confidence second), because any change to component order or separator would alter every legacy hash and defeat the compatibility this exists to provide.

**Verified end to end** with a v1 rule file written by the parent binary and applied by this build:

| scenario | result |
|---|---|
| v1 rule (55) on `m/a` | suppressed under **both** binaries — compat holds |
| v1 rule (55) on `m/b` | not suppressed under either — a v1 hash encodes 55, so it can only match at 55 |
| **v2 rule (55) on `m/b`** | **SUPPRESSED** — the fix |

And on a real 10 MB `.docx`: all **78** rules generated by the parent binary still match under this build.

**Honest limit,** pinned by `TestLegacyHashRemainsConfidenceBound`: a legacy hash carries the score it was written with, so old rules stay confidence-bound. The fix is that *new* rules are score-free, not that old ones become so.

## Testing

Per `docs/testing/TEST_PLAN.md`.

**D10 non-vacuity, both halves mutated separately:** restoring confidence to the current formula fails 2 tests; dropping the legacy candidate fails 2 different ones.

**D4 timing** — the match path now computes two hashes instead of one. At 8,000 active rules over 4,000 findings that is **1.03×**, and the `maxHashLineLen` cap bounding the expensive component is unchanged.

**D1/D2/D3/D12/D13:** 61 packages pass · gofmt clean · vet clean *and* test binaries compile for darwin/linux/windows · `-race` clean on the package (`IsSuppressed` is the concurrent read path) · goldens unchanged.

## Why this one first

It's the root cause of three related problems. The cross-path correlation boost and same-span double-reporting both *change confidence values*, so removing confidence from the identity defuses their consequence for saved suppressions before either is touched. Fixing them first would mean fixing symptoms while the mechanism stayed armed.

It also unblocks the PASSPORT proximity fix, which was held back precisely because it moves confidence.