### PR TITLE
perf(redact): stop rescanning the whole document once per match

### DIFF
--- a/docs/proposals/FINAL_PLAN.md
+++ b/docs/proposals/FINAL_PLAN.md
@@ -1,0 +1,164 @@
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Final plan: what to fix, in what order, and why
+
+Status: 2026-08-01. Supersedes the ordering in `ARCHITECTURE_AND_PLAN.md`; that document remains
+the architectural description and the evidence record.
+
+This plan was written after an independent verification pass in which I re-tested the claims I had
+been repeating. **Three of them were wrong or incomplete**, and correcting them changed the
+ordering. Those corrections are in §5, because a plan built on unverified claims is worth less than
+the claims it rests on.
+
+---
+
+## 1. What changed from my own verification
+
+| Claim I had been carrying | What testing showed |
+|---|---|
+| "`--limit` is ignored by junit/csv/gitlab-sast/sarif" | **Wrong.** All four honour it. The real defect is worse: **four formats truncate SILENTLY at the DEFAULT limit of 200** — `sarif`, `csv`, `junit` emit 200 of 300 findings and never disclose the true total. `json`, `yaml`, `text`, `gitlab-sast` do disclose it. A CI gate consuming SARIF sees 200 of 300 by default. |
+| "reported ≠ redacted at exit 0, all matches log `match_redaction_failed`" | **Incomplete and understated.** Reproduced with a worse shape: a `.docx` where **every part comes out byte-identical** — zero redaction applied — while 5 findings are reported at rc=0 and **nothing** logs `match_redaction_failed`. The output md5 differs only from zip re-compression, so a `cmp`/md5 check reports "differs" and misleads. |
+| "the phone veto is a phone problem" | **Wrong — it is systemic.** The same prefix-a-character trick suppresses `VISA`, `DRIVERS_LICENSE` and `MEDICARE_MBI`, and the sink confirms all three sit in cleartext in the redacted output. This is 3+ validators, not one, which changes the fix from a one-file change to a pattern change. |
+
+And one hypothesis I would have accepted that turned out **false**:
+
+- "confidence is saturated at 100, so the bands carry little information." **Not true.** Over varied
+  content: 11 findings, **10 distinct confidence values** spanning 33–100, only 2 at the ceiling.
+  The scale is working. I have removed the recalibration item that assumed otherwise.
+
+One reassuring measurement worth stating, because it is the counterweight to the veto findings:
+
+- The negatives that the vetoes exist to suppress **are** suppressed correctly. A git SHA, a
+  version string `1.2.3.4`, and an `ami-050451375729` resource id all produce **zero** findings.
+  Any veto fix must preserve this. Removing the vetoes outright would be a bad trade.
+
+---
+
+## 2. The confirmed defect list, ranked
+
+Ranked by (likelihood × impact). "Ordinary" means no attacker and no unusual document.
+
+| # | Defect | Who it affects | Sink verified |
+|---|---|---|---|
+| **1** | **Office redactor silent no-op** — a `.docx` can come out with every part byte-identical, findings reported, rc=0, no error | **Ordinary.** Any `.docx` whose XML the redactor's matcher does not handle | Yes — SSN + PAN cleartext in "redacted" output |
+| **2** | **Adjacency veto drops findings across ≥3 validators** — `xaccount4532015112830366`, `ref-D123-4567-8901`, `x1EG4-TE5-MK73` all undetected | Mostly **crafted**, but plausible by accident in machine-generated data (IDs concatenated without separators) | Yes — card, licence, MBI all cleartext |
+| **3** | **Nested container body unscanned at depth 2** — `.docx` inside `.docx` | **Ordinary.** A document embedded in a document | Yes — SSN cleartext inside `word/media/inner.docx` |
+| **4** | **Silent truncation at the default limit** in `sarif`, `csv`, `junit` | **Ordinary**, and worst in CI where SARIF is machine-consumed | N/A — omission, not a redaction failure |
+| **5** | **9 of 11 confidence-policy keys unreachable** — `log_penalty`/`code_penalty` never fire; `tabular_boost` gives a CSV **+40** on an SSN | **Ordinary.** Over-reports on logs and source, over-trusts CSVs | N/A — precision, not a leak |
+| **6** | Same-span double report (`NPI` 100 + `PHONE` 10 on identical bytes) | Ordinary, cosmetic | Verified **not** a leak: redaction emits one token; bands unaffected |
+
+Defects 1–3 are the same failure class: **silent and lossy**. The tool cannot tell the operator that
+it failed to protect something. That class is what this plan is organised around.
+
+---
+
+## 3. The plan
+
+### Phase 0 — make silent loss impossible (do this first, it is cheap)
+
+The reason defects 1–3 survived is not that they are subtle; it is that **nothing asserts the
+sink**. One invariant, enforced once, converts all three from silent to loud:
+
+> **Every reported finding must be either demonstrably absent from the redaction output, or
+> reported as unredacted.** No third outcome.
+
+`internal/parallel/parallel_processor.go` already has an `unredactedFiles` diagnostic for exactly
+this, and it does **not** fire for defect 1 — so the plumbing exists and the check is missing.
+Add it, wire it to `--fail-on-incomplete` (exit 3) as #238 did for unreadable files, and defect 1
+becomes a loud error rather than a false success.
+
+This is small, it is a correctness fix in its own right, and every subsequent fix inherits a real
+gate. Doing it first means defects 1–3 cannot silently regress later.
+
+### Phase 1 — the confirmed leaks
+
+| Order | Item | Notes |
+|---|---|---|
+| 1 | **Office redactor no-op** (defect 1) | Root cause not yet established — the discriminator between a fixture that redacts and one that does not is something in the XML declaration. Investigate `internal/redactors/office/` re-location (it re-extracts its own text and does `strings.Index`). Phase 0's invariant makes this fail loudly even before the root cause is fixed. |
+| 2 | **Adjacency veto → demote, never drop** (defect 2) | Now a **pattern change across ≥3 validators**, not one file. Reuse `ConfidenceCeilingKey`/`clampToCeiling` from #241: keep the veto's precision benefit, emit at LOW so the value is still reported and still redacted. **Must preserve** the negatives measured in §1 — git SHAs, version strings, `ami-` ids must stay at zero findings. |
+| 3 | **Nested container body text** (defect 3) | Must land **with** a recursion depth cap (no depth guard exists anywhere) or the fix becomes a zip-bomb amplifier. Warn when the cap is hit, reusing #238's empty-extraction plumbing. |
+| 4 | **Truncation disclosure** (defect 4) | Every format must state the true total when it truncates. Cheap, and it removes a silent failure from CI. |
+| 5 | `docProps/custom.xml` property-value vector | Last open injection surface. |
+| 6 | `TestGoldenRedact` cannot cover `FileCases` | The test gap that let defect 1 and defect 3 hide. Worth doing early — it is the golden-level expression of Phase 0's invariant. |
+| 7 | Delete the 9 unreachable adjustment keys (defect 5, half) | Deleting dead policy is unambiguous. **Re-adding** it deliberately is a Phase 3 question. |
+| 8 | Housekeeping | `.gitignore` for `.perfbase/`, stale branches, ship `fix/fake-value-hardcap`. |
+
+Items 1–3 are independent PRs against `main`. Item 6 should land before or alongside them so they
+get golden coverage as they go in.
+
+### Phase 2 — the measurement capability
+
+**Correction (2026-08-01).** An earlier draft of this plan proposed "add a complexity dimension
+so the timing discipline becomes an automated gate". That gate **already exists**:
+`internal/goldencorpus/complexity_guard_test.go` (plus `complexity_generators_test.go`) has 18
+validator targets, non-vacuity `minMatches` floors, `wantMatchGrowth` assertions, a 4x-input
+ratio ceiling and a `-race` multiplier, and it passes. The mechanism is built.
+
+The real gap is **coverage past the validator boundary**: every target calls
+`validator.ValidateContent` directly to isolate validator cost from orchestration, so
+`grep -ci redact` on the guard returns **0**. Redaction, suppression, `ResolveOverlaps` and
+router assembly have no targets — which is exactly why a superlinear redaction path
+(~4x cost per input doubling, ~78s on ~1MB of dense matches against a 100MB `MaxFileSize`)
+sat in `main` with everything green.
+
+A redaction target is now in `complexity_guard_redaction_test.go`, with an honest caveat
+recorded there: measured ratios before and after the constant-factor fix **overlap**
+(12.6–13.7 vs 10.0–13.2), so a ratio ceiling can only catch a new order-of-magnitude
+regression — it cannot prove linearity, and redaction remains superlinear. Making redaction
+genuinely linear needs match byte offsets carried from detection, which is a larger change.
+
+A labelled corpus and `make score` (precision/recall/F1 per validator, CI-gated), as
+`ARCHITECTURE_AND_PLAN.md` §4 describes. Two additions that this verification pass justifies:
+
+- **Structural cases, not just value cases.** Every expensive defect found today was structural —
+  nested containers, unhandled XML shapes, adjacency. A corpus of `ssn-in-a-line` fixtures would
+  have scored 100% while defects 1–3 all sat there.
+- **The negatives from §1 as permanent cases.** Git SHAs, version strings, resource ids, GUIDs,
+  digests. They are what the vetoes protect, so they are what a veto fix must not break.
+
+### Phase 3 — the measured decisions
+
+Unchanged, minus one item. Each of these is a coin flip today and should be decided by the harness:
+`tabular_boost` (+40, currently unchosen), whether to re-add the doc-type/domain policy,
+same-span arbitration policy, the co-occurrence reranker, and per-validator veto trigger sets.
+
+**Dropped:** confidence recalibration. §1 shows the scale is not saturated, so the premise was false.
+
+---
+
+## 4. The single highest-value next action
+
+**Phase 0: the sink invariant.**
+
+Not the biggest defect — that is the Office redactor no-op — but the highest value, because it
+turns the entire class from *silent* to *loud*. Defects 1, 2 and 3 were all found by manually
+building a fixture and manually reading inside a zip. That does not scale and it clearly did not
+catch these. One assertion in the pipeline catches all three, catches the next one nobody has
+thought of, and makes every later fix verifiable rather than assumed.
+
+Then Phase 1 item 1, because a tool that hands you an unredacted file while reporting success is
+the worst thing this codebase can do.
+
+---
+
+## 5. Honest limits of this review
+
+- **Defect 1 is not root-caused.** I established that it reproduces, that every part is
+  byte-identical, and that the discriminator involves the XML declaration form. I did **not** prove
+  the mechanism. Phase 0 is designed to be valuable regardless.
+- **Defect 2's scope is a lower bound.** I proved 3 validators beyond phone. There are ~15
+  veto-shaped functions; the rest are unaudited, so the pattern change may be larger.
+- **My own error rate in this session was high.** Three carried claims were wrong (§1), plus
+  earlier: a recorded phone repro that used a character which does not trigger the veto, and a
+  golden fixture set that silently tested nothing because of a path guard. The lesson is the same
+  one Phase 0 encodes — **do not trust a claim without a test that fails when it is false.**
+- **Two subagent review workflows were still running** when this was written (12 cross-cutting
+  dimensions, 9 components + 3 seams). This plan is deliberately based on what I verified myself.
+  Their findings should be merged in as a revision, and any finding of theirs that contradicts
+  something here should be re-tested rather than averaged.
+- **Not assessed by me at all:** i18n/encoding offset survival through transcoding, `--web`
+  security posture, `pkg/redact` compatibility surface, goroutine lifecycle under cancellation,
+  and per-format schema validity. Those are with the subagent reviews.

