### PR TITLE
test(score): gate that an unscanned file is never reportable as clean

### DIFF
--- a/internal/scorecorpus/cases_unscanned.go
+++ b/internal/scorecorpus/cases_unscanned.go
@@ -1,0 +1,134 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package scorecorpus
+
+// The unscanned-file contract: a file the tool did not examine must never be
+// reportable as clean.
+//
+// This is a different assertion from every other case in this corpus. Elsewhere the
+// question is "was the right thing detected in this document". Here the document is
+// deliberately broken, nothing can be detected, and the only thing that matters is
+// whether the tool ADMITS it. A validator cannot leak from a file it never opened —
+// but a scanner that reports `[]` and exits 0 on a file it never opened causes the
+// same harm by a different route: a CI job merges the change believing the file was
+// checked.
+//
+// Measured on main before these cases existed, one file per mode:
+//
+//	noperm.txt     rc=0  json=[]   (permission denied)
+//	corrupt.docx   rc=0  json=[]   (not a valid zip)
+//	empty.csv      rc=0  json=[]   (0 bytes)
+//
+// All three print a warning on stderr and are counted toward
+// --fail-on-incomplete, so the information exists. What is missing is that the
+// MACHINE-READABLE output says nothing at all: `[]` is indistinguishable from a
+// clean scan, and rc is 0 unless the operator already knew to pass an opt-in flag.
+//
+// These cases pin today's library-level behaviour so the upcoming error-reporting
+// change can be measured rather than asserted. They exist BEFORE that change on
+// purpose: a fix to a silent-failure class needs a gate that would have caught the
+// silence, otherwise the same class returns unnoticed.
+type UnscannedCase struct {
+	// Name is the subtest name.
+	Name string
+	// Origin records provenance.
+	Origin string
+	// Rationale says why this shape matters, in user terms.
+	Rationale string
+	// Basename's extension drives routing, so it must be plausible for the content.
+	Basename string
+	// Build returns the (broken) file bytes.
+	Build func() []byte
+	// Unreadable makes the fixture unreadable (chmod 0o000) after it is written.
+	//
+	// A bool rather than an os.FileMode field: 0o000 IS the zero value, so a
+	// `Mode os.FileMode` field cannot distinguish "no permissions" from "not set".
+	// The first version of this file made exactly that mistake and the chmod never
+	// ran — the fixture stayed readable and the case passed for the wrong reason
+	// until a probe printed the actual mode (rw------- instead of ---------).
+	Unreadable bool
+	// Checks is the validator set, validated against core.CheckNames().
+	Checks []string
+
+	// MustNotBeReportedClean is the whole point: after scanning, the tool must
+	// signal that this file was not examined — via ScanResult.Incomplete, or by
+	// returning an error. Both mean "not scanned"; the corpus accepts either
+	// because the two failure modes genuinely take different paths today
+	// (measured: an unreadable file ERRORS out of ScanFile, while a corrupt or
+	// empty one sets Incomplete).
+	MustNotBeReportedClean bool
+
+	// IsGenuinelyClean marks a file that is NOT a failure and must therefore be
+	// scanned normally: today an empty file is reported as "could not be
+	// processed... any sensitive data in them was NOT detected", which is a false
+	// alarm. A 0-byte file contains no sensitive data; saying otherwise trains
+	// operators to ignore the warning that matters.
+	//
+	// Set true for exactly that case, so the upcoming fix has a witness. Until it
+	// lands, KnownFalseAlarm below records that the current behaviour is wrong.
+	IsGenuinelyClean bool
+
+	// KnownFalseAlarm records that today's behaviour contradicts
+	// IsGenuinelyClean. It is the honest way to commit a case whose CORRECT
+	// outcome is known but not yet implemented, without either a permanently
+	// failing test or a test that asserts the bug is right.
+	KnownFalseAlarm bool
+}
+
+// UnscannedCases are the inputs the tool cannot examine.
+var UnscannedCases = []UnscannedCase{
+	{
+		Name:   "unreadable_permission_denied",
+		Origin: "authored 2026-08 for scorecorpus; behavior measured on main",
+		Rationale: "A file the process cannot open may be full of PII. Reporting it as clean " +
+			"is the worst possible answer, because a reviewer has no way to tell it apart " +
+			"from a file that was read and found empty. Measured on main: rc=0 and `[]` in " +
+			"JSON; only stderr mentions it.",
+		Basename:               "unreadable_permission_denied.txt",
+		Build:                  func() []byte { return []byte("SSN 130-07-5728\n") },
+		Unreadable:             true,
+		Checks:                 []string{"SSN"},
+		MustNotBeReportedClean: true,
+	},
+	{
+		Name:   "unparseable_container",
+		Origin: "authored 2026-08 for scorecorpus; behavior measured on main",
+		Rationale: "A truncated or corrupt .docx — the shape produced by a failed download or " +
+			"a partial upload. The extension promises a container the bytes cannot deliver, " +
+			"so no text is extracted and no validator ever runs. This is the case most " +
+			"likely to occur by accident rather than by attack.",
+		Basename:               "unparseable_container.docx",
+		Build:                  func() []byte { return []byte("PK\x03\x04truncated-not-a-real-zip") },
+		Checks:                 []string{"SSN"},
+		MustNotBeReportedClean: true,
+	},
+	{
+		Name:   "empty_file_is_genuinely_clean",
+		Origin: "authored 2026-08 for scorecorpus; behavior measured on main",
+		Rationale: "A 0-byte file is NOT a failure: it contains no sensitive data, so " +
+			"'scanned and clean' is the correct answer. Today it is reported as 'could not " +
+			"be processed ... any sensitive data in them was NOT detected', which is a false " +
+			"alarm, and false alarms are how a warning becomes noise that operators filter " +
+			"out — including the ones that matter. Recorded as a known defect so the fix " +
+			"has a witness.",
+		Basename:         "empty_file_is_genuinely_clean.csv",
+		Build:            func() []byte { return nil },
+		Checks:           []string{"SSN"},
+		IsGenuinelyClean: true,
+		KnownFalseAlarm:  true,
+	},
+	{
+		Name:   "control_readable_file_scans_cleanly",
+		Origin: "authored 2026-08 for scorecorpus; the anti-vacuity control",
+		Rationale: "The control that makes the three cases above meaningful. A well-formed " +
+			"file with a real SSN must be scanned, must NOT be flagged incomplete, and must " +
+			"produce a finding. Without it, a change that marked EVERY file unscanned would " +
+			"satisfy MustNotBeReportedClean everywhere and look like a pass.",
+		Basename:               "control_readable_file_scans_cleanly.csv",
+		Build:                  func() []byte { return []byte("ssn\n130-07-5728\n") },
+		Checks:                 []string{"SSN"},
+		MustNotBeReportedClean: false,
+		IsGenuinelyClean:       false,
+	},
+}

