### PR TITLE
fix: disclose --limit truncation in machine-readable formats

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2012,6 +2012,10 @@ func main() {
 		fmt.Println(result)
 	}
 
+	if note := truncationNote(unsuppressedMatches, formatterOptions, *limitFlag); note != "" {
+		fmt.Fprint(os.Stderr, note)
+	}
+
 	// Determine appropriate exit code based on findings and pre-commit configuration
 	hasFindings := len(unsuppressedMatches) > 0
 	hasErrors := failedFiles > 0 // Track if there were any system errors during processing

--- a/cmd/truncation_note.go
+++ b/cmd/truncation_note.go
@@ -1,0 +1,52 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/formatters"
+	"github.com/awslabs/ferret-scan/v2/internal/formatters/shared"
+)
+
+// truncationNote returns the out-of-band message announcing that --limit dropped
+// findings, or "" when the report is complete.
+//
+// The four machine-readable formats declare truncation in band (SARIF run
+// properties, the GitLab scan block, JUnit <system-out>), but CSV cannot: it is a
+// pure tabular format with nowhere to put metadata. A comment line is not CSV
+// syntax and a strict parser rejects it, and an extra data row inflates the row
+// count consumers use to count findings — TestLimit_EveryFormatHonorsIt asserts
+// exactly that contract and caught the attempt.
+//
+// So CSV's disclosure is out of band, and since it costs nothing to be consistent
+// it is emitted for every format. The caller writes it to stderr, not stdout, so
+// redirecting a report to a file still yields a clean parseable artifact.
+//
+// Without any disclosure a truncated report is indistinguishable from a complete
+// one: the count looks authoritative, so silently under-reporting is worse for a
+// security tool than reporting nothing at all.
+func truncationNote(matches []detector.Match, options formatters.FormatterOptions, limit int) string {
+	if limit <= 0 {
+		return ""
+	}
+
+	// Count the CONFIDENCE-FILTERED set, not every unsuppressed match. Formatters
+	// filter by confidence and only then apply the limit, so the two sets diverge
+	// whenever --confidence is narrowed: on a 37-finding scan holding one HIGH
+	// finding, `--confidence high --limit 3` emits a complete 1-row report, and
+	// counting the unfiltered set announced "limited to 3 of 37". Announcing
+	// truncation that did not happen is the same class of bug as hiding truncation
+	// that did, so this reuses the formatters' own filter instead of reimplementing
+	// the predicate and letting the two drift.
+	shown := shared.FilterMatchesByConfidence(matches, options)
+	if len(shown) <= limit {
+		return ""
+	}
+
+	return fmt.Sprintf(
+		"NOTE: output limited to %d of %d findings by --limit. Re-run with --limit 0 to see all.\n",
+		limit, len(shown))
+}

