### PR TITLE
fix(ssn): stop a dense numeric line deleting a labelled SSN

### DIFF
--- a/internal/validators/ssn/encoded_data_demotion_test.go
+++ b/internal/validators/ssn/encoded_data_demotion_test.go
@@ -1,0 +1,194 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ssn
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// isEncodedData used to be consumed as a hard `continue`, and both of its tests
+// count things ANYWHERE on the line. That made a line-global, author-controlled
+// heuristic able to delete a value that had already passed structural validation.
+//
+// Deleting it is the worst outcome this tool has: only reported findings are handed
+// to the redactor, so an erased finding is left in cleartext in the "redacted"
+// output, and the run still exits 0. Measured before the change, each of these a
+// valid SSN behind an explicit label:
+//
+//	"Employee SSN: 130-07-5728 1 2 ... 12"  -> HIGH 100
+//	"Employee SSN: 130-07-5728 1 2 ... 13"  -> NO FINDINGS   (>15 number groups)
+//	"Employee SSN: 130-07-5728"             -> HIGH 100
+//	"130-07-5728 1 2 3 4"                   -> NO FINDINGS   (>85% numeric)
+//
+// One extra number is the entire difference, and no attacker is needed: a log line,
+// a CSV row of counters, or an ID printed beside a few figures all reach it.
+//
+// These tests pin the demotion. There was no coverage of this heuristic's EFFECT
+// before — the only mention in the suite is a comment — which is how the veto
+// shipped and survived.
+
+func findSSN(t *testing.T, content string) (found bool, confidence float64) {
+	t.Helper()
+	v := NewValidator()
+	matches, err := v.ValidateContentCtx(context.Background(), content, "test.txt")
+	if err != nil {
+		t.Fatalf("ValidateContentCtx: %v", err)
+	}
+	for _, m := range matches {
+		if strings.Contains(m.Text, "5728") || strings.Contains(m.Text, "4100") {
+			return true, m.Confidence
+		}
+	}
+	return false, 0
+}
+
+// The regression, both triggers. A labelled SSN must survive any amount of
+// surrounding numeric noise.
+func TestEncodedDataDemotesRatherThanDeletes(t *testing.T) {
+	cases := []struct {
+		desc    string
+		content string
+	}{
+		{
+			desc:    "16 number groups, the >15 trigger",
+			content: "Employee SSN: 130-07-5728 1 2 3 4 5 6 7 8 9 10 11 12 13\n",
+		},
+		{
+			desc:    "far past the trigger",
+			content: "Employee SSN: 130-07-5728 " + strings.Repeat("7 ", 40) + "\n",
+		},
+		{
+			desc:    "over 85% numeric with 5 number groups",
+			content: "130-07-5728 1 2 3 4\n",
+		},
+		{
+			desc:    "over 85% numeric, no label at all",
+			content: "130-07-5728 11 22 33 44 55\n",
+		},
+		{
+			desc:    "a real SSN in a row of counters",
+			content: "130-07-5728 4 17 92 3 88 12 45 6 231 9 14 77 2 58 31 6\n",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			found, conf := findSSN(t, tc.content)
+			if !found {
+				t.Fatalf("the SSN was DELETED (%s).\ninput: %q\n"+
+					"A value that passed structural validation must never be erased by a "+
+					"line-global heuristic: an unreported finding is never redacted, so it "+
+					"stays in cleartext in the output while the run exits 0.",
+					tc.desc, tc.content)
+			}
+			// The canonical hyphenated form must remain visible under the default
+			// confidence filter. Anything below MEDIUM is filtered out of the review
+			// surface, which for this shape is a deletion in all but name.
+			if conf < encodedDataStrongFloor {
+				t.Errorf("confidence %.1f is below the %.1f floor.\ninput: %q\n"+
+					"The canonical XXX-XX-XXXX form with a valid area number is what an SSN "+
+					"looks like; no quantity of surrounding digits should push it out of the "+
+					"default view.", conf, encodedDataStrongFloor, tc.content)
+			}
+		})
+	}
+}
+
+// The complement, and the reason this is a DEMOTION and not simply removing the
+// heuristic: a dense numeric line must still score lower than the same value in
+// clean labelled prose. Without this, the fix would be "delete the heuristic",
+// which reintroduces the false positives it exists to suppress.
+func TestEncodedDataStillCostsConfidence(t *testing.T) {
+	// A weak shape — bare 9 digits, no label — is where the penalty must bite. The
+	// hyphenated form is protected by the floor and so is excluded here on purpose.
+	clean := "449874100\n"
+	dense := "449874100 " + strings.Repeat("5 ", 20) + "\n"
+
+	_, cleanConf := findSSN(t, clean)
+	denseFound, denseConf := findSSN(t, dense)
+
+	if !denseFound {
+		t.Fatal("the bare candidate was deleted on a dense line; the demotion must " +
+			"lower confidence, not erase the finding")
+	}
+	if denseConf >= cleanConf {
+		t.Errorf("dense line scored %.1f, clean line %.1f — the encoded-data signal must "+
+			"still COST confidence, or this change is just deleting the heuristic and "+
+			"restoring the false positives it exists to suppress", denseConf, cleanConf)
+	}
+	t.Logf("bare candidate: clean %.1f -> dense %.1f (penalty %.1f)",
+		cleanConf, denseConf, cleanConf-denseConf)
+}
+
+// The two control cases from the measurement above: lines just BELOW each trigger
+// must be untouched, so the change cannot be credited for a difference that was
+// never there.
+func TestEncodedDataControlsUnchanged(t *testing.T) {
+	controls := map[string]string{
+		"15 number groups, below the >15 trigger": "Employee SSN: 130-07-5728 1 2 3 4 5 6 7 8 9 10 11 12\n",
+		"labelled SSN alone":                      "Employee SSN: 130-07-5728\n",
+		"labelled SSN in prose":                   "The employee SSN is 130-07-5728 per the HR record.\n",
+	}
+	for desc, content := range controls {
+		t.Run(desc, func(t *testing.T) {
+			found, conf := findSSN(t, content)
+			if !found {
+				t.Fatalf("control case lost its finding: %q", content)
+			}
+			if conf < 90 {
+				t.Errorf("control confidence dropped to %.1f (want HIGH >= 90): %q — "+
+					"the demotion must not reach lines the heuristic never flagged",
+					conf, content)
+			}
+		})
+	}
+}
+
+// A structurally INVALID candidate must still be rejected on a dense line. The
+// demotion changes what an encoded-data verdict costs, not what counts as an SSN.
+func TestEncodedDataDoesNotAdmitInvalidValues(t *testing.T) {
+	for _, invalid := range []string{
+		"000-12-3456", // area 000
+		"666-12-3456", // area 666
+		"900-12-3456", // area 900+
+		"123-00-4567", // group 00
+		"123-45-0000", // serial 0000
+	} {
+		content := invalid + " " + strings.Repeat("3 ", 20) + "\n"
+		v := NewValidator()
+		matches, err := v.ValidateContentCtx(context.Background(), content, "test.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, m := range matches {
+			if m.Text == invalid {
+				t.Errorf("structurally invalid %q was reported on a dense line; the "+
+					"demotion must not weaken validation", invalid)
+			}
+		}
+	}
+}
+
+// The denylisted test SSNs must still be dropped. That drop happens after context
+// analysis and is a deliberate exception to demote-never-delete: those values are
+// not PII, so removing them costs nothing and reporting them at any confidence is
+// a false positive.
+func TestEncodedDataDoesNotResurrectTestSSNs(t *testing.T) {
+	for _, fake := range []string{"123-45-6789", "111-11-1111", "000-00-0000"} {
+		content := "SSN " + fake + " " + strings.Repeat("2 ", 20) + "\n"
+		v := NewValidator()
+		matches, err := v.ValidateContentCtx(context.Background(), content, "test.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, m := range matches {
+			if m.Text == fake {
+				t.Errorf("denylisted test SSN %q was reported; the demotion must not "+
+					"resurrect known non-PII values", fake)
+			}
+		}
+	}
+}