--- a/internal/scorecorpus/posixmode_unix_test.go
+++ b/internal/scorecorpus/posixmode_unix_test.go
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package scorecorpus
+
+// posixModesEnforced reports whether chmod 0o000 actually makes a file unreadable.
+//
+// True on unix. Split by build tag rather than checked at runtime because the
+// answer is a property of the platform, and a runtime probe would itself have to
+// create and read a file to find out.
+func posixModesEnforced() bool { return true }

--- a/internal/scorecorpus/posixmode_windows_test.go
+++ b/internal/scorecorpus/posixmode_windows_test.go
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package scorecorpus
+
+// posixModesEnforced reports whether chmod 0o000 actually makes a file unreadable.
+//
+// False on Windows: os.Chmod only toggles the read-only attribute, so a 0o000 file
+// remains readable and the permission-denied case would pass for the wrong reason.
+// The unreadable-file contract is still covered on ubuntu and macos in CI.
+func posixModesEnforced() bool { return false }

--- a/internal/scorecorpus/unscanned_test.go
+++ b/internal/scorecorpus/unscanned_test.go
@@ -165,12 +165,30 @@ func TestUnscannedFilesAreNotReportedCleanByTheCLI(t *testing.T) {
 					"scanned and nothing said so", c.Name)
 			}
 
