### PR TITLE
fix(routing): scan and redact a text file that carries a container extension

### DIFF
--- a/internal/goldencorpus/corpus.go
+++ b/internal/goldencorpus/corpus.go
@@ -763,10 +763,13 @@ var FileCases = []FileCase{
 	},
 	{
 		Name: "file_doc_legacy_not_a_container",
-		Description: "Tier 4 negative: plain text named .doc. The extension now routes to the OLE path, so this " +
-			"records what happens when the bytes are not a compound file — the failure must be graceful and must " +
-			"not invent metadata. Without this the corpus would only cover the happy path of a format whose " +
-			"routing is decided by extension alone.",
+		Description: "Tier 4: plain text named .doc — the extension routes to the OLE path, but the bytes are not a " +
+			"compound file. This used to record \"No matches found.\": routing is decided by extension, the Office " +
+			"extractor failed, no other preprocessor had claimed the file, and the SSN in it was never reported and " +
+			"therefore never redacted. It now records the SSN as FOUND, which is the point of the case — a " +
+			"mislabelled file is exactly as sensitive as a correctly named one, and needs no attacker (an export " +
+			"pipeline, a hand-rename, or a truncated download all land here). The failure must still be graceful and " +
+			"must not invent metadata, which the METADATA check keeps covered.",
 		Checks:              []string{"SSN", "METADATA"},
 		Filename:            "notreally.doc",
 		Content:             []byte("This is plain text that happens to be named .doc.\nEmployee SSN 449-87-4100 here.\n"),

--- a/internal/goldencorpus/testdata/golden/file_doc_legacy_not_a_container.csv
+++ b/internal/goldencorpus/testdata/golden/file_doc_legacy_not_a_container.csv
@@ -1,1 +1,2 @@
 Filename,Type,Confidence Level,Confidence %,Line Number,Text
+<TMPDIR>/notreally.doc,SSN,HIGH,100.0,2,449-87-4100

--- a/internal/goldencorpus/testdata/golden/file_doc_legacy_not_a_container.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_doc_legacy_not_a_container.gitlab-sast.json
@@ -25,5 +25,32 @@
     "type": "sast"
   },
   "version": "15.0.4",
