### PR TITLE
fix(validators): stop a finding's confidence depending on what else is in the file

### DIFF
--- a/internal/core/confidence_independence_test.go
+++ b/internal/core/confidence_independence_test.go
@@ -1,0 +1,168 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package core_test
+
+import (
+	"archive/zip"
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/core"
+)
+
+// A finding's confidence must not depend on what else is in the file.
+//
+// The bridge used to add a flat +5 to EVERY finding whenever both validation paths
+// reported something. So scanning the same value in two documents gave two answers.
+// Measured on two .docx files with identical content and identical basenames, differing
+// only by an unrelated author name in the metadata, the same API_KEY_OR_SECRET scored 55
+// in one and 60 in the other. On a real 10 MB .docx all 78 findings carried the boost and
+// 14 had their score genuinely shifted by it, across 9 types.
+//
+// That is wrong on its own terms — a confidence answers "how sure are we about THIS
+// value" — and it had a second-order cost: while the suppression hash folded confidence,
+// adding one unrelated finding to a file silently invalidated the saved rules of every
+// other finding in it, turning a reviewed-and-accepted finding back into noise.
+//
+// Driven through core.ScanFile rather than the bridge directly: the defect lived in how
+// the paths were combined, and a hand-wired bridge would test the test's own wiring.
+
+const unlabelledSecret = `value "wJalrXUtnFEMI7K7MDENGbPxRfiCYzz1"`
+
+// TestConfidenceIsIndependentOfUnrelatedFindings is the regression.
+func TestConfidenceIsIndependentOfUnrelatedFindings(t *testing.T) {
+	alone := secretConfidence(t, "alone", "")
+	withMeta := secretConfidence(t, "withmeta", "Jane Analyst")
+
+	if alone == 0 {
+		t.Fatal("no API_KEY_OR_SECRET finding in the control fixture; the comparison " +
+			"below would be vacuous")
+	}
+	if alone != withMeta {
+		t.Errorf("the same value scored %v alone and %v when the document also carried an "+
+			"unrelated metadata finding.\nConfidence must describe the finding, not the "+
+			"file it happens to live in: the same secret in two documents has to score the "+
+			"same. While the suppression hash folded confidence this also invalidated "+
+			"saved rules for findings that had not changed at all.", alone, withMeta)
+	}
+}
+
+// TestMetadataConfidenceIsIndependentOfTheBody covers the other direction — the boost
+// applied to every match, so a metadata finding moved merely because the body had one.
+func TestMetadataConfidenceIsIndependentOfTheBody(t *testing.T) {
+	withBody := metadataConfidence(t, "mwith", unlabelledSecret)
+	withoutBody := metadataConfidence(t, "mwithout", "nothing sensitive here")
+
+	if withoutBody == 0 {
+		t.Fatal("no metadata finding produced; the comparison below would be vacuous")
+	}
+	if withBody != withoutBody {
+		t.Errorf("a metadata finding scored %v when the body also had a finding and %v when "+
+			"it did not; its confidence must not depend on the body", withBody, withoutBody)
+	}
+}
+
+func secretConfidence(t *testing.T, name, creator string) float64 {
+	t.Helper()
+	for _, m := range scanDOCXWith(t, name, creator, unlabelledSecret) {
+		if m == "API_KEY_OR_SECRET" {
+			return confidences[m]
+		}
+	}
+	return 0
+}
+
+func metadataConfidence(t *testing.T, name, body string) float64 {
+	t.Helper()
+	for _, m := range scanDOCXWith(t, name, "Jane Analyst", body) {
+		switch m {
+		case "AUTHOR_INFO", "LAST_MODIFIED_BY", "COMPANY_INFO":
+			return confidences[m]
+		}
+	}
+	return 0
+}
+
+// confidences is populated by scanDOCXWith for the most recent scan.
+var confidences = map[string]float64{}
+
+func scanDOCXWith(t *testing.T, name, creator, body string) []string {
+	t.Helper()
+
+	dir, err := os.MkdirTemp(".", "conf-indep-")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	path := filepath.Join(dir, name+".docx")
+	if err := os.WriteFile(path, buildDOCX(creator, body), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	res, err := core.ScanFile(core.ScanConfig{
+		FilePath:            filepath.ToSlash(path),
+		Checks:              []string{"SECRETS", "METADATA"},
+		EnablePreprocessors: true,
+		LogWriter:           io.Discard,
+	})
+	if err != nil {
+		t.Fatalf("ScanFile: %v", err)
+	}
+
+	confidences = map[string]float64{}
+	var types []string
+	for _, m := range res.Matches {
+		confidences[m.Type] = m.Confidence
+		types = append(types, m.Type)
+	}
+	return types
+}
+
+// buildDOCX makes a .docx with the given body, and core properties only when creator is
+// non-empty — the presence of a metadata finding is the variable under test.
+func buildDOCX(creator, body string) []byte {
+	const decl = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>`
+	ov := `<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>`
+	rel := `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>`
+	if creator != "" {
+		ov += `<Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/>`
+		rel += `<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" Target="docProps/core.xml"/>`
+	}
+
+	parts := []struct{ name, body string }{
+		{"[Content_Types].xml", decl + `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+			`<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+			`<Default Extension="xml" ContentType="application/xml"/>` + ov + `</Types>`},
+		{"_rels/.rels", decl + `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` + rel + `</Relationships>`},
+		{"word/document.xml", decl + `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>` +
+			`<w:p><w:r><w:t xml:space="preserve">` + strings.ReplaceAll(body, `"`, "&quot;") + `</w:t></w:r></w:p>` +
+			`</w:body></w:document>`},
+	}
+	if creator != "" {
+		parts = append(parts, struct{ name, body string }{"docProps/core.xml",
+			decl + `<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/">` +
+				`<dc:creator>` + creator + `</dc:creator></cp:coreProperties>`})
+	}
+
+	out := new(bytes.Buffer)
+	zw := zip.NewWriter(out)
+	for _, p := range parts {
+		w, err := zw.Create(p.name)
+		if err != nil {
+			panic(err)
+		}
+		if _, err := io.WriteString(w, p.body); err != nil {
+			panic(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		panic(err)
+	}
+	return out.Bytes()
+}

--- a/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.csv
+++ b/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.csv
@@ -1,5 +1,5 @@
 Filename,Type,Confidence Level,Confidence %,Line Number,Text
 <TMPDIR>/report.docx,SSN,HIGH,100.0,3,449-87-4100
 <TMPDIR>/report.docx,VISA,HIGH,100.0,5,4532-0151-1283-0366
-<TMPDIR>/report.docx,AUTHOR_INFO,MEDIUM,65.0,1,Jane Analyst
-<TMPDIR>/report.docx,LAST_MODIFIED_BY,MEDIUM,65.0,2,Ops Reviewer
+<TMPDIR>/report.docx,AUTHOR_INFO,MEDIUM,60.0,1,Jane Analyst
+<TMPDIR>/report.docx,LAST_MODIFIED_BY,MEDIUM,60.0,2,Ops Reviewer

--- a/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.gitlab-sast.json
@@ -81,7 +81,7 @@
     {
       "category": "sast",
       "confidence": "Medium",
-      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/report.docx (line 1)\n**Confidence:** MEDIUM (65.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nAuthor: Jane Analyst\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/report.docx (line 1)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nAuthor: Jane Analyst\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {
@@ -107,7 +107,7 @@
     {
       "category": "sast",
       "confidence": "Medium",
-      "description": "Ferret Scan detected sensitive data (last modified by) in this file.\n\n**Location:** <TMPDIR>/report.docx (line 2)\n**Confidence:** MEDIUM (65.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nLastModifiedBy: Ops Reviewer\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "description": "Ferret Scan detected sensitive data (last modified by) in this file.\n\n**Location:** <TMPDIR>/report.docx (line 2)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nLastModifiedBy: Ops Reviewer\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {

--- a/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.json.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.json.json
@@ -11,8 +11,6 @@
         "context_doctype": "Unknown",
         "context_domain": "HR_Payroll",
         "context_impact": 45,
-        "correlation_boost": 5,
-        "cross_path_correlation": true,
         "original_confidence": 100,
         "original_file": "<TMPDIR>/report.docx",
         "semantic_context": {
@@ -50,8 +48,6 @@
         "context_doctype": "Unknown",
         "context_domain": "HR_Payroll",
         "context_impact": 15,
-        "correlation_boost": 5,
-        "cross_path_correlation": true,
         "original_confidence": 100,
         "original_file": "<TMPDIR>/report.docx",
         "semantic_context": {
@@ -79,7 +75,7 @@
       "validator": "creditcard"
     },
     {
-      "confidence": 65,
+      "confidence": 60.00000000000001,
       "confidence_level": "MEDIUM",
       "filename": "<TMPDIR>/report.docx",
       "line_number": 1,
@@ -89,8 +85,6 @@
         "context_doctype": "Unknown",
         "context_domain": "HR_Payroll",
         "context_impact": 0,
-        "correlation_boost": 5,
-        "cross_path_correlation": true,
         "full_field": "Author: Jane Analyst",
         "metadata_type": "AUTHOR_INFO",
         "original_confidence": 60.00000000000001,
@@ -119,7 +113,7 @@
       "validator": "metadata"
     },
     {
-      "confidence": 65,
+      "confidence": 60.00000000000001,
       "confidence_level": "MEDIUM",
       "filename": "<TMPDIR>/report.docx",
       "line_number": 2,
@@ -129,8 +123,6 @@
         "context_doctype": "Unknown",
         "context_domain": "HR_Payroll",
         "context_impact": 0,
-        "correlation_boost": 5,
-        "cross_path_correlation": true,
         "full_field": "LastModifiedBy: Ops Reviewer",
         "metadata_type": "LAST_MODIFIED_BY",
         "original_confidence": 60.00000000000001,

--- a/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.junit.xml
+++ b/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.junit.xml
@@ -2,7 +2,7 @@
 <testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
   <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
     <testcase name="report.docx" classname="security-scan" time="0.001">
-      <failure message="4 security findings detected" type="SECURITY_FINDINGS">Line 3: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 5: VISA detected with 100.0% confidence (HIGH)&#xA;Match: 4532-0151-1283-0366&#xA;Validator: creditcard&#xA;Line 1: AUTHOR_INFO detected with 65.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata&#xA;Line 2: LAST_MODIFIED_BY detected with 65.0% confidence (MEDIUM)&#xA;Match: Ops Reviewer&#xA;Validator: metadata</failure>
+      <failure message="4 security findings detected" type="SECURITY_FINDINGS">Line 3: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 5: VISA detected with 100.0% confidence (HIGH)&#xA;Match: 4532-0151-1283-0366&#xA;Validator: creditcard&#xA;Line 1: AUTHOR_INFO detected with 60.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata&#xA;Line 2: LAST_MODIFIED_BY detected with 60.0% confidence (MEDIUM)&#xA;Match: Ops Reviewer&#xA;Validator: metadata</failure>
     </testcase>
   </testsuite>
 </testsuites>

--- a/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.sarif.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.sarif.json
@@ -40,8 +40,6 @@
               "context_doctype": "Unknown",
               "context_domain": "HR_Payroll",
               "context_impact": 45,
-              "correlation_boost": 5,
-              "cross_path_correlation": true,
               "original_confidence": 100,
               "original_file": "<TMPDIR>/report.docx",
               "semantic_context": {
@@ -109,8 +107,6 @@
               "context_doctype": "Unknown",
               "context_domain": "HR_Payroll",
               "context_impact": 15,
-              "correlation_boost": 5,
-              "cross_path_correlation": true,
               "original_confidence": 100,
               "original_file": "<TMPDIR>/report.docx",
               "semantic_context": {
@@ -158,10 +154,10 @@
             }
           ],
           "message": {
-            "text": "AUTHOR_INFO Detected in report.docx at line 1 (confidence: 65.0% - MEDIUM). Matched text: 'Jane Analyst'"
+            "text": "AUTHOR_INFO Detected in report.docx at line 1 (confidence: 60.0% - MEDIUM). Matched text: 'Jane Analyst'"
           },
           "properties": {
-            "confidence": 65,
+            "confidence": 60,
             "confidenceLevel": "MEDIUM",
             "metadata": {
               "confidence_adjustment": 0,
@@ -169,8 +165,6 @@
               "context_doctype": "Unknown",
               "context_domain": "HR_Payroll",
               "context_impact": 0,
-              "correlation_boost": 5,
-              "cross_path_correlation": true,
               "full_field": "Author: Jane Analyst",
               "metadata_type": "AUTHOR_INFO",
               "original_confidence": 60,
@@ -196,7 +190,7 @@
             },
             "validator": "metadata"
           },
-          "rank": 57.5,
+          "rank": 55,
           "ruleId": "AUTHOR_INFO"
         },
         {
@@ -219,10 +213,10 @@
             }
           ],
           "message": {
-            "text": "LAST_MODIFIED_BY Detected in report.docx at line 2 (confidence: 65.0% - MEDIUM). Matched text: 'Ops Reviewer'"
+            "text": "LAST_MODIFIED_BY Detected in report.docx at line 2 (confidence: 60.0% - MEDIUM). Matched text: 'Ops Reviewer'"
           },
           "properties": {
-            "confidence": 65,
+            "confidence": 60,
             "confidenceLevel": "MEDIUM",
             "metadata": {
               "confidence_adjustment": 0,
@@ -230,8 +224,6 @@
               "context_doctype": "Unknown",
               "context_domain": "HR_Payroll",
               "context_impact": 0,
-              "correlation_boost": 5,
-              "cross_path_correlation": true,
               "full_field": "LastModifiedBy: Ops Reviewer",
               "metadata_type": "LAST_MODIFIED_BY",
               "original_confidence": 60,
@@ -257,7 +249,7 @@
             },
             "validator": "metadata"
           },
-          "rank": 57.5,
+          "rank": 55,
           "ruleId": "LAST_MODIFIED_BY"
         }
       ],

--- a/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.txt
+++ b/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.txt
@@ -2,5 +2,5 @@ LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH            
 ---------------------------------------------------------------------------------------------
 [HIGH  ] ssn          SSN                   100.00% line     3 449-87-4100         report.docx
 [HIGH  ] creditcard   VISA                  100.00% line     5 4532-0151-1283-0366 report.docx
-[MEDIUM] metadata     AUTHOR_INFO            65.00% line     1 Jane Analyst        report.docx
-[MEDIUM] metadata     LAST_MODIFIED_BY       65.00% line     2 Ops Reviewer        report.docx
+[MEDIUM] metadata     AUTHOR_INFO            60.00% line     1 Jane Analyst        report.docx
+[MEDIUM] metadata     LAST_MODIFIED_BY       60.00% line     2 Ops Reviewer        report.docx

--- a/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.yaml
+++ b/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.yaml
@@ -12,8 +12,6 @@ results:
         context_doctype: Unknown
         context_domain: HR_Payroll
         context_impact: 45
-        correlation_boost: 5
-        cross_path_correlation: true
         original_confidence: 100
         original_file: <TMPDIR>/report.docx
         semantic_context:
@@ -46,8 +44,6 @@ results:
         context_doctype: Unknown
         context_domain: HR_Payroll
         context_impact: 15
-        correlation_boost: 5
-        cross_path_correlation: true
         original_confidence: 100
         original_file: <TMPDIR>/report.docx
         semantic_context:
@@ -70,7 +66,7 @@ results:
     - text: Jane Analyst
       line_number: 1
       type: AUTHOR_INFO
-      confidence: 65
+      confidence: 60.00000000000001
       confidence_level: MEDIUM
       filename: <TMPDIR>/report.docx
       validator: metadata
@@ -80,8 +76,6 @@ results:
         context_doctype: Unknown
         context_domain: HR_Payroll
         context_impact: 0
-        correlation_boost: 5
-        cross_path_correlation: true
         full_field: 'Author: Jane Analyst'
         metadata_type: AUTHOR_INFO
         original_confidence: 60.00000000000001
@@ -105,7 +99,7 @@ results:
     - text: Ops Reviewer
       line_number: 2
       type: LAST_MODIFIED_BY
-      confidence: 65
+      confidence: 60.00000000000001
       confidence_level: MEDIUM
       filename: <TMPDIR>/report.docx
       validator: metadata
@@ -115,8 +109,6 @@ results:
         context_doctype: Unknown
         context_domain: HR_Payroll
         context_impact: 0
-        correlation_boost: 5
-        cross_path_correlation: true
         full_field: 'LastModifiedBy: Ops Reviewer'
         metadata_type: LAST_MODIFIED_BY
         original_confidence: 60.00000000000001

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.csv
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.csv
@@ -1,5 +1,5 @@
 Filename,Type,Confidence Level,Confidence %,Line Number,Text
 <TMPDIR>/forged_first.docx,SSN,HIGH,100.0,3,449-87-4100
 <TMPDIR>/forged_first.docx,VISA,HIGH,100.0,5,4532-0151-1283-0366
-<TMPDIR>/forged_first.docx,AUTHOR_INFO,MEDIUM,65.0,1,Jane Analyst
-<TMPDIR>/forged_first.docx,LAST_MODIFIED_BY,MEDIUM,65.0,2,Ops Reviewer
+<TMPDIR>/forged_first.docx,AUTHOR_INFO,MEDIUM,60.0,1,Jane Analyst
+<TMPDIR>/forged_first.docx,LAST_MODIFIED_BY,MEDIUM,60.0,2,Ops Reviewer

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.gitlab-sast.json
@@ -81,7 +81,7 @@
     {
       "category": "sast",
       "confidence": "Medium",
-      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/forged_first.docx (line 1)\n**Confidence:** MEDIUM (65.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nAuthor: Jane Analyst\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/forged_first.docx (line 1)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nAuthor: Jane Analyst\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {
@@ -107,7 +107,7 @@
     {
       "category": "sast",
       "confidence": "Medium",
-      "description": "Ferret Scan detected sensitive data (last modified by) in this file.\n\n**Location:** <TMPDIR>/forged_first.docx (line 2)\n**Confidence:** MEDIUM (65.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nLastModifiedBy: Ops Reviewer\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "description": "Ferret Scan detected sensitive data (last modified by) in this file.\n\n**Location:** <TMPDIR>/forged_first.docx (line 2)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nLastModifiedBy: Ops Reviewer\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.json.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.json.json
@@ -11,8 +11,6 @@
         "context_doctype": "Unknown",
         "context_domain": "HR_Payroll",
         "context_impact": 45,
-        "correlation_boost": 5,
-        "cross_path_correlation": true,
         "original_confidence": 100,
         "original_file": "<TMPDIR>/forged_first.docx",
         "semantic_context": {
@@ -50,8 +48,6 @@
         "context_doctype": "Unknown",
         "context_domain": "HR_Payroll",
         "context_impact": 15,
-        "correlation_boost": 5,
-        "cross_path_correlation": true,
         "original_confidence": 100,
         "original_file": "<TMPDIR>/forged_first.docx",
         "semantic_context": {
@@ -79,7 +75,7 @@
       "validator": "creditcard"
     },
     {
-      "confidence": 65,
+      "confidence": 60.00000000000001,
       "confidence_level": "MEDIUM",
       "filename": "<TMPDIR>/forged_first.docx",
       "line_number": 1,
@@ -89,8 +85,6 @@
         "context_doctype": "Unknown",
         "context_domain": "HR_Payroll",
         "context_impact": 0,
-        "correlation_boost": 5,
-        "cross_path_correlation": true,
         "full_field": "Author: Jane Analyst",
         "metadata_type": "AUTHOR_INFO",
         "original_confidence": 60.00000000000001,
@@ -119,7 +113,7 @@
       "validator": "metadata"
     },
     {
-      "confidence": 65,
+      "confidence": 60.00000000000001,
       "confidence_level": "MEDIUM",
       "filename": "<TMPDIR>/forged_first.docx",
       "line_number": 2,
@@ -129,8 +123,6 @@
         "context_doctype": "Unknown",
         "context_domain": "HR_Payroll",
         "context_impact": 0,
-        "correlation_boost": 5,
-        "cross_path_correlation": true,
         "full_field": "LastModifiedBy: Ops Reviewer",
         "metadata_type": "LAST_MODIFIED_BY",
         "original_confidence": 60.00000000000001,

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.junit.xml
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.junit.xml
@@ -2,7 +2,7 @@
 <testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
   <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
     <testcase name="forged_first.docx" classname="security-scan" time="0.001">
-      <failure message="4 security findings detected" type="SECURITY_FINDINGS">Line 3: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 5: VISA detected with 100.0% confidence (HIGH)&#xA;Match: 4532-0151-1283-0366&#xA;Validator: creditcard&#xA;Line 1: AUTHOR_INFO detected with 65.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata&#xA;Line 2: LAST_MODIFIED_BY detected with 65.0% confidence (MEDIUM)&#xA;Match: Ops Reviewer&#xA;Validator: metadata</failure>
+      <failure message="4 security findings detected" type="SECURITY_FINDINGS">Line 3: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 5: VISA detected with 100.0% confidence (HIGH)&#xA;Match: 4532-0151-1283-0366&#xA;Validator: creditcard&#xA;Line 1: AUTHOR_INFO detected with 60.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata&#xA;Line 2: LAST_MODIFIED_BY detected with 60.0% confidence (MEDIUM)&#xA;Match: Ops Reviewer&#xA;Validator: metadata</failure>
     </testcase>
   </testsuite>
 </testsuites>

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.sarif.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.sarif.json
@@ -40,8 +40,6 @@
               "context_doctype": "Unknown",
               "context_domain": "HR_Payroll",
               "context_impact": 45,
-              "correlation_boost": 5,
-              "cross_path_correlation": true,
               "original_confidence": 100,
               "original_file": "<TMPDIR>/forged_first.docx",
               "semantic_context": {
@@ -109,8 +107,6 @@
               "context_doctype": "Unknown",
               "context_domain": "HR_Payroll",
               "context_impact": 15,
-              "correlation_boost": 5,
-              "cross_path_correlation": true,
               "original_confidence": 100,
               "original_file": "<TMPDIR>/forged_first.docx",
               "semantic_context": {
@@ -158,10 +154,10 @@
             }
           ],
           "message": {
-            "text": "AUTHOR_INFO Detected in forged_first.docx at line 1 (confidence: 65.0% - MEDIUM). Matched text: 'Jane Analyst'"
+            "text": "AUTHOR_INFO Detected in forged_first.docx at line 1 (confidence: 60.0% - MEDIUM). Matched text: 'Jane Analyst'"
           },
           "properties": {
-            "confidence": 65,
+            "confidence": 60,
             "confidenceLevel": "MEDIUM",
             "metadata": {
               "confidence_adjustment": 0,
@@ -169,8 +165,6 @@
               "context_doctype": "Unknown",
               "context_domain": "HR_Payroll",
               "context_impact": 0,
-              "correlation_boost": 5,
-              "cross_path_correlation": true,
               "full_field": "Author: Jane Analyst",
               "metadata_type": "AUTHOR_INFO",
               "original_confidence": 60,
@@ -196,7 +190,7 @@
             },
             "validator": "metadata"
           },
-          "rank": 57.5,
+          "rank": 55,
           "ruleId": "AUTHOR_INFO"
         },
         {
@@ -219,10 +213,10 @@
             }
           ],
           "message": {
-            "text": "LAST_MODIFIED_BY Detected in forged_first.docx at line 2 (confidence: 65.0% - MEDIUM). Matched text: 'Ops Reviewer'"
+            "text": "LAST_MODIFIED_BY Detected in forged_first.docx at line 2 (confidence: 60.0% - MEDIUM). Matched text: 'Ops Reviewer'"
           },
           "properties": {
-            "confidence": 65,
+            "confidence": 60,
             "confidenceLevel": "MEDIUM",
             "metadata": {
               "confidence_adjustment": 0,
@@ -230,8 +224,6 @@
               "context_doctype": "Unknown",
               "context_domain": "HR_Payroll",
               "context_impact": 0,
-              "correlation_boost": 5,
-              "cross_path_correlation": true,
               "full_field": "LastModifiedBy: Ops Reviewer",
               "metadata_type": "LAST_MODIFIED_BY",
               "original_confidence": 60,
@@ -257,7 +249,7 @@
             },
             "validator": "metadata"
           },
-          "rank": 57.5,
+          "rank": 55,
           "ruleId": "LAST_MODIFIED_BY"
         }
       ],

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.txt
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.txt
@@ -2,5 +2,5 @@ LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH            
 ---------------------------------------------------------------------------------------------
 [HIGH  ] ssn          SSN                   100.00% line     3 449-87-4100         forged_first.docx
 [HIGH  ] creditcard   VISA                  100.00% line     5 4532-0151-1283-0366 forged_first.docx
-[MEDIUM] metadata     AUTHOR_INFO            65.00% line     1 Jane Analyst        forged_first.docx
-[MEDIUM] metadata     LAST_MODIFIED_BY       65.00% line     2 Ops Reviewer        forged_first.docx
+[MEDIUM] metadata     AUTHOR_INFO            60.00% line     1 Jane Analyst        forged_first.docx
+[MEDIUM] metadata     LAST_MODIFIED_BY       60.00% line     2 Ops Reviewer        forged_first.docx

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.yaml
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.yaml
@@ -12,8 +12,6 @@ results:
         context_doctype: Unknown
         context_domain: HR_Payroll
         context_impact: 45
-        correlation_boost: 5
-        cross_path_correlation: true
         original_confidence: 100
         original_file: <TMPDIR>/forged_first.docx
         semantic_context:
@@ -46,8 +44,6 @@ results:
         context_doctype: Unknown
         context_domain: HR_Payroll
         context_impact: 15
-        correlation_boost: 5
-        cross_path_correlation: true
         original_confidence: 100
         original_file: <TMPDIR>/forged_first.docx
         semantic_context:
@@ -70,7 +66,7 @@ results:
     - text: Jane Analyst
       line_number: 1
       type: AUTHOR_INFO
-      confidence: 65
+      confidence: 60.00000000000001
       confidence_level: MEDIUM
       filename: <TMPDIR>/forged_first.docx
       validator: metadata
@@ -80,8 +76,6 @@ results:
         context_doctype: Unknown
         context_domain: HR_Payroll
         context_impact: 0
-        correlation_boost: 5
-        cross_path_correlation: true
         full_field: 'Author: Jane Analyst'
         metadata_type: AUTHOR_INFO
         original_confidence: 60.00000000000001
@@ -105,7 +99,7 @@ results:
     - text: Ops Reviewer
       line_number: 2
       type: LAST_MODIFIED_BY
-      confidence: 65
+      confidence: 60.00000000000001
       confidence_level: MEDIUM
       filename: <TMPDIR>/forged_first.docx
       validator: metadata
@@ -115,8 +109,6 @@ results:
         context_doctype: Unknown
         context_domain: HR_Payroll
         context_impact: 0
-        correlation_boost: 5
-        cross_path_correlation: true
         full_field: 'LastModifiedBy: Ops Reviewer'
         metadata_type: LAST_MODIFIED_BY
         original_confidence: 60.00000000000001

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.csv
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.csv
@@ -1,5 +1,5 @@
 Filename,Type,Confidence Level,Confidence %,Line Number,Text
 <TMPDIR>/forged_mid.docx,SSN,HIGH,100.0,5,449-87-4100
 <TMPDIR>/forged_mid.docx,VISA,HIGH,100.0,7,4532-0151-1283-0366
-<TMPDIR>/forged_mid.docx,AUTHOR_INFO,MEDIUM,65.0,1,Jane Analyst
-<TMPDIR>/forged_mid.docx,LAST_MODIFIED_BY,MEDIUM,65.0,2,Ops Reviewer
+<TMPDIR>/forged_mid.docx,AUTHOR_INFO,MEDIUM,60.0,1,Jane Analyst
+<TMPDIR>/forged_mid.docx,LAST_MODIFIED_BY,MEDIUM,60.0,2,Ops Reviewer

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.gitlab-sast.json
@@ -81,7 +81,7 @@
     {
       "category": "sast",
       "confidence": "Medium",
-      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/forged_mid.docx (line 1)\n**Confidence:** MEDIUM (65.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nAuthor: Jane Analyst\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/forged_mid.docx (line 1)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nAuthor: Jane Analyst\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {
@@ -107,7 +107,7 @@
     {
       "category": "sast",
       "confidence": "Medium",
-      "description": "Ferret Scan detected sensitive data (last modified by) in this file.\n\n**Location:** <TMPDIR>/forged_mid.docx (line 2)\n**Confidence:** MEDIUM (65.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nLastModifiedBy: Ops Reviewer\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "description": "Ferret Scan detected sensitive data (last modified by) in this file.\n\n**Location:** <TMPDIR>/forged_mid.docx (line 2)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nLastModifiedBy: Ops Reviewer\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.json.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.json.json
@@ -11,8 +11,6 @@
         "context_doctype": "Unknown",
         "context_domain": "HR_Payroll",
         "context_impact": 45,
-        "correlation_boost": 5,
-        "cross_path_correlation": true,
         "original_confidence": 100,
         "original_file": "<TMPDIR>/forged_mid.docx",
         "semantic_context": {
@@ -50,8 +48,6 @@
         "context_doctype": "Unknown",
         "context_domain": "HR_Payroll",
         "context_impact": 15,
-        "correlation_boost": 5,
-        "cross_path_correlation": true,
         "original_confidence": 100,
         "original_file": "<TMPDIR>/forged_mid.docx",
         "semantic_context": {
@@ -79,7 +75,7 @@
       "validator": "creditcard"
     },
     {
-      "confidence": 65,
+      "confidence": 60.00000000000001,
       "confidence_level": "MEDIUM",
       "filename": "<TMPDIR>/forged_mid.docx",
       "line_number": 1,
@@ -89,8 +85,6 @@
         "context_doctype": "Unknown",
         "context_domain": "HR_Payroll",
         "context_impact": 0,
-        "correlation_boost": 5,
-        "cross_path_correlation": true,
         "full_field": "Author: Jane Analyst",
         "metadata_type": "AUTHOR_INFO",
         "original_confidence": 60.00000000000001,
@@ -119,7 +113,7 @@
       "validator": "metadata"
     },
     {
-      "confidence": 65,
+      "confidence": 60.00000000000001,
       "confidence_level": "MEDIUM",
       "filename": "<TMPDIR>/forged_mid.docx",
       "line_number": 2,
@@ -129,8 +123,6 @@
         "context_doctype": "Unknown",
         "context_domain": "HR_Payroll",
         "context_impact": 0,
-        "correlation_boost": 5,
-        "cross_path_correlation": true,
         "full_field": "LastModifiedBy: Ops Reviewer",
         "metadata_type": "LAST_MODIFIED_BY",
         "original_confidence": 60.00000000000001,

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.junit.xml
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.junit.xml
@@ -2,7 +2,7 @@
 <testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
   <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
     <testcase name="forged_mid.docx" classname="security-scan" time="0.001">
-      <failure message="4 security findings detected" type="SECURITY_FINDINGS">Line 5: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 7: VISA detected with 100.0% confidence (HIGH)&#xA;Match: 4532-0151-1283-0366&#xA;Validator: creditcard&#xA;Line 1: AUTHOR_INFO detected with 65.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata&#xA;Line 2: LAST_MODIFIED_BY detected with 65.0% confidence (MEDIUM)&#xA;Match: Ops Reviewer&#xA;Validator: metadata</failure>
+      <failure message="4 security findings detected" type="SECURITY_FINDINGS">Line 5: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 7: VISA detected with 100.0% confidence (HIGH)&#xA;Match: 4532-0151-1283-0366&#xA;Validator: creditcard&#xA;Line 1: AUTHOR_INFO detected with 60.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata&#xA;Line 2: LAST_MODIFIED_BY detected with 60.0% confidence (MEDIUM)&#xA;Match: Ops Reviewer&#xA;Validator: metadata</failure>
     </testcase>
   </testsuite>
 </testsuites>

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.sarif.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.sarif.json
@@ -40,8 +40,6 @@
               "context_doctype": "Unknown",
               "context_domain": "HR_Payroll",
               "context_impact": 45,
-              "correlation_boost": 5,
-              "cross_path_correlation": true,
               "original_confidence": 100,
               "original_file": "<TMPDIR>/forged_mid.docx",
               "semantic_context": {
@@ -109,8 +107,6 @@
               "context_doctype": "Unknown",
               "context_domain": "HR_Payroll",
               "context_impact": 15,
-              "correlation_boost": 5,
-              "cross_path_correlation": true,
               "original_confidence": 100,
               "original_file": "<TMPDIR>/forged_mid.docx",
               "semantic_context": {
@@ -158,10 +154,10 @@
             }
           ],
           "message": {
-            "text": "AUTHOR_INFO Detected in forged_mid.docx at line 1 (confidence: 65.0% - MEDIUM). Matched text: 'Jane Analyst'"
+            "text": "AUTHOR_INFO Detected in forged_mid.docx at line 1 (confidence: 60.0% - MEDIUM). Matched text: 'Jane Analyst'"
           },
           "properties": {
-            "confidence": 65,
+            "confidence": 60,
             "confidenceLevel": "MEDIUM",
             "metadata": {
               "confidence_adjustment": 0,
@@ -169,8 +165,6 @@
               "context_doctype": "Unknown",
               "context_domain": "HR_Payroll",
               "context_impact": 0,
-              "correlation_boost": 5,
-              "cross_path_correlation": true,
               "full_field": "Author: Jane Analyst",
               "metadata_type": "AUTHOR_INFO",
               "original_confidence": 60,
@@ -196,7 +190,7 @@
             },
             "validator": "metadata"
           },
-          "rank": 57.5,
+          "rank": 55,
           "ruleId": "AUTHOR_INFO"
         },
         {
@@ -219,10 +213,10 @@
             }
           ],
           "message": {
-            "text": "LAST_MODIFIED_BY Detected in forged_mid.docx at line 2 (confidence: 65.0% - MEDIUM). Matched text: 'Ops Reviewer'"
+            "text": "LAST_MODIFIED_BY Detected in forged_mid.docx at line 2 (confidence: 60.0% - MEDIUM). Matched text: 'Ops Reviewer'"
           },
           "properties": {
-            "confidence": 65,
+            "confidence": 60,
             "confidenceLevel": "MEDIUM",
             "metadata": {
               "confidence_adjustment": 0,
@@ -230,8 +224,6 @@
               "context_doctype": "Unknown",
               "context_domain": "HR_Payroll",
               "context_impact": 0,
-              "correlation_boost": 5,
-              "cross_path_correlation": true,
               "full_field": "LastModifiedBy: Ops Reviewer",
               "metadata_type": "LAST_MODIFIED_BY",
               "original_confidence": 60,
@@ -257,7 +249,7 @@
             },
             "validator": "metadata"
           },
-          "rank": 57.5,
+          "rank": 55,
           "ruleId": "LAST_MODIFIED_BY"
         }
       ],

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.txt
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.txt
@@ -2,5 +2,5 @@ LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH            
 ---------------------------------------------------------------------------------------------
 [HIGH  ] ssn          SSN                   100.00% line     5 449-87-4100         forged_mid.docx
 [HIGH  ] creditcard   VISA                  100.00% line     7 4532-0151-1283-0366 forged_mid.docx
-[MEDIUM] metadata     AUTHOR_INFO            65.00% line     1 Jane Analyst        forged_mid.docx
-[MEDIUM] metadata     LAST_MODIFIED_BY       65.00% line     2 Ops Reviewer        forged_mid.docx
+[MEDIUM] metadata     AUTHOR_INFO            60.00% line     1 Jane Analyst        forged_mid.docx
+[MEDIUM] metadata     LAST_MODIFIED_BY       60.00% line     2 Ops Reviewer        forged_mid.docx

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.yaml
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.yaml
@@ -12,8 +12,6 @@ results:
         context_doctype: Unknown
         context_domain: HR_Payroll
         context_impact: 45
-        correlation_boost: 5
-        cross_path_correlation: true
         original_confidence: 100
         original_file: <TMPDIR>/forged_mid.docx
         semantic_context:
@@ -46,8 +44,6 @@ results:
         context_doctype: Unknown
         context_domain: HR_Payroll
         context_impact: 15
-        correlation_boost: 5
-        cross_path_correlation: true
         original_confidence: 100
         original_file: <TMPDIR>/forged_mid.docx
         semantic_context:
@@ -70,7 +66,7 @@ results:
     - text: Jane Analyst
       line_number: 1
       type: AUTHOR_INFO
-      confidence: 65
+      confidence: 60.00000000000001
       confidence_level: MEDIUM
       filename: <TMPDIR>/forged_mid.docx
       validator: metadata
@@ -80,8 +76,6 @@ results:
         context_doctype: Unknown
         context_domain: HR_Payroll
         context_impact: 0
-        correlation_boost: 5
-        cross_path_correlation: true
         full_field: 'Author: Jane Analyst'
         metadata_type: AUTHOR_INFO
         original_confidence: 60.00000000000001
@@ -105,7 +99,7 @@ results:
     - text: Ops Reviewer
       line_number: 2
       type: LAST_MODIFIED_BY
-      confidence: 65
+      confidence: 60.00000000000001
       confidence_level: MEDIUM
       filename: <TMPDIR>/forged_mid.docx
       validator: metadata
@@ -115,8 +109,6 @@ results:
         context_doctype: Unknown
         context_domain: HR_Payroll
         context_impact: 0
-        correlation_boost: 5
-        cross_path_correlation: true
         full_field: 'LastModifiedBy: Ops Reviewer'
         metadata_type: LAST_MODIFIED_BY
         original_confidence: 60.00000000000001

--- a/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.csv
+++ b/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.csv
@@ -1,5 +1,5 @@
 Filename,Type,Confidence Level,Confidence %,Line Number,Text
 <TMPDIR>/alt_case.docx,SSN,HIGH,100.0,3,449-87-4100
 <TMPDIR>/alt_case.docx,VISA,HIGH,100.0,5,4532-0151-1283-0366
-<TMPDIR>/alt_case.docx,AUTHOR_INFO,MEDIUM,65.0,1,Jane Analyst
-<TMPDIR>/alt_case.docx,LAST_MODIFIED_BY,MEDIUM,65.0,2,Ops Reviewer
+<TMPDIR>/alt_case.docx,AUTHOR_INFO,MEDIUM,60.0,1,Jane Analyst
+<TMPDIR>/alt_case.docx,LAST_MODIFIED_BY,MEDIUM,60.0,2,Ops Reviewer

--- a/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.gitlab-sast.json
@@ -81,7 +81,7 @@
     {
       "category": "sast",
       "confidence": "Medium",
-      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/alt_case.docx (line 1)\n**Confidence:** MEDIUM (65.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nAuthor: Jane Analyst\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/alt_case.docx (line 1)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nAuthor: Jane Analyst\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {
@@ -107,7 +107,7 @@
     {
       "category": "sast",
       "confidence": "Medium",
-      "description": "Ferret Scan detected sensitive data (last modified by) in this file.\n\n**Location:** <TMPDIR>/alt_case.docx (line 2)\n**Confidence:** MEDIUM (65.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nLastModifiedBy: Ops Reviewer\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "description": "Ferret Scan detected sensitive data (last modified by) in this file.\n\n**Location:** <TMPDIR>/alt_case.docx (line 2)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nLastModifiedBy: Ops Reviewer\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {

--- a/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.json.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.json.json
@@ -11,8 +11,6 @@
         "context_doctype": "Unknown",
         "context_domain": "HR_Payroll",
         "context_impact": 45,
-        "correlation_boost": 5,
-        "cross_path_correlation": true,
         "original_confidence": 100,
         "original_file": "<TMPDIR>/alt_case.docx",
         "semantic_context": {
@@ -50,8 +48,6 @@
         "context_doctype": "Unknown",
         "context_domain": "HR_Payroll",
         "context_impact": 15,
-        "correlation_boost": 5,
-        "cross_path_correlation": true,
         "original_confidence": 100,
         "original_file": "<TMPDIR>/alt_case.docx",
         "semantic_context": {
@@ -79,7 +75,7 @@
       "validator": "creditcard"
     },
     {
-      "confidence": 65,
+      "confidence": 60.00000000000001,
       "confidence_level": "MEDIUM",
       "filename": "<TMPDIR>/alt_case.docx",
       "line_number": 1,
@@ -89,8 +85,6 @@
         "context_doctype": "Unknown",
         "context_domain": "HR_Payroll",
         "context_impact": 0,
-        "correlation_boost": 5,
-        "cross_path_correlation": true,
         "full_field": "Author: Jane Analyst",
         "metadata_type": "AUTHOR_INFO",
         "original_confidence": 60.00000000000001,
@@ -119,7 +113,7 @@
       "validator": "metadata"
     },
     {
-      "confidence": 65,
+      "confidence": 60.00000000000001,
       "confidence_level": "MEDIUM",
       "filename": "<TMPDIR>/alt_case.docx",
       "line_number": 2,
@@ -129,8 +123,6 @@
         "context_doctype": "Unknown",
         "context_domain": "HR_Payroll",
         "context_impact": 0,
-        "correlation_boost": 5,
-        "cross_path_correlation": true,
         "full_field": "LastModifiedBy: Ops Reviewer",
         "metadata_type": "LAST_MODIFIED_BY",
         "original_confidence": 60.00000000000001,

--- a/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.junit.xml
+++ b/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.junit.xml
@@ -2,7 +2,7 @@
 <testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
   <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
     <testcase name="alt_case.docx" classname="security-scan" time="0.001">
-      <failure message="4 security findings detected" type="SECURITY_FINDINGS">Line 3: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 5: VISA detected with 100.0% confidence (HIGH)&#xA;Match: 4532-0151-1283-0366&#xA;Validator: creditcard&#xA;Line 1: AUTHOR_INFO detected with 65.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata&#xA;Line 2: LAST_MODIFIED_BY detected with 65.0% confidence (MEDIUM)&#xA;Match: Ops Reviewer&#xA;Validator: metadata</failure>
+      <failure message="4 security findings detected" type="SECURITY_FINDINGS">Line 3: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 5: VISA detected with 100.0% confidence (HIGH)&#xA;Match: 4532-0151-1283-0366&#xA;Validator: creditcard&#xA;Line 1: AUTHOR_INFO detected with 60.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata&#xA;Line 2: LAST_MODIFIED_BY detected with 60.0% confidence (MEDIUM)&#xA;Match: Ops Reviewer&#xA;Validator: metadata</failure>
     </testcase>
   </testsuite>
 </testsuites>

--- a/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.sarif.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.sarif.json
@@ -40,8 +40,6 @@
               "context_doctype": "Unknown",
               "context_domain": "HR_Payroll",
               "context_impact": 45,
-              "correlation_boost": 5,
-              "cross_path_correlation": true,
               "original_confidence": 100,
               "original_file": "<TMPDIR>/alt_case.docx",
               "semantic_context": {
@@ -109,8 +107,6 @@
               "context_doctype": "Unknown",
               "context_domain": "HR_Payroll",
               "context_impact": 15,
-              "correlation_boost": 5,
-              "cross_path_correlation": true,
               "original_confidence": 100,
               "original_file": "<TMPDIR>/alt_case.docx",
               "semantic_context": {
@@ -158,10 +154,10 @@
             }
           ],
           "message": {
-            "text": "AUTHOR_INFO Detected in alt_case.docx at line 1 (confidence: 65.0% - MEDIUM). Matched text: 'Jane Analyst'"
+            "text": "AUTHOR_INFO Detected in alt_case.docx at line 1 (confidence: 60.0% - MEDIUM). Matched text: 'Jane Analyst'"
           },
           "properties": {
-            "confidence": 65,
+            "confidence": 60,
             "confidenceLevel": "MEDIUM",
             "metadata": {
               "confidence_adjustment": 0,
@@ -169,8 +165,6 @@
               "context_doctype": "Unknown",
               "context_domain": "HR_Payroll",
               "context_impact": 0,
-              "correlation_boost": 5,
-              "cross_path_correlation": true,
               "full_field": "Author: Jane Analyst",
               "metadata_type": "AUTHOR_INFO",
               "original_confidence": 60,
@@ -196,7 +190,7 @@
             },
             "validator": "metadata"
           },
-          "rank": 57.5,
+          "rank": 55,
           "ruleId": "AUTHOR_INFO"
         },
         {
@@ -219,10 +213,10 @@
             }
           ],
           "message": {
-            "text": "LAST_MODIFIED_BY Detected in alt_case.docx at line 2 (confidence: 65.0% - MEDIUM). Matched text: 'Ops Reviewer'"
+            "text": "LAST_MODIFIED_BY Detected in alt_case.docx at line 2 (confidence: 60.0% - MEDIUM). Matched text: 'Ops Reviewer'"
           },
           "properties": {
-            "confidence": 65,
+            "confidence": 60,
             "confidenceLevel": "MEDIUM",
             "metadata": {
               "confidence_adjustment": 0,
@@ -230,8 +224,6 @@
               "context_doctype": "Unknown",
               "context_domain": "HR_Payroll",
               "context_impact": 0,
-              "correlation_boost": 5,
-              "cross_path_correlation": true,
               "full_field": "LastModifiedBy: Ops Reviewer",
               "metadata_type": "LAST_MODIFIED_BY",
               "original_confidence": 60,
@@ -257,7 +249,7 @@
             },
             "validator": "metadata"
           },
-          "rank": 57.5,
+          "rank": 55,
           "ruleId": "LAST_MODIFIED_BY"
         }
       ],

--- a/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.txt
+++ b/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.txt
@@ -2,5 +2,5 @@ LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH            
 ---------------------------------------------------------------------------------------------
 [HIGH  ] ssn          SSN                   100.00% line     3 449-87-4100         alt_case.docx
 [HIGH  ] creditcard   VISA                  100.00% line     5 4532-0151-1283-0366 alt_case.docx
-[MEDIUM] metadata     AUTHOR_INFO            65.00% line     1 Jane Analyst        alt_case.docx
-[MEDIUM] metadata     LAST_MODIFIED_BY       65.00% line     2 Ops Reviewer        alt_case.docx
+[MEDIUM] metadata     AUTHOR_INFO            60.00% line     1 Jane Analyst        alt_case.docx
+[MEDIUM] metadata     LAST_MODIFIED_BY       60.00% line     2 Ops Reviewer        alt_case.docx

--- a/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.yaml
+++ b/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.yaml
@@ -12,8 +12,6 @@ results:
         context_doctype: Unknown
         context_domain: HR_Payroll
         context_impact: 45
-        correlation_boost: 5
-        cross_path_correlation: true
         original_confidence: 100
         original_file: <TMPDIR>/alt_case.docx
         semantic_context:
@@ -46,8 +44,6 @@ results:
         context_doctype: Unknown
         context_domain: HR_Payroll
         context_impact: 15
-        correlation_boost: 5
-        cross_path_correlation: true
         original_confidence: 100
         original_file: <TMPDIR>/alt_case.docx
         semantic_context:
@@ -70,7 +66,7 @@ results:
     - text: Jane Analyst
       line_number: 1
       type: AUTHOR_INFO
-      confidence: 65
+      confidence: 60.00000000000001
       confidence_level: MEDIUM
       filename: <TMPDIR>/alt_case.docx
       validator: metadata
@@ -80,8 +76,6 @@ results:
         context_doctype: Unknown
         context_domain: HR_Payroll
         context_impact: 0
-        correlation_boost: 5
-        cross_path_correlation: true
         full_field: 'Author: Jane Analyst'
         metadata_type: AUTHOR_INFO
         original_confidence: 60.00000000000001
@@ -105,7 +99,7 @@ results:
     - text: Ops Reviewer
       line_number: 2
       type: LAST_MODIFIED_BY
-      confidence: 65
+      confidence: 60.00000000000001
       confidence_level: MEDIUM
       filename: <TMPDIR>/alt_case.docx
       validator: metadata
@@ -115,8 +109,6 @@ results:
         context_doctype: Unknown
         context_domain: HR_Payroll
         context_impact: 0
-        correlation_boost: 5
-        cross_path_correlation: true
         full_field: 'LastModifiedBy: Ops Reviewer'
         metadata_type: LAST_MODIFIED_BY
         original_confidence: 60.00000000000001

--- a/internal/goldencorpus/testdata/golden/file_wav_metadata_pii.csv
+++ b/internal/goldencorpus/testdata/golden/file_wav_metadata_pii.csv
@@ -1,6 +1,6 @@
 Filename,Type,Confidence Level,Confidence %,Line Number,Text
 <TMPDIR>/clip.wav,DOCUMENT_COMMENTS,HIGH,100.0,7,contact 212-555-0142 or AKIAIOSFODNN7EXAMPLE
-<TMPDIR>/clip.wav,AWS_ACCESS_KEY,MEDIUM,89.0,7,AKIAIOSFODNN7EXAMPLE
-<TMPDIR>/clip.wav,PHONE,MEDIUM,87.0,7,212-555-0142
-<TMPDIR>/clip.wav,AUTHOR_INFO,MEDIUM,85.0,6,john.doe@example.com
-<TMPDIR>/clip.wav,BUSINESS,LOW,30.0,6,john.doe@example.com
+<TMPDIR>/clip.wav,AWS_ACCESS_KEY,MEDIUM,84.0,7,AKIAIOSFODNN7EXAMPLE
+<TMPDIR>/clip.wav,PHONE,MEDIUM,82.0,7,212-555-0142
+<TMPDIR>/clip.wav,AUTHOR_INFO,MEDIUM,80.0,6,john.doe@example.com
+<TMPDIR>/clip.wav,BUSINESS,LOW,25.0,6,john.doe@example.com

--- a/internal/goldencorpus/testdata/golden/file_wav_metadata_pii.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_wav_metadata_pii.gitlab-sast.json
@@ -55,7 +55,7 @@
     {
       "category": "sast",
       "confidence": "High",
-      "description": "Ferret Scan detected aws access key in this file.\n\n**Location:** <TMPDIR>/clip.wav (line 7)\n**Confidence:** MEDIUM (89.0%)\n**Detected by:** secrets validator\n\n**Matched value:**\n```\nAKIAIOSFODNN7EXAMPLE\n```\n\n**Additional Information:**\n- source: preprocessed_content\n\n**Remediation:**\nRemove AWS credentials immediately and rotate them. Use IAM roles or environment variables instead.",
+      "description": "Ferret Scan detected aws access key in this file.\n\n**Location:** <TMPDIR>/clip.wav (line 7)\n**Confidence:** MEDIUM (84.0%)\n**Detected by:** secrets validator\n\n**Matched value:**\n```\nAKIAIOSFODNN7EXAMPLE\n```\n\n**Additional Information:**\n- source: preprocessed_content\n\n**Remediation:**\nRemove AWS credentials immediately and rotate them. Use IAM roles or environment variables instead.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {
@@ -81,7 +81,7 @@
     {
       "category": "sast",
       "confidence": "High",
-      "description": "Ferret Scan detected phone number in this file.\n\n**Location:** <TMPDIR>/clip.wav (line 7)\n**Confidence:** MEDIUM (87.0%)\n**Detected by:** phone validator\n\n**Context:**\n```\nComment: contact 212-555-0142 or AKIAIOSFODNN7EXAMPLE\n```\n\n**Additional Information:**\n- context_impact: -3\n- source: preprocessed_content\n\n**Remediation:**\nRemove phone numbers or replace with example numbers (e.g., 555-0123).",
+      "description": "Ferret Scan detected phone number in this file.\n\n**Location:** <TMPDIR>/clip.wav (line 7)\n**Confidence:** MEDIUM (82.0%)\n**Detected by:** phone validator\n\n**Context:**\n```\nComment: contact 212-555-0142 or AKIAIOSFODNN7EXAMPLE\n```\n\n**Additional Information:**\n- context_impact: -3\n- source: preprocessed_content\n\n**Remediation:**\nRemove phone numbers or replace with example numbers (e.g., 555-0123).",
       "id": "ferret-<HASH>",
       "identifiers": [
         {
@@ -107,7 +107,7 @@
     {
       "category": "sast",
       "confidence": "High",
-      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/clip.wav (line 6)\n**Confidence:** MEDIUM (85.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nArtist: john.doe@example.com\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/clip.wav (line 6)\n**Confidence:** MEDIUM (80.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nArtist: john.doe@example.com\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {
@@ -133,7 +133,7 @@
     {
       "category": "sast",
       "confidence": "Low",
-      "description": "Ferret Scan detected sensitive data (business) in this file.\n\n**Location:** <TMPDIR>/clip.wav (line 6)\n**Confidence:** LOW (30.0%)\n**Detected by:** email validator\n\n**Context:**\n```\nArtist: john.doe@example.com\n```\n\n**Additional Information:**\n- context_impact: -20\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "description": "Ferret Scan detected sensitive data (business) in this file.\n\n**Location:** <TMPDIR>/clip.wav (line 6)\n**Confidence:** LOW (25.0%)\n**Detected by:** email validator\n\n**Context:**\n```\nArtist: john.doe@example.com\n```\n\n**Additional Information:**\n- context_impact: -20\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {

--- a/internal/goldencorpus/testdata/golden/file_wav_metadata_pii.json.json
+++ b/internal/goldencorpus/testdata/golden/file_wav_metadata_pii.json.json
@@ -12,8 +12,6 @@
         "context_doctype": "Configuration",
         "context_domain": "Unknown",
         "context_impact": -0.04999999999999999,
-        "correlation_boost": 5,
-        "cross_path_correlation": true,
         "full_field": "Comment: contact 212-555-0142 or AKIAIOSFODNN7EXAMPLE",
         "metadata_type": "DOCUMENT_COMMENTS",
         "original_confidence": 100,
@@ -43,7 +41,7 @@
       "validator": "metadata"
     },
     {
-      "confidence": 89,
+      "confidence": 84,
       "confidence_level": "MEDIUM",
       "filename": "<TMPDIR>/clip.wav",
       "line_number": 7,
@@ -53,8 +51,6 @@
         "context_doc_type": "Configuration",
         "context_doctype": "Configuration",
         "context_domain": "Unknown",
-        "correlation_boost": 5,
-        "cross_path_correlation": true,
         "detection_method": "keyword_pattern",
         "environment_type": "test",
         "original_confidence": 84,
@@ -84,7 +80,7 @@
       "validator": "secrets"
     },
     {
-      "confidence": 87,
+      "confidence": 82,
       "confidence_level": "MEDIUM",
       "filename": "<TMPDIR>/clip.wav",
       "line_number": 7,
@@ -95,9 +91,7 @@
         "context_doctype": "Configuration",
         "context_domain": "Unknown",
         "context_impact": -3,
-        "correlation_boost": 5,
         "country": "US/CA",
-        "cross_path_correlation": true,
         "format": "XXX-XXX-XXXX",
         "original_confidence": 82,
         "original_file": "<TMPDIR>/clip.wav",
@@ -128,7 +122,7 @@
       "validator": "phone"
     },
     {
-      "confidence": 85,
+      "confidence": 80,
       "confidence_level": "MEDIUM",
       "filename": "<TMPDIR>/clip.wav",
       "line_number": 6,
@@ -138,8 +132,6 @@
         "context_doctype": "Configuration",
         "context_domain": "Unknown",
         "context_impact": 0,
-        "correlation_boost": 5,
-        "cross_path_correlation": true,
         "full_field": "Artist: john.doe@example.com",
         "metadata_type": "AUTHOR_INFO",
         "original_confidence": 80,
@@ -171,7 +163,7 @@
       "validator": "metadata"
     },
     {
-      "confidence": 30,
+      "confidence": 25,
       "confidence_level": "LOW",
       "filename": "<TMPDIR>/clip.wav",
       "line_number": 6,
@@ -181,8 +173,6 @@
         "context_doctype": "Configuration",
         "context_domain": "Unknown",
         "context_impact": -20,
-        "correlation_boost": 5,
-        "cross_path_correlation": true,
         "domain": "example.com",
         "email_provider": "BUSINESS",
         "original_confidence": 25,

--- a/internal/goldencorpus/testdata/golden/file_wav_metadata_pii.junit.xml
+++ b/internal/goldencorpus/testdata/golden/file_wav_metadata_pii.junit.xml
@@ -2,7 +2,7 @@
 <testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
   <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
     <testcase name="clip.wav" classname="security-scan" time="0.001">
-      <failure message="5 security findings detected" type="SECURITY_FINDINGS">Line 7: DOCUMENT_COMMENTS detected with 100.0% confidence (HIGH)&#xA;Match: contact 212-555-0142 or AKIAIOSFODNN7EXAMPLE&#xA;Validator: metadata&#xA;Line 7: AWS_ACCESS_KEY detected with 89.0% confidence (MEDIUM)&#xA;Match: AKIAIOSFODNN7EXAMPLE&#xA;Validator: secrets&#xA;Line 7: PHONE detected with 87.0% confidence (MEDIUM)&#xA;Match: 212-555-0142&#xA;Validator: phone&#xA;Line 6: AUTHOR_INFO detected with 85.0% confidence (MEDIUM)&#xA;Match: john.doe@example.com&#xA;Validator: metadata&#xA;Line 6: BUSINESS detected with 30.0% confidence (LOW)&#xA;Match: john.doe@example.com&#xA;Validator: email</failure>
+      <failure message="5 security findings detected" type="SECURITY_FINDINGS">Line 7: DOCUMENT_COMMENTS detected with 100.0% confidence (HIGH)&#xA;Match: contact 212-555-0142 or AKIAIOSFODNN7EXAMPLE&#xA;Validator: metadata&#xA;Line 7: AWS_ACCESS_KEY detected with 84.0% confidence (MEDIUM)&#xA;Match: AKIAIOSFODNN7EXAMPLE&#xA;Validator: secrets&#xA;Line 7: PHONE detected with 82.0% confidence (MEDIUM)&#xA;Match: 212-555-0142&#xA;Validator: phone&#xA;Line 6: AUTHOR_INFO detected with 80.0% confidence (MEDIUM)&#xA;Match: john.doe@example.com&#xA;Validator: metadata&#xA;Line 6: BUSINESS detected with 25.0% confidence (LOW)&#xA;Match: john.doe@example.com&#xA;Validator: email</failure>
     </testcase>
   </testsuite>
 </testsuites>

--- a/internal/goldencorpus/testdata/golden/file_wav_metadata_pii.sarif.json
+++ b/internal/goldencorpus/testdata/golden/file_wav_metadata_pii.sarif.json
@@ -35,8 +35,6 @@
               "context_doctype": "Configuration",
               "context_domain": "Unknown",
               "context_impact": -0,
-              "correlation_boost": 5,
-              "cross_path_correlation": true,
               "full_field": "Comment: contact 212-555-0142 or AKIAIOSFODNN7EXAMPLE",
               "metadata_type": "DOCUMENT_COMMENTS",
               "original_confidence": 100,
@@ -81,10 +79,10 @@
             }
           ],
           "message": {
-            "text": "AWS_ACCESS_KEY Detected in clip.wav at line 7 (confidence: 89.0% - MEDIUM). Matched text: 'AKIAIOSFODNN7EXAMPLE'"
+            "text": "AWS_ACCESS_KEY Detected in clip.wav at line 7 (confidence: 84.0% - MEDIUM). Matched text: 'AKIAIOSFODNN7EXAMPLE'"
           },
           "properties": {
-            "confidence": 89,
+            "confidence": 84,
             "confidenceLevel": "MEDIUM",
             "metadata": {
               "confidence_adjustment": 0,
@@ -92,8 +90,6 @@
               "context_doc_type": "Configuration",
               "context_doctype": "Configuration",
               "context_domain": "Unknown",
-              "correlation_boost": 5,
-              "cross_path_correlation": true,
               "detection_method": "keyword_pattern",
               "environment_type": "test",
               "original_confidence": 84,
@@ -120,7 +116,7 @@
             },
             "validator": "secrets"
           },
-          "rank": 69.5,
+          "rank": 67,
           "ruleId": "AWS_ACCESS_KEY"
         },
         {
@@ -149,10 +145,10 @@
             }
           ],
           "message": {
-            "text": "Phone Number Detected in clip.wav at line 7 (confidence: 87.0% - MEDIUM). Matched text: '212-555-0142'"
+            "text": "Phone Number Detected in clip.wav at line 7 (confidence: 82.0% - MEDIUM). Matched text: '212-555-0142'"
           },
           "properties": {
-            "confidence": 87,
+            "confidence": 82,
             "confidenceLevel": "MEDIUM",
             "metadata": {
               "clean_number": "2125550142",
@@ -161,9 +157,7 @@
               "context_doctype": "Configuration",
               "context_domain": "Unknown",
               "context_impact": -3,
-              "correlation_boost": 5,
               "country": "US/CA",
-              "cross_path_correlation": true,
               "format": "XXX-XXX-XXXX",
               "original_confidence": 82,
               "original_file": "<TMPDIR>/clip.wav",
@@ -197,7 +191,7 @@
             ],
             "validator": "phone"
           },
-          "rank": 68.5,
+          "rank": 66,
           "ruleId": "PHONE"
         },
         {
@@ -220,10 +214,10 @@
             }
           ],
           "message": {
-            "text": "AUTHOR_INFO Detected in clip.wav at line 6 (confidence: 85.0% - MEDIUM). Matched text: 'john.doe@example.com'"
+            "text": "AUTHOR_INFO Detected in clip.wav at line 6 (confidence: 80.0% - MEDIUM). Matched text: 'john.doe@example.com'"
           },
           "properties": {
-            "confidence": 85,
+            "confidence": 80,
             "confidenceLevel": "MEDIUM",
             "metadata": {
               "confidence_adjustment": 0,
@@ -231,8 +225,6 @@
               "context_doctype": "Configuration",
               "context_domain": "Unknown",
               "context_impact": 0,
-              "correlation_boost": 5,
-              "cross_path_correlation": true,
               "full_field": "Artist: john.doe@example.com",
               "metadata_type": "AUTHOR_INFO",
               "original_confidence": 80,
@@ -261,7 +253,7 @@
             },
             "validator": "metadata"
           },
-          "rank": 67.5,
+          "rank": 65,
           "ruleId": "AUTHOR_INFO"
         },
         {
@@ -290,10 +282,10 @@
             }
           ],
           "message": {
-            "text": "BUSINESS Detected in clip.wav at line 6 (confidence: 30.0% - LOW). Matched text: 'john.doe@example.com'"
+            "text": "BUSINESS Detected in clip.wav at line 6 (confidence: 25.0% - LOW). Matched text: 'john.doe@example.com'"
           },
           "properties": {
-            "confidence": 30,
+            "confidence": 25,
             "confidenceLevel": "LOW",
             "metadata": {
               "confidence_adjustment": 0,
@@ -301,8 +293,6 @@
               "context_doctype": "Configuration",
               "context_domain": "Unknown",
               "context_impact": -20,
-              "correlation_boost": 5,
-              "cross_path_correlation": true,
               "domain": "example.com",
               "email_provider": "BUSINESS",
               "original_confidence": 25,
@@ -334,7 +324,7 @@
             ],
             "validator": "email"
           },
-          "rank": 40,
+          "rank": 37.5,
           "ruleId": "BUSINESS"
         }
       ],

--- a/internal/goldencorpus/testdata/golden/file_wav_metadata_pii.txt
+++ b/internal/goldencorpus/testdata/golden/file_wav_metadata_pii.txt
@@ -1,7 +1,7 @@
 LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH                          FILE
 --------------------------------------------------------------------------------------------------------
 [HIGH  ] metadata     DOCUMENT_COMMENTS     100.00% line     7 contact 212-555-0142 or AKI... clip.wav
-[MEDIUM] secrets      AWS_ACCESS_KEY         89.00% line     7 AKIAIOSFODNN7EXAMPLE           clip.wav
-[MEDIUM] phone        PHONE                  87.00% line     7 212-555-0142                   clip.wav
-[MEDIUM] metadata     AUTHOR_INFO            85.00% line     6 john.doe@example.com           clip.wav
-[LOW   ] email        BUSINESS               30.00% line     6 john.doe@example.com           clip.wav
+[MEDIUM] secrets      AWS_ACCESS_KEY         84.00% line     7 AKIAIOSFODNN7EXAMPLE           clip.wav
+[MEDIUM] phone        PHONE                  82.00% line     7 212-555-0142                   clip.wav
+[MEDIUM] metadata     AUTHOR_INFO            80.00% line     6 john.doe@example.com           clip.wav
+[LOW   ] email        BUSINESS               25.00% line     6 john.doe@example.com           clip.wav

--- a/internal/goldencorpus/testdata/golden/file_wav_metadata_pii.yaml
+++ b/internal/goldencorpus/testdata/golden/file_wav_metadata_pii.yaml
@@ -13,8 +13,6 @@ results:
         context_doctype: Configuration
         context_domain: Unknown
         context_impact: -0.04999999999999999
-        correlation_boost: 5
-        cross_path_correlation: true
         full_field: 'Comment: contact 212-555-0142 or AKIAIOSFODNN7EXAMPLE'
         metadata_type: DOCUMENT_COMMENTS
         original_confidence: 100
@@ -39,7 +37,7 @@ results:
     - text: AKIAIOSFODNN7EXAMPLE
       line_number: 7
       type: AWS_ACCESS_KEY
-      confidence: 89
+      confidence: 84
       confidence_level: MEDIUM
       filename: <TMPDIR>/clip.wav
       validator: secrets
@@ -49,8 +47,6 @@ results:
         context_doc_type: Configuration
         context_doctype: Configuration
         context_domain: Unknown
-        correlation_boost: 5
-        cross_path_correlation: true
         detection_method: keyword_pattern
         environment_type: test
         original_confidence: 84
@@ -75,7 +71,7 @@ results:
     - text: 212-555-0142
       line_number: 7
       type: PHONE
-      confidence: 87
+      confidence: 82
       confidence_level: MEDIUM
       filename: <TMPDIR>/clip.wav
       validator: phone
@@ -86,9 +82,7 @@ results:
         context_doctype: Configuration
         context_domain: Unknown
         context_impact: -3
-        correlation_boost: 5
         country: US/CA
-        cross_path_correlation: true
         format: XXX-XXX-XXXX
         original_confidence: 82
         original_file: <TMPDIR>/clip.wav
@@ -114,7 +108,7 @@ results:
     - text: john.doe@example.com
       line_number: 6
       type: AUTHOR_INFO
-      confidence: 85
+      confidence: 80
       confidence_level: MEDIUM
       filename: <TMPDIR>/clip.wav
       validator: metadata
@@ -124,8 +118,6 @@ results:
         context_doctype: Configuration
         context_domain: Unknown
         context_impact: 0
-        correlation_boost: 5
-        cross_path_correlation: true
         full_field: 'Artist: john.doe@example.com'
         metadata_type: AUTHOR_INFO
         original_confidence: 80
@@ -152,7 +144,7 @@ results:
     - text: john.doe@example.com
       line_number: 6
       type: BUSINESS
-      confidence: 30
+      confidence: 25
       confidence_level: LOW
       filename: <TMPDIR>/clip.wav
       validator: email
@@ -162,8 +154,6 @@ results:
         context_doctype: Configuration
         context_domain: Unknown
         context_impact: -20
-        correlation_boost: 5
-        cross_path_correlation: true
         domain: example.com
         email_provider: BUSINESS
         original_confidence: 25

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.csv
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.csv
@@ -1,4 +1,4 @@
 Filename,Type,Confidence Level,Confidence %,Line Number,Text
 <TMPDIR>/books.xlsx,SSN,HIGH,100.0,2,449-87-4100
 <TMPDIR>/books.xlsx,VISA,HIGH,100.0,3,4532-0151-1283-0366
-<TMPDIR>/books.xlsx,AUTHOR_INFO,MEDIUM,65.0,1,Jane Analyst
+<TMPDIR>/books.xlsx,AUTHOR_INFO,MEDIUM,60.0,1,Jane Analyst

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.gitlab-sast.json
@@ -81,7 +81,7 @@
     {
       "category": "sast",
       "confidence": "Medium",
-      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/books.xlsx (line 1)\n**Confidence:** MEDIUM (65.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nAuthor: Jane Analyst\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/books.xlsx (line 1)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nAuthor: Jane Analyst\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.json.json
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.json.json
@@ -11,8 +11,6 @@
         "context_doctype": "Unknown",
         "context_domain": "HR_Payroll",
         "context_impact": 50,
-        "correlation_boost": 5,
-        "cross_path_correlation": true,
         "original_confidence": 100,
         "original_file": "<TMPDIR>/books.xlsx",
         "semantic_context": {
@@ -50,8 +48,6 @@
         "context_doctype": "Unknown",
         "context_domain": "HR_Payroll",
         "context_impact": 15,
-        "correlation_boost": 5,
-        "cross_path_correlation": true,
         "original_confidence": 100,
         "original_file": "<TMPDIR>/books.xlsx",
         "semantic_context": {
@@ -79,7 +75,7 @@
       "validator": "creditcard"
     },
     {
-      "confidence": 65,
+      "confidence": 60.00000000000001,
       "confidence_level": "MEDIUM",
       "filename": "<TMPDIR>/books.xlsx",
       "line_number": 1,
@@ -89,8 +85,6 @@
         "context_doctype": "Unknown",
         "context_domain": "HR_Payroll",
         "context_impact": 0,
-        "correlation_boost": 5,
-        "cross_path_correlation": true,
         "full_field": "Author: Jane Analyst",
         "metadata_type": "AUTHOR_INFO",
         "original_confidence": 60.00000000000001,

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.junit.xml
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.junit.xml
@@ -2,7 +2,7 @@
 <testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
   <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
     <testcase name="books.xlsx" classname="security-scan" time="0.001">
-      <failure message="3 security findings detected" type="SECURITY_FINDINGS">Line 2: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 3: VISA detected with 100.0% confidence (HIGH)&#xA;Match: 4532-0151-1283-0366&#xA;Validator: creditcard&#xA;Line 1: AUTHOR_INFO detected with 65.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata</failure>
+      <failure message="3 security findings detected" type="SECURITY_FINDINGS">Line 2: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 3: VISA detected with 100.0% confidence (HIGH)&#xA;Match: 4532-0151-1283-0366&#xA;Validator: creditcard&#xA;Line 1: AUTHOR_INFO detected with 60.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata</failure>
     </testcase>
   </testsuite>
 </testsuites>

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.sarif.json
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.sarif.json
@@ -40,8 +40,6 @@
               "context_doctype": "Unknown",
               "context_domain": "HR_Payroll",
               "context_impact": 50,
-              "correlation_boost": 5,
-              "cross_path_correlation": true,
               "original_confidence": 100,
               "original_file": "<TMPDIR>/books.xlsx",
               "semantic_context": {
@@ -109,8 +107,6 @@
               "context_doctype": "Unknown",
               "context_domain": "HR_Payroll",
               "context_impact": 15,
-              "correlation_boost": 5,
-              "cross_path_correlation": true,
               "original_confidence": 100,
               "original_file": "<TMPDIR>/books.xlsx",
               "semantic_context": {
@@ -158,10 +154,10 @@
             }
           ],
           "message": {
-            "text": "AUTHOR_INFO Detected in books.xlsx at line 1 (confidence: 65.0% - MEDIUM). Matched text: 'Jane Analyst'"
+            "text": "AUTHOR_INFO Detected in books.xlsx at line 1 (confidence: 60.0% - MEDIUM). Matched text: 'Jane Analyst'"
           },
           "properties": {
-            "confidence": 65,
+            "confidence": 60,
             "confidenceLevel": "MEDIUM",
             "metadata": {
               "confidence_adjustment": 0,
@@ -169,8 +165,6 @@
               "context_doctype": "Unknown",
               "context_domain": "HR_Payroll",
               "context_impact": 0,
-              "correlation_boost": 5,
-              "cross_path_correlation": true,
               "full_field": "Author: Jane Analyst",
               "metadata_type": "AUTHOR_INFO",
               "original_confidence": 60,
@@ -196,7 +190,7 @@
             },
             "validator": "metadata"
           },
-          "rank": 57.5,
+          "rank": 55,
           "ruleId": "AUTHOR_INFO"
         }
       ],

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.txt
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.txt
@@ -2,4 +2,4 @@ LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH            
 ---------------------------------------------------------------------------------------------
 [HIGH  ] ssn          SSN                   100.00% line     2 449-87-4100         books.xlsx
 [HIGH  ] creditcard   VISA                  100.00% line     3 4532-0151-1283-0366 books.xlsx
-[MEDIUM] metadata     AUTHOR_INFO            65.00% line     1 Jane Analyst        books.xlsx
+[MEDIUM] metadata     AUTHOR_INFO            60.00% line     1 Jane Analyst        books.xlsx

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.yaml
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.yaml
@@ -12,8 +12,6 @@ results:
         context_doctype: Unknown
         context_domain: HR_Payroll
         context_impact: 50
-        correlation_boost: 5
-        cross_path_correlation: true
         original_confidence: 100
         original_file: <TMPDIR>/books.xlsx
         semantic_context:
@@ -46,8 +44,6 @@ results:
         context_doctype: Unknown
         context_domain: HR_Payroll
         context_impact: 15
-        correlation_boost: 5
-        cross_path_correlation: true
         original_confidence: 100
         original_file: <TMPDIR>/books.xlsx
         semantic_context:
@@ -70,7 +66,7 @@ results:
     - text: Jane Analyst
       line_number: 1
       type: AUTHOR_INFO
-      confidence: 65
+      confidence: 60.00000000000001
       confidence_level: MEDIUM
       filename: <TMPDIR>/books.xlsx
       validator: metadata
@@ -80,8 +76,6 @@ results:
         context_doctype: Unknown
         context_domain: HR_Payroll
         context_impact: 0
-        correlation_boost: 5
-        cross_path_correlation: true
         full_field: 'Author: Jane Analyst'
         metadata_type: AUTHOR_INFO
         original_confidence: 60.00000000000001

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.csv
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.csv
@@ -1,4 +1,4 @@
 Filename,Type,Confidence Level,Confidence %,Line Number,Text
 <TMPDIR>/books_named.xlsx,SSN,HIGH,100.0,2,449-87-4100
 <TMPDIR>/books_named.xlsx,VISA,HIGH,100.0,3,4532-0151-1283-0366
-<TMPDIR>/books_named.xlsx,AUTHOR_INFO,MEDIUM,65.0,1,Jane Analyst
+<TMPDIR>/books_named.xlsx,AUTHOR_INFO,MEDIUM,60.0,1,Jane Analyst

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.gitlab-sast.json
@@ -81,7 +81,7 @@
     {
       "category": "sast",
       "confidence": "Medium",
-      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/books_named.xlsx (line 1)\n**Confidence:** MEDIUM (65.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nAuthor: Jane Analyst\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/books_named.xlsx (line 1)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nAuthor: Jane Analyst\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.json.json
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.json.json
@@ -11,8 +11,6 @@
         "context_doctype": "Unknown",
         "context_domain": "HR_Payroll",
         "context_impact": 50,
-        "correlation_boost": 5,
-        "cross_path_correlation": true,
         "original_confidence": 100,
         "original_file": "<TMPDIR>/books_named.xlsx",
         "semantic_context": {
@@ -50,8 +48,6 @@
         "context_doctype": "Unknown",
         "context_domain": "HR_Payroll",
         "context_impact": 15,
-        "correlation_boost": 5,
-        "cross_path_correlation": true,
         "original_confidence": 100,
         "original_file": "<TMPDIR>/books_named.xlsx",
         "semantic_context": {
@@ -79,7 +75,7 @@
       "validator": "creditcard"
     },
     {
-      "confidence": 65,
+      "confidence": 60.00000000000001,
       "confidence_level": "MEDIUM",
       "filename": "<TMPDIR>/books_named.xlsx",
       "line_number": 1,
@@ -89,8 +85,6 @@
         "context_doctype": "Unknown",
         "context_domain": "HR_Payroll",
         "context_impact": 0,
-        "correlation_boost": 5,
-        "cross_path_correlation": true,
         "full_field": "Author: Jane Analyst",
         "metadata_type": "AUTHOR_INFO",
         "original_confidence": 60.00000000000001,

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.junit.xml
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.junit.xml
@@ -2,7 +2,7 @@
 <testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
   <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
     <testcase name="books_named.xlsx" classname="security-scan" time="0.001">
-      <failure message="3 security findings detected" type="SECURITY_FINDINGS">Line 2: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 3: VISA detected with 100.0% confidence (HIGH)&#xA;Match: 4532-0151-1283-0366&#xA;Validator: creditcard&#xA;Line 1: AUTHOR_INFO detected with 65.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata</failure>
+      <failure message="3 security findings detected" type="SECURITY_FINDINGS">Line 2: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 3: VISA detected with 100.0% confidence (HIGH)&#xA;Match: 4532-0151-1283-0366&#xA;Validator: creditcard&#xA;Line 1: AUTHOR_INFO detected with 60.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata</failure>
     </testcase>
   </testsuite>
 </testsuites>

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.sarif.json
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.sarif.json
@@ -40,8 +40,6 @@
               "context_doctype": "Unknown",
               "context_domain": "HR_Payroll",
               "context_impact": 50,
-              "correlation_boost": 5,
-              "cross_path_correlation": true,
               "original_confidence": 100,
               "original_file": "<TMPDIR>/books_named.xlsx",
               "semantic_context": {
@@ -109,8 +107,6 @@
               "context_doctype": "Unknown",
               "context_domain": "HR_Payroll",
               "context_impact": 15,
-              "correlation_boost": 5,
-              "cross_path_correlation": true,
               "original_confidence": 100,
               "original_file": "<TMPDIR>/books_named.xlsx",
               "semantic_context": {
@@ -158,10 +154,10 @@
             }
           ],
           "message": {
-            "text": "AUTHOR_INFO Detected in books_named.xlsx at line 1 (confidence: 65.0% - MEDIUM). Matched text: 'Jane Analyst'"
+            "text": "AUTHOR_INFO Detected in books_named.xlsx at line 1 (confidence: 60.0% - MEDIUM). Matched text: 'Jane Analyst'"
           },
           "properties": {
-            "confidence": 65,
+            "confidence": 60,
             "confidenceLevel": "MEDIUM",
             "metadata": {
               "confidence_adjustment": 0,
@@ -169,8 +165,6 @@
               "context_doctype": "Unknown",
               "context_domain": "HR_Payroll",
               "context_impact": 0,
-              "correlation_boost": 5,
-              "cross_path_correlation": true,
               "full_field": "Author: Jane Analyst",
               "metadata_type": "AUTHOR_INFO",
               "original_confidence": 60,
@@ -196,7 +190,7 @@
             },
             "validator": "metadata"
           },
-          "rank": 57.5,
+          "rank": 55,
           "ruleId": "AUTHOR_INFO"
         }
       ],

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.txt
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.txt
@@ -2,4 +2,4 @@ LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH            
 ---------------------------------------------------------------------------------------------
 [HIGH  ] ssn          SSN                   100.00% line     2 449-87-4100         books_named.xlsx
 [HIGH  ] creditcard   VISA                  100.00% line     3 4532-0151-1283-0366 books_named.xlsx
-[MEDIUM] metadata     AUTHOR_INFO            65.00% line     1 Jane Analyst        books_named.xlsx
+[MEDIUM] metadata     AUTHOR_INFO            60.00% line     1 Jane Analyst        books_named.xlsx

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.yaml
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.yaml
@@ -12,8 +12,6 @@ results:
         context_doctype: Unknown
         context_domain: HR_Payroll
         context_impact: 50
-        correlation_boost: 5
-        cross_path_correlation: true
         original_confidence: 100
         original_file: <TMPDIR>/books_named.xlsx
         semantic_context:
@@ -46,8 +44,6 @@ results:
         context_doctype: Unknown
         context_domain: HR_Payroll
         context_impact: 15
-        correlation_boost: 5
-        cross_path_correlation: true
         original_confidence: 100
         original_file: <TMPDIR>/books_named.xlsx
         semantic_context:
@@ -70,7 +66,7 @@ results:
     - text: Jane Analyst
       line_number: 1
       type: AUTHOR_INFO
-      confidence: 65
+      confidence: 60.00000000000001
       confidence_level: MEDIUM
       filename: <TMPDIR>/books_named.xlsx
       validator: metadata
@@ -80,8 +76,6 @@ results:
         context_doctype: Unknown
         context_domain: HR_Payroll
         context_impact: 0
-        correlation_boost: 5
-        cross_path_correlation: true
         full_field: 'Author: Jane Analyst'
         metadata_type: AUTHOR_INFO
         original_confidence: 60.00000000000001

--- a/internal/validators/dual_path_bridge.go
+++ b/internal/validators/dual_path_bridge.go
@@ -507,8 +507,13 @@ func (evb *EnhancedValidatorBridge) processDualPath(ctx stdctx.Context, routedCo
 		return result, cerr
 	}
 
-	// Apply cross-path confidence adjustments based on context
-	result.AllMatches = evb.applyCrossPathConfidenceAdjustments(result.AllMatches, contextInsights)
+	// No cross-path pass. applyCrossPathConfidenceAdjustments existed only to add a flat
+	// +5 to every finding when both validation paths reported, which made a finding's
+	// confidence depend on what else was in the file; with the boost gone the function
+	// grouped matches by path and then returned them unchanged, so it is deleted rather
+	// than left as an identity call a reader has to verify does nothing. Per-path context
+	// adjustments still happen inside each bridge, where the match's own validator is
+	// known.
 
 	result.ProcessingTime = time.Since(startTime)
 
@@ -563,61 +568,6 @@ func clampToCeiling(match *detector.Match) {
 	if match.Confidence > ceiling {
 		match.Confidence = ceiling
 	}
-}
-
-// applyCrossPathConfidenceAdjustments applies confidence adjustments based on cross-path analysis
-func (evb *EnhancedValidatorBridge) applyCrossPathConfidenceAdjustments(matches []detector.Match, contextInsights context.ContextInsights) []detector.Match {
-	if len(matches) == 0 {
-		return matches
-	}
-
-	// Group matches by validation path
-	documentMatches := make([]detector.Match, 0)
-	metadataMatches := make([]detector.Match, 0)
-
-	for _, match := range matches {
-		if match.Metadata != nil {
-			if preprocessorType, exists := match.Metadata["preprocessor_type"]; exists && preprocessorType != nil {
-				metadataMatches = append(metadataMatches, match)
-			} else {
-				documentMatches = append(documentMatches, match)
-			}
-		} else {
-			documentMatches = append(documentMatches, match)
-		}
-	}
-
-	// Apply cross-path correlation boosts
-	if len(documentMatches) > 0 && len(metadataMatches) > 0 {
-		// Both paths found matches - apply correlation boost
-		correlationBoost := 5.0
-
-		for i := range matches {
-			originalConfidence := matches[i].Confidence
-			matches[i].Confidence += correlationBoost
-			clampToCeiling(&matches[i])
-
-			// Ensure confidence stays within bounds
-			if matches[i].Confidence > 100 {
-				matches[i].Confidence = 100
-			}
-
-			// Add correlation information to metadata
-			if matches[i].Metadata == nil {
-				matches[i].Metadata = make(map[string]interface{})
-			}
-			matches[i].Metadata["cross_path_correlation"] = true
-			matches[i].Metadata["correlation_boost"] = correlationBoost
-			matches[i].Metadata["original_confidence"] = originalConfidence
-		}
-
-		if evb.observer != nil && evb.observer.Debug() != nil {
-			evb.observer.Debug().LogDetail("cross_path_correlation",
-				fmt.Sprintf("Applied %.1f correlation boost to %d matches", correlationBoost, len(matches)))
-		}
-	}
-
-	return matches
 }
 
 // routeContentWithRetry attempts content routing with retry logic


### PR DESCRIPTION
**Independent of #247.** Replaces #248, which was based on #247's branch. This one is cherry-picked straight onto `main`, so the two can merge in either order with no conflict — verified zero file overlap between them.

## The defect

The bridge added a flat **+5 to every finding** whenever both validation paths reported something, on the theory that a document with both body and metadata findings is more likely to hold real data. The consequence: a finding's confidence described the **file**, not the finding. Scanning the same value in two documents gave two answers.

Two `.docx` files with identical content and identical basenames, differing only by an unrelated author name in the metadata:

| fixture | `API_KEY_OR_SECRET` |
|---|---|
| no metadata | **55** |
| unrelated metadata | **60** |

On a real 10 MB `.docx`, **all 78** findings carried the boost and **14** had their score genuinely shifted by it (the rest were already clamped at 100), across 9 types: `PERSON_NAME`, `IMAGE_SOFTWARE`, `AUTHOR_INFO`, `LAST_MODIFIED_BY`, `COMPANY_INFO`, `APPLICATION_INFO`, `DOCUMENT_COMMENTS`, `API_KEY_OR_SECRET`, `TEMPLATE_INFO`.

## Why it's wrong

A confidence answers *"how sure are we about **this** value"* — so the same secret in two documents has to score the same.

There was a second-order cost too: while the suppression hash folded confidence, adding one unrelated finding to a file silently invalidated the saved rules of **every other finding in it**. An operator's reviewed-and-accepted finding came back as noise, and in a pre-commit gate as a block. #247 removes confidence from that hash, which defuses that consequence independently — but the scores themselves were still arbitrary, which is what this fixes.

## What else went

Removing the boost left `applyCrossPathConfidenceAdjustments` grouping matches by path and then returning them unchanged, so the function is **deleted** rather than kept as an identity call a reader has to verify does nothing (TEST_PLAN D10: a fix that makes a branch unreachable must remove it).

Per-path context adjustments still happen inside each bridge, where the match's own validator is known. The confidence-ceiling clamp from #241 survives at both remaining raise sites; the one inside the deleted function went with the raise it guarded.

## Cross-finding correlation is still worth having

Just not like this. A MEDIUM name next to a HIGH SSN probably *is* a person. Doing it properly needs **proximity** (this applied document-wide), a **stated per-type policy** (this hit every type equally, including metadata types whose confidence means something different), and an **opt-in flag with a benchmark**. That's the co-occurrence reranker — a separate change, and one this unblocks: you cannot evaluate a co-occurrence reranker while an undocumented co-occurrence boost is already firing.

## Golden impact

**7 cases move, all dual-path containers; no text-only case moves** — the expected shape, since the boost only fired when both paths reported.

Diffs are confidence-only at exactly **−5** per finding, counts unchanged:

| case | before → after |
|---|---|
| `file_docx_body_and_metadata` | 4 → 4 findings |
| `file_wav_metadata_pii` | 5 → 5 findings |
| `file_xlsx_sheet_cells` | 3 → 3 findings |

The extra removed lines are the `cross_path_correlation`, `correlation_boost` and `original_confidence` metadata keys the boost used to attach.

## Testing

Per `docs/testing/TEST_PLAN.md`.

Tests drive `core.ScanFile` with real `.docx` bytes rather than the bridge directly, because the defect lived in *how the two paths were combined* — a hand-wired bridge would test the test's own wiring.

**D10 non-vacuity:** restoring the boost fails both tests. Each carries a floor that fails if its fixture produces no finding at all, so neither can pass by finding nothing. Coverage is symmetric: a body finding must not move because metadata exists, **and** a metadata finding must not move because the body has one.

Verified standalone on `main` without #247: 61 packages pass · gofmt clean · vet clean for darwin/linux/windows · `-race` clean on validators and core.