--- a/internal/goldencorpus/complexity_guard_redaction_test.go
+++ b/internal/goldencorpus/complexity_guard_redaction_test.go
@@ -36,24 +36,37 @@ import (
 //     must stay proportional to content, not to content x matches. This is the
 //     family that isolates a per-match whole-document rescan.
 
+// Why this file asserts ABSOLUTE cost and not a growth RATIO.
+//
+// A 4x-input ratio is the right assertion for the validator guard, and it was the
+// first thing tried here. It does not work for redaction, and the measurements
+// say so plainly. For the fixture pair below, on one machine:
+//
+//	no -race   9.3, 12.6, 12.7, 12.5, 12.9
+//	-race      10.3, 9.5, 11.9, 12.2, 11.8
+//	CI runner  16.6
+//
+// and the KNOWN-QUADRATIC code before the per-match rescan was removed measured
+// 12.6-13.7. A threshold high enough not to flake on 16.6 sits above the very
+// behaviour it is supposed to catch, so it would have zero detection power while
+// still failing builds at random. The first version of this test was set at 16.0
+// and did exactly that: it passed on the quadratic code (vacuous) and then failed
+// CI at 16.6 (flaky) — the worst of both.
+//
+// So: the ratio is LOGGED for a human, and the assertion is an absolute ceiling,
+// which is immune to noise in the base measurement and still catches an
+// order-of-magnitude regression. Redaction remains superlinear; nothing here
+// should be read as proving otherwise.
 const (
-	// redactionRatioCeiling bounds the growth factor for a 4x input. Linear is
-	// ~4x; quadratic is ~16x.
-	//
-	// MEASURED HONESTLY: on the code this test was written against, the growing
-	// family ratio is 10.0-13.2 and the pre-fix ratio was 12.6-13.7. Those
-	// overlap, so a ratio ceiling CANNOT distinguish "quadratic" from "quadratic
-	// with a better constant" at these sizes — it can only catch a NEW
-	// order-of-magnitude regression. The ceiling is therefore set above the
-	// current behaviour deliberately: it is a regression backstop, not a proof
-	// of linearity, and redaction is still superlinear. Do not read a pass here
-	// as "redaction is linear".
-	redactionRatioCeiling = 16.0
+	// redactionAbsoluteCeiling bounds the wall time to redact the big fixture
+	// (2000 matches). Measured ~150-250ms locally and ~440ms on a slow shared
+	// runner, so this tolerates a heavily loaded machine while failing on a
+	// 20-30x blowup. Scaled by raceCeilingMultiplier under -race.
+	redactionAbsoluteCeiling = 8 * time.Second
 
-	// fixedMatchRatioCeiling applies with the match count PINNED, so cost should
-	// track content only. Measured 4.8-6.3x for an 8x content rise (pre-fix
-	// 5.4-6.9x), i.e. sublinear in content because per-match work dominates.
-	fixedMatchRatioCeiling = 10.0
+	// fixedMatchAbsoluteCeiling bounds the fixed-match family, whose big case is
+	// smaller (200 matches over 8x content, measured well under 100ms).
+	fixedMatchAbsoluteCeiling = 5 * time.Second
 )
 
 // buildRedactionFixture returns text with n distinct SSNs, one per line, plus
@@ -160,14 +173,34 @@ func TestRedactionComplexity_GrowingMatchesAndContent(t *testing.T) {
 			"O(n^2) path passes the ratio check below", nBig, nBase)
 	}
 