--- a/cmd/truncation_note_test.go
+++ b/cmd/truncation_note_test.go
@@ -1,0 +1,120 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/formatters"
+)
+
+// noteMatches builds n findings at the given confidence on distinct lines.
+func noteMatches(n int, confidence float64) []detector.Match {
+	out := make([]detector.Match, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, detector.Match{
+			Text:       fmt.Sprintf("user%02d@example.com", i),
+			LineNumber: i + 1,
+			Type:       "EMAIL",
+			Confidence: confidence,
+			Filename:   "many.txt",
+			Validator:  "email",
+		})
+	}
+	return out
+}
+
+func noteOptions(levels ...string) formatters.FormatterOptions {
+	filter := map[string]bool{}
+	for _, l := range levels {
+		filter[l] = true
+	}
+	return formatters.FormatterOptions{ConfidenceLevel: filter, NoColor: true}
+}
+
+// The disclosure must fire when, and only when, the report is actually short.
+func TestTruncationNote(t *testing.T) {
+	const low, high = 40.0, 95.0
+
+	tests := []struct {
+		name    string
+		matches []detector.Match
+		options formatters.FormatterOptions
+		limit   int
+		want    string // "" means no note
+	}{
+		{
+			name:    "truncated reports disclose the real total",
+			matches: noteMatches(36, low),
+			options: noteOptions("high", "medium", "low"),
+			limit:   3,
+			want:    "limited to 3 of 36 findings",
+		},
+		{
+			// The regression this helper exists for. Formatters filter by confidence
+			// and only then apply the limit, so counting every unsuppressed match
+			// announced truncation on a report that carried every finding it had.
+			// 36 LOW findings are filtered out entirely, leaving 1 HIGH: a complete
+			// report, which previously printed "limited to 3 of 37".
+			name:    "confidence filter removes more than the limit would",
+			matches: append(noteMatches(36, low), noteMatches(1, high)...),
+			options: noteOptions("high"),
+			limit:   3,
+			want:    "",
+		},
+		{
+			name:    "exactly at the limit is complete",
+			matches: noteMatches(3, low),
+			options: noteOptions("high", "medium", "low"),
+			limit:   3,
+			want:    "",
+		},
+		{
+			name:    "one over the limit truncates",
+			matches: noteMatches(4, low),
+			options: noteOptions("high", "medium", "low"),
+			limit:   3,
+			want:    "limited to 3 of 4 findings",
+		},
+		{
+			name:    "limit 0 means unlimited",
+			matches: noteMatches(36, low),
+			options: noteOptions("high", "medium", "low"),
+			limit:   0,
+			want:    "",
+		},
+		{
+			name:    "no findings",
+			matches: nil,
+			options: noteOptions("high", "medium", "low"),
+			limit:   3,
+			want:    "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := truncationNote(tc.matches, tc.options, tc.limit)
+
+			if tc.want == "" {
+				if got != "" {
+					t.Errorf("a complete report announced truncation: %q\n"+
+						"Claiming findings were dropped when none were is the same class "+
+						"of bug as hiding a truncation that happened.", got)
+				}
+				return
+			}
+
+			if !strings.Contains(got, tc.want) {
+				t.Errorf("note = %q, want it to contain %q", got, tc.want)
+			}
+			if !strings.Contains(got, "--limit 0") {
+				t.Errorf("note = %q, want it to tell the user how to see everything", got)
+			}
+		})
+	}
+}

