### PR TITLE
test(router): fix the Windows CI break in my own unreadable-file test

### DIFF
--- a/internal/router/empty_file_not_unreadable_test.go
+++ b/internal/router/empty_file_not_unreadable_test.go
@@ -62,10 +62,6 @@ func TestEmptyFileIsNotReportedUnreadable(t *testing.T) {
 // genuinely cannot be read must still be reported. Without this, "silence the
 // empty-file warning" could be implemented by silencing the whole diagnostic.
 func TestUnreadableFileIsStillReported(t *testing.T) {
-	if os.Geteuid() == 0 {
-		t.Skip("running as root: a 0o000 file is still readable, so this cannot be exercised")
-	}
-
 	dir := t.TempDir()
 	locked := filepath.Join(dir, "locked.txt")
 	if err := os.WriteFile(locked, []byte("ssn 449-87-4100\n"), 0o600); err != nil {
@@ -75,6 +71,23 @@ func TestUnreadableFileIsStillReported(t *testing.T) {
 		t.Fatalf("chmod fixture: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Chmod(locked, 0o600) })
+
+	// Verify the PRECONDITION instead of guessing which platforms and users can
+	// express it. Chmod does not deny read access everywhere: on Windows it only
+	// clears the read-only bit, so a 0o000 file opens normally, and root ignores
+	// the mode on Unix. In both cases the file is readable, the router correctly
+	// answers "Text file", and asserting otherwise fails the test for a reason
+	// that has nothing to do with the code under test.
+	//
+	// An earlier version guarded this with os.Geteuid() == 0, which is wrong twice
+	// over: it does not cover Windows at all (Geteuid returns -1 there, so the
+	// guard never fires), and it encodes an assumption about WHO is running rather
+	// than checking WHAT happened. This broke the Windows CI job on main. Opening
+	// the file is the direct question, so ask that.
+	if f, err := os.Open(locked); err == nil {
+		f.Close()
+		t.Skip("this platform/user can still read a 0o000 file, so an unreadable file cannot be simulated with Chmod")
+	}
 
 	fr := &FileRouter{}
 	ok, reason := fr.CanProcessFile(locked, true)


### PR DESCRIPTION
## The break

`TestUnreadableFileIsStillReported`, which I added in #256, fails on `windows-latest`. **Main's "Go Tests" job has been red since that merge** — `f245fdf` is the first failing run, and every PR opened since inherits the failure (that is how I found it, on #260).

```
--- FAIL: TestUnreadableFileIsStillReported
    unreadable file was accepted for processing (reason "Text file")
    unreadable file reported as "Text file", want a reason containing "Unreadable"
```

## Cause

The test simulates an unreadable file with `os.Chmod(f, 0o000)`. On Windows that does **not** deny read access — it only clears the read-only bit. So the file opens fine, the router correctly answers `"Text file"`, and the assertion fails for a reason that has nothing to do with the code under test.

My guard was `os.Geteuid() == 0`, which is wrong twice over:

1. It does not cover Windows at all — `Geteuid` returns `-1` there, so the guard never fires.
2. It encodes an assumption about **who** is running instead of checking **what** happened.

## Fix

Verify the precondition directly: if the `0o000` file can still be opened, this platform/user cannot express "unreadable" via `Chmod`, so skip. Asking the direct question covers Windows, root, and any future platform with the same property without enumerating them.

## Verified, not assumed

The risk with a skip guard is that it silences the test everywhere and nobody notices, so I checked both directions:

- **darwin** — the file really is unreadable, so the test **runs its assertions and passes**. The real coverage is preserved, not skipped away. Confirmed with a probe: `chmod-000 file NOT readable (permission denied) -> real test RUNS its assertions`.
- **the Windows path** — a probe exercising the guard against a readable file confirmed it **skips**, and that without the guard the router returns `ok=true reason="Text file"` — byte-for-byte the CI failure.
- **compilation** — `GOOS=windows go vet` compiles the test. This matters: `go build` does **not** compile `_test.go` files, so `vet` is the only local check that would have caught a Windows-specific test problem. linux and darwin also clean.

| Gate | Result |
|---|---|
| Full suite | 61 packages ok |
| `-race` (router) | ok, no races |
| 3-platform vet | darwin / linux / windows ok |

### Merge safety

Branched off `main`. Touches one test file; **no shared files with #260** (verified). Should land promptly since it un-reds main and every open PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)