+	// The ratio is reported but NOT asserted, and that is deliberate — see
+	// redactionRatioCeiling. Measured spread on one machine for this exact
+	// fixture pair: 9.3-12.9 without -race, 9.5-12.2 with it, and 16.6 on a CI
+	// runner. A threshold that accommodates 16.6 cannot detect the ~13x that the
+	// known-quadratic code produced, so the assertion would be pure flake with no
+	// detection power. Logging keeps the number visible for a human comparing
+	// runs.
 	if tBase > 2*time.Millisecond {
-		ratio := float64(tBig) / float64(tBase)
-		if ratio > redactionRatioCeiling {
-			t.Errorf("4x input took %.1fx longer to redact (base=%v big=%v) — superlinear "+
-				"growth suggests redaction is O(matches x content). Scanning the same "+
-				"fixtures is linear, so this is a redaction-side regression",
-				ratio, tBase, tBig)
-		}
+		t.Logf("4x input redaction ratio: %.1fx (base=%v big=%v) — informational; "+
+			"redaction is still superlinear, see the absolute ceiling below",
+			float64(tBig)/float64(tBase), tBase, tBig)
+	}
+
+	// ABSOLUTE ceiling instead. This is what a ratio cannot give: it is immune to
+	// the noise in tBase, it fails on a genuine order-of-magnitude regression,
+	// and it is scaled for the race detector exactly as the validator guard does.
+	//
+	// Sized from measurement with real headroom: the fixture costs ~150-250ms
+	// here and ~440ms on a slow shared runner, so 8s catches a 20-30x blowup
+	// while tolerating a heavily loaded machine.
+	ceiling := redactionAbsoluteCeiling
+	if raceDetectorEnabled {
+		ceiling *= raceCeilingMultiplier
+	}
+	if tBig > ceiling {
+		t.Errorf("redacting %d matches took %v (> %v ceiling%s) — a regression of this "+
+			"size means redaction cost is scaling with (matches x content) again",
+			bigN, tBig, ceiling, raceNote())
 	}
 }
 
@@ -201,13 +234,20 @@ func TestRedactionComplexity_FixedMatchesGrowingContent(t *testing.T) {
 			"meaningful with the match count pinned", nBase, nBig)
 	}
 
+	// Ratio logged, not asserted — same reasoning as the growing family.
 	if tBase > 2*time.Millisecond {
-		ratio := float64(tBig) / float64(tBase)
-		if ratio > fixedMatchRatioCeiling {
-			t.Errorf("%.0fx more content at a FIXED %d matches took %.1fx longer "+
-				"(base=%v big=%v) — cost is scaling with content x matches, which means "+
-				"each match is being located by scanning the whole document",
-				contentRise, matchCount, ratio, tBase, tBig)
-		}
+		t.Logf("%.0fx more content at a FIXED %d matches: %.1fx longer (base=%v big=%v) "+
+			"— informational", contentRise, matchCount, float64(tBig)/float64(tBase), tBase, tBig)
+	}
+
+	ceiling := fixedMatchAbsoluteCeiling
+	if raceDetectorEnabled {
+		ceiling *= raceCeilingMultiplier
+	}
+	if tBig > ceiling {
+		t.Errorf("%.0fx more content at a FIXED %d matches took %v (> %v ceiling%s) — with "+
+			"the match count pinned, a blowup of this size means each match is being "+
+			"located by scanning the whole document again",
+			contentRise, matchCount, tBig, ceiling, raceNote())
 	}
 }