--- a/internal/formatters/gitlab-sast/formatter.go
+++ b/internal/formatters/gitlab-sast/formatter.go
@@ -149,7 +149,19 @@ func (f *Formatter) Format(matches []detector.Match, suppressedMatches []detecto
 
 	// Honor --limit, after the sort so the vulnerabilities kept are the
 	// highest-confidence ones rather than an arbitrary prefix.
-	sortedMatches, _, _ = shared.ApplyLimit(sortedMatches, options)
+	sortedMatches, totalVulns, truncated := shared.ApplyLimit(sortedMatches, options)
+
+	// Say so when --limit dropped vulnerabilities.
+	//
+	// Without this the report is indistinguishable from a complete one: a GitLab
+	// security dashboard counting `vulnerabilities` sees the capped number and
+	// nothing anywhere says more existed. Silently under-reporting is worse than
+	// reporting nothing, because the count looks authoritative. text/json/yaml
+	// already disclose this; the four machine-readable formats did not.
+	if truncated {
+		report.Scan.Truncated = true
+		report.Scan.TotalVulnerabilities = totalVulns
+	}
 
 	// Process each match with proper error handling
 	processedCount := 0

--- a/internal/formatters/gitlab-sast/models.go
+++ b/internal/formatters/gitlab-sast/models.go
@@ -66,6 +66,17 @@ type GitLabScanInfo struct {
 	StartTime string         `json:"start_time"`
 	EndTime   string         `json:"end_time"`
 	Status    string         `json:"status"`
+
+	// Truncated and TotalVulnerabilities declare that --limit dropped findings,
+	// and how many the scan actually produced.
+	//
+	// Both are omitempty and additive, so a complete report is byte-for-byte
+	// unchanged. They are separate fields rather than a reuse of Status because the
+	// GitLab schema constrains Status to "success" or "failure" (see
+	// validator.go's allowed set) — a truncated scan DID succeed, so overloading
+	// that field would make a correct report look like a failed one.
+	Truncated            bool `json:"truncated,omitempty"`
+	TotalVulnerabilities int  `json:"total_vulnerabilities,omitempty"`
 }
 
 // GitLabAnalyzer represents the analyzer information

--- a/internal/formatters/junit/formatter.go
+++ b/internal/formatters/junit/formatter.go
@@ -34,6 +34,15 @@ type TestSuite struct {
 	Errors    int        `xml:"errors,attr"`
 	Time      string     `xml:"time,attr"`
 	TestCases []TestCase `xml:"testcase"`
+
+	// SystemOut carries suite-level informational detail, the same standard
+	// <system-out> element TestCase already uses for suppressed findings. It is
+	// used here to declare that --limit dropped findings and what the real total
+	// was, because JUnit has no field for "this report is partial" and the
+	// tests/failures attributes describe the report rather than the scan.
+	//
+	// omitempty keeps a complete report byte-for-byte unchanged.
+	SystemOut string `xml:"system-out,omitempty"`
 }
 
 type TestCase struct {
@@ -91,7 +100,7 @@ func (f *Formatter) Format(matches []detector.Match, suppressedMatches []detecto
 	// Honor --limit before grouping, so the per-file <testcase> split and the
 	// suite's Tests/Failures counters describe the findings the report actually
 	// carries.
-	filteredMatches, _, _ = shared.ApplyLimit(filteredMatches, options)
+	filteredMatches, totalFindings, truncated := shared.ApplyLimit(filteredMatches, options)
 
 	// Group matches by file for better organization
 	fileGroups := f.groupMatchesByFile(filteredMatches)
@@ -155,6 +164,24 @@ func (f *Formatter) Format(matches []detector.Match, suppressedMatches []detecto
 	}
 
 	// Add the main security suite
+	// Say so when --limit dropped findings.
+	//
+	// Without this the report is indistinguishable from a complete one: the
+	// tests/failures attributes count what the report CARRIES, so a CI job reading
+	// them sees the capped number and nothing anywhere says more findings existed.
+	// Silently under-reporting is worse than reporting nothing, because the count
+	// looks authoritative. text/json/yaml already disclose this.
+	if truncated {
+		// Count FINDINGS, not testcases. JUnit groups findings by file, so a
+		// 3-finding cap inside one file produces a single <testcase> — reporting
+		// len(TestCases) said "showing 1 of 36" for a --limit 3 run, which is a
+		// different and wronger claim than the one being fixed.
+		securitySuite.SystemOut = fmt.Sprintf(
+			"ferret-scan: output truncated by --limit. Showing %d of %d findings. "+
+				"Re-run with --limit 0 for the complete set.",
+			len(filteredMatches), totalFindings)
+	}
+
 	testSuites.TestSuites = append(testSuites.TestSuites, securitySuite)
 	testSuites.Tests += securitySuite.Tests
 	testSuites.Failures += securitySuite.Failures

--- a/internal/formatters/sarif/formatter.go
+++ b/internal/formatters/sarif/formatter.go
@@ -70,7 +70,7 @@ func (f *Formatter) Format(matches []detector.Match, suppressedMatches []detecto
 	// Honor --limit before the report is built, so tool.driver.rules is derived
 	// from the results actually emitted rather than from findings the report
 	// never mentions.
-	filteredMatches, _, _ = shared.ApplyLimit(filteredMatches, options)
+	filteredMatches, totalFindings, truncated := shared.ApplyLimit(filteredMatches, options)
 
 	// Fresh per-call rule manager + mapper so the rules array derives only from
 	// THIS call's matches (no cross-call accumulation).
@@ -78,7 +78,7 @@ func (f *Formatter) Format(matches []detector.Match, suppressedMatches []detecto
 	mapper := NewVulnerabilityMapper(ruleManager)
 
 	// Build the SARIF report
-	report := f.buildReport(mapper, ruleManager, filteredMatches, suppressedMatches, options)
+	report := f.buildReport(mapper, ruleManager, filteredMatches, suppressedMatches, options, totalFindings, truncated)
 
 	// Marshal to JSON with indentation for readability
 	jsonBytes, err := json.MarshalIndent(report, "", "  ")
@@ -92,7 +92,7 @@ func (f *Formatter) Format(matches []detector.Match, suppressedMatches []detecto
 // buildReport constructs the complete SARIF report structure. The mapper and
 // ruleManager are per-call (constructed in Format) so the rules array reflects
 // only this report's matches.
-func (f *Formatter) buildReport(mapper *VulnerabilityMapper, ruleManager *RuleManager, matches []detector.Match, suppressedMatches []detector.SuppressedMatch, options formatters.FormatterOptions) *SARIFReport {
+func (f *Formatter) buildReport(mapper *VulnerabilityMapper, ruleManager *RuleManager, matches []detector.Match, suppressedMatches []detector.SuppressedMatch, options formatters.FormatterOptions, totalFindings int, truncated bool) *SARIFReport {
 	// Convert matches to SARIF results
 	var results []SARIFResult
 
@@ -127,6 +127,21 @@ func (f *Formatter) buildReport(mapper *VulnerabilityMapper, ruleManager *RuleMa
 		},
 		Results:                  results,
 		VersionControlProvenance: f.buildVersionControlProvenance(),
+	}
+
+	// Say so when --limit dropped results.
+	//
+	// Without this the report is indistinguishable from a complete one: a consumer
+	// counting `results` gets the capped number and nothing anywhere says more
+	// findings existed. For a security tool feeding a dashboard or a gate, silently
+	// under-reporting is worse than reporting nothing, because the number looks
+	// authoritative. text/json/yaml already disclose it; these four formats did not.
+	if truncated {
+		run.Properties = map[string]interface{}{
+			"ferretScanTruncated":     true,
+			"ferretScanTotalFindings": totalFindings,
+			"ferretScanResultsShown":  len(results),
+		}
 	}
 
 	// Create the top-level SARIF report

--- a/internal/formatters/sarif/models.go
+++ b/internal/formatters/sarif/models.go
@@ -16,6 +16,16 @@ type SARIFRun struct {
 	Tool                     SARIFTool             `json:"tool"`
 	Results                  []SARIFResult         `json:"results"`
 	VersionControlProvenance []SARIFVersionControl `json:"versionControlProvenance,omitempty"`
+
+	// Properties carries run-level metadata. It is currently used for one thing:
+	// declaring that --limit truncated the results, and what the true total was.
+	//
+	// A consumer reading `results` has no way to tell a complete report from a
+	// truncated one, and SARIF has no standard field for "this is a partial
+	// result set". The properties bag is the spec's designated place for
+	// tool-specific metadata, so it is where the disclosure goes rather than
+	// inventing a non-standard top-level key that would fail schema validation.
+	Properties map[string]interface{} `json:"properties,omitempty"`
 }
 
 // SARIFVersionControl represents version control information

--- a/internal/formatters/shared/truncation_disclosure_test.go
+++ b/internal/formatters/shared/truncation_disclosure_test.go
@@ -1,0 +1,175 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package shared_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/formatters"
+	csvfmt "github.com/awslabs/ferret-scan/v2/internal/formatters/csv"
+	gitlabfmt "github.com/awslabs/ferret-scan/v2/internal/formatters/gitlab-sast"
+	junitfmt "github.com/awslabs/ferret-scan/v2/internal/formatters/junit"
+	sariffmt "github.com/awslabs/ferret-scan/v2/internal/formatters/sarif"
+)
+
+// A truncated report must SAY it is truncated.
+//
+// TestLimit_EveryFormatHonorsIt next door pins that every format respects --limit.
+// That fix left a second problem: the four machine-readable formats truncated
+// silently, so a CI job, a security dashboard or a spreadsheet counting findings
+// received the capped number with nothing anywhere saying more existed. For a
+// security tool that is worse than reporting nothing, because the count looks
+// authoritative.
+//
+// Measured before this change, one 36-finding scan at --limit 3:
+//
+//	text          "... and 33 more findings"      disclosed
+//	json / yaml   truncated:true, total:36        disclosed
+//	csv           3 rows, nothing else            SILENT
+//	junit         tests/failures describe 3       SILENT
+//	sarif         3 results                       SILENT
+//	gitlab-sast   3 vulnerabilities               SILENT
+//
+// CSV is deliberately absent from the in-band assertions below and covered by an
+// explicit negative test instead: see TestCSVCannotDiscloseInBand.
+
+func truncTestMatches(n int) []detector.Match {
+	out := make([]detector.Match, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, detector.Match{
+			Type:       "EMAIL",
+			Text:       "user@example.com",
+			Confidence: 40,
+			LineNumber: i + 1,
+			Filename:   "many.txt",
+			Validator:  "email",
+		})
+	}
+	return out
+}
+
+func truncOptions(limit int) formatters.FormatterOptions {
+	return formatters.FormatterOptions{
+		ConfidenceLevel: map[string]bool{"high": true, "medium": true, "low": true},
+		NoColor:         true,
+		ShowMatch:       true,
+		Limit:           limit,
+	}
+}
+
+// The regression: each machine-readable format must declare truncation AND the
+// true total, so a consumer can tell it received a partial result set and knows
+// how much it is missing.
+func TestMachineFormatsDiscloseTruncation(t *testing.T) {
+	const total, limit = 36, 3
+	matches := truncTestMatches(total)
+
+	cases := []struct {
+		name string
+		f    formatters.Formatter
+		// wants are substrings that must all be present. Each format declares this
+		// in its own idiom, so the assertion is per-format rather than shared.
+		wants []string
+	}{
+		{
+			name:  "junit",
+			f:     junitfmt.NewFormatter(),
+			wants: []string{"truncated by --limit", "Showing 3 of 36", "--limit 0"},
+		},
+		{
+			name:  "sarif",
+			f:     sariffmt.NewFormatter(),
+			wants: []string{"ferretScanTruncated", "ferretScanTotalFindings", "36"},
+		},
+		{
+			name:  "gitlab-sast",
+			f:     gitlabfmt.NewFormatter(),
+			wants: []string{`"truncated": true`, `"total_vulnerabilities": 36`},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := tc.f.Format(matches, nil, truncOptions(limit))
+			if err != nil {
+				t.Fatalf("Format: %v", err)
+			}
+			for _, want := range tc.wants {
+				if !strings.Contains(out, want) {
+					t.Errorf("truncated %s output does not contain %q.\n"+
+						"A consumer counting findings sees %d and has no way to learn that "+
+						"%d existed — silently under-reporting is worse than reporting "+
+						"nothing, because the count looks authoritative.",
+						tc.name, want, limit, total)
+				}
+			}
+		})
+	}
+}
+
+// The complement, and the reason the disclosure fields are all omitempty: a
+// COMPLETE report must be byte-for-byte what it was before this change. Otherwise
+// every consumer and every golden snapshot churns for a case that did not truncate.
+func TestCompleteReportsCarryNoTruncationMarker(t *testing.T) {
+	matches := truncTestMatches(5)
+
+	cases := map[string]formatters.Formatter{
+		"csv":         csvfmt.NewFormatter(),
+		"junit":       junitfmt.NewFormatter(),
+		"sarif":       sariffmt.NewFormatter(),
+		"gitlab-sast": gitlabfmt.NewFormatter(),
+	}
+
+	for name, f := range cases {
+		t.Run(name, func(t *testing.T) {
+			// Limit 0 (unlimited) and a limit ABOVE the finding count must both be
+			// clean: neither truncates, so neither may claim to.
+			for _, limit := range []int{0, 100} {
+				out, err := f.Format(matches, nil, truncOptions(limit))
+				if err != nil {
+					t.Fatalf("Format(limit=%d): %v", limit, err)
+				}
+				for _, marker := range []string{"truncated", "Truncated", "TRUNCATED", "--limit 0"} {
+					if strings.Contains(out, marker) {
+						t.Errorf("a complete %s report (limit=%d, %d findings) contains %q; "+
+							"the disclosure must be omitempty so an untruncated report is "+
+							"unchanged", name, limit, len(matches), marker)
+					}
+				}
+			}
+		})
+	}
+}
+
+// CSV genuinely cannot disclose in band, and this records that as a decision rather
+// than an oversight.
+//
+// A "#" comment has no CSV syntax and a strict parser rejects it. An extra data row
+// inflates the row count consumers use to count findings —
+// TestLimit_EveryFormatHonorsIt asserts exactly that contract and caught the
+// attempt during this change. So CSV's disclosure is out of band, written to stderr
+// by cmd/main.go for every format, which corrupts nothing and is visible even when
+// the report is redirected to a file.
+//
+// If someone later adds a CSV comment or trailing row, this test fails and points at
+// the parity contract.
+func TestCSVCannotDiscloseInBand(t *testing.T) {
+	const total, limit = 36, 3
+	out, err := csvfmt.NewFormatter().Format(truncTestMatches(total), nil, truncOptions(limit))
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	// One header + exactly `limit` data rows. Any extra line is either a comment a
+	// parser will choke on or a row that miscounts the findings.
+	if got := len(lines) - 1; got != limit {
+		t.Errorf("CSV emitted %d data rows at --limit %d.\n"+
+			"CSV has nowhere to put metadata: a comment line is not valid CSV and an "+
+			"extra row inflates the count consumers read. Truncation is disclosed on "+
+			"stderr instead (cmd/main.go).", got, limit)
+	}
+}


### PR DESCRIPTION
A truncated report must say it is truncated.

## Problem

`--limit` caps how many findings a report carries. `text`/`json`/`yaml` already disclose that. The four machine-readable formats did not. Measured on one 36-finding scan at `--limit 3`:

| format | output | |
|---|---|---|
| text | `... and 33 more findings` | disclosed |
| json / yaml | `truncated:true`, `total:36` | disclosed |
| **csv** | 3 rows, nothing else | **SILENT** |
| **junit** | tests/failures describe 3 | **SILENT** |
| **sarif** | 3 results | **SILENT** |
| **gitlab-sast** | 3 vulnerabilities | **SILENT** |

Those four are exactly the formats consumed by machines: a CI gate, a security dashboard, a spreadsheet counting rows. Each received the capped number with nothing anywhere saying more findings existed, so a partial result set was indistinguishable from a clean-ish scan. For a security tool that is worse than reporting nothing, because the count looks authoritative.

## Fix

Each format declares truncation in its own idiom:

- **sarif** — `run.properties.ferretScanTruncated` / `ferretScanTotalFindings` / `ferretScanResultsShown`. The properties bag is the spec's designated place for tool metadata, so this does not break schema validation.
- **gitlab-sast** — `scan.truncated` and `scan.total_vulnerabilities`. Separate fields rather than reusing `scan.status`, which the schema constrains to `success`/`failure` — a truncated scan did succeed.
- **junit** — suite-level `<system-out>`, the same standard element testcases already use. It counts **findings, not testcases**: junit groups by file, so `len(TestCases)` reported "showing 1 of 36" for a `--limit 3` run.
- **csv** — cannot disclose in band; handled out of band (below).

Every disclosure field is `omitempty`, so **a complete report is byte-for-byte what it was before**: csv, junit, gitlab-sast, sarif and text outputs are identical to the previous build when nothing truncates.

### Why CSV is out of band

CSV has nowhere to put metadata. A `#` comment is not CSV syntax and a strict parser rejects it; an extra data row inflates the row count consumers use to count findings — `TestLimit_EveryFormatHonorsIt` asserts precisely that contract and caught the attempt during this change. So CSV's disclosure goes to **stderr**, and since consistency is free it is emitted for every format. stderr rather than stdout keeps a redirected report a clean parseable artifact.

### The inverse bug, found while testing

The stderr note counts the **confidence-filtered** set. Formatters filter by confidence and only then apply the limit, so counting every unsuppressed match announced truncation on reports that carried everything they had — a 37-finding scan holding one HIGH finding at `--confidence high --limit 3` emits a complete 1-row report and printed `limited to 3 of 37`. Claiming a truncation that did not happen is the same class of bug as hiding one that did, so `truncationNote` reuses the formatters' own filter rather than reimplementing the predicate and letting the two drift.

## Testing

- `TestMachineFormatsDiscloseTruncation` — each format declares truncation and the true total.
- `TestCompleteReportsCarryNoTruncationMarker` — at limit 0 and at a limit above the finding count, no format claims truncation.
- `TestCSVCannotDiscloseInBand` — records CSV's out-of-band handling as a decision, and fails if someone later adds a comment or trailing row.
- `TestTruncationNote` — 6 cases including the confidence-filter regression, exactly-at-limit, one-over, limit 0, no findings.
- **Non-vacuity, each proven with a COMPILING mutation** (a build failure is not a proof): disabling any of the three in-band disclosures fails its subtest; restoring the unfiltered count fails with the real string `limited to 3 of 37 findings`.
- Full suite passes. **Golden corpus 185 findings, zero drift.**
- **Complexity guard passes.** Disclosure is O(1) (one field write). Formatter scaling stays linear with the path active at `limit=n/2`, ~1.8x per doubling over n=1000..8000 (csv 0.38→2.54ms, junit 0.73→4.86ms, sarif 2.67→14.55ms, gitlab 6.52→38.91ms). End-to-end scan time unchanged vs main (10k-row input: 0.38s vs 0.39s).