### PR TITLE
chore: gitignore the local performance-baseline scratch directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -242,3 +242,10 @@ ferret-scan-results.sarif
 .claude/
 .security-scan/
 uv.lock
+
+# Local performance-baseline scratch: holds checked-out worktrees of older commits
+# for before/after timing comparisons. Several hundred MB of duplicated source, and
+# entirely reproducible from git, so it must never be committed. Ignoring it also
+# keeps `git status` readable — an 11MB untracked directory at the top of every
+# status listing is how a real stray file gets overlooked.
+.perfbase/


### PR DESCRIPTION
Adds `.perfbase/` to `.gitignore`.

It holds checked-out worktrees of older commits for before/after timing comparisons — 11MB of duplicated source in my tree, entirely reproducible from git, and referenced by nothing in the repository except the two plan documents that ask for this change.

The reason to ignore it is not disk. An untracked directory sitting permanently at the top of every `git status` is how a real stray file gets overlooked — which already happened here: an audit probe file was swept into a commit because the listing it should have stood out in was noisy.

**Not included:** deleting the 23 local branches whose remotes are gone. I verified all 23 have their contribution on `main` (comparing each branch's own diff from its merge base, since this repo squash-merges and both `git log origin/main..branch` and a plain tree diff give misleading answers), but branch deletion is irreversible and is not a code change, so it does not belong in a commit. Happy to run the deletions separately on request.

Wave 1 of the verified backlog plan. Golden-free, shares no file with any other open PR.