--- a/internal/goldencorpus/complexity_guard_redaction_test.go
+++ b/internal/goldencorpus/complexity_guard_redaction_test.go
@@ -1,0 +1,213 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package goldencorpus
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/redactors"
+	"github.com/awslabs/ferret-scan/v2/internal/redactors/plaintext"
+)
+
+// The complexity guard in complexity_guard_test.go covers 18 validators and
+// nothing else: every target calls validator.ValidateContent directly, so the
+// timing reflects a validator's own scanning cost. That deliberate scoping left
+// the REDACTION path unguarded, and redaction is where the tool's security value
+// is realised — a reported finding that is not redacted is a cleartext leak.
+//
+// The gap was not theoretical. Redaction was quadratic in
+// (matches x content bytes) while scanning the same fixtures stayed linear:
+// cost grew ~4x per input doubling, reaching ~78s on roughly 1MB of dense
+// matches, against a 100MB MaxFileSize ceiling. Nothing failed.
+//
+// Two families are needed, and the second is the one that matters:
+//
+//   - growing: matches AND content grow together. This is the shape a user
+//     hits, but it cannot distinguish O(m) from O(m*n) — both look superlinear
+//     in total input.
+//   - fixedMatches: match count held CONSTANT while content grows. Cost here
+//     must stay proportional to content, not to content x matches. This is the
+//     family that isolates a per-match whole-document rescan.
+
+const (
+	// redactionRatioCeiling bounds the growth factor for a 4x input. Linear is
+	// ~4x; quadratic is ~16x.
+	//
+	// MEASURED HONESTLY: on the code this test was written against, the growing
+	// family ratio is 10.0-13.2 and the pre-fix ratio was 12.6-13.7. Those
+	// overlap, so a ratio ceiling CANNOT distinguish "quadratic" from "quadratic
+	// with a better constant" at these sizes — it can only catch a NEW
+	// order-of-magnitude regression. The ceiling is therefore set above the
+	// current behaviour deliberately: it is a regression backstop, not a proof
+	// of linearity, and redaction is still superlinear. Do not read a pass here
+	// as "redaction is linear".
+	redactionRatioCeiling = 16.0
+
+	// fixedMatchRatioCeiling applies with the match count PINNED, so cost should
+	// track content only. Measured 4.8-6.3x for an 8x content rise (pre-fix
+	// 5.4-6.9x), i.e. sublinear in content because per-match work dominates.
+	fixedMatchRatioCeiling = 10.0
+)
+
+// buildRedactionFixture returns text with n distinct SSNs, one per line, plus
+// the matches a scan would report for them.
+//
+// The values are DISTINCT by construction. Identical repeated values would let
+// a redactor replace every occurrence in one pass and defeat the measurement —
+// the same trap complexity_generators_test.go documents for the validator half.
+func buildRedactionFixture(n int, fillerLines int) (string, []detector.Match) {
+	var b strings.Builder
+	matches := make([]detector.Match, 0, n)
+	for i := 0; i < n; i++ {
+		// Distinct, and none of these are real: area group 900+ is unassigned.
+		ssn := fmt.Sprintf("9%02d-%02d-%04d", i%100, (i/100)%100, i%10000)
+		line := fmt.Sprintf("record %d ssn %s", i, ssn)
+		b.WriteString(line)
+		b.WriteByte('\n')
+		matches = append(matches, detector.Match{
+			Text:       ssn,
+			Type:       "SSN",
+			Confidence: 100,
+			LineNumber: i + 1,
+			Context:    detector.ContextInfo{FullLine: line},
+		})
+	}
+	for i := 0; i < fillerLines; i++ {
+		b.WriteString("filler line carrying no sensitive value whatsoever\n")
+	}
+	return b.String(), matches
+}
+
+// timeRedact redacts and returns the elapsed time plus the number of redaction
+// mappings produced. The mapping count is the non-vacuity signal: a redactor
+// that fails to locate its matches is fast and produces nothing.
+//
+// It goes through the exported RedactDocument (real files) rather than the
+// unexported text-level helper: the public entry point is what the CLI uses, and
+// a timing guard should measure the path that ships. File I/O adds a constant
+// that cancels in the ratio.
+func timeRedact(t *testing.T, text string, matches []detector.Match) (time.Duration, int) {
+	t.Helper()
+
+	dir := t.TempDir()
+	in := filepath.Join(dir, "in.txt")
+	if err := os.WriteFile(in, []byte(text), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	outPath := filepath.Join(dir, "out.txt")
+
+	r := plaintext.NewPlainTextRedactor(nil, nil)
+	start := time.Now()
+	res, err := r.RedactDocument(in, outPath, matches, redactors.RedactionSimple)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("RedactDocument: %v", err)
+	}
+	raw, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read redacted output: %v", err)
+	}
+	out := string(raw)
+	mappings := res.RedactionMap
+	// Correctness floor, asserted on every timing sample: a redaction that
+	// leaves the value in place is not a faster redaction, it is a leak. This
+	// is what stops an "optimisation" that skips matches from passing.
+	for i := range matches {
+		if strings.Contains(out, matches[i].Text) {
+			t.Fatalf("redacted output still contains match %d of %d (type %s, line %d) — "+
+				"a timing target must never accept a redaction that leaks",
+				i, len(matches), matches[i].Type, matches[i].LineNumber)
+		}
+	}
+	return elapsed, len(mappings)
+}
+
+// TestRedactionComplexity_GrowingMatchesAndContent is the user-facing shape.
+func TestRedactionComplexity_GrowingMatchesAndContent(t *testing.T) {
+	const (
+		baseN = 500
+		bigN  = 2000 // 4x
+	)
+
+	baseText, baseMatches := buildRedactionFixture(baseN, 0)
+	bigText, bigMatches := buildRedactionFixture(bigN, 0)
+
+	tBase, nBase := timeRedact(t, baseText, baseMatches)
+	tBig, nBig := timeRedact(t, bigText, bigMatches)
+
+	// NON-VACUITY: assert the measurement had something to measure. Every
+	// assertion below is a ratio or a ceiling, and all of them pass trivially
+	// when nothing is redacted.
+	if nBase < baseN {
+		t.Fatalf("base input produced %d redaction mappings, want %d — the timing "+
+			"assertions would be measuring a path that skips matches, not redaction",
+			nBase, baseN)
+	}
+	if nBig < bigN {
+		t.Fatalf("4x input produced %d redaction mappings, want %d — a redactor that "+
+			"stops redacting as input grows makes a timing ratio meaningless", nBig, bigN)
+	}
+	if nBig <= nBase {
+		t.Errorf("4x input produced %d mappings vs %d at base — the redacted count must "+
+			"grow with the input, otherwise per-match cost is constant and a per-match "+
+			"O(n^2) path passes the ratio check below", nBig, nBase)
+	}
+
+	if tBase > 2*time.Millisecond {
+		ratio := float64(tBig) / float64(tBase)
+		if ratio > redactionRatioCeiling {
+			t.Errorf("4x input took %.1fx longer to redact (base=%v big=%v) — superlinear "+
+				"growth suggests redaction is O(matches x content). Scanning the same "+
+				"fixtures is linear, so this is a redaction-side regression",
+				ratio, tBase, tBig)
+		}
+	}
+}
+
+// TestRedactionComplexity_FixedMatchesGrowingContent is the family that isolates
+// a per-match whole-document rescan: the match count never changes, so any
+// growth beyond the content ratio is per-match work over the whole document.
+func TestRedactionComplexity_FixedMatchesGrowingContent(t *testing.T) {
+	const (
+		matchCount  = 200
+		baseFiller  = 1000
+		bigFiller   = 8000 // 8x the filler
+		contentRise = 8.0
+	)
+
+	baseText, matches := buildRedactionFixture(matchCount, baseFiller)
+	bigText, _ := buildRedactionFixture(matchCount, bigFiller)
+
+	tBase, nBase := timeRedact(t, baseText, matches)
+	tBig, nBig := timeRedact(t, bigText, matches)
+
+	// NON-VACUITY: both runs must actually redact all of the same matches.
+	if nBase < matchCount || nBig < matchCount {
+		t.Fatalf("mappings base=%d big=%d, want >= %d for both — the ratio below is "+
+			"meaningless if either run skipped matches", nBase, nBig, matchCount)
+	}
+
+	// Guard the premise: the match count MUST be identical across the two runs,
+	// otherwise this is just the growing family with extra steps.
+	if nBase != nBig {
+		t.Fatalf("mappings differ between runs (base=%d big=%d) — this family is only "+
+			"meaningful with the match count pinned", nBase, nBig)
+	}
+
+	if tBase > 2*time.Millisecond {
+		ratio := float64(tBig) / float64(tBase)
+		if ratio > fixedMatchRatioCeiling {
+			t.Errorf("%.0fx more content at a FIXED %d matches took %.1fx longer "+
+				"(base=%v big=%v) — cost is scaling with content x matches, which means "+
+				"each match is being located by scanning the whole document",
+				contentRise, matchCount, ratio, tBase, tBig)
+		}
+	}
+}

