### PR TITLE
fix(redact): stop a metadata match from suppressing body redaction

### DIFF
--- a/internal/redactors/office/emit_order_test.go
+++ b/internal/redactors/office/emit_order_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/awslabs/ferret-scan/v2/internal/detector"
@@ -224,6 +225,86 @@ func TestRepackage_RedactsSensitiveValues(t *testing.T) {
 			if bytes.Contains(content, []byte(secret)) {
 				t.Errorf("entry %s still contains the raw value", f.Name)
 			}
+		}
+	}
+}
+
+// TestRepackage_MetadataMatchDoesNotSuppressBodyRedaction covers the gap that
+// let a real leak through: TestRepackage_RedactsSensitiveValues passes matches
+// with no Context.FullLine, so every match is position-unresolvable and the
+// overlap-containment path is never entered at all.
+//
+// Here the matches carry FullLine the way the scanner really populates it. The
+// metadata match comes from docProps/core.xml and the body match from
+// word/document.xml, and both are reported as line 1 because line numbers are
+// counted per part. Their offsets are measured against different strings, so
+// treating one as "contained" in the other is a coordinate-system error — and
+// it silently dropped the body SSN before redaction was attempted.
+func TestRepackage_MetadataMatchDoesNotSuppressBodyRedaction(t *testing.T) {
+	src := writeFixtureDocx(t)
+	out := filepath.Join("testdata", "tmp-emit-order", "out", "metaline.docx")
+
+	const (
+		ssn        = "449-87-4100"
+		bodyLine   = "Employee SSN: 449-87-4100"
+		author     = "Jane Quincy Analyst-Smith"
+		authorLine = "Creator: Jane Quincy Analyst-Smith"
+	)
+
+	// Guard against this test quietly becoming vacuous: it is only meaningful
+	// while the author's span numerically contains the SSN's span and is wider.
+	// If someone edits the strings so containment no longer holds, the test
+	// would pass without exercising anything.
+	ssnStart := strings.Index(bodyLine, ssn)
+	ssnEnd := ssnStart + len(ssn)
+	authorStart := strings.Index(authorLine, author)
+	authorEnd := authorStart + len(author)
+	if ssnStart < 0 || authorStart < 0 {
+		t.Fatalf("fixture strings are inconsistent: ssnStart=%d authorStart=%d", ssnStart, authorStart)
+	}
+	if !(authorStart <= ssnStart && ssnEnd <= authorEnd && (authorEnd-authorStart) > (ssnEnd-ssnStart)) {
+		t.Fatalf("precondition lost: author span [%d,%d) must strictly contain SSN span [%d,%d), else this test proves nothing",
+			authorStart, authorEnd, ssnStart, ssnEnd)
+	}
+
+	matches := []detector.Match{
+		{
+			Text: ssn, LineNumber: 1, Type: "SSN", Confidence: 100,
+			Filename: src, Validator: "ssn",
+			Context: detector.ContextInfo{FullLine: bodyLine},
+		},
+		{
+			Text: author, LineNumber: 1, Type: "AUTHOR_INFO", Confidence: 80,
+			Filename: src, Validator: "metadata",
+			Context: detector.ContextInfo{FullLine: authorLine},
+		},
+	}
+
+	r := NewOfficeRedactor(nil, nil)
+	if _, err := r.RedactDocument(src, out, matches, redactors.RedactionSimple); err != nil {
+		t.Fatalf("RedactDocument: %v", err)
+	}
+
+	raw, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	zr, err := zip.NewReader(bytes.NewReader(raw), int64(len(raw)))
+	if err != nil {
+		t.Fatalf("open output as zip: %v", err)
+	}
+	for _, f := range zr.File {
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("open entry %s: %v", f.Name, err)
+		}
+		content, err := io.ReadAll(rc)
+		rc.Close()
+		if err != nil {
+			t.Fatalf("read entry %s: %v", f.Name, err)
+		}
+		if bytes.Contains(content, []byte(ssn)) {
+			t.Errorf("entry %s still contains the raw SSN: a metadata match on the same line NUMBER must not suppress body redaction", f.Name)
 		}
 	}
 }

