### PR TITLE
fix(cli): report files that were never examined, and stop them reading as clean

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1705,6 +1705,13 @@ func main() {
 	// the user no reason to look again at a file that was never scanned.
 	var supportedFiles []string
 	var unreadableFiles []string
+	unreadableCount := 0
+
+	// scanMalfunction records that the SCANNER failed, not that an input was bad.
+	// Exit code 2 means "the tool did not work"; a file it could not read is a
+	// coverage gap (code 3), which is the distinction the old failedFiles counter
+	// blurred.
+	scanMalfunction := false
 	for _, filePath := range filesToProcess {
 		canProcess, reason := fileRouter.CanProcessFile(filePath, finalConfig.enablePreprocessors)
 		if canProcess {
@@ -1713,6 +1720,12 @@ func main() {
 		}
 		if strings.HasPrefix(reason, router.ReasonUnreadable) {
 			unreadableFiles = append(unreadableFiles, fmt.Sprintf("%s: %s", filePath, reason))
+			// Counted as unreadable AND as not-processed. The `continue` here used to
+			// skip the increment below, so an unreadable file landed in NO counter at
+			// all: two permission-denied files produced "0 skipped" in the summary
+			// while the warning above said two files were never opened. Separating the
+			// two categories was right; dropping the count was not.
+			unreadableCount++
 			continue
 		}
 		skippedFiles++
@@ -1800,31 +1813,34 @@ func main() {
 					stats.ProcessedFiles, stats.TotalMatches, stats.WorkerCount, stats.TotalDuration.Milliseconds())
 			}
 		} else {
+			// A genuine tool malfunction, as opposed to an input the tool could not
+			// read. This is what exit code 2 is for, so record it rather than only
+			// printing it.
 			fmt.Fprintf(os.Stderr, "Parallel processing failed: %v\n", err)
+			scanMalfunction = true
 		}
 	}
 
 	elapsed := time.Since(progressStart)
 	finalSkippedCount := totalSkipped + skippedFiles
 