-  "vulnerabilities": []
+  "vulnerabilities": [
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <TMPDIR>/notreally.doc (line 2)\n**Confidence:** HIGH (100.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\nEmployee SSN 449-87-4100 here.\n```\n\n**Additional Information:**\n- context_impact: 45\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "SSN"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "ssn"
+        }
+      ],
+      "location": {
+        "end_line": 2,
+        "file": "notreally.doc",
+        "start_line": 2
+      },
+      "message": "Social Security Number detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Social Security Number Detected",
+      "severity": "Critical"
+    }
+  ]
 }

--- a/internal/goldencorpus/testdata/golden/file_doc_legacy_not_a_container.json.json
+++ b/internal/goldencorpus/testdata/golden/file_doc_legacy_not_a_container.json.json
@@ -1,1 +1,40 @@
-[]
+{
+  "results": [
+    {
+      "confidence": 100,
+      "confidence_level": "HIGH",
+      "filename": "<TMPDIR>/notreally.doc",
+      "line_number": 2,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 45,
+        "original_confidence": 100,
+        "original_file": "<TMPDIR>/notreally.doc",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "format": true,
+          "not_common_pattern": true,
+          "not_repeating": true,
+          "not_sequential": true,
+          "not_test_number": true,
+          "valid_area": true
+        },
+        "validation_path": "document"
+      },
+      "text": "449-87-4100",
+      "type": "SSN",
+      "validator": "ssn"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/file_doc_legacy_not_a_container.junit.xml
+++ b/internal/goldencorpus/testdata/golden/file_doc_legacy_not_a_container.junit.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="ferret-scan" tests="0" failures="0" errors="0" time="0.000">
-  <testsuite name="security-scan" tests="0" failures="0" errors="0" time="0.000"></testsuite>
+<testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
+  <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
+    <testcase name="notreally.doc" classname="security-scan" time="0.001">
+      <failure message="SSN found: 449-87-4100" type="SSN">Line 2: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 449-87-4100&#xA;Validator: ssn</failure>
+    </testcase>
+  </testsuite>
 </testsuites>

--- a/internal/goldencorpus/testdata/golden/file_doc_legacy_not_a_container.sarif.json
+++ b/internal/goldencorpus/testdata/golden/file_doc_legacy_not_a_container.sarif.json
@@ -2,11 +2,93 @@
   "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/refs/heads/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
   "runs": [
     {
-      "results": null,
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/notreally.doc"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "Employee SSN \nEmployee SSN 449-87-4100 here.\n here."
+                  },
+                  "startLine": 2
+                },
+                "region": {
+                  "endColumn": 25,
+                  "snippet": {
+                    "text": "Employee SSN 449-87-4100 here."
+                  },
+                  "startColumn": 14,
+                  "startLine": 2
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Social Security Number Detected in notreally.doc at line 2 (confidence: 100.0% - HIGH). Matched text: '449-87-4100'"
+          },
+          "properties": {
+            "confidence": 100,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 45,
+              "original_confidence": 100,
+              "original_file": "<TMPDIR>/notreally.doc",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "digits": true,
+                "format": true,
+                "not_common_pattern": true,
+                "not_repeating": true,
+                "not_sequential": true,
+                "not_test_number": true,
+                "valid_area": true
+              },
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "ssn"
+            ],
+            "validator": "ssn"
+          },
+          "rank": 100,
+          "ruleId": "SSN"
+        }
+      ],
       "tool": {
         "driver": {
           "informationUri": "https://github.com/awslabs/ferret-scan",
           "name": "Ferret Scan",
+          "rules": [
+            {
+              "fullDescription": {
+                "text": "A Social Security Number (SSN) pattern was detected in the scanned content. SSNs are highly sensitive personally identifiable information (PII) that must be protected under various regulations."
+              },
+              "help": {
+                "text": "Social Security Numbers are protected under numerous regulations including GDPR, HIPAA, and various state privacy laws. SSNs should never be stored in source code, configuration files, or logs. Remove this SSN immediately and ensure it is stored in a secure, encrypted system with appropriate access controls. Consider implementing tokenization or other data protection mechanisms."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/SSN.md",
+              "id": "SSN",
+              "shortDescription": {
+                "text": "Social Security Number Detected"
+              }
+            }
+          ],
           "semanticVersion": "0.0.0-development",
           "version": "0.0.0-development"
         }

--- a/internal/goldencorpus/testdata/golden/file_doc_legacy_not_a_container.txt
+++ b/internal/goldencorpus/testdata/golden/file_doc_legacy_not_a_container.txt
@@ -1,1 +1,3 @@
-No matches found.
+LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH       FILE
+-------------------------------------------------------------------------------------
+[HIGH  ] ssn          SSN                   100.00% line     2 449-87-4100 notreally.doc

--- a/internal/goldencorpus/testdata/golden/file_doc_legacy_not_a_container.yaml
+++ b/internal/goldencorpus/testdata/golden/file_doc_legacy_not_a_container.yaml
@@ -1,1 +1,32 @@
-results: []
+results:
+    - text: 449-87-4100
+      line_number: 2
+      type: SSN
+      confidence: 100
+      confidence_level: HIGH
+      filename: <TMPDIR>/notreally.doc
+      validator: ssn
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 45
+        original_confidence: 100
+        original_file: <TMPDIR>/notreally.doc
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            format: true
+            not_common_pattern: true
+            not_repeating: true
+            not_sequential: true
+            not_test_number: true
+            valid_area: true
+        validation_path: document

--- a/internal/preprocessors/plaintext_preprocessor.go
+++ b/internal/preprocessors/plaintext_preprocessor.go
@@ -91,7 +91,44 @@ func (ptp *PlainTextPreprocessor) CanProcess(filePath string) bool {
 		return ptp.isTextFile(filePath)
 	}
 
+	// A container extension whose BYTES are text: claim it as text.
+	//
+	// Routing picks preprocessors by extension, so a file named .docx went to the
+	// Office extractor alone. When the bytes are not a ZIP that extractor fails,
+	// no other preprocessor had claimed the file, and the scan reported zero
+	// findings. Since only reported findings are redacted, everything in such a
+	// file was left in cleartext. Measured on identical bytes holding an SSN:
+	// 1 finding as .txt, 0 as .doc / .docx / .xlsx.
+	//
+	// It needs no attacker. An export pipeline that writes CSV or HTML and labels
+	// it .doc, a hand-renamed file, or a truncated download all land here. As a
+	// pre-commit bypass it is cheaper still: rename the file.
+	//
+	// This is deliberately a CLAIM, not a fallback. The router already runs every
+	// preprocessor that claims a file and combines the successes, so on a real
+	// container the Office extractor still wins and this contributes nothing (a
+	// real .docx is a ZIP, so isTextFile rejects it on the binary sniff). Adding a
+	// claim therefore recovers the mislabelled case without a second code path,
+	// and without changing anything for well-formed documents.
+	if containerExtensions[ext] {
+		return ptp.isTextFile(filePath)
+	}
+
 	return false
+}
+
+// containerExtensions are the extensions whose files are normally binary
+// containers, and which therefore route away from this preprocessor on name alone.
+// Each is admitted only after isTextFile inspects the actual bytes.
+//
+// PDF is included for the same reason as the rest: a text file named .pdf is
+// exactly as unscannable as one named .docx, and the sniff is what decides.
+var containerExtensions = map[string]bool{
+	".docx": true, ".xlsx": true, ".pptx": true,
+	".docm": true, ".xlsm": true, ".pptm": true,
+	".doc": true, ".xls": true, ".ppt": true,
+	".odt": true, ".ods": true, ".odp": true,
+	".pdf": true,
 }
 
 // Process extracts text content from the file

--- a/internal/redactors/manager.go
+++ b/internal/redactors/manager.go
@@ -5,6 +5,7 @@ package redactors
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -303,7 +304,67 @@ func (rm *RedactionManager) GetRedactorForFile(filePath string) (Redactor, error
 		return nil, fmt.Errorf("no redactor registered for file type: %s", ext)
 	}
 
+	// A container extension whose BYTES are plain text must be redacted as text.
+	//
+	// Selection here is by extension, exactly as routing was, and the two have to
+	// agree: once the scanner detects a value in a text file named .docx, refusing
+	// to redact it produces the worst outcome available — the finding is REPORTED,
+	// so the report says it was handled, and no output file is written at all.
+	// Measured before this: 1 finding, zero bytes redacted, exit 0.
+	//
+	// The check is deliberately narrow. It runs only for extensions a
+	// container-format redactor claims, and only when the file does not carry that
+	// format's signature, so a well-formed document is never diverted. Reading a
+	// few hundred bytes is also cheap next to the redaction that follows.
+	if plain, ok := rm.redactors[".txt"]; ok && !hasContainerSignature(filePath) {
+		if _, isContainer := containerRedactorExtensions[ext]; isContainer {
+			return plain, nil
+		}
+	}
+
 	return redactor, nil
+}
+
+// containerRedactorExtensions are the extensions handled by a redactor that
+// requires a specific binary container format. A file with one of these names but
+// without the matching signature cannot be redacted by that redactor, so it falls
+// back to text.
+//
+// .pdf is absent on purpose: PDF redaction is unimplemented and refuses to write
+// output rather than falsely report success, and diverting a text file named .pdf
+// to the text redactor would be correct but is a behaviour change beyond this fix.
+var containerRedactorExtensions = map[string]struct{}{
+	".docx": {}, ".xlsx": {}, ".pptx": {},
+	".docm": {}, ".xlsm": {}, ".pptm": {},
+	".doc": {}, ".xls": {}, ".ppt": {},
+}
+
+// hasContainerSignature reports whether a file begins with the ZIP (OOXML) or OLE
+// compound-file magic. A read failure returns true so an unreadable file keeps its
+// extension-selected redactor and fails through the existing path, rather than
+// being silently rewritten as text.
+func hasContainerSignature(filePath string) bool {
+	f, err := os.Open(filepath.Clean(filePath)) // #nosec G304 -- path already vetted by the caller
+	if err != nil {
+		return true
+	}
+	defer f.Close()
+
+	var head [8]byte
+	n, err := io.ReadFull(f, head[:])
+	if err != nil && n < 4 {
+		return true
+	}
+
+	// ZIP local file header: OOXML and OpenDocument.
+	if n >= 4 && head[0] == 0x50 && head[1] == 0x4B {
+		return true
+	}
+	// OLE compound file: legacy .doc/.xls/.ppt.
+	if n >= 8 && head[0] == 0xD0 && head[1] == 0xCF && head[2] == 0x11 && head[3] == 0xE0 {
+		return true
+	}
+	return false
 }
 
 // updateStats safely updates statistics using a callback function


### PR DESCRIPTION
Fixes #264.

## The defect

A file whose **extension** says Office but whose **bytes** are plain text was silently unscanned. Routing picks preprocessors by extension, so the file went to the Office extractor alone; when the bytes are not a ZIP that extractor failed, no other preprocessor had claimed the file, and the scan reported zero findings. Only reported findings are redacted, so everything in such a file stayed in cleartext.

Measured on identical bytes holding an SSN:

```
control.txt   1 finding
f.doc         0 findings
f.docx        0 findings
f.xlsx        0 findings
```

No attacker is needed — an export pipeline that writes CSV or HTML and labels it `.doc`, a hand-renamed file, or a truncated download all land here. As a pre-commit bypass it is cheaper still: rename the file.

## Two halves, because fixing detection alone made it worse

Once the scanner reports a value in a text file named `.docx`, the redaction manager — which **also** selects by extension — handed it to the Office redactor, which refused it. That is the worst outcome available: the finding is **reported**, so the report says it was handled, and **no output file is written at all**. Measured mid-change: 1 finding, zero bytes redacted, exit 0.

| Half | Change |
|---|---|
| `plaintext_preprocessor.go` | The plaintext preprocessor now **claims** a container-extension file whose bytes sniff as text |
| `redactors/manager.go` | `GetRedactorForFile` diverts to the text redactor when the extension belongs to a container redactor **and** the file lacks the ZIP/OLE signature |

The first is deliberately a *claim*, not a fallback: the router already runs every preprocessor that claims a file and combines the successes, so on a real container the Office extractor still wins and this contributes nothing (a real `.docx` is a ZIP, so `isTextFile` rejects it). No second code path.

A read failure in the signature check keeps the extension-selected redactor, so an unreadable file fails through the existing path rather than being silently rewritten as text.

## No regression on real containers — the actual risk here

| Fixture | Before | After |
|---|---|---|
| Real 690KB `.doc` | 32 findings | 32 findings |
| …redacted | byte-identical size, parses in macOS `textutil` | same |
| Real `.docx` | 5 findings | 5 findings, redacts to a valid 4-part zip |
| 3 other container fixtures | unchanged | unchanged |

## Golden impact — exactly one case, as predicted

`file_doc_legacy_not_a_container` recorded `"No matches found."` and now records the SSN as found, across all 7 formats. Its description is rewritten: it was written as a *negative* case documenting the defect.

No other golden case moved — predicted in advance from the legacy fixtures using only routed stream names, and confirmed by the regeneration diff.

## Mutation-proven, and the two halves fail different tests

- disabling the plaintext claim → `TestGoldenFileScanFormats` fails with `No matches found.`
- disabling the redactor fallback → `TestGoldenFileRedactionSink` fails with `not an OLE compound file`

Both mutations compile — a build failure would not be a proof.

## Merge safety

Zero conflict markers vs `main`. **No shared files** with #269 or #270. The union of all three Wave-1 branches merges, builds, and passes the full suite with an identical package count (74 = 74), so nothing was silently dropped.

Wave 1 of the verified backlog plan. This one also unblocks Wave 2 (#2, nested containers) by keeping `internal/router/file_router.go` untouched.