-			// stderr must name the problem. This is the channel that works today.
-			if !strings.Contains(strings.ToLower(got.stderr), "not scanned") &&
-				!strings.Contains(strings.ToLower(got.stderr), "could not") {
-				t.Errorf("%s: stderr does not explain that the file was not scanned "+
-					"(%d bytes). Without it the only signal is an empty result set.",
-					c.Name, len(got.stderr))
+			// The output must name the problem somewhere. Checked against a SET of
+			// phrasings rather than one string: the wording is presentation and is
+			// expected to be improved, but the OBLIGATION to say something is the
+			// contract. An earlier version asserted only "not scanned"/"could not" and
+			// went red when the renderer was reworded to "NOT EXAMINED" — a stale
+			// assertion failing on an improvement, which teaches people to loosen tests.
+			//
+			// Both streams are accepted because the destination legitimately differs by
+			// format: text renders it inside its summary block on stdout so a piped
+			// report keeps a closed frame, while machine formats put it on stderr to
+			// leave stdout parseable.
+			combined := strings.ToLower(got.stdout + got.stderr)
+			said := false
+			for _, phrase := range []string{"not examined", "not scanned", "could not", "unreadable"} {
+				if strings.Contains(combined, phrase) {
+					said = true
+					break
+				}
+			}
+			if !said {
+				t.Errorf("%s: neither stream explains that the file was not examined "+
+					"(stdout %d bytes, stderr %d bytes). Without it the only signal is an "+
+					"empty result set, which is what a clean scan also produces.",
+					c.Name, len(got.stdout), len(got.stderr))
 			}
 
 			// The machine-readable half. Recorded, not yet gated: today an empty

--- a/internal/scorecorpus/unscanned_test.go
+++ b/internal/scorecorpus/unscanned_test.go
@@ -1,0 +1,209 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package scorecorpus
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/config"
+	"github.com/awslabs/ferret-scan/v2/internal/core"
+)
+
+// writeUnscannedFixture materialises a case and returns its path.
+func writeUnscannedFixture(t *testing.T, dir string, c UnscannedCase) string {
+	t.Helper()
+
+	p := filepath.Join(dir, c.Basename)
+	if err := os.WriteFile(p, c.Build(), 0o600); err != nil {
+		t.Fatalf("%s: write fixture: %v", c.Name, err)
+	}
+	if c.Unreadable {
+		if err := os.Chmod(p, 0o000); err != nil {
+			t.Fatalf("%s: chmod: %v", c.Name, err)
+		}
+		// Prove the chmod took effect. Without this the case can pass because the
+		// file was READABLE, which is the opposite of what it tests.
+		if _, err := os.ReadFile(p); err == nil { //nolint:gosec // fixture path
+			t.Fatalf("%s: fixture is still readable after chmod 0o000, so this case "+
+				"would pass for the wrong reason", c.Name)
+		}
+		// Restore write permission so t.TempDir() cleanup can remove it; without
+		// this a 0o000 fixture leaks a directory on some platforms.
+		t.Cleanup(func() { _ = os.Chmod(p, 0o600) })
+	}
+	return p
+}
+
+// TestUnscannedFilesAreNotReportedClean — the library must admit it did not read a
+// file.
+//
+// "Admit" means either ScanResult.Incomplete is set OR ScanFile returns an error.
+// Both are accepted because the two failure modes take genuinely different paths
+// today: measured, an unreadable file errors out with "file type not supported for
+// processing" (itself a misleading message for a permission problem, since .txt IS
+// supported), while a corrupt or empty one returns successfully with Incomplete set.
+//
+// Accepting either is deliberate rather than lax: the assertion is about the
+// OUTCOME the operator depends on — "this file was not examined" — not about which
+// internal path produced it. A later change that unifies the two paths must not have
+// to rewrite this test.
+func TestUnscannedFilesAreNotReportedClean(t *testing.T) {
+	cfg, err := config.LoadConfig("")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	for _, c := range UnscannedCases {
+		t.Run(c.Name, func(t *testing.T) {
+			if runtimeSkipsMode(t, c) {
+				return
+			}
+
+			path := writeUnscannedFixture(t, t.TempDir(), c)
+
+			res, scanErr := core.ScanFile(core.ScanConfig{
+				FilePath:            path,
+				Checks:              c.Checks,
+				Config:              cfg,
+				EnablePreprocessors: true,
+				LogWriter:           io.Discard,
+			})
+
+			admitted := scanErr != nil || (res != nil && res.Incomplete)
+
+			switch {
+			case c.MustNotBeReportedClean:
+				if !admitted {
+					t.Errorf("%s was NOT examined, yet the scan reported success with no "+
+						"incomplete signal (err=%v, incomplete=%v). A file the tool never read "+
+						"must never be indistinguishable from a file that was read and found "+
+						"clean — a reviewer merges the change believing it was checked.",
+						c.Name, scanErr, res != nil && res.Incomplete)
+				}
+
+			case c.IsGenuinelyClean:
+				if !admitted {
+					// The correct outcome. Nothing to assert beyond "no false alarm".
+					return
+				}
+				if c.KnownFalseAlarm {
+					t.Logf("KNOWN DEFECT (not yet fixed): %s is reported as not-scanned, but a "+
+						"0-byte file contains no sensitive data and 'scanned, clean' is the "+
+						"correct answer. err=%v incomplete=%v", c.Name, scanErr, res != nil && res.Incomplete)
+					return
+				}
+				t.Errorf("%s is genuinely clean but was reported as not-scanned "+
+					"(err=%v, incomplete=%v). False alarms turn the warning that matters "+
+					"into noise operators filter out.", c.Name, scanErr, res != nil && res.Incomplete)
+
+			default:
+				// The control: must scan, must not be flagged, must find something.
+				if admitted {
+					t.Errorf("control case %s should scan normally but was flagged "+
+						"(err=%v, incomplete=%v)", c.Name, scanErr, res != nil && res.Incomplete)
+					return
+				}
+				if len(res.Matches) == 0 {
+					t.Errorf("control case %s produced no findings; the other cases in this "+
+						"test would then pass vacuously — a change marking EVERY file unscanned "+
+						"would look like success", c.Name)
+				}
+			}
+		})
+	}
+}
+
+// TestUnscannedFilesAreNotReportedCleanByTheCLI is the same contract at the
+// EXECUTABLE layer, which is what a CI pipeline actually consumes.
+//
+// The library test above proves the information exists. This one asks the harder
+// question: can an operator SEE it? Measured on main, and this test records that
+// answer rather than asserting a behaviour that does not exist yet:
+//
+//	rc=0 and `[]` on stdout for all three failure modes — a JSON-parsing CI job
+//	cannot distinguish "nothing found" from "never looked".
+//
+// --fail-on-incomplete raises rc to 3, but it is opt-in and does not change the
+// JSON. Once the reporting change lands, the t.Logf lines below become t.Errorf and
+// this test starts gating the fix.
+func TestUnscannedFilesAreNotReportedCleanByTheCLI(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds a binary; skipped under -short")
+	}
+	bin := buildCLI(t)
+
+	for _, c := range UnscannedCases {
+		if !c.MustNotBeReportedClean {
+			continue
+		}
+		t.Run(c.Name, func(t *testing.T) {
+			if runtimeSkipsMode(t, c) {
+				return
+			}
+			path := writeUnscannedFixture(t, t.TempDir(), c)
+
+			got := runCLI(t, bin, nil,
+				"--file", path,
+				"--config", os.DevNull,
+				"--checks", strings.Join(c.Checks, ","),
+				"--limit", "0",
+				"--enable-preprocessors",
+				"--format", "json",
+			)
+
+			// Whatever else happens, the operator must be told SOMETHING. Total
+			// silence on both streams is the failure that shipped once already
+			// (#193) and it is gated here, not merely logged.
+			if len(got.stdout)+len(got.stderr) == 0 {
+				t.Errorf("%s produced zero bytes on stdout AND stderr: the file was not "+
+					"scanned and nothing said so", c.Name)
+			}
+
+			// stderr must name the problem. This is the channel that works today.
+			if !strings.Contains(strings.ToLower(got.stderr), "not scanned") &&
+				!strings.Contains(strings.ToLower(got.stderr), "could not") {
+				t.Errorf("%s: stderr does not explain that the file was not scanned "+
+					"(%d bytes). Without it the only signal is an empty result set.",
+					c.Name, len(got.stderr))
+			}
+
+			// The machine-readable half. Recorded, not yet gated: today an empty
+			// results array is the whole story a JSON consumer receives.
+			var results []json.RawMessage
+			if err := json.Unmarshal([]byte(got.stdout), &results); err == nil && len(results) == 0 {
+				t.Logf("KNOWN GAP (not yet fixed): %s emitted `[]` with rc=%d — a JSON "+
+					"consumer cannot tell 'nothing found' from 'never looked'. The upcoming "+
+					"reporting change adds an out-of-band 'unscanned' key; when it lands, "+
+					"this becomes an assertion.", c.Name, got.code)
+			}
+		})
+	}
+}
+
+// runtimeSkipsMode reports whether a case cannot be exercised on this platform.
+//
+// A 0o000 file is still readable by an elevated user, and Windows does not honour
+// POSIX mode bits the same way, so the permission case would silently pass for the
+// wrong reason there. Skipping loudly is better than a green test that proves
+// nothing.
+func runtimeSkipsMode(t *testing.T, c UnscannedCase) bool {
+	t.Helper()
+	if !c.Unreadable {
+		return false
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: a 0o000 file is still readable, so this case cannot fail")
+		return true
+	}
+	if !posixModesEnforced() {
+		t.Skip("platform does not enforce POSIX mode bits for this case")
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
Prerequisite for the error-reporting change. A fix to a silent-failure class needs a gate that would have caught the silence, or the same class returns unnoticed — so the gate lands **first**, against today's measured behaviour.

## The contract

A file the tool did not examine must never be indistinguishable from a file that was read and found clean. A validator cannot leak from a file it never opened, but a scanner that reports `[]` and exits 0 on one causes the same harm by a different route: a reviewer merges the change believing it was checked.

Measured on `main`, one file per failure mode:

| input | rc | JSON |
|---|---|---|
| unreadable (`chmod 000`) | **0** | `[]` |
| corrupt `.docx` | **0** | `[]` |
| empty `.csv` | **0** | `[]` |

The information exists on stderr and counts toward `--fail-on-incomplete`. What is missing is that the **machine-readable output says nothing** — `[]` cannot be distinguished from a clean scan, and rc is 0 unless the operator already knew to pass an opt-in flag.

## Four cases, two layers

**Library** (`core.ScanFile`): the tool must ADMIT it did not read the file, via `ScanResult.Incomplete` **or** an error. Both are accepted because the two modes take genuinely different paths today — an unreadable file errors out with `"file type not supported for processing"` (a misleading message for a permission problem, since `.txt` *is* supported), while a corrupt or empty one returns successfully with `Incomplete` set. The assertion is about the outcome an operator depends on, not which internal path produced it, so a later change that unifies them need not rewrite this test.

**Executable** (the real CLI): total silence on both streams is **gated** — that exact regression shipped in [#193](https://github.com/awslabs/ferret-scan/pull/193). stderr must name the problem. The JSON-consumer gap is recorded with `t.Logf` rather than asserted, because the behaviour does not exist yet; those lines become assertions when the reporting change lands.

Two cases are deliberately **not** failures:

- **`empty_file_is_genuinely_clean`** records a **false alarm**. A 0-byte file contains no sensitive data, so "scanned, clean" is the correct answer; today it is reported as *"could not be processed … any sensitive data in them was NOT detected"*. False alarms are how the warning that matters becomes noise operators filter out. `KnownFalseAlarm` marks it so the case can be committed without either a permanently red test or a test asserting the bug is right.
- **`control_readable_file_scans_cleanly`** is the anti-vacuity control. Without it, a change marking *every* file unscanned would satisfy the other three and look like a pass.

## Non-vacuity

With a **compiling** mutation — forcing `ScanResult.Incomplete` to false at both assignment sites in `core/scanner.go` — a corrupt `.docx` reports clean:

```
--- FAIL: TestUnscannedFilesAreNotReportedClean/unparseable_container
    unparseable_container was NOT examined, yet the scan reported success
    with no incomplete signal (err=<nil>, incomplete=false)
```

**Every other package passes at rc=0 (63 ok, 0 FAIL).** That gap is the whole reason this file exists.

## Two of my own bugs, found by probes rather than by tests passing

- **`Mode os.FileMode` could not express "no permissions".** `0o000` **is** the zero value, so `if c.Mode != 0` never fired, the chmod never ran, and the permission case passed against a *readable* file. Replaced with an explicit `Unreadable bool`, plus an assertion that the file really is unreadable after the chmod.
- **My first two mutation attempts were invalid.** The first patched 1 of 2 assignment sites and aborted, making the "gate catches it" result vacuous; the second produced a build failure, which proves nothing either. Only the third — compiling, both sites — is a real proof.

## Cross-platform

The permission case is skipped **loudly** on Windows (`os.Chmod` only toggles the read-only attribute there, so the file stays readable and the case would pass for the wrong reason) and when running as root. Split by build tag rather than probed at runtime. `GOOS=windows go vet` clean.

## Verification

- Scored numbers **unchanged** — these are a separate contract, not labelled findings: 143 cases, 180 labels, `recall_all` 1.0000, `prec_hm` 0.7920, `whole_leak` 0.
- Full module `-race`: **rc=0, 64 packages, 0 FAIL**. Golden **186 = 186**. gofmt/vet clean.
- Test-only: **no production code changes.**