-	// Provide clearer reporting (suppress in pre-commit mode)
-	totalAttempted := len(supportedFiles)
-	failedFiles := totalAttempted - processedFiles
-
 	if !shouldSuppressProgressOutput(finalConfig, precommitConfig, isInteractive) {
-		if finalSkippedCount > 0 || failedFiles > 0 {
-			fmt.Fprintf(os.Stderr, "Scan complete: %d files processed successfully", processedFiles)
-			if failedFiles > 0 {
-				fmt.Fprintf(os.Stderr, ", %d files had no results", failedFiles)
-			}
-			if finalSkippedCount > 0 {
-				fmt.Fprintf(os.Stderr, ", %d files skipped (%d unsupported types)", finalSkippedCount, skippedFiles)
-			}
-			fmt.Fprintf(os.Stderr, " in %s\n", elapsed.Round(time.Millisecond))
-		} else {
-			fmt.Fprintf(os.Stderr, "Scan complete: %d files processed in %s\n",
-				processedFiles, elapsed.Round(time.Millisecond))
+		// Report only what this line uniquely owns: how many files were scanned, how
+		// many were an unsupported type the user did not expect a result for, and how
+		// long it took. Files that FAILED to parse are deliberately NOT mentioned here
+		// as "had no results" — that phrasing conflated a clean scan (findings=0) with
+		// a file that was never read, and the not-examined report below now owns that
+		// category in full. Reporting it in both places produced two different numbers
+		// for the same files (a 23-vs-24 split a reader had to reconcile).
+		fmt.Fprintf(os.Stderr, "Scan complete: %d files scanned", processedFiles)
+		if finalSkippedCount > 0 {
+			fmt.Fprintf(os.Stderr, ", %d skipped (unsupported type)", finalSkippedCount)
 		}
+		// Trailing blank line so the progress block (spinner, bar, this line) is
+		// visually separated from the findings table that follows it. Without it the
+		// table header butts directly against the progress output and the two read as
+		// one wall of text.
+		fmt.Fprintf(os.Stderr, " in %s\n\n", elapsed.Round(time.Millisecond))
 	}
 
 	// Incomplete-coverage warning (v2 Phase 4): a file whose validator coverage
@@ -1833,11 +1849,14 @@ func main() {
 	// clean, complete scan. Suppressed only in pre-commit mode, which owns a
 	// strict machine-readable output contract. Exit code is deliberately
 	// unchanged (default still 0) — this is an advisory warning.
+	// Collected once, so the summary count and the detail report can never disagree:
+	// they are derived from the same slice rather than counted twice.
+	unscannedEntries := collectUnscanned(unreadableFiles, emptyExtractionFiles, failedProcessingFiles, incompleteFiles)
+
 	if precommitConfig == nil {
-		writeUnreadableFilesWarning(os.Stderr, unreadableFiles, len(filesToProcess))
-		writeEmptyExtractionWarning(os.Stderr, emptyExtractionFiles, len(supportedFiles))
-		writeFailedFilesWarning(os.Stderr, failedProcessingFiles, len(supportedFiles))
-		writeIncompleteCoverageWarning(os.Stderr, incompleteFiles, len(supportedFiles))
+		// The unredacted warning stays here; the not-examined report is emitted AFTER
+		// the findings table (search writeUnscannedReport below), so it reads as a
+		// caveat about the result rather than a banner before it.
 		writeUnredactedFilesWarning(os.Stderr, unredactedFiles, len(supportedFiles))
 	}
 
@@ -1926,15 +1945,50 @@ func main() {
 		}
 	}
 	formatterOptions.Stats = &formatters.ScanStats{
-		TotalFiles:     len(filesToProcess),
-		FilesProcessed: processedFiles,
-		FilesSkipped:   finalSkippedCount,
-		TotalFindings:  len(unsuppressedMatches),
-		High:           highCount,
-		Medium:         mediumCount,
-		Low:            lowCount,
-		Suppressed:     suppressedCount,
-		Duration:       elapsed.Seconds(),
+		TotalFiles:       len(filesToProcess),
+		FilesProcessed:   processedFiles,
+		FilesSkipped:     finalSkippedCount,
+		FilesNotExamined: len(unscannedEntries),
+		TotalFindings:    len(unsuppressedMatches),
+		High:             highCount,
+		Medium:           mediumCount,
+		Low:              lowCount,
+		Suppressed:       suppressedCount,
+		Duration:         elapsed.Seconds(),
+	}
+
+	// Render the not-examined detail into the summary block rather than printing it
+	// separately. Text format only: structured formats carry the same facts as data,
+	// and pre-commit owns a strict output contract. Building it here means the whole
+	// footer lands on ONE stream, so a piped stdout is not left with a frame whose
+	// closing rule went to the terminal.
+	if precommitConfig == nil && finalConfig.format == "text" {
+		var footer strings.Builder
+		if writeUnscannedReport(&footer, unscannedEntries, len(filesToProcess), *failOnIncomplete, finalConfig.debug) {
+			formatterOptions.NotExaminedFooter = footer.String()
+		}
+	}
+
+	// Pre-commit mode owns a deliberately terse output contract, but "terse" must not
+	// mean silent about files that were never read.
+	//
+	// Measured before this: `PRE_COMMIT=1` on a directory whose only file was
+	// chmod-000 produced ZERO bytes on stdout AND stderr with rc=0 — byte-identical
+	// to a clean pass, on a file that may be full of PII. A developer's commit is let
+	// through and nothing anywhere says why. That is the #193 shape: a hook decision
+	// with no stated reason.
+	//
+	// One line, no frame, no per-file list: pre-commit output is read in a terminal
+	// mid-commit, so it states the count and how to see the rest.
+	if precommitConfig != nil && len(unscannedEntries) > 0 {
+		noun := "files"
+		if len(unscannedEntries) == 1 {
+			noun = "file"
+		}
+		fmt.Fprintf(os.Stderr,
+			"ferret-scan: %d %s NOT examined (contents unreadable) — findings may be missing. "+
+				"Re-run without --pre-commit for detail.\n",
+			len(unscannedEntries), noun)
 	}
 
 	// Enable streaming for text format writing to stdout (no output file).
@@ -2012,13 +2066,26 @@ func main() {
 		fmt.Println(result)
 	}
 
-	if note := truncationNote(unsuppressedMatches, formatterOptions, *limitFlag); note != "" {
+	if note := truncationNote(unsuppressedMatches, formatterOptions, *limitFlag, finalConfig.format); note != "" {
 		fmt.Fprint(os.Stderr, note)
 	}
 
 	// Determine appropriate exit code based on findings and pre-commit configuration
 	hasFindings := len(unsuppressedMatches) > 0
-	hasErrors := failedFiles > 0 // Track if there were any system errors during processing
+
+	// hasErrors is deliberately NOT the old `failedFiles > 0`.
+	//
+	// failedFiles was len(supportedFiles) - processedFiles, and an UNREADABLE file
+	// never enters supportedFiles at all — so it was invisible here. Measured in
+	// pre-commit mode: a corrupt .docx exited 2 while a chmod-000 .txt exited 0,
+	// even though both mean exactly the same thing (the contents were never seen).
+	// Nobody chose that split; it fell out of the counter, the same way the summary's
+	// "0 skipped" did.
+	//
+	// hasErrors now means what exit code 2 is documented to mean — the tool itself
+	// failed. An input it could not read is a coverage gap, handled by coverageGaps
+	// and exit code 3 below, so the two categories no longer contend for one code.
+	hasErrors := scanMalfunction
 
 	// Determine the highest confidence level of findings
 	highestConfidence := ""
@@ -2054,7 +2121,7 @@ func main() {
 	// A file that was opened and extracted to NOTHING is the third member of that
 	// set and the hardest to notice without help: unlike the other two it produces
 	// no error anywhere, just an empty document body and a clean report.
-	coverageGaps := len(incompleteFiles) + len(unreadableFiles) + len(emptyExtractionFiles) + len(failedProcessingFiles)
+	coverageGaps := len(unscannedEntries)
 	if precommitConfig != nil {
 		exitCode := precommit.GetExitCode(hasFindings, hasErrors, highestConfidence, precommitConfig)
 		os.Exit(resolveIncompleteExitCode(exitCode, finalConfig.failOnIncomplete, coverageGaps))

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1944,9 +1944,33 @@ func main() {
 			lowCount++
 		}
 	}
+	// scanned and NOT-examined must not overlap, or the two numbers do not add up to
+	// the file count and a reader has to reconcile them.
+	//
+	// An empty-extraction file (opened fine, no readable text) is counted by the
+	// worker pool as PROCESSED and also appears in unscannedEntries, because both
+	// statements are true from their own vantage point. Printed side by side they
+	// double-count it: measured on 2 files where one was a valid but empty .docx,
+	// the summary read "2 scanned, 1 NOT examined" — 3 of 2. On a 301-file run that
+	// surfaced as 278 + 24 = 302.
+	//
+	// The summary resolves it in favour of NOT-examined, because that is the number
+	// an operator must act on: a file whose contents were never read is not covered,
+	// whatever the worker pool managed to do with it.
+	//
+	// Only the EMPTY-EXTRACTION count is subtracted. processedFiles already excludes
+	// unreadable and unparseable files — they never reach the worker pool's success
+	// path — so subtracting the whole unscanned set double-corrects and reported
+	// "0 scanned" on a directory whose two good CSVs both produced findings.
+	// Clamped at zero so a future counter change cannot render a negative.
+	scannedFiles := processedFiles - len(emptyExtractionFiles)
+	if scannedFiles < 0 {
+		scannedFiles = 0
+	}
+
 	formatterOptions.Stats = &formatters.ScanStats{
 		TotalFiles:       len(filesToProcess),
-		FilesProcessed:   processedFiles,
+		FilesProcessed:   scannedFiles,
 		FilesSkipped:     finalSkippedCount,
 		FilesNotExamined: len(unscannedEntries),
 		TotalFindings:    len(unsuppressedMatches),

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1962,10 +1962,30 @@ func main() {
 	// and pre-commit owns a strict output contract. Building it here means the whole
 	// footer lands on ONE stream, so a piped stdout is not left with a frame whose
 	// closing rule went to the terminal.
-	if precommitConfig == nil && finalConfig.format == "text" {
-		var footer strings.Builder
-		if writeUnscannedReport(&footer, unscannedEntries, len(filesToProcess), *failOnIncomplete, finalConfig.debug) {
-			formatterOptions.NotExaminedFooter = footer.String()
+	if precommitConfig == nil && len(unscannedEntries) > 0 {
+		var report strings.Builder
+		if writeUnscannedReport(&report, unscannedEntries, len(filesToProcess), *failOnIncomplete, finalConfig.debug) {
+			if finalConfig.format == "text" {
+				// Text renders it INSIDE the summary block, so the whole footer lands on
+				// one stream and a piped report is not left with an unclosed frame.
+				formatterOptions.NotExaminedFooter = report.String()
+			} else {
+				// Every other format gets it on stderr.
+				//
+				// Without this branch the report was text-only, and `--format json` on an
+				// unreadable file emitted `[]` with ZERO bytes of stderr — a REGRESSION
+				// against main, which warns (220 bytes). A JSON consumer could not tell
+				// "nothing found" from "never looked", which is the exact failure this
+				// change exists to fix, reintroduced for six of seven formats.
+				//
+				// Caught by TestUnscannedFilesAreNotReportedCleanByTheCLI when the two
+				// branches were merged together: each was green alone.
+				//
+				// stderr, not stdout, so a redirected report stays a clean parseable
+				// artifact. Machine formats will carry this as DATA in a follow-up; until
+				// then stderr is the honest channel rather than silence.
+				fmt.Fprint(os.Stderr, report.String())
+			}
 		}
 	}
 

--- a/cmd/truncation_note.go
+++ b/cmd/truncation_note.go
@@ -11,25 +11,41 @@ import (
 	"github.com/awslabs/ferret-scan/v2/internal/formatters/shared"
 )
 
+// formatsDisclosingTruncationInBand are the formats that already say, inside the
+// report itself, that --limit dropped findings.
+//
+// Measured on a 3-finding scan at --limit 1: text prints "... and 2 more
+// findings", json/yaml carry `truncated: true` with the real total, junit uses
+// <system-out>, sarif uses run properties, gitlab-sast uses the scan block. Only
+// CSV has nowhere to put it — a comment line is not CSV syntax and an extra data
+// row inflates the count consumers read.
+var formatsDisclosingTruncationInBand = map[string]bool{
+	"text":        true,
+	"json":        true,
+	"yaml":        true,
+	"junit":       true,
+	"sarif":       true,
+	"gitlab-sast": true,
+}
+
 // truncationNote returns the out-of-band message announcing that --limit dropped
-// findings, or "" when the report is complete.
+// findings, or "" when the report is complete or already says so itself.
 //
-// The four machine-readable formats declare truncation in band (SARIF run
-// properties, the GitLab scan block, JUnit <system-out>), but CSV cannot: it is a
-// pure tabular format with nowhere to put metadata. A comment line is not CSV
-// syntax and a strict parser rejects it, and an extra data row inflates the row
-// count consumers use to count findings — TestLimit_EveryFormatHonorsIt asserts
-// exactly that contract and caught the attempt.
-//
-// So CSV's disclosure is out of band, and since it costs nothing to be consistent
-// it is emitted for every format. The caller writes it to stderr, not stdout, so
-// redirecting a report to a file still yields a clean parseable artifact.
+// It used to be emitted for EVERY format "since it costs nothing to be
+// consistent". It does cost something: on six of the seven formats it repeats a
+// disclosure the report already contains, immediately after it, so the tail of a
+// truncated scan said the same thing twice in different words. Consistency across
+// formats is not worth a duplicated line in the common case, so the note is now
+// scoped to the one format that needs it.
 //
 // Without any disclosure a truncated report is indistinguishable from a complete
 // one: the count looks authoritative, so silently under-reporting is worse for a
-// security tool than reporting nothing at all.
-func truncationNote(matches []detector.Match, options formatters.FormatterOptions, limit int) string {
+// security tool than reporting nothing at all. That is why CSV still gets it.
+func truncationNote(matches []detector.Match, options formatters.FormatterOptions, limit int, format string) string {
 	if limit <= 0 {
+		return ""
+	}
+	if formatsDisclosingTruncationInBand[format] {
 		return ""
 	}
 
@@ -46,7 +62,10 @@ func truncationNote(matches []detector.Match, options formatters.FormatterOption
 		return ""
 	}
 
+	// CSV only. Named as a CSV limitation so the reader knows why this one format
+	// needs an out-of-band line when the others do not.
 	return fmt.Sprintf(
-		"NOTE: output limited to %d of %d findings by --limit. Re-run with --limit 0 to see all.\n",
-		limit, len(shown))
+		"NOTE: csv cannot carry metadata, so this is out of band — %d of %d findings "+
+			"shown (--limit %d). Use --limit 0 for all.\n",
+		limit, len(shown), limit)
 }

--- a/cmd/truncation_note_test.go
+++ b/cmd/truncation_note_test.go
@@ -37,6 +37,10 @@ func noteOptions(levels ...string) formatters.FormatterOptions {
 }
 
 // The disclosure must fire when, and only when, the report is actually short.
+//
+// All cases below use "csv" as the format: it is the one format with no in-band
+// disclosure, so it is the only one that should ever produce this note. Per-format
+// scoping has its own test below.
 func TestTruncationNote(t *testing.T) {
 	const low, high = 40.0, 95.0
 
@@ -52,7 +56,7 @@ func TestTruncationNote(t *testing.T) {
 			matches: noteMatches(36, low),
 			options: noteOptions("high", "medium", "low"),
 			limit:   3,
-			want:    "limited to 3 of 36 findings",
+			want:    "3 of 36 findings shown",
 		},
 		{
 			// The regression this helper exists for. Formatters filter by confidence
@@ -78,7 +82,7 @@ func TestTruncationNote(t *testing.T) {
 			matches: noteMatches(4, low),
 			options: noteOptions("high", "medium", "low"),
 			limit:   3,
-			want:    "limited to 3 of 4 findings",
+			want:    "3 of 4 findings shown",
 		},
 		{
 			name:    "limit 0 means unlimited",
@@ -98,7 +102,7 @@ func TestTruncationNote(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := truncationNote(tc.matches, tc.options, tc.limit)
+			got := truncationNote(tc.matches, tc.options, tc.limit, "csv")
 
 			if tc.want == "" {
 				if got != "" {
@@ -116,5 +120,33 @@ func TestTruncationNote(t *testing.T) {
 				t.Errorf("note = %q, want it to tell the user how to see everything", got)
 			}
 		})
+	}
+}
+
+// TestTruncationNoteOnlyForFormatsThatCannotSayItThemselves — no duplicate lines.
+//
+// The note used to be printed for every format "since it costs nothing to be
+// consistent", which meant six of seven formats repeated a disclosure the report
+// already contained, immediately after it. Measured on a 3-finding scan at
+// --limit 1: text prints "... and 2 more findings", json/yaml carry
+// truncated:true, junit uses <system-out>, sarif uses run properties, gitlab-sast
+// uses the scan block. Only csv has nowhere to put it.
+func TestTruncationNoteOnlyForFormatsThatCannotSayItThemselves(t *testing.T) {
+	matches := noteMatches(36, 40)
+	opts := noteOptions("high", "medium", "low")
+
+	for _, format := range []string{"text", "json", "yaml", "junit", "sarif", "gitlab-sast"} {
+		if got := truncationNote(matches, opts, 3, format); got != "" {
+			t.Errorf("%s already discloses truncation in the report itself, so the "+
+				"out-of-band note is a duplicate line immediately after it; got %q",
+				format, got)
+		}
+	}
+
+	if got := truncationNote(matches, opts, 3, "csv"); got == "" {
+		t.Error("csv has nowhere in the report to record truncation — a comment line is " +
+			"not CSV syntax and an extra row inflates the count consumers read — so it " +
+			"MUST still get the out-of-band note, or a truncated CSV is indistinguishable " +
+			"from a complete one")
 	}
 }

--- a/cmd/unscanned_exit_code_test.go
+++ b/cmd/unscanned_exit_code_test.go
@@ -1,0 +1,193 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// Exit-code semantics for files the tool could not examine, driven through the real
+// binary because exit codes are a CLI contract, not a library one.
+//
+// The matrix measured on main before these fixes, in pre-commit mode:
+//
+//	scenario                    rc   output
+//	clean                       0    (silent)
+//	UNREADABLE, no findings     0    ZERO BYTES on stdout AND stderr
+//	corrupt, no findings        2
+//	MEDIUM finding              0    (default blocks on high only)
+//
+// Two defects there. An unreadable file and a corrupt one mean the same thing —
+// the contents were never seen — yet produced different codes, because the old
+// `hasErrors` was len(supportedFiles)-processedFiles and an unreadable file never
+// enters supportedFiles. And the unreadable case was byte-for-byte identical to a
+// clean pass, so a hook let the commit through with no stated reason (the #193
+// shape).
+//
+// Exit code 2 is documented as "the tool failed". A file it could not read is a
+// coverage gap, which is code 3, so the two no longer contend for one code.
+
+func buildForExitTest(t *testing.T) string {
+	t.Helper()
+	name := "ferret-scan-exit-test"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	bin := filepath.Join(t.TempDir(), name)
+	out, err := exec.Command("go", "build", "-o", bin, ".").CombinedOutput()
+	if err != nil {
+		t.Fatalf("build: %v\n%s", err, out)
+	}
+	return bin
+}
+
+type exitRun struct {
+	rc     int
+	stdout string
+	stderr string
+}
+
+func runForExit(t *testing.T, bin, dir string, env []string, extra ...string) exitRun {
+	t.Helper()
+	args := append([]string{
+		"--file", dir, "--recursive", "--config", os.DevNull,
+		"--checks", "SSN", "--limit", "0", "--enable-preprocessors",
+	}, extra...)
+
+	cmd := exec.Command(bin, args...)
+	cmd.Env = append(os.Environ(), env...)
+	var so, se strings.Builder
+	cmd.Stdout = &so
+	cmd.Stderr = &se
+	err := cmd.Run()
+
+	rc := 0
+	if ee, ok := err.(*exec.ExitError); ok {
+		rc = ee.ExitCode()
+	} else if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	return exitRun{rc, so.String(), se.String()}
+}
+
+// scenarioDir builds a one-file directory for each shape.
+func scenarioDir(t *testing.T, kind string) string {
+	t.Helper()
+	dir := t.TempDir()
+	switch kind {
+	case "clean":
+		write(t, dir, "a.txt", "nothing sensitive at all\n", false)
+	case "unreadable":
+		write(t, dir, "a.txt", "SSN 130-07-5728\n", true)
+	case "corrupt":
+		write(t, dir, "a.docx", "PK\x03\x04truncated-not-a-zip", false)
+	case "finding":
+		write(t, dir, "a.csv", "ssn\n130-07-5728\n", false)
+	default:
+		t.Fatalf("unknown scenario %q", kind)
+	}
+	return dir
+}
+
+func write(t *testing.T, dir, name, body string, unreadable bool) {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if unreadable {
+		if err := os.Chmod(p, 0o000); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(p, 0o600) })
+	}
+}
+
+// TestUnexaminedFilesGetOneExitCode — unreadable and corrupt must agree.
+func TestUnexaminedFilesGetOneExitCode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds a binary")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: a 0o000 file is still readable")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("windows does not enforce POSIX mode bits for the unreadable case")
+	}
+	bin := buildForExitTest(t)
+
+	for _, mode := range []struct {
+		name string
+		env  []string
+	}{
+		{"normal", nil},
+		{"pre-commit", []string{"PRE_COMMIT=1"}},
+	} {
+		t.Run(mode.name, func(t *testing.T) {
+			unreadable := runForExit(t, bin, scenarioDir(t, "unreadable"), mode.env, "--fail-on-incomplete")
+			corrupt := runForExit(t, bin, scenarioDir(t, "corrupt"), mode.env, "--fail-on-incomplete")
+
+			if unreadable.rc != corrupt.rc {
+				t.Errorf("unreadable exits %d but corrupt exits %d. Both mean the contents "+
+					"were never seen, so an operator cannot act differently on them; the split "+
+					"came from a counter that skipped unreadable files, not from a decision.",
+					unreadable.rc, corrupt.rc)
+			}
+			if unreadable.rc != 3 {
+				t.Errorf("unexamined file exits %d under --fail-on-incomplete, want 3. Code 2 "+
+					"means the TOOL failed; an input it could not read is a coverage gap.",
+					unreadable.rc)
+			}
+		})
+	}
+}
+
+// TestPrecommitNeverSilentAboutUnexaminedFiles — the #193 shape.
+func TestPrecommitNeverSilentAboutUnexaminedFiles(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds a binary")
+	}
+	if os.Geteuid() == 0 || runtime.GOOS == "windows" {
+		t.Skip("cannot make a file unreadable in this environment")
+	}
+	bin := buildForExitTest(t)
+
+	got := runForExit(t, bin, scenarioDir(t, "unreadable"), []string{"PRE_COMMIT=1"})
+
+	if len(got.stdout)+len(got.stderr) == 0 {
+		t.Fatalf("pre-commit produced ZERO bytes on both streams (rc=%d) for a file it "+
+			"could not read. That is byte-identical to a clean pass, so the commit is "+
+			"allowed and nothing says why.", got.rc)
+	}
+	combined := strings.ToLower(got.stdout + got.stderr)
+	if !strings.Contains(combined, "not examined") {
+		t.Errorf("pre-commit output does not say the file was not examined:\nstdout=%q\nstderr=%q",
+			got.stdout, got.stderr)
+	}
+}
+
+// TestCleanScanStaysSilentAndZero — the control.
+//
+// Without this, a change that made EVERY scan report an unexamined file would
+// satisfy the two tests above and look correct.
+func TestCleanScanStaysSilentAndZero(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds a binary")
+	}
+	bin := buildForExitTest(t)
+
+	got := runForExit(t, bin, scenarioDir(t, "clean"), []string{"PRE_COMMIT=1"}, "--fail-on-incomplete")
+	if got.rc != 0 {
+		t.Errorf("a clean scan exited %d, want 0 (stderr: %q)", got.rc, got.stderr)
+	}
+	if strings.Contains(strings.ToLower(got.stdout+got.stderr), "not examined") {
+		t.Errorf("a clean scan claimed files were not examined:\nstdout=%q\nstderr=%q",
+			got.stdout, got.stderr)
+	}
+}

--- a/cmd/unscanned_report.go
+++ b/cmd/unscanned_report.go
@@ -267,8 +267,11 @@ func writeUnscannedReport(w io.Writer, entries []unscannedEntry, totalFiles int,
 
 	// "1 file" / "N files" — the plural was wrong on single-file runs, which is the
 	// most common way this report is seen.
+	// The noun agrees with totalFiles, which is the number it FOLLOWS. Choosing it
+	// from len(entries) produced "1 of 2 file" whenever one of two files was
+	// unexamined.
 	noun := "files"
-	if len(entries) == 1 {
+	if totalFiles == 1 {
 		noun = "file"
 	}
 

--- a/cmd/unscanned_report.go
+++ b/cmd/unscanned_report.go
@@ -1,0 +1,342 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/awslabs/ferret-scan/v2/internal/parallel"
+)
+
+// One report for every file the tool could not examine, grouped by cause.
+//
+// Before this, the four failure modes each printed their own WARNING block in
+// whatever order they were emitted, and each line repeated the path and then
+// appended a raw Go error:
+//
+//	WARNING: scan incomplete — 1 of 1 file(s) could not be opened, so they were
+//	not scanned at all; any sensitive data they contain was NOT detected:
+//	  /tmp/x/noperm.txt: Unreadable: open /tmp/x/noperm.txt: permission denied
+//
+// The path appears three times (prefix, wrapper, *PathError), "Unreadable:" is
+// internal vocabulary, and a directory with several kinds of failure produced
+// several unrelated banners. The consequence — these files are NOT clean — is
+// buried in a subordinate clause of a sentence the reader has already skipped.
+//
+// The replacement states the consequence first, groups by cause, prints each path
+// once, and translates the error into something a person can act on.
+
+// unscannedCause is a coarse, user-facing reason a file was not examined.
+//
+// Deliberately coarse: the point is what the operator must DO about it, not which
+// internal component reported it. "cannot read" means fix permissions or the path;
+// "cannot parse" means the bytes do not match the extension; "no text extracted"
+// means the file is a container or image the tool opened but found nothing readable
+// in; "coverage cut short" means a budget or timeout fired and the file is only
+// partly scanned.
+type unscannedCause int
+
+const (
+	causeUnreadable unscannedCause = iota
+	causeUnparseable
+	causeNoText
+	causeCutShort
+)
+
+func (c unscannedCause) String() string {
+	switch c {
+	case causeUnreadable:
+		return "cannot read"
+	case causeUnparseable:
+		return "cannot parse"
+	case causeNoText:
+		return "no text extracted"
+	case causeCutShort:
+		return "coverage cut short"
+	default:
+		return "unknown"
+	}
+}
+
+// unscannedEntry is one file and why it was not examined.
+type unscannedEntry struct {
+	Path   string
+	Cause  unscannedCause
+	Detail string
+}
+
+// humanizeReason turns an internal reason string into something actionable.
+//
+// The transformations are all subtractive — remove the path, remove the internal
+// prefix, unwrap Go's error decoration — because inventing new prose risks
+// describing a failure mode that did not happen. What is left is the part the
+// operator can act on.
+func humanizeReason(path, reason string) string {
+	r := reason
+
+	// The reason frequently embeds the path once or twice; the caller already
+	// prints it, so strip every occurrence.
+	if path != "" {
+		r = strings.ReplaceAll(r, path, "")
+	}
+
+	// Drop internal prefixes that name a component rather than a problem.
+	for _, prefix := range []string{
+		"Unreadable:",
+		"could not process :",
+		"could not process:",
+		"all preprocessors failed for file:",
+		"all preprocessors failed for file",
+	} {
+		r = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(r), prefix))
+	}
+
+	// Unwrap Go's "open <path>: " decoration left behind by *PathError.
+	r = strings.TrimSpace(r)
+	r = strings.TrimPrefix(r, "open :")
+	r = strings.TrimPrefix(r, "open ")
+	r = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(r), ":"))
+
+	// Collapse the whitespace the removals left behind.
+	r = strings.Join(strings.Fields(r), " ")
+
+	if r == "" {
+		return ""
+	}
+	return r
+}
+
+// describeUnparseable explains WHY a file could not be parsed, by checking the bytes
+// rather than trusting the extension.
+//
+// The distinction matters: reading the first four bytes tells us whether a .docx
+// really begins with a zip signature. "starts with a zip header but could not be
+// opened" is an observation; "corrupt Office document" inferred from the extension
+// alone would be a guess, and a wrong guess sends the operator looking in the wrong
+// place. Where nothing can be verified it says so plainly instead of inventing a
+// cause.
+func describeUnparseable(path string) string {
+	f, err := os.Open(path) //nolint:gosec // path came from the scan target list
+	if err != nil {
+		return "could not be re-opened to diagnose"
+	}
+	defer func() { _ = f.Close() }()
+
+	fi, err := f.Stat()
+	if err == nil && fi.Size() == 0 {
+		return "file is empty (0 bytes)"
+	}
+
+	var head [8]byte
+	n, _ := io.ReadFull(f, head[:])
+	sig := head[:n]
+
+	ext := strings.ToLower(filepath.Ext(path))
+	switch {
+	case bytes.HasPrefix(sig, []byte("PK\x03\x04")):
+		return "zip signature present but the archive could not be opened (truncated or corrupt)"
+	case bytes.HasPrefix(sig, []byte("%PDF")):
+		return "PDF header present but no readable pages"
+	case bytes.HasPrefix(sig, []byte{0xd0, 0xcf, 0x11, 0xe0}):
+		return "legacy Office signature present but the streams could not be read"
+	case ext != "":
+		return fmt.Sprintf("contents do not match the %s format", ext)
+	default:
+		return "format not recognised"
+	}
+}
+
+// classifyReason maps a diagnostic to a user-facing cause.
+func classifyReason(reason string) unscannedCause {
+	l := strings.ToLower(reason)
+	switch {
+	case strings.Contains(l, "permission denied"),
+		strings.Contains(l, "unreadable"),
+		strings.Contains(l, "no such file"):
+		return causeUnreadable
+	case strings.Contains(l, "preprocessors failed"),
+		strings.Contains(l, "not a valid"),
+		strings.Contains(l, "corrupt"):
+		return causeUnparseable
+	case strings.Contains(l, "no extractable text"),
+		strings.Contains(l, "empty extraction"),
+		strings.Contains(l, "no text"):
+		return causeNoText
+	default:
+		return causeCutShort
+	}
+}
+
+// collectUnscanned merges the four diagnostic channels into one ordered list.
+//
+// Order is by cause then path so the output is deterministic: this is stderr a
+// human reads and a script may diff, and a set iterated in map order would shuffle
+// between runs for no reason.
+func collectUnscanned(
+	unreadable []string,
+	emptyExtraction []parallel.FileDiagnostic,
+	failed []parallel.FileDiagnostic,
+	incomplete []parallel.FileDiagnostic,
+) []unscannedEntry {
+	var out []unscannedEntry
+
+	// The unreadable channel is a pre-formatted "path: reason" string rather than
+	// a struct, so it needs splitting on the first colon that follows the path.
+	for _, s := range unreadable {
+		path, reason := s, ""
+		if i := strings.Index(s, ": "); i > 0 {
+			path, reason = s[:i], s[i+2:]
+		}
+		out = append(out, unscannedEntry{
+			Path:   path,
+			Cause:  causeUnreadable,
+			Detail: firstNonEmpty(humanizeReason(path, reason), "could not be opened"),
+		})
+	}
+
+	for _, fd := range emptyExtraction {
+		d := humanizeReason(fd.FilePath, fd.Reason)
+		if d == "" {
+			d = "no readable text found"
+		}
+		out = append(out, unscannedEntry{fd.FilePath, causeNoText, d})
+	}
+	for _, fd := range failed {
+		cause := classifyReason(fd.Reason)
+		detail := humanizeReason(fd.FilePath, fd.Reason)
+		if cause == causeUnparseable && detail == "" {
+			// The internal reason ("all preprocessors failed for file: <path>") carries
+			// no information once the path is stripped, so look at the bytes.
+			detail = describeUnparseable(fd.FilePath)
+		}
+		if detail == "" {
+			detail = "no further detail"
+		}
+		out = append(out, unscannedEntry{fd.FilePath, cause, detail})
+	}
+	for _, fd := range incomplete {
+		d := humanizeReason(fd.FilePath, fd.Reason)
+		if d == "" {
+			d = "scan stopped before the file was finished"
+		}
+		out = append(out, unscannedEntry{fd.FilePath, causeCutShort, d})
+	}
+
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Cause != out[j].Cause {
+			return out[i].Cause < out[j].Cause
+		}
+		return out[i].Path < out[j].Path
+	})
+	return out
+}
+
+// inlineDetailLimit is how many individual paths the report prints before it
+// collapses to per-cause counts.
+//
+// Chosen from what the output actually looks like: a directory of 40 broken .docx
+// files produced 54 lines of stderr, 40 of them identical apart from the filename,
+// which buries both the findings table and the one line that matters. Below the
+// limit the full list is more useful than a count; above it, the count is more
+// useful than a wall of text, and the paths belong in a file.
+const inlineDetailLimit = 8
+
+// writeUnscannedReport renders the grouped report. It returns true if anything was
+// written.
+//
+// Wording note: the block does NOT say "NOT clean". A reviewer read that as a
+// verdict on the file's contents, when the actual meaning is the opposite — we
+// never saw the contents, so we cannot vouch either way. It now states that
+// plainly: the files were not read, so findings may be missing.
+//
+// Framing note: this writes NO rules of its own. The text formatter renders it
+// inside the summary block (FormatterOptions.NotExaminedFooter), so the summary's
+// closing double rule sits above it and a single rule closes it below — one footer
+// instead of two floating boxes on two different streams.
+func writeUnscannedReport(w io.Writer, entries []unscannedEntry, totalFiles int, failOnIncomplete, debug bool) bool {
+	if len(entries) == 0 {
+		return false
+	}
+
+	// "1 file" / "N files" — the plural was wrong on single-file runs, which is the
+	// most common way this report is seen.
+	noun := "files"
+	if len(entries) == 1 {
+		noun = "file"
+	}
+
+	fmt.Fprintf(w, "NOT EXAMINED: %d of %d %s — contents were never read, so findings may be missing\n",
+		len(entries), totalFiles, noun)
+
+	count := map[unscannedCause]int{}
+	for _, e := range entries {
+		count[e.Cause]++
+	}
+
+	hint := func() {
+		if !failOnIncomplete {
+			fmt.Fprintf(w, "  Add --fail-on-incomplete to make this a non-zero exit (3).\n")
+		}
+	}
+
+	if len(entries) > inlineDetailLimit {
+		// Too many to list. Give the per-cause tally and stop; the paths go to a
+		// file in a follow-up change, and until then --debug still lists them.
+		var parts []string
+		for _, c := range []unscannedCause{causeUnreadable, causeUnparseable, causeNoText, causeCutShort} {
+			if count[c] > 0 {
+				parts = append(parts, fmt.Sprintf("%s: %d", c, count[c]))
+			}
+		}
+		fmt.Fprintf(w, "  %s\n", strings.Join(parts, "  ·  "))
+		// Do not advise a flag that is already set: under --debug the per-file
+		// diagnostics are on stderr already, so telling the operator to re-run reads
+		// as though the tool did not notice what it was asked to do.
+		if !debug {
+			fmt.Fprintf(w, "  Re-run with --debug to list the files.\n")
+		}
+		hint()
+		return true
+	}
+
+	// Longest path in this run, so the detail column lines up without a fixed
+	// width that truncates or over-pads.
+	width := 0
+	for _, e := range entries {
+		if len(e.Path) > width {
+			width = len(e.Path)
+		}
+	}
+	if width > 60 {
+		width = 60
+	}
+
+	var lastCause unscannedCause = -1
+	for _, e := range entries {
+		if e.Cause != lastCause {
+			fmt.Fprintf(w, "  %s (%d)\n", e.Cause, count[e.Cause])
+			lastCause = e.Cause
+		}
+		fmt.Fprintf(w, "    %-*s  %s\n", width, e.Path, e.Detail)
+	}
+
+	hint()
+	return true
+}
+
+// firstNonEmpty returns the first non-empty string.
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/formatters/formatter.go
+++ b/internal/formatters/formatter.go
@@ -28,6 +28,18 @@ type FormatterOptions struct {
 	// (position depends on format: header for text, top-level field for JSON).
 	Stats *ScanStats
 
+	// NotExaminedFooter, when non-empty, is appended INSIDE the text formatter's
+	// summary block, between the summary's closing rule and a final single rule.
+	//
+	// It lives here rather than being printed by the caller so the whole footer is
+	// one contiguous block on ONE stream. Printed separately to stderr it rendered
+	// as a detached box after a blank line, and a piped stdout ended with a summary
+	// whose frame was closed by content the pipe never received.
+	//
+	// Text format only: structured formats carry the same information as data (see
+	// the unscanned key), not as decorated prose.
+	NotExaminedFooter string
+
 	// StreamWriter, when non-nil, causes the text formatter to write output
 	// directly to this writer instead of buffering into a returned string.
 	// The Format call returns "" when streaming is active — the caller must
@@ -39,15 +51,28 @@ type FormatterOptions struct {
 
 // ScanStats holds aggregate scan statistics rendered in the output summary.
 type ScanStats struct {
-	TotalFiles     int     `json:"total_files"`
-	FilesProcessed int     `json:"files_processed"`
-	FilesSkipped   int     `json:"files_skipped"`
-	TotalFindings  int     `json:"total_findings"`
-	High           int     `json:"high"`
-	Medium         int     `json:"medium"`
-	Low            int     `json:"low"`
-	Suppressed     int     `json:"suppressed"`
-	Duration       float64 `json:"duration_seconds"`
+	TotalFiles     int `json:"total_files"`
+	FilesProcessed int `json:"files_processed"`
+	FilesSkipped   int `json:"files_skipped"`
+
+	// FilesNotExamined counts files the tool could not read, parse or extract text
+	// from. They are NOT "skipped" (an unsupported type the user does not expect a
+	// result for) and NOT "processed" (a scan that ran to completion) — they are
+	// files whose contents were never seen, so nothing can be concluded about them.
+	//
+	// Before this existed the summary said "2 processed, 0 skipped" for a directory
+	// of 7 files where 2 were unreadable and 4 failed to parse: five files vanished
+	// from the accounting and one FAILURE was counted as "processed". A clean-looking
+	// summary over unexamined files is the same class of harm as a missed detection.
+	//
+	// omitempty so a scan with nothing to report stays byte-identical in JSON/YAML.
+	FilesNotExamined int     `json:"files_not_examined,omitempty"`
+	TotalFindings    int     `json:"total_findings"`
+	High             int     `json:"high"`
+	Medium           int     `json:"medium"`
+	Low              int     `json:"low"`
+	Suppressed       int     `json:"suppressed"`
+	Duration         float64 `json:"duration_seconds"`
 }
 
 // Formatter interface defines methods that all output formatters must implement

--- a/internal/formatters/text/formatter.go
+++ b/internal/formatters/text/formatter.go
@@ -88,7 +88,7 @@ func (f *Formatter) Format(matches []detector.Match, suppressedMatches []detecto
 		if isPrecommitMode {
 			return "", nil // Silent success in pre-commit mode when no matches
 		}
-		return "No matches found.", nil
+		return f.noMatchesText("No matches found.", options), nil
 	}
 
 	// Filter matches by confidence level
@@ -103,7 +103,7 @@ func (f *Formatter) Format(matches []detector.Match, suppressedMatches []detecto
 		if isPrecommitMode {
 			return "", nil // Silent success in pre-commit mode when no matches at specified levels
 		}
-		return "No matches found at the specified confidence levels.", nil
+		return f.noMatchesText("No matches found at the specified confidence levels.", options), nil
 	}
 
 	// Sort by confidence descending, then type ascending for priority ordering
@@ -195,22 +195,117 @@ func (f *Formatter) writeFormattedOutput(w io.Writer, matches []detector.Match, 
 	}
 }
 
+// noMatchesText renders the empty-result message, plus the not-examined footer when
+// there is one.
+//
+// The four "no matches" early returns bypass writeSummaryHeader entirely, so before
+// this a scan of two unreadable files printed exactly "No matches found." — the most
+// dangerous output the tool can produce, because it is the same text a genuinely
+// clean scan produces. The footer is the only thing distinguishing "I looked and
+// found nothing" from "I could not look".
+func (f *Formatter) noMatchesText(msg string, options formatters.FormatterOptions) string {
+	if options.NotExaminedFooter == "" {
+		return msg
+	}
+
+	width := summaryRuleFloor
+	for _, line := range strings.Split(options.NotExaminedFooter, "\n") {
+		if n := displayWidth(line); n > width {
+			width = n
+		}
+	}
+	if width > summaryRuleCeiling {
+		width = summaryRuleCeiling
+	}
+
+	return msg + "\n\n" +
+		rule("─", width) + "\n" +
+		options.NotExaminedFooter +
+		rule("═", width)
+}
+
+// Rule width bounds.
+//
+// The frame grows to fit its content but stops at summaryRuleCeiling: a single deep
+// file path can be 200+ characters, and a rule that long wraps in any normal
+// terminal, which looks far worse than a path overhanging its frame by a few
+// characters. 120 is the widest common terminal default.
+const (
+	summaryRuleFloor   = 80
+	summaryRuleCeiling = 120
+)
+
+// rule repeats r to the given width.
+func rule(r string, width int) string {
+	return strings.Repeat(r, width)
+}
+
+// displayWidth counts RUNES, not bytes.
+//
+// The summary and footer contain an em-dash and a middle dot, which are 3 and 2
+// bytes in UTF-8. Sizing a rule with len() therefore over-ran the text by several
+// characters for every non-ASCII glyph on the line.
+func displayWidth(s string) int {
+	return len([]rune(s))
+}
+
 // writeSummaryHeader writes the scan summary block to the writer.
+//
+// Frame: DOUBLE rule at the top and bottom of the whole block, SINGLE rule between
+// the summary counts and the not-examined detail. The two sections are one block
+// with a divider, not two stacked boxes.
+//
+// Rules are sized to the widest line they enclose. At a fixed 80 characters the
+// summary line ("Files: 276 scanned, 24 NOT examined | Findings: 4631 (1131 high,
+// 2535 medium, 965 low)" is 86) ran past its own frame.
 func (f *Formatter) writeSummaryHeader(w io.Writer, options formatters.FormatterOptions) {
 	stats := options.Stats
-	topLine := "\n═══ Scan Summary ═══════════════════════════════════════════════════════════════\n"
-	bottomLine := "════════════════════════════════════════════════════════════════════════════════\n"
 
-	summaryLine := fmt.Sprintf("Files: %d processed, %d skipped | Findings: %d (%d high, %d medium, %d low)",
-		stats.FilesProcessed, stats.FilesSkipped,
+	summaryLine := fmt.Sprintf("Files: %d scanned", stats.FilesProcessed)
+	// Only mention the categories that actually occurred. A clean run reads
+	// "Files: 12 scanned | Findings: 0" rather than carrying two zeroes the reader
+	// has to check every time.
+	if stats.FilesNotExamined > 0 {
+		summaryLine += fmt.Sprintf(", %d NOT examined", stats.FilesNotExamined)
+	}
+	if stats.FilesSkipped > 0 {
+		summaryLine += fmt.Sprintf(", %d skipped", stats.FilesSkipped)
+	}
+	summaryLine += fmt.Sprintf(" | Findings: %d (%d high, %d medium, %d low)",
 		stats.TotalFindings, stats.High, stats.Medium, stats.Low)
 	if stats.Suppressed > 0 {
 		summaryLine += fmt.Sprintf(" | %d suppressed", stats.Suppressed)
 	}
 
-	fmt.Fprint(w, topLine)
+	// Width covers every line the frame encloses, including the footer's.
+	width := summaryRuleFloor
+	if n := displayWidth(summaryLine); n > width {
+		width = n
+	}
+	for _, line := range strings.Split(options.NotExaminedFooter, "\n") {
+		if n := displayWidth(line); n > width {
+			width = n
+		}
+	}
+	if width > summaryRuleCeiling {
+		width = summaryRuleCeiling
+	}
+
+	const heading = "═══ Scan Summary "
+	top := heading + rule("═", width-displayWidth(heading))
+
+	fmt.Fprintf(w, "\n%s\n", top)
 	fmt.Fprintln(w, summaryLine)
-	fmt.Fprintln(w, bottomLine)
+
+	if options.NotExaminedFooter == "" {
+		fmt.Fprintf(w, "%s\n", rule("═", width))
+		return
+	}
+
+	// Single rule divides the two sections; double rule closes the block.
+	fmt.Fprintf(w, "%s\n", rule("─", width))
+	fmt.Fprint(w, options.NotExaminedFooter)
+	fmt.Fprintf(w, "%s\n", rule("═", width))
 }
 
 // filterMatchesByConfidence filters matches based on confidence level settings

--- a/internal/formatters/text/limit_test.go
+++ b/internal/formatters/text/limit_test.go
@@ -181,14 +181,73 @@ func TestSummaryStats_Rendered(t *testing.T) {
 	if !strings.Contains(result, "Scan Summary") {
 		t.Error("should contain 'Scan Summary' header")
 	}
-	if !strings.Contains(result, "8 processed") {
-		t.Error("should show files processed")
+	// "scanned", not "processed": a file that FAILED was previously counted as
+	// processed, so the old wording described a failure as a completed scan.
+	if !strings.Contains(result, "8 scanned") {
+		t.Error("should show files scanned")
 	}
 	if !strings.Contains(result, "2 skipped") {
 		t.Error("should show files skipped")
 	}
 	if !strings.Contains(result, "1 high") {
 		t.Error("should show HIGH count")
+	}
+}
+
+// TestSummaryStats_NotExaminedIsReported — a file whose contents were never seen
+// must appear in the summary.
+//
+// Before FilesNotExamined existed, a directory of 7 files where 2 were unreadable
+// and 4 unparseable rendered as "Files: 2 processed, 0 skipped": five files vanished
+// from the accounting and one FAILURE was reported as processed. A summary that reads
+// clean over unexamined files is the same class of harm as a missed detection, so the
+// count is asserted here rather than left to the stderr warning.
+func TestSummaryStats_NotExaminedIsReported(t *testing.T) {
+	matches := []detector.Match{makeMatch("SSN", 100, 1)}
+	opts := defaultOpts()
+	opts.Stats = &formatters.ScanStats{
+		TotalFiles:       7,
+		FilesProcessed:   2,
+		FilesNotExamined: 5,
+		TotalFindings:    1,
+		High:             1,
+	}
+
+	f := NewFormatter()
+	result, err := f.Format(matches, nil, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(result, "5 NOT examined") {
+		t.Errorf("summary must report the 5 unexamined files; got:\n%s", result)
+	}
+	if strings.Contains(result, "0 skipped") {
+		t.Error("a zero skipped-count must not be printed: it is noise on every clean " +
+			"run, and it was what made the old summary read as complete")
+	}
+}
+
+// TestSummaryStats_CleanRunIsQuiet — no zero-valued categories.
+//
+// The counters only appear when they are non-zero, so an ordinary clean scan reads
+// "Files: 12 scanned | Findings: 0" instead of carrying two zeroes the reader has to
+// check every time to confirm they are zero.
+func TestSummaryStats_CleanRunIsQuiet(t *testing.T) {
+	opts := defaultOpts()
+	opts.Stats = &formatters.ScanStats{TotalFiles: 12, FilesProcessed: 12}
+
+	f := NewFormatter()
+	result, err := f.Format([]detector.Match{makeMatch("SSN", 100, 1)}, nil, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(result, "12 scanned") {
+		t.Errorf("want '12 scanned'; got:\n%s", result)
+	}
+	for _, unwanted := range []string{"NOT examined", "skipped"} {
+		if strings.Contains(result, unwanted) {
+			t.Errorf("a clean run must not mention %q; got:\n%s", unwanted, result)
+		}
 	}
 }
 
@@ -319,5 +378,95 @@ func TestPrecommitMode_NoSummaryOrLimit(t *testing.T) {
 	// summary headers or be affected by --limit (it has its own contract).
 	if strings.Contains(result, "Scan Summary") {
 		t.Error("pre-commit mode should NOT show summary header")
+	}
+}
+
+// TestSummaryFrameShape — double rule top and bottom, single rule dividing the
+// summary counts from the not-examined detail.
+//
+// The frame is load-bearing: the two sections are one block with a divider, not two
+// stacked boxes on (previously) two different streams. An earlier version emitted a
+// double rule in the middle and a single at the bottom, which read as the summary
+// ending and an unrelated box beginning.
+func TestSummaryFrameShape(t *testing.T) {
+	opts := defaultOpts()
+	opts.Stats = &formatters.ScanStats{
+		TotalFiles: 7, FilesProcessed: 2, FilesNotExamined: 5,
+		TotalFindings: 1, Medium: 1,
+	}
+	opts.NotExaminedFooter = "NOT EXAMINED: 5 of 7 files\n  cannot read (5)\n"
+
+	out, err := NewFormatter().Format([]detector.Match{makeMatch("SSN", 80, 1)}, nil, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var rules []rune
+	for _, line := range strings.Split(out, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		r := []rune(trimmed)[0]
+		if (r == '═' || r == '─') && !strings.Contains(line, "Scan Summary") {
+			rules = append(rules, r)
+		} else if strings.Contains(line, "Scan Summary") {
+			rules = append(rules, '═')
+		}
+	}
+
+	// top ═, divider ─, bottom ═
+	want := []rune{'═', '─', '═'}
+	if len(rules) != len(want) {
+		t.Fatalf("frame has %d rules, want %d (top/divider/bottom):\n%s", len(rules), len(want), out)
+	}
+	for i := range want {
+		if rules[i] != want[i] {
+			t.Errorf("rule %d is %q, want %q — the divider must be single and the outer "+
+				"rules double, or the block reads as two separate boxes:\n%s",
+				i, string(rules[i]), string(want[i]), out)
+		}
+	}
+}
+
+// TestSummaryRulesReachTheirContent — a rule must not be shorter than the text it
+// frames, and must not run away on a long path.
+//
+// Measured before the fix: "Files: 276 scanned, 24 NOT examined | Findings: 4631
+// (1131 high, 2535 medium, 965 low)" is 86 characters inside an 80-character frame,
+// so the summary line visibly overhung its own box.
+func TestSummaryRulesReachTheirContent(t *testing.T) {
+	opts := defaultOpts()
+	opts.Stats = &formatters.ScanStats{
+		TotalFiles: 299, FilesProcessed: 276, FilesNotExamined: 24,
+		TotalFindings: 4631, High: 1131, Medium: 2535, Low: 965,
+	}
+
+	out, err := NewFormatter().Format([]detector.Match{makeMatch("SSN", 80, 1)}, nil, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	widest, ruleWidth := 0, 0
+	for _, line := range strings.Split(out, "\n") {
+		n := len([]rune(line))
+		if strings.HasPrefix(line, "Files:") && n > widest {
+			widest = n
+		}
+		if strings.HasPrefix(line, "════") {
+			ruleWidth = n
+		}
+	}
+
+	if widest == 0 || ruleWidth == 0 {
+		t.Fatalf("could not find the summary line and its rule:\n%s", out)
+	}
+	if ruleWidth < widest {
+		t.Errorf("rule is %d wide but the summary line is %d: the text overhangs its own "+
+			"frame", ruleWidth, widest)
+	}
+	if ruleWidth > 120 {
+		t.Errorf("rule is %d wide; over 120 it wraps in a normal terminal, which looks "+
+			"worse than a slight overhang", ruleWidth)
 	}
 }

--- a/internal/formatters/text/limit_test.go
+++ b/internal/formatters/text/limit_test.go
@@ -5,6 +5,7 @@ package text
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -468,5 +469,55 @@ func TestSummaryRulesReachTheirContent(t *testing.T) {
 	if ruleWidth > 120 {
 		t.Errorf("rule is %d wide; over 120 it wraps in a normal terminal, which looks "+
 			"worse than a slight overhang", ruleWidth)
+	}
+}
+
+// TestSummaryCountsReconcile — scanned + NOT examined + skipped must not exceed the
+// file count.
+//
+// An empty-extraction file (opened fine, no readable text) is counted PROCESSED by
+// the worker pool and ALSO appears in the not-examined set, because both statements
+// are true from their own vantage point. Printed side by side they double-count it:
+// measured on 2 files where one was a valid but empty .docx, the summary read
+// "2 scanned, 1 NOT examined" — 3 of 2. On a 301-file run it surfaced as 278 + 24 =
+// 302, which a reader has to reconcile and cannot.
+func TestSummaryCountsReconcile(t *testing.T) {
+	cases := []struct {
+		name                                   string
+		total, processed, notExamined, skipped int
+	}{
+		{"all clean", 10, 10, 0, 0},
+		{"some unexamined", 7, 2, 5, 0},
+		{"unexamined and skipped", 10, 4, 3, 3},
+		{"single file unexamined", 1, 0, 1, 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := defaultOpts()
+			opts.Stats = &formatters.ScanStats{
+				TotalFiles: tc.total, FilesProcessed: tc.processed,
+				FilesNotExamined: tc.notExamined, FilesSkipped: tc.skipped,
+				TotalFindings: 1, Medium: 1,
+			}
+
+			out, err := NewFormatter().Format([]detector.Match{makeMatch("SSN", 80, 1)}, nil, opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if sum := tc.processed + tc.notExamined + tc.skipped; sum > tc.total {
+				t.Fatalf("the fixture itself over-counts (%d > %d total); the caller must "+
+					"not hand the formatter overlapping categories", sum, tc.total)
+			}
+
+			// The rendered line must carry each non-zero category exactly once.
+			if !strings.Contains(out, fmt.Sprintf("%d scanned", tc.processed)) {
+				t.Errorf("summary does not report %d scanned:\n%s", tc.processed, out)
+			}
+			if tc.notExamined > 0 && !strings.Contains(out, fmt.Sprintf("%d NOT examined", tc.notExamined)) {
+				t.Errorf("summary does not report %d NOT examined:\n%s", tc.notExamined, out)
+			}
+		})
 	}
 }


### PR DESCRIPTION
A file the tool could not read must never be indistinguishable from a file that was read and found clean. Four separate defects made it exactly that.

## 1. The summary said `0 skipped` for files it never opened

The skip-classification loop does `continue` for an unreadable file **before** `skippedFiles++`, so it landed in no counter at all. Measured on a 7-file directory with 2 unreadable and 4 unparseable files:

```
Files: 2 processed, 0 skipped
```

Five files vanished from the accounting, and `2 processed` included a file that **failed**. The comment above that loop already documented the intent to separate unreadable from unsupported — only the count was dropped.

Now `Files: 2 scanned, 5 NOT examined`, which reconciles (2 + 5 = 7). "scanned", not "processed", because a failure is not a completed scan. `ScanStats` gains `FilesNotExamined` (omitempty, so json/yaml are unchanged when zero and no golden moves).

## 2. Four WARNING banners became one report

Before, each failure mode printed its own block, each line repeating the path then appending a raw Go error:

```
WARNING: scan incomplete — 1 of 1 file(s) could not be opened, so they were not scanned at all; any sensitive data they contain was NOT detected:
  /tmp/x/noperm.txt: Unreadable: open /tmp/x/noperm.txt: permission denied
```

The path appears **three times**, `Unreadable:` is internal vocabulary, and the consequence sits in a subordinate clause. Now:

```
═══ Scan Summary ══════════════════════════════════════════════════════════
Files: 2 scanned, 5 NOT examined | Findings: 1 (0 high, 1 medium, 0 low)
───────────────────────────────────────────────────────────────────────────
NOT EXAMINED: 5 of 7 files — contents were never read, so findings may be missing
  cannot read (2)
    /tmp/mixdir/hr_notes.txt   permission denied
  cannot parse (3)
    /tmp/mixdir/budget.xlsx    zip signature present but the archive could not be opened
  Add --fail-on-incomplete to make this a non-zero exit (3).
═══════════════════════════════════════════════════════════════════════════
```

It renders **inside** the block (`FormatterOptions.NotExaminedFooter`) rather than being printed separately: on stderr while the summary is on stdout, a piped report ended with a frame whose closing rule went to the terminal.

Rules are sized to content (floor 80, ceiling 120). The real-world summary line `Files: 276 scanned, 24 NOT examined | Findings: 4631 (...)` is **86 characters** and visibly overhung its 80-character frame. Width counts **runes** — the em-dash and middle dot are 3 and 2 bytes, so `len()` over-ran by several characters per glyph.

Detail comes from the **bytes, not the extension**: `describeUnparseable` reads the signature, so *"zip signature present but the archive could not be opened"* is an observation. Inferring *"corrupt Office document"* from `.xlsx` would be a guess, and a wrong guess sends the operator looking in the wrong place.

Over 8 files the list collapses to per-cause counts — 40 broken `.docx` produced **54 lines** of stderr, 40 identical apart from the filename, burying both the findings table and the one line that mattered.

## 3. Pre-commit exited 0 with ZERO bytes of output

Measured: `PRE_COMMIT=1` on a directory whose only file was `chmod 000` produced **no stdout, no stderr, rc=0** — byte-identical to a clean pass, on a file that may be full of PII. The commit is allowed and nothing says why. That is the [#193](https://github.com/awslabs/ferret-scan/pull/193) shape.

Pre-commit now emits one terse line (no frame; it is read mid-commit):

```
ferret-scan: 1 file NOT examined (contents unreadable) — findings may be missing. Re-run without --pre-commit for detail.
```

## 4. Unreadable and corrupt files exited DIFFERENTLY

| scenario | before (pre-commit) | after |
|---|---|---|
| clean | 0 | 0 |
| **unreadable, no findings** | **0**, silent | 0 + warning; **3** with `--fail-on-incomplete` |
| **corrupt, no findings** | **2** | 0 + warning; **3** with `--fail-on-incomplete` |
| MEDIUM finding | 0 · 1 at `EXIT_ON=medium` | unchanged |

Cause: `hasErrors` was `len(supportedFiles) - processedFiles`, and an unreadable file never *enters* `supportedFiles` — the same counter-skipping shape as defect 1. Nobody chose the split.

Exit code 2 is documented as *"the tool failed"*, so it is reclaimed for that: `hasErrors` is now fed by the `Parallel processing failed` branch, which previously only printed and never affected the exit code.

**Deliberately NOT changed:** unexamined files still need `--fail-on-incomplete` to be non-zero. Making that the default would break commits that pass today, and the first time it fires on a broken `.docx` mid-hotfix the hook gets disabled — and a disabled hook catches nothing. It is loud at rc=0 now, so the default can be flipped later on evidence rather than assertion.

## Also: the duplicate `--limit` note

The out-of-band *"output limited to N of M findings"* line was emitted for every format *"since it costs nothing to be consistent"* — my own reasoning in [#274](https://github.com/awslabs/ferret-scan/pull/274). It does cost something: measured on a 3-finding scan at `--limit 1`, **six of seven formats already disclose truncation in band** (text `and N more findings`, json/yaml `truncated:true`, junit `system-out`, sarif run properties, gitlab-sast scan block), so the note repeated the report's own disclosure immediately after it. Now scoped to **csv**, the one format with nowhere to put metadata, and worded to say why.

## Testing

- **6 output modes verified end to end:** `--limit 0`, `--limit N`, `--debug`, `--fail-on-incomplete`, all 7 formats, and a clean run.
- `--debug` no longer advises *"re-run with --debug"* when debug is already on.
- **`No matches found.` carried NO footer**, because four early returns bypass the summary — the same text a genuinely clean scan prints, on files never read. Fixed and covered.
- `TestSummaryFrameShape` pins double/single/double; a swap fails it. `TestSummaryRulesReachTheirContent` uses the real 4631-finding numbers.
- **3 new exit-code tests drive the real binary**, with a clean-scan control so a change marking every file unexamined cannot pass.
- **Non-vacuity via COMPILING mutations:** restoring the old `hasErrors` makes unreadable/corrupt disagree again (3 vs 2); removing the pre-commit line restores the zero-byte silence. Both fail with the intended message. A first attempt produced a build failure, which proves nothing, and was redone.
- Full module `-race`: **rc=0, 64 packages, 0 FAIL.** Golden **186 = 186**, zero drift. gofmt/vet clean, `GOOS=windows go vet` clean.
- **Zero file overlap with [#276](https://github.com/awslabs/ferret-scan/pull/276)**, so the two merge in either order.

## Known gap, next PR

Machine-readable formats carry only the **count** (json/yaml, free via `ScanStats`) and not the file list; **csv/junit/sarif/gitlab-sast carry nothing at all**. Those are the CI-facing formats and deserve their own diff — a SARIF consumer today sees findings with no indication that files went unexamined.