--- a/internal/redactors/overlap.go
+++ b/internal/redactors/overlap.go
@@ -28,17 +28,50 @@ import (
 // A match whose position cannot be determined (empty FullLine, text not found)
 // is kept as-is and never subsumes another, so callers see no behavior change
 // for inputs that don't overlap. Input order is preserved for survivors.
+//
+// Containment is only ever tested between matches from the SAME line of the
+// SAME source text. LineNumber alone does not identify a line: an Office
+// package reports line numbers per part, so a metadata match in
+// docProps/core.xml and a body match in word/document.xml both arrive as
+// "line 1" with offsets measured against different strings. Comparing those
+// offsets is meaningless, and when the body span happened to fall numerically
+// inside the metadata span the body match was dropped — leaving real PII
+// (an SSN) in cleartext in the "redacted" output. The line's own text is
+// therefore part of its identity: two matches whose FullLine differs are on
+// different lines by definition and can never subsume one another.
 func ResolveOverlaps(matches []detector.Match) []detector.Match {
 	if len(matches) < 2 {
 		return matches
 	}
 
 	// span records where a match sits within its line, or ok=false when the
-	// position could not be resolved.
+	// position could not be resolved. line is an interned id identifying the
+	// containing line by both its reported number and its text, so offsets are
+	// only ever compared within one shared coordinate system.
+	//
+	// The id is interned rather than carrying the line text itself: the
+	// containment loop below is O(n²) in the number of matches, and comparing
+	// full line strings there made a dense single-line document 48x slower
+	// (1.1ms -> 55ms for 800 matches on one long line). Interning pays the
+	// string hash once per match and reduces the hot comparison to an int.
+	type lineKey struct {
+		number int
+		text   string
+	}
 	type span struct {
 		line       int
 		start, end int
 		ok         bool
+	}
+	lineIDs := make(map[lineKey]int, len(matches))
+	lineIDFor := func(number int, text string) int {
+		k := lineKey{number: number, text: text}
+		if id, ok := lineIDs[k]; ok {
+			return id
+		}
+		id := len(lineIDs) + 1 // 1-based; 0 is the zero value of span.line
+		lineIDs[k] = id
+		return id
 	}
 
 	// Assign each match to a concrete occurrence of its text within the line.
@@ -52,10 +85,11 @@ func ResolveOverlaps(matches []detector.Match) []detector.Match {
 		if line == "" || m.Text == "" {
 			continue
 		}
-		byText, ok := cursor[m.LineNumber]
+		lineID := lineIDFor(m.LineNumber, line)
+		byText, ok := cursor[lineID]
 		if !ok {
 			byText = make(map[string]int)
-			cursor[m.LineNumber] = byText
+			cursor[lineID] = byText
 		}
 		from := byText[m.Text]
 		idx := strings.Index(line[from:], m.Text)
@@ -65,11 +99,11 @@ func ResolveOverlaps(matches []detector.Match) []detector.Match {
 			if idx < 0 {
 				continue
 			}
-			spans[i] = span{line: m.LineNumber, start: idx, end: idx + len(m.Text), ok: true}
+			spans[i] = span{line: lineID, start: idx, end: idx + len(m.Text), ok: true}
 			continue
 		}
 		start := from + idx
-		spans[i] = span{line: m.LineNumber, start: start, end: start + len(m.Text), ok: true}
+		spans[i] = span{line: lineID, start: start, end: start + len(m.Text), ok: true}
 		byText[m.Text] = start + len(m.Text)
 	}
 

--- a/internal/redactors/overlap_test.go
+++ b/internal/redactors/overlap_test.go
@@ -75,6 +75,50 @@ func TestResolveOverlaps_DifferentLinesNeverSubsume(t *testing.T) {
 	}
 }
 
+func TestResolveOverlaps_SameLineNumberDifferentSourceNeverSubsume(t *testing.T) {
+	// Regression: an Office package numbers lines per part, so a metadata match
+	// in docProps/core.xml and a body match in word/document.xml both arrive as
+	// "line 1" with offsets measured against DIFFERENT strings. Comparing those
+	// offsets is meaningless. Here the body SSN's span [9,20) falls numerically
+	// inside the author's [8,20), and the SSN was dropped before redaction was
+	// ever attempted — leaving it in cleartext in the "redacted" output.
+	//
+	// The two matches are on different lines despite sharing a line NUMBER, so
+	// neither may subsume the other.
+	matches := []detector.Match{
+		mkMatch("SSN", "449-87-4100", "body ssn 449-87-4100", 1),
+		mkMatch("AUTHOR_INFO", "Jane Analyst", "Author: Jane Analyst", 1),
+	}
+	got := ResolveOverlaps(matches)
+	if len(got) != 2 {
+		t.Fatalf("matches from different source text must both survive; got %v (len %d) — a dropped match is never redacted, so this is a cleartext leak", types(got), len(got))
+	}
+	var sawSSN bool
+	for _, m := range got {
+		if m.Type == "SSN" {
+			sawSSN = true
+		}
+	}
+	if !sawSSN {
+		t.Fatalf("the body SSN must survive: it lives in a different part than the metadata match, got %v", types(got))
+	}
+}
+
+func TestResolveOverlaps_SameLineNumberSameTextStillSubsumes(t *testing.T) {
+	// The complement of the case above: when the FullLine really is the same
+	// line, containment must still collapse to the widest span. This is what
+	// keeps the original card/phone fix working.
+	line := "card 4532 0151 1283 0366"
+	matches := []detector.Match{
+		mkMatch("VISA", "4532 0151 1283 0366", line, 1),
+		mkMatch("PHONE", "0151 1283 0366", line, 1),
+	}
+	got := ResolveOverlaps(matches)
+	if len(got) != 1 || got[0].Type != "VISA" {
+		t.Fatalf("identical FullLine must still collapse to the widest span, got %v", types(got))
+	}
+}
+
 func TestResolveOverlaps_PartialOverlapKeepsBoth(t *testing.T) {
 	// Overlapping but neither fully contains the other: keep both (dropping
 	// either would leave part of it exposed).


### PR DESCRIPTION
## The defect

`ResolveOverlaps` compared match offsets that were measured against **different source texts**.

An Office package numbers lines **per part**. So an `AUTHOR_INFO` match from `docProps/core.xml` and an `SSN` from `word/document.xml` both arrive as "line 1", with offsets computed against two unrelated strings. When the body span happened to fall numerically inside the metadata span, the body match was dropped as "contained" — before redaction was ever attempted.

**A dropped match is never redacted, so this is a cleartext leak.** It is also the worst shape of one:

- findings reported, exit code 0
- nothing logs `match_redaction_failed`
- every part of the output is byte-identical to the input

The output md5 *does* differ, but only because of zip re-compression — so a `cmp`/md5 check reports "differs" and misleads. The leak is only visible by comparing parts *inside* the zip.

## Reproduction

A one-word minimal pair in `dc:creator`:

| `dc:creator` | types reported | body SSN in output |
|---|---|---|
| `Jane` | `AUTHOR_INFO, SSN` | redacted |
| `Jane Analyst` | `AUTHOR_INFO, PERSON_NAME, SSN` | **cleartext** |

With the two-word name the author span `[8,20)` contains the SSN's `[9,20)` and is wider, so the SSN loses. Measured directly inside `ResolveOverlaps`:

```
PROBESPAN SSN         line=1 span=[9,20)  fullline="body ssn 449-87-4100"
PROBESPAN AUTHOR_INFO line=1 span=[8,20)  fullline="Author: Jane Analyst"
```

Every Office document has an author and most author names are two words, so this needs no unusual document and no attacker.

## The fix

A line's identity is its **number and its text**. Two matches whose `FullLine` differs are on different lines by definition and can never subsume one another.

Line identities are **interned to ints** rather than compared as strings, because the containment loop is O(n²) in match count. Comparing line strings there cost **48×** on a dense single-line document (1.1ms → 55ms at 800 matches). That was a regression I introduced and measured before committing.

## Scope

This fixes body PII being dropped as collateral. It does **not** change which parts are redactable: `docProps/core.xml` still cannot be selected by `isTextContainingFile` (it requires a `word/` prefix), so metadata values themselves remain un-redactable. That is a separate, pre-existing gap.

## Testing

Both new tests are **mutation-proven** — reverting `overlap.go` makes them fail with the expected diagnostic:

```
--- FAIL: TestResolveOverlaps_SameLineNumberDifferentSourceNeverSubsume
    matches from different source text must both survive; got [AUTHOR_INFO] (len 1)
--- FAIL: TestRepackage_MetadataMatchDoesNotSuppressBodyRedaction
    entry word/document.xml still contains the raw SSN
```

**Why existing coverage missed it:** `TestRepackage_RedactsSensitiveValues` looks thorough — it decompresses every entry and asserts the raw value is gone — but `fixtureMatches` sets no `Context.FullLine`. Every match was therefore position-unresolvable and kept, so the containment path was never entered at all. The new end-to-end test populates `FullLine` the way the scanner really does, and guards its own preconditions so it cannot silently become vacuous if someone edits the fixture strings.

### Per the test plan

| Gate | Result |
|---|---|
| Full suite | 61 packages ok |
| Golden corpus | ok |
| `-race` | ok, no races |
| 3-platform vet (darwin/linux/windows) | ok |
| Complexity / O(n²) | growth order unchanged vs baseline; ~1.15× constant factor |
| Regression (5 real inputs) | detection counts identical (10-MB docx 78→78) |
| Redaction sink | leak closed on 2 fixtures, no new leaks |
| Determinism | 1 distinct output over 10 runs |
| End-to-end timing | 0.25s → 0.24s on the 10MB docx |

### Union with open PRs

Base is `main`. Verified conflict-free **and** semantically green when merged with #247 and #249 (0 test failures in each union), since textual cleanliness alone has proven insufficient on this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)