### PR TITLE
fix(metadata): score metadata by value, and stop dropping custom properties

### DIFF
--- a/internal/validators/metadata/metadata_validator.go
+++ b/internal/validators/metadata/metadata_validator.go
@@ -15,6 +15,7 @@ import (
 	"github.com/awslabs/ferret-scan/v2/internal/observability"
 	"github.com/awslabs/ferret-scan/v2/internal/router"
 	"github.com/awslabs/ferret-scan/v2/internal/validators"
+	"github.com/awslabs/ferret-scan/v2/internal/validators/kwmatch"
 )
 
 // Import MetadataContent from router package to avoid duplication
@@ -248,6 +249,14 @@ func (v *Validator) initializeDefaultValidationRules() {
 			"comments", "description", "keywords", "subject",
 			"copyright", "rights", "copyrightnotice", "application",
 			"template",
+			// custom_ covers docProps/custom.xml properties. The extractor
+			// already surfaces these (they appear in --preprocess-only output),
+			// but without this entry validateWithPreprocessorRules filtered them
+			// out and they produced ZERO findings — a Classification property
+			// reading "SECRET - <codename>" was extracted, printed, and never
+			// reported. analyzeCustomPropertyRisk existed for exactly this and
+			// was unreachable for real documents.
+			"custom_",
 		},
 		ConfidenceBoosts: map[string]float64{
 			"manager":     0.4, // High confidence for manager info
@@ -1166,6 +1175,26 @@ func (v *Validator) validateWithPreprocessorRules(content router.MetadataContent
 
 		// Check if this line contains any sensitive fields for this preprocessor type
 		if v.containsSensitiveFieldForPreprocessor(line, rules.SensitiveFields) {
+			// Determine match type based on content and preprocessor type
+			matchType := v.determineMatchType(line, content.PreprocessorType)
+
+			// Extract just the sensitive value from the metadata field
+			sensitiveValue := v.extractSensitiveValue(line, matchType)
+
+			// Custom properties are mostly machine bookkeeping. Skip the values
+			// that cannot disclose anything, so enabling this field does not
+			// bury the ones that can.
+			//
+			// This is deliberately BEFORE the scoring calls below: profiling
+			// showed CalculateConfidence dominates this loop (33% of samples on
+			// a metadata-dense package), and running it on a value that is about
+			// to be discarded is pure waste. Skipping first keeps the cost of
+			// enabling custom properties proportional to the findings actually
+			// reported.
+			if matchType == "CUSTOM_PROPERTY" && isValuelessProperty(sensitiveValue) {
+				continue
+			}
+
 			confidence, checks := v.CalculateConfidence(line)
 
 			// Create context info for the line
@@ -1186,11 +1215,41 @@ func (v *Validator) validateWithPreprocessorRules(content router.MetadataContent
 
 			contextInfo.ConfidenceImpact = contextImpact
 
-			// Determine match type based on content and preprocessor type
-			matchType := v.determineMatchType(line, content.PreprocessorType)
+			// Apply the value-shape risk analysis this path used to skip.
+			//
+			// This function is the LIVE path for every registered preprocessor
+			// type (office/image/audio/video/document _metadata), while the
+			// per-field blocks in checkOfficeMetadataFields are only reached as
+			// a fallback for UNREGISTERED types. The per-field blocks call
+			// analyzeTemplatePathRisk / analyzeCustomPropertyRisk to score the
+			// field's VALUE; this one did not, so the analyzers were effectively
+			// dead for real documents. Measured: a template pointing at
+			// \\host\confidential\... scored 25 here versus 100 there, ranking a
+			// disclosed internal fileserver path BELOW a mundane company name.
+			//
+			// Additive only, and never applied to a type the risk function does
+			// not understand — see applyValueShapeRisk.
+			riskBoost, riskMeta := v.applyValueShapeRisk(matchType, line, sensitiveValue)
+			confidence += riskBoost
+			if confidence > 1.0 {
+				confidence = 1.0
+			} else if confidence < 0.0 {
+				confidence = 0.0
+			}
 
-			// Extract just the sensitive value from the metadata field
-			sensitiveValue := v.extractSensitiveValue(line, matchType)
+			matchMetadata := map[string]interface{}{
+				"metadata_type":     matchType,
+				"validation_checks": checks,
+				"context_impact":    contextImpact,
+				"source":            "preprocessed_content",
+				"original_file":     content.SourceFile,
+				"preprocessor_type": content.PreprocessorType,
+				"preprocessor_name": content.PreprocessorName,
+				"full_field":        line, // Keep the original field for reference
+			}
+			for k, val := range riskMeta {
+				matchMetadata[k] = val
+			}
 
 			matches = append(matches, detector.Match{
 				Text:       sensitiveValue,
@@ -1200,16 +1259,7 @@ func (v *Validator) validateWithPreprocessorRules(content router.MetadataContent
 				Filename:   content.SourceFile,
 				Validator:  "metadata",
 				Context:    contextInfo,
-				Metadata: map[string]interface{}{
-					"metadata_type":     matchType,
-					"validation_checks": checks,
-					"context_impact":    contextImpact,
-					"source":            "preprocessed_content",
-					"original_file":     content.SourceFile,
-					"preprocessor_type": content.PreprocessorType,
-					"preprocessor_name": content.PreprocessorName,
-					"full_field":        line, // Keep the original field for reference
-				},
+				Metadata:   matchMetadata,
 			})
 		}
 	}
@@ -1238,6 +1288,15 @@ func (v *Validator) containsSensitiveFieldForPreprocessor(line string, sensitive
 // determineMatchType determines the match type based on content and preprocessor type
 func (v *Validator) determineMatchType(line, preprocessorType string) string {
 	lineLower := strings.ToLower(line)
+
+	// Custom document properties, checked FIRST because the field name is
+	// author-chosen and can contain any of the substrings the checks below look
+	// for: "Custom_DeviceOwner" would otherwise be typed DEVICE_INFO and
+	// "Custom_ProjectManager" MANAGER_INFO, and neither would reach the
+	// custom-property risk analysis. The prefix is what the extractor emits.
+	if strings.HasPrefix(lineLower, "custom_") {
+		return "CUSTOM_PROPERTY"
+	}
 
 	// GPS-related patterns
 	if strings.Contains(lineLower, "gps") || strings.Contains(lineLower, "latitude") || strings.Contains(lineLower, "longitude") {
@@ -2648,6 +2707,123 @@ type CustomPropertyRisk struct {
 	PropertyName    string
 }
 
+// isValuelessProperty reports whether a custom-property VALUE cannot disclose
+// anything, no matter what the property is named.
+//
+// Custom document properties are dominated in practice by sensitivity-label and
+// content-management bookkeeping. Measured over 119 real documents, enabling the
+// field emitted 1,228 findings, of which 488 were Microsoft Purview
+// MSIP_Label_<guid>_* sub-properties: _Enabled "true", _ContentBits "0",
+// _Method "Standard", _SetDate, _SiteId, _ActionId. None of those reveal
+// anything about the document, and reporting them buries the sub-property that
+// does — _Name, which holds the human-readable classification (measured values
+// included "Amazon Confidential" and "Amazon Pending_Classification").
+//
+// The test is on the VALUE, not the property name, deliberately. A name-based
+// denylist would be a denylist of the exact form BSC1 warns about: incomplete
+// by construction, and it would drop a genuinely sensitive value that happened
+// to sit under a boilerplate-looking name. Judging the value keeps the rule
+// honest — a boolean, a bare integer, a GUID, a timestamp, or an empty string
+// carries no disclosure regardless of where it appears, while any human-readable
+// string is kept and scored normally.
+func isValuelessProperty(value string) bool {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return true
+	}
+
+	switch strings.ToLower(trimmed) {
+	case "true", "false", "standard", "none", "null", "n/a":
+		return true
+	}
+
+	// Bare integers ("0"), integer tuples ("50, 3, 0, 1"), GUIDs, and ISO
+	// timestamps are all machine identifiers or counters. A value made only of
+	// digits, hex, and structural punctuation has no prose in it to disclose.
+	hasLetter := false
+	for _, r := range trimmed {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
+			hasLetter = true
+			break
+		}
+	}
+	if !hasLetter {
+		return true
+	}
+
+	// Everything below is a machine identifier of some shape, and all of those
+	// forms are single-token. Any whitespace means prose, so this one check
+	// short-circuits the regexes for every human-readable value — which is the
+	// case worth keeping fast, since those are the values that become findings.
+	// ("Amazon Confidential", "Nasdaq - Internal Use: ..." exit here.)
+	if strings.ContainsAny(trimmed, " \t") {
+		return false
+	}
+
+	// GUID: 8-4-4-4-12 hex. Purview writes several per label.
+	if guidPattern.MatchString(trimmed) {
+		return true
+	}
+
+	// Opaque machine identifiers: a long unbroken hex/base64 run is a digest or
+	// an internal id, not prose. SharePoint's ContentTypeId
+	// ("0x010100D3F06DC0...") and similar per-library ids are the common case;
+	// hex has letters, so the has-a-letter check above lets them through.
+	if opaqueIdentifierPattern.MatchString(trimmed) {
+		return true
+	}
+
+	// ISO-8601 timestamp, e.g. 2026-01-14T21:22:37Z. The only letters are the
+	// T/Z separators, so the hasLetter check above does not catch these.
+	return isoTimestampPattern.MatchString(trimmed)
+}
+
+var (
+	guidPattern         = regexp.MustCompile(`^\{?[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\}?$`)
+	isoTimestampPattern = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(:\d{2})?(\.\d+)?(Z|[+-]\d{2}:?\d{2})?$`)
+	// 0x-prefixed or bare hex of 16+ digits, or a base64-ish run of 20+ chars.
+	// The length floors keep short human words (a "Privileged" label, a
+	// "Confidential" marker) out of this branch.
+	opaqueIdentifierPattern = regexp.MustCompile(`^(?:0[xX][0-9a-fA-F]{16,}|[0-9a-fA-F]{16,}|[A-Za-z0-9+/]{20,}={0,2})$`)
+)
+
+// applyValueShapeRisk returns the additive confidence boost and the metadata
+// keys for a finding whose VALUE carries an intrinsic risk signal — a UNC path
+// that discloses an internal server, a classification marker, a project
+// codename, a user directory that names an employee.
+//
+// It exists so the preprocessor-rule path and the per-field fallback path score
+// a value identically instead of drifting apart. Only types whose risk shape is
+// actually understood are handled; anything else returns a zero boost, so
+// adding a new metadata type can never silently pick up a wrong score.
+//
+// The boost is strictly ADDITIVE. It is deliberately incapable of lowering a
+// confidence, because metadata values are entirely attacker-controlled: a
+// subtractive rule here would hand an attacker a suppression oracle (they could
+// append a token to a field and demote a real finding below the reporting
+// threshold — the TM-11 shape). Raising a score cannot hide anything.
+func (v *Validator) applyValueShapeRisk(matchType, line, value string) (float64, map[string]interface{}) {
+	switch matchType {
+	case "TEMPLATE_INFO":
+		risk := v.analyzeTemplatePathRisk(value)
+		return risk.ConfidenceBoost, map[string]interface{}{
+			"template_risk_level":   risk.RiskLevel,
+			"template_risk_factors": risk.RiskFactors,
+		}
+
+	case "CUSTOM_PROPERTY":
+		risk := v.analyzeCustomPropertyRisk(line)
+		return risk.ConfidenceBoost, map[string]interface{}{
+			"custom_property_name":         risk.PropertyName,
+			"custom_property_risk_level":   risk.RiskLevel,
+			"custom_property_risk_factors": risk.RiskFactors,
+		}
+
+	default:
+		return 0, nil
+	}
+}
+
 // analyzeTemplatePathRisk analyzes template paths for security risks
 func (v *Validator) analyzeTemplatePathRisk(templatePath string) TemplatePathRisk {
 	risk := TemplatePathRisk{
@@ -2757,7 +2933,17 @@ func (v *Validator) analyzeCustomPropertyRisk(line string) CustomPropertyRisk {
 			}
 
 			// PII and employee information (HIGH)
-			piiFields := []string{"employee", "ssn", "social", "id", "badge", "clearance"}
+			//
+			// "id" is matched on a whole-word boundary, not as a substring.
+			// Measured over 119 real documents: a plain strings.Contains fired on
+			// the SharePoint/Purview plumbing that dominates real custom
+			// properties — ContentTypeId, ComplianceAssetId, _dlc_DocIdItemGuid —
+			// promoting 45 occurrences of pure boilerplate to HIGH. kwmatch
+			// treats '_' as a boundary, so "user_id" and "employee_id" still
+			// match while "contenttypeid" does not. Compound names with no
+			// separator ("employeeid", "badgeid") are still caught by their own
+			// keyword in this same list.
+			piiFields := []string{"employee", "ssn", "social", "badge", "clearance"}
 			for _, field := range piiFields {
 				if strings.Contains(propNameLower, field) {
 					risk.RiskFactors = append(risk.RiskFactors, "Contains PII: "+field)
@@ -2765,6 +2951,13 @@ func (v *Validator) analyzeCustomPropertyRisk(line string) CustomPropertyRisk {
 					if risk.RiskLevel != "CRITICAL" {
 						risk.RiskLevel = "HIGH"
 					}
+				}
+			}
+			if kwmatch.ContainsLower(propNameLower, "id") {
+				risk.RiskFactors = append(risk.RiskFactors, "Contains PII: id")
+				risk.ConfidenceBoost += 0.4
+				if risk.RiskLevel != "CRITICAL" {
+					risk.RiskLevel = "HIGH"
 				}
 			}
 

--- a/internal/validators/metadata/value_shape_risk_test.go
+++ b/internal/validators/metadata/value_shape_risk_test.go
@@ -1,0 +1,208 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package metadata
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/router"
+)
+
+// confidenceFor returns the confidence of the first match of the given type, or
+// -1 when no such match was emitted.
+func confidenceFor(t *testing.T, pt, line, wantType string) float64 {
+	t.Helper()
+	v := NewValidator()
+	body := "--- " + pt + " ---\n" + line
+	matches, err := v.ValidateMetadataContent(router.MetadataContent{
+		Content:          body,
+		SourceFile:       "probe.docx",
+		PreprocessorType: pt,
+	})
+	if err != nil {
+		t.Fatalf("ValidateMetadataContent(%q): %v", pt, err)
+	}
+	for _, m := range matches {
+		if m.Type == wantType {
+			return m.Confidence
+		}
+	}
+	return -1
+}
+
+// TestLivePathAppliesTemplateValueShapeRisk is the regression guard for the
+// scoring loss. validateWithPreprocessorRules is the path every REGISTERED
+// preprocessor type takes; the per-field blocks in checkOfficeMetadataFields are
+// only a fallback for unregistered types. The registered path labelled a finding
+// TEMPLATE_INFO but never called analyzeTemplatePathRisk, so the risk analysis
+// was dead for real documents: a template disclosing an internal fileserver
+// ranked BELOW a mundane company name.
+func TestLivePathAppliesTemplateValueShapeRisk(t *testing.T) {
+	const (
+		sensitive = `Template: \\corp-fs01\confidential\nightjar\t.dotx`
+		mundane   = `Template: Normal.dotm`
+	)
+
+	got := confidenceFor(t, PreprocessorTypeOfficeMetadata, sensitive, "TEMPLATE_INFO")
+	base := confidenceFor(t, PreprocessorTypeOfficeMetadata, mundane, "TEMPLATE_INFO")
+
+	if got < 0 || base < 0 {
+		t.Fatalf("expected a TEMPLATE_INFO match for both inputs, got sensitive=%.0f mundane=%.0f", got, base)
+	}
+
+	// The whole point of the fix: a UNC path into a share named "confidential"
+	// must outrank boilerplate by a band, not by a rounding error.
+	if got < 90 {
+		t.Errorf("a UNC template path into a share named 'confidential' scored %.0f, want >= 90 (HIGH): the value-shape risk analysis is not being applied on the live path", got)
+	}
+	if got-base < 40 {
+		t.Errorf("sensitive template scored %.0f vs mundane %.0f (gap %.0f): the gap must be large enough to rank one above the other, not a flat offset", got, base, got-base)
+	}
+}
+
+// TestLivePathEmitsCustomProperties guards the harder half: custom document
+// properties were extracted and printed by --preprocess-only but produced ZERO
+// findings, because office_metadata's SensitiveFields had no custom_ entry and
+// validateWithPreprocessorRules filters on that list. A Classification property
+// reading "SECRET - <codename>" was visible in the preprocessed text and never
+// reported.
+func TestLivePathEmitsCustomProperties(t *testing.T) {
+	got := confidenceFor(t, PreprocessorTypeOfficeMetadata,
+		`Custom_Classification: SECRET - Project Nightjar`, "CUSTOM_PROPERTY")
+	if got < 0 {
+		t.Fatalf("a Custom_Classification property produced NO CUSTOM_PROPERTY finding: it is extracted and printed by --preprocess-only, so failing to report it is a silent disclosure gap")
+	}
+	if got < 90 {
+		t.Errorf("Custom_Classification 'SECRET - ...' scored %.0f, want >= 90 (HIGH)", got)
+	}
+}
+
+// TestCustomPropertyTypeWinsOverSubstringMatch pins the ordering in
+// determineMatchType. Custom property names are author-chosen, so a name like
+// Custom_ProjectManager contains "manager" and would be typed MANAGER_INFO by
+// the substring checks — which would route it away from the custom-property risk
+// analysis entirely.
+func TestCustomPropertyTypeWinsOverSubstringMatch(t *testing.T) {
+	v := NewValidator()
+	for _, line := range []string{
+		"Custom_ProjectManager: Jane Analyst",
+		"Custom_DeviceOwner: Jane Analyst",
+		"Custom_AuthorNotes: internal",
+		"Custom_CameraSerial: SN-1",
+	} {
+		if got := v.determineMatchType(line, PreprocessorTypeOfficeMetadata); got != "CUSTOM_PROPERTY" {
+			t.Errorf("determineMatchType(%q) = %q, want CUSTOM_PROPERTY: a substring in an author-chosen property name must not steal the type and bypass custom-property risk analysis", line, got)
+		}
+	}
+}
+
+// TestValuelessPropertiesAreSkipped is the false-positive guard, and the numbers
+// in it are measured rather than assumed. Enabling custom properties on a corpus
+// of 119 real documents emitted 1,228 findings; 488 were Microsoft Purview
+// MSIP_Label_<guid>_* bookkeeping. Filtering on the VALUE (not the property
+// name) brought the delta to 186 while keeping every human-readable
+// classification label.
+func TestValuelessPropertiesAreSkipped(t *testing.T) {
+	// Values measured from real documents that disclose nothing.
+	valueless := []string{
+		"true", "false", "0", "Standard", "None", "n/a", "",
+		"50, 3, 0, 1",                          // MSIP_Label _Tag
+		"5280104a-472d-4538-9ccf-1e1d0efe8b1b", // _SiteId GUID
+		"2026-01-14T21:22:37Z",                 // _SetDate
+		"0x010100D3F06DC058215A4D90BF",         // SharePoint ContentTypeId
+	}
+	for _, v := range valueless {
+		if !isValuelessProperty(v) {
+			t.Errorf("isValuelessProperty(%q) = false, want true: machine bookkeeping must not be reported, it buries the values that matter", v)
+		}
+	}
+
+	// Values measured from real documents that DO disclose something. These are
+	// the reason the field is surfaced at all, so a filter that drops any of
+	// them has defeated its own purpose.
+	meaningful := []string{
+		"Amazon Confidential",
+		"Amazon Pending_Classification",
+		"Privileged",
+		"Not Classified",
+		"Nasdaq - Internal Use: Distribution limited to personnel",
+		"SECRET - Project Nightjar",
+		"CC-99213-NIGHTJAR",
+	}
+	for _, v := range meaningful {
+		if isValuelessProperty(v) {
+			t.Errorf("isValuelessProperty(%q) = true, want false: this is a real classification/disclosure value and dropping it defeats the point of surfacing custom properties", v)
+		}
+	}
+}
+
+// TestValueShapeRiskIsAdditiveOnly is a security invariant, not a behaviour
+// test. Metadata values are entirely attacker-controlled: anyone can set
+// dc:title or a custom property to any string. A subtractive rule here would let
+// an attacker append a token to demote a real finding below the reporting
+// threshold, and a finding that is not reported is never redacted (the TM-11
+// suppression-oracle shape). applyValueShapeRisk must therefore never return a
+// negative boost, for any input.
+func TestValueShapeRiskIsAdditiveOnly(t *testing.T) {
+	v := NewValidator()
+	adversarial := []string{
+		"Template: Normal.dotm",
+		"Template: ",
+		`Template: \\host\share\x.dotx test sample example dummy fake`,
+		"Custom_Classification: test sample example dummy ignore",
+		"Custom_X: " + strings.Repeat("a", 4096),
+		"Custom_: ",
+		"Template: ../../../etc/passwd",
+		"Custom_Budget: not-a-number",
+	}
+	for _, line := range adversarial {
+		for _, mt := range []string{"TEMPLATE_INFO", "CUSTOM_PROPERTY", "COMPANY_INFO", "UNKNOWN_TYPE"} {
+			boost, _ := v.applyValueShapeRisk(mt, line, strings.TrimSpace(strings.TrimPrefix(line, "Template:")))
+			if boost < 0 {
+				t.Errorf("applyValueShapeRisk(%q, %q) returned %.2f: a negative boost is an attacker-controllable suppression oracle", mt, line, boost)
+			}
+		}
+	}
+}
+
+// TestValueShapeRiskIgnoresUnknownTypes keeps the switch honest: a metadata type
+// whose risk shape is not understood must get exactly zero, so adding a new type
+// later cannot silently inherit another type's scoring.
+func TestValueShapeRiskIgnoresUnknownTypes(t *testing.T) {
+	v := NewValidator()
+	for _, mt := range []string{"COMPANY_INFO", "APPLICATION_INFO", "AUTHOR_INFO", "GPS", ""} {
+		boost, meta := v.applyValueShapeRisk(mt, `Template: \\host\confidential\x`, `\\host\confidential\x`)
+		if boost != 0 || meta != nil {
+			t.Errorf("applyValueShapeRisk(%q, ...) = (%.2f, %v), want (0, nil)", mt, boost, meta)
+		}
+	}
+}
+
+// TestCustomPropertyIDIsWholeWord is the measured false-positive fix. A plain
+// strings.Contains on "id" fired inside the SharePoint plumbing that dominates
+// real custom properties — ContentTypeId, ComplianceAssetId, _dlc_DocIdItemGuid
+// — promoting 45 corpus occurrences of pure boilerplate to HIGH.
+func TestCustomPropertyIDIsWholeWord(t *testing.T) {
+	v := NewValidator()
+
+	// Must NOT be flagged as containing an id.
+	for _, name := range []string{"ContentTypeId", "ComplianceAssetId", "_dlc_DocIdItemGuid", "GrammarlyDocumentId"} {
+		risk := v.analyzeCustomPropertyRisk("Custom_" + name + ": someValue")
+		for _, f := range risk.RiskFactors {
+			if strings.Contains(f, "PII: id") {
+				t.Errorf("property %q was flagged %q: 'id' must match on a word boundary, not as a substring of machine plumbing", name, f)
+			}
+		}
+	}
+
+	// Must still be flagged: '_' is a boundary in kwmatch, and compound names
+	// are caught by their own keyword in the PII list.
+	for _, name := range []string{"employee_id", "user_id", "EmployeeID", "BadgeId"} {
+		risk := v.analyzeCustomPropertyRisk("Custom_" + name + ": 88213")
+		if len(risk.RiskFactors) == 0 {
+			t.Errorf("property %q produced no risk factors: an employee/badge identifier must still be recognised", name)
+		}
+	}
+}


### PR DESCRIPTION
Two defects on the code path **every real document takes**. Both make sensitive metadata rank below mundane metadata, or vanish entirely.

## Defect 1 — the value-shape risk analysis was dead code for real files

`validateWithPreprocessorRules` is the live path for every *registered* preprocessor type (`office_metadata`, `image_metadata`, `audio_metadata`, `video_metadata`, `document_metadata`). The per-field blocks in `checkOfficeMetadataFields` are only a **fallback for unregistered types**.

The live path labelled a finding `TEMPLATE_INFO` but never called `analyzeTemplatePathRisk`. Same input, two paths:

| `Template:` value | live path | fallback path |
|---|---|---|
| `\\corp-fs01\confidential\nightjar\t.dotx` | **25** | 100 |
| `Normal.dotm` (mundane) | 25 | 35 |

A UNC path disclosing an internal fileserver scored **identically to stock boilerplate**, and both ranked *below* a mundane company name at 55. An operator triaging by confidence reads the disclosure as the least interesting row on the page.

After the fix that value scores **90** and sorts to the top; mundane moves only 25 → 35.

## Defect 2 — custom document properties produced ZERO findings

The extractor surfaces them — they are printed by `--preprocess-only`:

```
--- Custom Properties ---
Custom_Classification: SECRET - Project Nightjar
Custom_CostCenter: CC-99213-NIGHTJAR
```

…but `office_metadata`'s `SensitiveFields` had no `custom_` entry, and this path filters on that list. **Extracted, printed, never reported.** `analyzeCustomPropertyRisk` existed for exactly this and was unreachable.

`determineMatchType` also had no `custom_` case, so anything that did get through was typed by a substring in the author-chosen property name — `Custom_ProjectManager` → `MANAGER_INFO`, `Custom_DeviceOwner` → `DEVICE_INFO` — routing it away from the risk analysis regardless.

## False-positive cost, measured on 119 real documents

The first version of this change was **not acceptable** and the corpus is what caught it:

| version | findings delta | what happened |
|---|---|---|
| v1 (naive enable) | **+1228** | 488 were Microsoft Purview `MSIP_Label_<guid>_*` bookkeeping — `_Enabled: "true"`, `_ContentBits: "0"`, `_SiteId`, `_SetDate` |
| v2 (value filter) | +258 | SharePoint `ContentTypeId` hex still leaking through |
| **v3 (shipped)** | **+186** | 194 survivors, all human-readable labels |

Survivors are the right ones: `Amazon Confidential` (92), `Amazon Pending_Classification` (68), `Privileged`, `Not Classified`, `Nasdaq - Internal Use: Distribution limited to…`.

**The filter judges the VALUE, not the property name.** A name denylist is incomplete by construction (BSC1) and would drop a genuinely sensitive value that happened to sit under a boilerplate-looking name. A boolean, a bare integer, a GUID, a timestamp, or an opaque hex id discloses nothing *wherever* it appears.

## Also: a measured FP in the PII check

`"id"` was matched as a **substring**, so it fired inside `ContentTypeId`, `ComplianceAssetId`, `_dlc_DocIdItemGuid`, `GrammarlyDocumentId` — **45 corpus occurrences of pure SharePoint plumbing promoted to HIGH**. Now uses the shared `kwmatch`, whose `_`-is-a-boundary semantics keep `employee_id` and `user_id` matching while rejecting `contenttypeid`.

## Security: additive only

Metadata values are **entirely attacker-controlled** — anyone can set `dc:title` or a custom property to any string. A subtractive rule here would be a suppression oracle: append a token, demote a real finding below the reporting threshold, and an unreported finding is never redacted (the TM-11 shape this repo has hit before). `applyValueShapeRisk` can only ever raise a score, and `TestValueShapeRiskIsAdditiveOnly` asserts that across adversarial inputs. Unknown types get exactly zero, so a new metadata type cannot silently inherit another's scoring.

## Performance

The valueless-value skip runs **before** the scoring calls. Profiling showed `CalculateConfidence` dominates this loop (33% of samples), and the first version paid it on values it then discarded:

| n metadata lines | main | v1 | shipped |
|---|---|---|---|
| 800 | 1.40ms | 6.72ms (**4.79×**) | 2.70ms (1.93×) |

Growth stays **linear** (2.05/1.99/2.04 per doubling) — no complexity change. The residual 1.93× is the pre-existing per-finding cost applied to the 320 findings that *should* be reported. End-to-end on 30 real documents: **1.58s → 1.66s**; on the 10MB docx, 0.08s → 0.07s.

## Testing

All **four** production changes are independently **mutation-proven** — reverting each one alone fails a test with the expected diagnostic:

```
revert applyValueShapeRisk call  -> scored 75, want >= 90: risk analysis not being applied
remove custom_ from fields       -> produced NO CUSTOM_PROPERTY finding: silent disclosure gap
remove determineMatchType case   -> = "MANAGER_INFO", want CUSTOM_PROPERTY: substring stole the type
revert id to substring           -> "ContentTypeId" was flagged "Contains PII: id"
```

### Per the test plan

| Gate | Result |
|---|---|
| Full suite | 61 packages ok |
| Golden corpus | ok |
| `-race` | ok, no races |
| 3-platform vet (darwin/linux/windows) | ok |
| Complexity / O(n²) | linear before and after; constant factor 4.79× → 1.93× |
| End-to-end timing | 1.58s → 1.66s on 30 real docs |
| Determinism | 1 distinct result over 10 runs |
| FP corpus (119 real docs) | +186 findings, every delta accounted for by type, **0 findings lost** |

### One cross-PR interaction worth flagging

The corpus diff showed `PERSON_NAME` shifting **+5** on unrelated findings. Root cause: my new metadata findings make `len(metadataMatches) > 0` true, which fires the **+5 cross-path correlation boost** in `dual_path_bridge.go` on document findings that have nothing to do with metadata. That is precisely the contamination #249 removes — exposed by this PR, not caused by it, and it disappears once #249 lands.

`AUTHOR_INFO -2` / `METADATA -6` are **reclassifications, not losses**: those values are custom properties, now correctly typed `CUSTOM_PROPERTY` with confidence 30 → 50. Verified nothing dropped out of the report.

### Union with open PRs

Base is `main`. Verified conflict-free **and** semantically green when merged with #247, #249 and #250 (0 test failures in each union).

Note: `HyperlinkBase` (e.g. a UNC path to an internal share) is **not extracted at all**, so it is out of scope here — an extractor gap, not a scoring one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)