--- a/internal/validators/ssn/validator.go
+++ b/internal/validators/ssn/validator.go
@@ -48,6 +48,33 @@ func containsKeyword(text, keyword string) bool {
 	return kwmatch.Contains(text, keyword)
 }
 
+// Penalty and floor for a line that isEncodedData judges to be a dense numeric
+// blob rather than prose or a table.
+//
+// The pair replaces a hard `continue`. Choosing them is a choice about which
+// mistake to make, so both directions are stated:
+//
+//   - too small a penalty and dense machine output regains the confidence the
+//     heuristic exists to remove;
+//   - too large a penalty, or no floor, and the change is the old veto wearing a
+//     number — a value that has already passed structural validation disappears
+//     from the report and therefore from the redacted output.
+//
+// 40 is the size of the existing globalTestPatterns penalty, so a line that looks
+// like encoded data costs about what a line that looks like test data costs. A
+// bare 9-digit candidate on such a line lands in LOW and is filtered out of the
+// default review surface without being erased.
+//
+// The floor is 60, the MEDIUM boundary, and it applies only to the canonical
+// hyphenated form with a valid area number — the one shape the validator already
+// treats as strong enough to stand without a keyword (see isStrongHyphenatedSSN).
+// That value is what an SSN looks like, so no quantity of surrounding digits
+// should push it out of the default view. Anything weaker keeps the full penalty.
+const (
+	encodedDataPenalty     = 40.0
+	encodedDataStrongFloor = 60.0
+)
+
 // Validator implements the detector.Validator interface for detecting
 // Social Security Numbers using regex patterns and contextual analysis.
 type Validator struct {
@@ -288,9 +315,43 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 			// Calculate confidence
 			confidence, checks := v.CalculateConfidence(match)
 
-			// Skip if this looks like encoded data or numeric sequences
+			// "This line looks like encoded data" DEMOTES; it no longer deletes.
+			//
+			// It used to `continue`, and because both of isEncodedData's tests are
+			// LINE-GLOBAL and count things anywhere on the line, that made the veto
+			// reachable by anything appended near a real SSN. Two measured examples on
+			// the version before this change, each a valid SSN behind an explicit
+			// label:
+			//
+			//	"Employee SSN: 130-07-5728 1 2 ... 12"   -> HIGH 100
+			//	"Employee SSN: 130-07-5728 1 2 ... 13"   -> NO FINDINGS   (>15 groups)
+			//	"Employee SSN: 130-07-5728"              -> HIGH 100
+			//	"130-07-5728 1 2 3 4"                    -> NO FINDINGS   (>85% numeric)
+			//
+			// One extra number is the entire difference. A finding that is never
+			// reported is never handed to the redactor, so the value stayed in
+			// cleartext in the "redacted" output — the most serious failure this tool
+			// has, and it needed no attacker: a log line, a CSV row of counters, or an
+			// ID printed beside a few figures all reach it.
+			//
+			// Demoting keeps the value reported, visible and redacted while still
+			// expressing low confidence, which is what the heuristic was for. This is
+			// the same veto-to-demote rule the repository has already applied to
+			// adjacency vetoes and reserved example values: a line-global,
+			// author-controlled signal must never be able to erase a value that has
+			// already passed structural validation.
+			//
+			// The floor matters as much as the penalty. A structurally strong value —
+			// the canonical hyphenated form with a valid area number — keeps enough
+			// confidence to stay in MEDIUM and therefore stays visible under the
+			// default confidence filter, because no amount of surrounding text should
+			// be able to hide a value that looks exactly like an SSN.
 			if lc.isEncoded {
-				continue
+				confidence -= encodedDataPenalty
+				if v.isStrongHyphenatedSSN(match) && confidence < encodedDataStrongFloor {
+					confidence = encodedDataStrongFloor
+				}
+				checks["encoded_data_line"] = true
 			}
 
 			// For preprocessed content, create a simpler context info


### PR DESCRIPTION
## The defect

`isEncodedData` was consumed as a hard `continue`, and both of its tests count things **anywhere on the line**. That let a line-global, author-controlled heuristic erase a value that had already passed structural validation.

Each pair below is a valid SSN behind an explicit label, differing by **one number**:

```
"Employee SSN: 130-07-5728 1 2 ... 12"   HIGH 100
"Employee SSN: 130-07-5728 1 2 ... 13"   NO FINDINGS   (>15 number groups)

"Employee SSN: 130-07-5728"              HIGH 100
"130-07-5728 1 2 3 4"                    NO FINDINGS   (>85% numeric)
```

Only reported findings are handed to the redactor, so **this is a cleartext leak**, not a scoring quirk. Proven at the sink:

| | `--enable-redaction` output |
|---|---|
| before | **no output file at all**, exit 0 |
| after | `Employee SSN: ***-**-5728 1 2 3 …` and `***-**-5728 1 2 3 4` |

No attacker is needed — a log line, a CSV row of counters, or an ID printed beside a few figures all reach it. The second trigger is the more surprising one: a bare hyphenated SSN followed by four digits is enough.

## The fix

The verdict now **demotes** instead of deleting — the rule this repo has already applied to adjacency vetoes and reserved example values: *a line-global signal a document author controls must never erase a structurally valid value.*

`-40` matches the existing `globalTestPatterns` penalty, so a line that looks like encoded data costs about what a line that looks like test data costs.

**The floor is load-bearing, not decoration.** Without it the change is the same veto wearing a number — a value filtered out of the default confidence view is deleted in every way a user experiences. So the canonical hyphenated form with a valid area number (the one shape `isStrongHyphenatedSSN` already treats as strong enough to stand without a keyword) never falls below MEDIUM 60 however many digits surround it.

Weaker shapes keep the full penalty: a bare 9-digit candidate measured **50 → 30**, so the heuristic still costs what it is meant to cost.

## Scope is deliberately narrow

- Structural validation untouched — `000`/`666`/`900+` areas, group `00`, serial `0000` still rejected on dense lines.
- Denylisted test SSNs still dropped. That drop is a deliberate exception to demote-never-delete, because those values are not PII.

## Tests

There was **no coverage of this heuristic's effect** before this commit — the only mention in the suite is a comment. That is how the veto shipped and survived.

**Mutation-proven:** restoring `continue` fails three subtests with `the SSN was DELETED`, and the mutation compiles.

## Gates

| Gate | Result |
|---|---|
| Full suite, all packages | pass |
| Golden finding count | **185 = 185**, zero snapshot drift |
| Recall fixtures (prose + tabular) | **21 = 21** |
| FP fixtures (HIGH) | **16 = 16** — unchanged by design; that is #15's job |
| Complexity guard (incl. its SSN target) | pass |
| Conflict markers vs `main` | 0 |
| Shared files with #269–#272 | none |

## Provenance

Found by an adversarial verification pass while designing the tabular-SSN fix (#15). It is unrelated to that change and outranks it: #15 reduces false positives, this closes a live leak. Shipped separately for that reason.