--- a/internal/redactors/plaintext/redactor.go
+++ b/internal/redactors/plaintext/redactor.go
@@ -201,11 +201,6 @@ func (ptr *PlainTextRedactor) redactText(originalText string, matches []detector
 	redactedText := originalText
 	var redactionMap []redactors.RedactionMapping
 
-	// Line start offsets, computed ONCE for the whole document and reused by
-	// every match. Locating a match used to rescan the entire document per
-	// match, which made redaction quadratic; see lineOffsets.
-	offsets := lineOffsets(originalText)
-
 	// Process matches in reverse order to maintain position accuracy
 	for _, match := range sortedMatches {
 		replacement, err := ptr.generateReplacement(match.Text, match.Type, strategy)
@@ -260,7 +255,7 @@ func (ptr *PlainTextRedactor) redactText(originalText string, matches []detector
 
 				// Fall back to simple text search if enabled
 				if ptr.fallbackToSimple {
-					simpleStartPos, simpleEndPos, simpleErr := ptr.findMatchPosition(redactedText, match, offsets)
+					simpleStartPos, simpleEndPos, simpleErr := ptr.findMatchPosition(redactedText, match)
 					if simpleErr == nil {
 						startPos = simpleStartPos
 						endPos = simpleEndPos
@@ -283,7 +278,7 @@ func (ptr *PlainTextRedactor) redactText(originalText string, matches []detector
 			}
 		} else {
 			// Use simple text search when position correlation is disabled
-			simpleStartPos, simpleEndPos, err := ptr.findMatchPosition(redactedText, match, offsets)
+			simpleStartPos, simpleEndPos, err := ptr.findMatchPosition(redactedText, match)
 			if err != nil {
 				// Log warning but continue with other matches
 				ptr.logEvent("position_warning", false, map[string]interface{}{
@@ -324,7 +319,7 @@ func (ptr *PlainTextRedactor) redactText(originalText string, matches []detector
 			})
 
 			// Try to find the correct position if there's a mismatch
-			if correctedStart, correctedEnd, correctionErr := ptr.findMatchPosition(redactedText, match, offsets); correctionErr == nil {
+			if correctedStart, correctedEnd, correctionErr := ptr.findMatchPosition(redactedText, match); correctionErr == nil {
 				startPos = correctedStart
 				endPos = correctedEnd
 				confidence *= 0.7 // Reduce confidence for corrected positions
@@ -404,72 +399,10 @@ func (ptr *PlainTextRedactor) sortMatchesByPosition(matches []detector.Match) []
 	return sorted
 }
 
-// lineOffsets returns the byte offset at which each line of text begins.
-//
-// This is computed ONCE per document and shared by every match, replacing the
-// per-match whole-document rescans that made redaction quadratic in
-// (matches x content bytes). Measured on N distinct SSNs one per line:
-// redaction cost grew 4.2x/3.6x/3.5x per input doubling (4.0x = quadratic)
-// while scanning the same fixtures stayed linear, and a fixed-match/
-// growing-content family showed cost tracking CONTENT at a constant match
-// count — the signature of a per-match full-document scan. At ~1MB of dense
-// matches this reached 78s, against a 100MB MaxFileSize ceiling.
-//
-// The table is returned rather than cached on the receiver because a redactor
-// instance may be reused across documents and by concurrent callers; per-
-// document state on the receiver would be a data race.
-func lineOffsets(text string) []int {
-	// One entry per line: len(text)/40 is a rough average line length, and the
-	// slice grows from there rather than reallocating from zero.
-	offsets := make([]int, 1, len(text)/40+2)
-	for i := 0; i < len(text); i++ {
-		if text[i] == '\n' {
-			offsets = append(offsets, i+1)
-		}
-	}
-	return offsets
-}
-
-// lineBounds returns the byte range of the given 1-based line in text, using a
-// precomputed offset table. Only the line's own bytes are scanned, to find its
-// terminating newline in text as it stands now.
-//
-// The caller may pass text that has already been partially rewritten. That is
-// safe precisely because matches are applied in DESCENDING line order: every
-// replacement made so far sits at a strictly later offset than any line still
-// to be processed, so a line's start offset is still the one recorded in the
-// table built from the original text. ok=false when the line is out of range.
-func lineBounds(text string, offsets []int, lineNumber int) (start, end int, ok bool) {
-	if lineNumber < 1 || lineNumber > len(offsets) {
-		return 0, 0, false
-	}
-	start = offsets[lineNumber-1]
-	if start > len(text) {
-		return 0, 0, false
-	}
-	if idx := strings.IndexByte(text[start:], '\n'); idx >= 0 {
-		return start, start + idx, true
-	}
-	return start, len(text), true
-}
-
-// findMatchPosition finds the start and end position of a match in the text.
-//
-// The match's own line is searched first, which is what the line number is for
-// and is O(line) rather than O(document). A whole-document search remains as
-// the fallback so behaviour is unchanged for a match whose recorded line number
-// does not actually contain its text (a bounded/consolidated match, or a
-// line-number drift from an extractor) — such a match is still located and
-// still redacted, exactly as before.
-func (ptr *PlainTextRedactor) findMatchPosition(text string, match detector.Match, offsets []int) (int, int, error) {
-	if start, end, ok := lineBounds(text, offsets, match.LineNumber); ok {
-		if idx := strings.Index(text[start:end], match.Text); idx >= 0 {
-			pos := start + idx
-			return pos, pos + len(match.Text), nil
-		}
-	}
-
-	// Fall back to the first occurrence anywhere in the document.
+// findMatchPosition finds the start and end position of a match in the text
+func (ptr *PlainTextRedactor) findMatchPosition(text string, match detector.Match) (int, int, error) {
+	// Simple approach: find the first occurrence of the match text
+	// In a more sophisticated implementation, we would use the line number and character position
 	startPos := strings.Index(text, match.Text)
 	if startPos == -1 {
 		return 0, 0, fmt.Errorf("match text not found in document")

--- a/internal/redactors/plaintext/redactor.go
+++ b/internal/redactors/plaintext/redactor.go
@@ -201,6 +201,11 @@ func (ptr *PlainTextRedactor) redactText(originalText string, matches []detector
 	redactedText := originalText
 	var redactionMap []redactors.RedactionMapping
 
+	// Line start offsets, computed ONCE for the whole document and reused by
+	// every match. Locating a match used to rescan the entire document per
+	// match, which made redaction quadratic; see lineOffsets.
+	offsets := lineOffsets(originalText)
+
 	// Process matches in reverse order to maintain position accuracy
 	for _, match := range sortedMatches {
 		replacement, err := ptr.generateReplacement(match.Text, match.Type, strategy)
@@ -255,7 +260,7 @@ func (ptr *PlainTextRedactor) redactText(originalText string, matches []detector
 
 				// Fall back to simple text search if enabled
 				if ptr.fallbackToSimple {
-					simpleStartPos, simpleEndPos, simpleErr := ptr.findMatchPosition(redactedText, match)
+					simpleStartPos, simpleEndPos, simpleErr := ptr.findMatchPosition(redactedText, match, offsets)
 					if simpleErr == nil {
 						startPos = simpleStartPos
 						endPos = simpleEndPos
@@ -278,7 +283,7 @@ func (ptr *PlainTextRedactor) redactText(originalText string, matches []detector
 			}
 		} else {
 			// Use simple text search when position correlation is disabled
-			simpleStartPos, simpleEndPos, err := ptr.findMatchPosition(redactedText, match)
+			simpleStartPos, simpleEndPos, err := ptr.findMatchPosition(redactedText, match, offsets)
 			if err != nil {
 				// Log warning but continue with other matches
 				ptr.logEvent("position_warning", false, map[string]interface{}{
@@ -319,7 +324,7 @@ func (ptr *PlainTextRedactor) redactText(originalText string, matches []detector
 			})
 
 			// Try to find the correct position if there's a mismatch
-			if correctedStart, correctedEnd, correctionErr := ptr.findMatchPosition(redactedText, match); correctionErr == nil {
+			if correctedStart, correctedEnd, correctionErr := ptr.findMatchPosition(redactedText, match, offsets); correctionErr == nil {
 				startPos = correctedStart
 				endPos = correctedEnd
 				confidence *= 0.7 // Reduce confidence for corrected positions
@@ -399,10 +404,72 @@ func (ptr *PlainTextRedactor) sortMatchesByPosition(matches []detector.Match) []
 	return sorted
 }
 
-// findMatchPosition finds the start and end position of a match in the text
-func (ptr *PlainTextRedactor) findMatchPosition(text string, match detector.Match) (int, int, error) {
-	// Simple approach: find the first occurrence of the match text
-	// In a more sophisticated implementation, we would use the line number and character position
+// lineOffsets returns the byte offset at which each line of text begins.
+//
+// This is computed ONCE per document and shared by every match, replacing the
+// per-match whole-document rescans that made redaction quadratic in
+// (matches x content bytes). Measured on N distinct SSNs one per line:
+// redaction cost grew 4.2x/3.6x/3.5x per input doubling (4.0x = quadratic)
+// while scanning the same fixtures stayed linear, and a fixed-match/
+// growing-content family showed cost tracking CONTENT at a constant match
+// count — the signature of a per-match full-document scan. At ~1MB of dense
+// matches this reached 78s, against a 100MB MaxFileSize ceiling.
+//
+// The table is returned rather than cached on the receiver because a redactor
+// instance may be reused across documents and by concurrent callers; per-
+// document state on the receiver would be a data race.
+func lineOffsets(text string) []int {
+	// One entry per line: len(text)/40 is a rough average line length, and the
+	// slice grows from there rather than reallocating from zero.
+	offsets := make([]int, 1, len(text)/40+2)
+	for i := 0; i < len(text); i++ {
+		if text[i] == '\n' {
+			offsets = append(offsets, i+1)
+		}
+	}
+	return offsets
+}
+
+// lineBounds returns the byte range of the given 1-based line in text, using a
+// precomputed offset table. Only the line's own bytes are scanned, to find its
+// terminating newline in text as it stands now.
+//
+// The caller may pass text that has already been partially rewritten. That is
+// safe precisely because matches are applied in DESCENDING line order: every
+// replacement made so far sits at a strictly later offset than any line still
+// to be processed, so a line's start offset is still the one recorded in the
+// table built from the original text. ok=false when the line is out of range.
+func lineBounds(text string, offsets []int, lineNumber int) (start, end int, ok bool) {
+	if lineNumber < 1 || lineNumber > len(offsets) {
+		return 0, 0, false
+	}
+	start = offsets[lineNumber-1]
+	if start > len(text) {
+		return 0, 0, false
+	}
+	if idx := strings.IndexByte(text[start:], '\n'); idx >= 0 {
+		return start, start + idx, true
+	}
+	return start, len(text), true
+}
+
+// findMatchPosition finds the start and end position of a match in the text.
+//
+// The match's own line is searched first, which is what the line number is for
+// and is O(line) rather than O(document). A whole-document search remains as
+// the fallback so behaviour is unchanged for a match whose recorded line number
+// does not actually contain its text (a bounded/consolidated match, or a
+// line-number drift from an extractor) — such a match is still located and
+// still redacted, exactly as before.
+func (ptr *PlainTextRedactor) findMatchPosition(text string, match detector.Match, offsets []int) (int, int, error) {
+	if start, end, ok := lineBounds(text, offsets, match.LineNumber); ok {
+		if idx := strings.Index(text[start:end], match.Text); idx >= 0 {
+			pos := start + idx
+			return pos, pos + len(match.Text), nil
+		}
+	}
+
+	// Fall back to the first occurrence anywhere in the document.
 	startPos := strings.Index(text, match.Text)
 	if startPos == -1 {
 		return 0, 0, fmt.Errorf("match text not found in document")

--- a/internal/redactors/position/correlator.go
+++ b/internal/redactors/position/correlator.go
@@ -267,15 +267,66 @@ func (dpc *DefaultPositionCorrelator) ValidateCorrelation(correlation *PositionC
 	return nil
 }
 
-// extractTextAtPosition extracts text at the specified position
-func (dpc *DefaultPositionCorrelator) extractTextAtPosition(pos redactors.TextPosition, text string) (string, error) {
-	lines := strings.Split(text, "\n")
-
-	if pos.Line < 1 || pos.Line > len(lines) {
-		return "", fmt.Errorf("line %d is out of range (1-%d)", pos.Line, len(lines))
+// lineAt returns the 1-based line of text without allocating, and ok=false when
+// the line number is out of range. Splitting the whole document to reach one
+// line is what made the per-match correlation path quadratic.
+func lineAt(text string, lineNumber int) (string, bool) {
+	if lineNumber < 1 {
+		return "", false
 	}
+	start := 0
+	for n := 1; ; n++ {
+		idx := strings.IndexByte(text[start:], '\n')
+		if n == lineNumber {
+			if idx < 0 {
+				// Final line, no trailing newline. strings.Split yields a
+				// trailing empty element for text ending in "\n", so an empty
+				// final segment must remain addressable to preserve behaviour.
+				return text[start:], true
+			}
+			return text[start : start+idx], true
+		}
+		if idx < 0 {
+			return "", false
+		}
+		start += idx + 1
+	}
+}
 
-	line := lines[pos.Line-1] // Convert to 0-based indexing
+// countLines reports the number of lines strings.Split(text, "\n") would yield,
+// so range errors keep reporting the same bound as before.
+func countLines(text string) int {
+	return strings.Count(text, "\n") + 1
+}
+
+// lineAndColumnAt returns the 1-based line number containing byte offset index
+// and the number of bytes between the start of that line and index. It replaces
+// a strings.Split(text[:index], "\n") that allocated every preceding line on
+// every call.
+func lineAndColumnAt(text string, index int) (line, column int) {
+	if index > len(text) {
+		index = len(text)
+	}
+	line = strings.Count(text[:index], "\n") + 1
+	if nl := strings.LastIndexByte(text[:index], '\n'); nl >= 0 {
+		return line, index - nl - 1
+	}
+	return line, index
+}
+
+// extractTextAtPosition extracts text at the specified position.
+//
+// The requested line is located by walking newlines rather than by
+// strings.Split of the whole document. Callers correlate one match at a time, so
+// splitting here allocated a slice of every line in the document per match —
+// one of three sites that together made redaction quadratic in
+// (matches x content bytes). Walking is O(offset of the line) with no
+// allocation, and the out-of-range error keeps its original 1-based line count.
+func (dpc *DefaultPositionCorrelator) extractTextAtPosition(pos redactors.TextPosition, text string) (string, error) {
+	line, ok := lineAt(text, pos.Line)
+	if !ok {
+		return "", fmt.Errorf("line %d is out of range (1-%d)", pos.Line, countLines(text))
+	}
 
 	if pos.StartChar < 0 || pos.StartChar >= len(line) {
 		return "", fmt.Errorf("start char %d is out of range (0-%d)", pos.StartChar, len(line)-1)
@@ -295,11 +346,19 @@ func (dpc *DefaultPositionCorrelator) tryExactMatch(extractedPos redactors.TextP
 		return nil
 	}
 
+	// Occurrence count of this match's text in the document, computed ONCE.
+	// It was previously computed twice per correlated match — once here for
+	// metadata and once inside calculateExactMatchConfidence — and each
+	// strings.Count scans the whole document, so a document with m matches paid
+	// 2*m full scans. That was the dominant term in the quadratic redaction
+	// cost measured before this change.
+	matchCount := strings.Count(originalText, targetText)
+
 	// Calculate document position
 	docPos := dpc.calculateDocumentPosition(index, len(targetText), originalText, documentType)
 
 	// Calculate confidence based on text uniqueness
-	confidence := dpc.calculateExactMatchConfidence(targetText, originalText)
+	confidence := exactMatchConfidence(matchCount)
 
 	return &PositionCorrelation{
 		ExtractedPosition: extractedPos,
@@ -311,7 +370,7 @@ func (dpc *DefaultPositionCorrelator) tryExactMatch(extractedPos redactors.TextP
 		DocumentType:      documentType,
 		Metadata: map[string]interface{}{
 			"match_index": index,
-			"match_count": strings.Count(originalText, targetText),
+			"match_count": matchCount,
 		},
 	}
 }
@@ -435,10 +494,9 @@ func (dpc *DefaultPositionCorrelator) tryHeuristicMatch(extractedPos redactors.T
 
 // calculateDocumentPosition calculates the document position from text index
 func (dpc *DefaultPositionCorrelator) calculateDocumentPosition(index, length int, text, documentType string) *redactors.DocumentPosition {
-	// Count lines and calculate position
-	lines := strings.Split(text[:index], "\n")
-	line := len(lines)
-	charInLine := len(lines[len(lines)-1])
+	// Count lines and calculate position. See lineAndColumnAt: this used to
+	// strings.Split everything before index on every call, once per match.
+	line, charInLine := lineAndColumnAt(text, index)
 
 	// For simple text documents, we don't have page/bounding box info
 	return &redactors.DocumentPosition{
@@ -457,12 +515,20 @@ func (dpc *DefaultPositionCorrelator) calculateDocumentPosition(index, length in
 // Helper functions for confidence calculation and matching algorithms
 
 func (dpc *DefaultPositionCorrelator) calculateExactMatchConfidence(targetText, originalText string) float64 {
+	return exactMatchConfidence(strings.Count(originalText, targetText))
+}
+
+// exactMatchConfidence scores an exact match from how many times its text occurs
+// in the document: a unique occurrence is trusted, a repeated one is discounted.
+//
+// Split out from calculateExactMatchConfidence so a caller that already knows the
+// occurrence count does not have to rescan the document to recompute it. The
+// arithmetic is unchanged.
+func exactMatchConfidence(matchCount int) float64 {
 	// Base confidence for exact match
 	baseConfidence := 0.95
 
-	// Adjust based on text uniqueness
-	matchCount := strings.Count(originalText, targetText)
-	if matchCount == 1 {
+	if matchCount <= 1 {
 		return baseConfidence
 	}
 

--- a/internal/redactors/position/correlator.go
+++ b/internal/redactors/position/correlator.go
@@ -267,66 +267,15 @@ func (dpc *DefaultPositionCorrelator) ValidateCorrelation(correlation *PositionC
 	return nil
 }
 
-// lineAt returns the 1-based line of text without allocating, and ok=false when
-// the line number is out of range. Splitting the whole document to reach one
-// line is what made the per-match correlation path quadratic.
-func lineAt(text string, lineNumber int) (string, bool) {
-	if lineNumber < 1 {
-		return "", false
-	}
-	start := 0
-	for n := 1; ; n++ {
-		idx := strings.IndexByte(text[start:], '\n')
-		if n == lineNumber {
-			if idx < 0 {
-				// Final line, no trailing newline. strings.Split yields a
-				// trailing empty element for text ending in "\n", so an empty
-				// final segment must remain addressable to preserve behaviour.
-				return text[start:], true
-			}
-			return text[start : start+idx], true
-		}
-		if idx < 0 {
-			return "", false
-		}
-		start += idx + 1
-	}
-}
-
-// countLines reports the number of lines strings.Split(text, "\n") would yield,
-// so range errors keep reporting the same bound as before.
-func countLines(text string) int {
-	return strings.Count(text, "\n") + 1
-}
-
-// lineAndColumnAt returns the 1-based line number containing byte offset index
-// and the number of bytes between the start of that line and index. It replaces
-// a strings.Split(text[:index], "\n") that allocated every preceding line on
-// every call.
-func lineAndColumnAt(text string, index int) (line, column int) {
-	if index > len(text) {
-		index = len(text)
-	}
-	line = strings.Count(text[:index], "\n") + 1
-	if nl := strings.LastIndexByte(text[:index], '\n'); nl >= 0 {
-		return line, index - nl - 1
-	}
-	return line, index
-}
-
-// extractTextAtPosition extracts text at the specified position.
-//
-// The requested line is located by walking newlines rather than by
-// strings.Split of the whole document. Callers correlate one match at a time, so
-// splitting here allocated a slice of every line in the document per match —
-// one of three sites that together made redaction quadratic in
-// (matches x content bytes). Walking is O(offset of the line) with no
-// allocation, and the out-of-range error keeps its original 1-based line count.
+// extractTextAtPosition extracts text at the specified position
 func (dpc *DefaultPositionCorrelator) extractTextAtPosition(pos redactors.TextPosition, text string) (string, error) {
-	line, ok := lineAt(text, pos.Line)
-	if !ok {
-		return "", fmt.Errorf("line %d is out of range (1-%d)", pos.Line, countLines(text))
+	lines := strings.Split(text, "\n")
+
+	if pos.Line < 1 || pos.Line > len(lines) {
+		return "", fmt.Errorf("line %d is out of range (1-%d)", pos.Line, len(lines))
 	}
+
+	line := lines[pos.Line-1] // Convert to 0-based indexing
 
 	if pos.StartChar < 0 || pos.StartChar >= len(line) {
 		return "", fmt.Errorf("start char %d is out of range (0-%d)", pos.StartChar, len(line)-1)
@@ -346,19 +295,11 @@ func (dpc *DefaultPositionCorrelator) tryExactMatch(extractedPos redactors.TextP
 		return nil
 	}
 
-	// Occurrence count of this match's text in the document, computed ONCE.
-	// It was previously computed twice per correlated match — once here for
-	// metadata and once inside calculateExactMatchConfidence — and each
-	// strings.Count scans the whole document, so a document with m matches paid
-	// 2*m full scans. That was the dominant term in the quadratic redaction
-	// cost measured before this change.
-	matchCount := strings.Count(originalText, targetText)
-
 	// Calculate document position
 	docPos := dpc.calculateDocumentPosition(index, len(targetText), originalText, documentType)
 
 	// Calculate confidence based on text uniqueness
-	confidence := exactMatchConfidence(matchCount)
+	confidence := dpc.calculateExactMatchConfidence(targetText, originalText)
 
 	return &PositionCorrelation{
 		ExtractedPosition: extractedPos,
@@ -370,7 +311,7 @@ func (dpc *DefaultPositionCorrelator) tryExactMatch(extractedPos redactors.TextP
 		DocumentType:      documentType,
 		Metadata: map[string]interface{}{
 			"match_index": index,
-			"match_count": matchCount,
+			"match_count": strings.Count(originalText, targetText),
 		},
 	}
 }
@@ -494,9 +435,10 @@ func (dpc *DefaultPositionCorrelator) tryHeuristicMatch(extractedPos redactors.T
 
 // calculateDocumentPosition calculates the document position from text index
 func (dpc *DefaultPositionCorrelator) calculateDocumentPosition(index, length int, text, documentType string) *redactors.DocumentPosition {
-	// Count lines and calculate position. See lineAndColumnAt: this used to
-	// strings.Split everything before index on every call, once per match.
-	line, charInLine := lineAndColumnAt(text, index)
+	// Count lines and calculate position
+	lines := strings.Split(text[:index], "\n")
+	line := len(lines)
+	charInLine := len(lines[len(lines)-1])
 
 	// For simple text documents, we don't have page/bounding box info
 	return &redactors.DocumentPosition{
@@ -515,20 +457,12 @@ func (dpc *DefaultPositionCorrelator) calculateDocumentPosition(index, length in
 // Helper functions for confidence calculation and matching algorithms
 
 func (dpc *DefaultPositionCorrelator) calculateExactMatchConfidence(targetText, originalText string) float64 {
-	return exactMatchConfidence(strings.Count(originalText, targetText))
-}
-
-// exactMatchConfidence scores an exact match from how many times its text occurs
-// in the document: a unique occurrence is trusted, a repeated one is discounted.
-//
-// Split out from calculateExactMatchConfidence so a caller that already knows the
-// occurrence count does not have to rescan the document to recompute it. The
-// arithmetic is unchanged.
-func exactMatchConfidence(matchCount int) float64 {
 	// Base confidence for exact match
 	baseConfidence := 0.95
 
-	if matchCount <= 1 {
+	// Adjust based on text uniqueness
+	matchCount := strings.Count(originalText, targetText)
+	if matchCount == 1 {
 		return baseConfidence
 	}
 


### PR DESCRIPTION
## The defect

Redaction located every match by scanning the **entire document**, so cost grew with (matches × content bytes) — while scanning the same input stayed linear.

Measured end to end, N distinct SSNs one per line, `--checks ssn`:

| n | scan | redact |
|---|---|---|
| 2,000 | 0.51s | 0.49s |
| 4,000 | 0.30s | 1.36s |
| 8,000 | 0.48s | 4.59s |
| 16,000 | 0.88s | **17.45s** |

The adversarial review took the same shape to **78s on ~1MB** of dense matches. `file_router.go` `MaxFileSize` permits **100MB**.

## Isolating the mechanism

A fixed-match / growing-content family separates O(m) from O(m·n): with the match count **pinned at 100**, cost still tracked content — the signature of a per-match whole-document scan rather than per-match work.

Profiling (`-cpuprofile` + `pprof -peek`) attributed it to four sites, each scanning the full document once per match:

| site | operation |
|---|---|
| `plaintext/redactor.go` `findMatchPosition` | `strings.Index(document)` |
| `position/correlator.go` `extractTextAtPosition` | `strings.Split(document)` |
| `position/correlator.go` `calculateDocumentPosition` | `strings.Split(prefix)` |
| `position/correlator.go` `tryExactMatch` + `calculateExactMatchConfidence` | `strings.Count(document)` **twice** |

## The fix

- A **line-offset table computed once** per document, so a match is located within its own line. Safe because matches are applied in **descending line order**: every rewrite so far sits at a strictly later offset than any line still to be processed. A whole-document search remains as the fallback, so a match whose recorded line number does not hold its text is still located and still redacted.
- `lineAt` / `lineAndColumnAt` walk newlines instead of allocating every line.
- The occurrence count is computed **once** and shared instead of twice per match.

**Result: 17.45s → 11.32s at n=16,000 (1.54×)**, identical finding counts, redaction sink byte-identical before and after at n=2,000/8,000/16,000.

## Stated plainly: this is a constant-factor fix, not a complexity fix

Redaction is **still superlinear**. Measured growth ratios before and after **overlap** (12.6–13.7 vs 10.0–13.2). Making it truly linear requires carrying each match's byte offset from detection, which touches every validator and belongs in its own change. I am not claiming more than I measured.

## Complexity guard: the reason this survived

The guard **already existed** — 18 validator targets, non-vacuity `minMatches` floors, `wantMatchGrowth` assertions, ratio ceilings, a `-race` multiplier — but every target calls `validator.ValidateContent` directly to isolate validator cost from orchestration. `grep -ci redact` on it returned **0**. Redaction, suppression and `ResolveOverlaps` had no targets at all.

This PR adds the first redaction targets. Two design points learned the hard way:

1. **The sink is asserted on every timing sample.** A redaction that leaves the value in place is not a faster redaction, it is a leak — so an "optimisation" that skips matches cannot pass.
2. **My first version of this guard was vacuous** — it passed on the known-quadratic code, because at n=500→2000 the ratio sits just under the 12× ceiling. I measured the actual ratios on both versions, found they overlap, and rewrote the ceilings as an explicitly documented **regression backstop rather than a proof of linearity**. A guard that passes on the bug it was written for is worse than no guard.

## Plan correction

`FINAL_PLAN.md` Phase 2 proposed "add a complexity dimension". That was **wrong** — the gate exists. The document now records that the real gap was coverage past the validator boundary, plus the honest caveat about what a ratio ceiling can and cannot prove.

## Testing

| Gate | Result |
|---|---|
| Full suite | 61 packages ok |
| Golden corpus | ok |
| `-race` (redactors + goldencorpus) | ok, no races |
| 3-platform vet (darwin/linux/windows) | ok |
| Redaction sink | byte-identical vs `main` at n=2,000/8,000/16,000 |
| Finding counts | identical at every size |
| Determinism | 1 distinct redacted output over 10 runs |
| End-to-end | 17.45s → 11.32s at n=16,000 |

### Union with open PRs

Base is `main`. Verified conflict-free **and** semantically green when merged with #247, #249, #250 and #251 — 0 test failures in each union, run in an isolated worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)