### PR TITLE
fix(ssn): read a value's column header as context for that value

### DIFF
--- a/internal/goldencorpus/testdata/golden/file_csv_tabular_pii.csv
+++ b/internal/goldencorpus/testdata/golden/file_csv_tabular_pii.csv
@@ -1,7 +1,7 @@
 Filename,Type,Confidence Level,Confidence %,Line Number,Text
+<TMPDIR>/people.csv,SSN,MEDIUM,85.0,2,449-87-4100
+<TMPDIR>/people.csv,SSN,MEDIUM,85.0,3,529-11-2233
 <TMPDIR>/people.csv,BUSINESS,MEDIUM,75.0,2,alice@example.com
 <TMPDIR>/people.csv,BUSINESS,MEDIUM,75.0,3,bob@example.org
-<TMPDIR>/people.csv,SSN,MEDIUM,75.0,2,449-87-4100
-<TMPDIR>/people.csv,SSN,MEDIUM,75.0,3,529-11-2233
 <TMPDIR>/people.csv,MASTERCARD,LOW,25.0,3,5425233430109903
 <TMPDIR>/people.csv,VISA,LOW,25.0,2,4532015112830366

--- a/internal/goldencorpus/testdata/golden/file_csv_tabular_pii.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_csv_tabular_pii.gitlab-sast.json
@@ -28,6 +28,58 @@
   "vulnerabilities": [
     {
       "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <TMPDIR>/people.csv (line 2)\n**Confidence:** MEDIUM (85.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\nAlice,alice@example.com,449-87-4100,4532015112830366\n```\n\n**Additional Information:**\n- context_impact: -20\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "SSN"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "ssn"
+        }
+      ],
+      "location": {
+        "end_line": 2,
+        "file": "people.csv",
+        "start_line": 2
+      },
+      "message": "Social Security Number detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Social Security Number Detected",
+      "severity": "High"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <TMPDIR>/people.csv (line 3)\n**Confidence:** MEDIUM (85.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\nBob,bob@example.org,529-11-2233,5425233430109903\n```\n\n**Additional Information:**\n- context_impact: -20\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "SSN"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "ssn"
+        }
+      ],
+      "location": {
+        "end_line": 3,
+        "file": "people.csv",
+        "start_line": 3
+      },
+      "message": "Social Security Number detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Social Security Number Detected",
+      "severity": "High"
+    },
+    {
+      "category": "sast",
       "confidence": "Medium",
       "description": "Ferret Scan detected sensitive data (business) in this file.\n\n**Location:** <TMPDIR>/people.csv (line 2)\n**Confidence:** MEDIUM (75.0%)\n**Detected by:** email validator\n\n**Context:**\n```\nAlice,alice@example.com,449-87-4100,4532015112830366\n```\n\n**Additional Information:**\n- context_impact: -5\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
       "id": "ferret-<HASH>",
@@ -76,58 +128,6 @@
       },
       "message": "Sensitive data (business) detected: [HIDDEN] (confidence: MEDIUM)",
       "name": "Business Detected",
-      "severity": "High"
-    },
-    {
-      "category": "sast",
-      "confidence": "Medium",
-      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <TMPDIR>/people.csv (line 2)\n**Confidence:** MEDIUM (75.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\nAlice,alice@example.com,449-87-4100,4532015112830366\n```\n\n**Additional Information:**\n- context_impact: -30\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
-      "id": "ferret-<HASH>",
-      "identifiers": [
-        {
-          "name": "Ferret Scan Check Type",
-          "type": "ferret_scan_check_type",
-          "value": "SSN"
-        },
-        {
-          "name": "Ferret Scan Validator",
-          "type": "ferret_scan_validator",
-          "value": "ssn"
-        }
-      ],
-      "location": {
-        "end_line": 2,
-        "file": "people.csv",
-        "start_line": 2
-      },
-      "message": "Social Security Number detected: [HIDDEN] (confidence: MEDIUM)",
-      "name": "Social Security Number Detected",
-      "severity": "High"
-    },
-    {
-      "category": "sast",
-      "confidence": "Medium",
-      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <TMPDIR>/people.csv (line 3)\n**Confidence:** MEDIUM (75.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\nBob,bob@example.org,529-11-2233,5425233430109903\n```\n\n**Additional Information:**\n- context_impact: -30\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
-      "id": "ferret-<HASH>",
-      "identifiers": [
-        {
-          "name": "Ferret Scan Check Type",
-          "type": "ferret_scan_check_type",
-          "value": "SSN"
-        },
-        {
-          "name": "Ferret Scan Validator",
-          "type": "ferret_scan_validator",
-          "value": "ssn"
-        }
-      ],
-      "location": {
-        "end_line": 3,
-        "file": "people.csv",
-        "start_line": 3
-      },
-      "message": "Social Security Number detected: [HIDDEN] (confidence: MEDIUM)",
-      "name": "Social Security Number Detected",
       "severity": "High"
     },
     {

--- a/internal/goldencorpus/testdata/golden/file_csv_tabular_pii.json.json
+++ b/internal/goldencorpus/testdata/golden/file_csv_tabular_pii.json.json
@@ -1,6 +1,78 @@
 {
   "results": [
     {
+      "confidence": 85,
+      "confidence_level": "MEDIUM",
+      "filename": "<TMPDIR>/people.csv",
+      "line_number": 2,
+      "metadata": {
+        "confidence_adjustment": 20,
+        "context_confidence": 1,
+        "context_doctype": "CSV",
+        "context_domain": "HR_Payroll",
+        "context_impact": -20,
+        "original_confidence": 65,
+        "original_file": "<TMPDIR>/people.csv",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0.125
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "format": true,
+          "not_common_pattern": true,
+          "not_repeating": true,
+          "not_sequential": true,
+          "not_test_number": true,
+          "valid_area": true
+        },
+        "validation_path": "document"
+      },
+      "text": "449-87-4100",
+      "type": "SSN",
+      "validator": "ssn"
+    },
+    {
+      "confidence": 85,
+      "confidence_level": "MEDIUM",
+      "filename": "<TMPDIR>/people.csv",
+      "line_number": 3,
+      "metadata": {
+        "confidence_adjustment": 20,
+        "context_confidence": 1,
+        "context_doctype": "CSV",
+        "context_domain": "HR_Payroll",
+        "context_impact": -20,
+        "original_confidence": 65,
+        "original_file": "<TMPDIR>/people.csv",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0.125
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "format": true,
+          "not_common_pattern": true,
+          "not_repeating": true,
+          "not_sequential": true,
+          "not_test_number": true,
+          "valid_area": true
+        },
+        "validation_path": "document"
+      },
+      "text": "529-11-2233",
+      "type": "SSN",
+      "validator": "ssn"
+    },
+    {
       "confidence": 75,
       "confidence_level": "MEDIUM",
       "filename": "<TMPDIR>/people.csv",
@@ -81,78 +153,6 @@
       "text": "bob@example.org",
       "type": "BUSINESS",
       "validator": "email"
-    },
-    {
-      "confidence": 75,
-      "confidence_level": "MEDIUM",
-      "filename": "<TMPDIR>/people.csv",
-      "line_number": 2,
-      "metadata": {
-        "confidence_adjustment": 20,
-        "context_confidence": 1,
-        "context_doctype": "CSV",
-        "context_domain": "HR_Payroll",
-        "context_impact": -30,
-        "original_confidence": 55,
-        "original_file": "<TMPDIR>/people.csv",
-        "semantic_context": {
-          "FinancialData": 0,
-          "MedicalData": 0,
-          "PersonalData": 0,
-          "Production": 0,
-          "TestData": 0.125
-        },
-        "source": "preprocessed_content",
-        "validation_checks": {
-          "digits": true,
-          "format": true,
-          "not_common_pattern": true,
-          "not_repeating": true,
-          "not_sequential": true,
-          "not_test_number": true,
-          "valid_area": true
-        },
-        "validation_path": "document"
-      },
-      "text": "449-87-4100",
-      "type": "SSN",
-      "validator": "ssn"
-    },
-    {
-      "confidence": 75,
-      "confidence_level": "MEDIUM",
-      "filename": "<TMPDIR>/people.csv",
-      "line_number": 3,
-      "metadata": {
-        "confidence_adjustment": 20,
-        "context_confidence": 1,
-        "context_doctype": "CSV",
-        "context_domain": "HR_Payroll",
-        "context_impact": -30,
-        "original_confidence": 55,
-        "original_file": "<TMPDIR>/people.csv",
-        "semantic_context": {
-          "FinancialData": 0,
-          "MedicalData": 0,
-          "PersonalData": 0,
-          "Production": 0,
-          "TestData": 0.125
-        },
-        "source": "preprocessed_content",
-        "validation_checks": {
-          "digits": true,
-          "format": true,
-          "not_common_pattern": true,
-          "not_repeating": true,
-          "not_sequential": true,
-          "not_test_number": true,
-          "valid_area": true
-        },
-        "validation_path": "document"
-      },
-      "text": "529-11-2233",
-      "type": "SSN",
-      "validator": "ssn"
     },
     {
       "confidence": 25,

--- a/internal/goldencorpus/testdata/golden/file_csv_tabular_pii.junit.xml
+++ b/internal/goldencorpus/testdata/golden/file_csv_tabular_pii.junit.xml
@@ -2,7 +2,7 @@
 <testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
   <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
     <testcase name="people.csv" classname="security-scan" time="0.001">
-      <failure message="6 security findings detected" type="SECURITY_FINDINGS">Line 2: BUSINESS detected with 75.0% confidence (MEDIUM)&#xA;Match: alice@example.com&#xA;Validator: email&#xA;Line 3: BUSINESS detected with 75.0% confidence (MEDIUM)&#xA;Match: bob@example.org&#xA;Validator: email&#xA;Line 2: SSN detected with 75.0% confidence (MEDIUM)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 3: SSN detected with 75.0% confidence (MEDIUM)&#xA;Match: 529-11-2233&#xA;Validator: ssn&#xA;Line 3: MASTERCARD detected with 25.0% confidence (LOW)&#xA;Match: 5425233430109903&#xA;Validator: creditcard&#xA;Line 2: VISA detected with 25.0% confidence (LOW)&#xA;Match: 4532015112830366&#xA;Validator: creditcard</failure>
+      <failure message="6 security findings detected" type="SECURITY_FINDINGS">Line 2: SSN detected with 85.0% confidence (MEDIUM)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 3: SSN detected with 85.0% confidence (MEDIUM)&#xA;Match: 529-11-2233&#xA;Validator: ssn&#xA;Line 2: BUSINESS detected with 75.0% confidence (MEDIUM)&#xA;Match: alice@example.com&#xA;Validator: email&#xA;Line 3: BUSINESS detected with 75.0% confidence (MEDIUM)&#xA;Match: bob@example.org&#xA;Validator: email&#xA;Line 3: MASTERCARD detected with 25.0% confidence (LOW)&#xA;Match: 5425233430109903&#xA;Validator: creditcard&#xA;Line 2: VISA detected with 25.0% confidence (LOW)&#xA;Match: 4532015112830366&#xA;Validator: creditcard</failure>
     </testcase>
   </testsuite>
 </testsuites>

--- a/internal/goldencorpus/testdata/golden/file_csv_tabular_pii.sarif.json
+++ b/internal/goldencorpus/testdata/golden/file_csv_tabular_pii.sarif.json
@@ -13,6 +13,144 @@
                 },
                 "contextRegion": {
                   "snippet": {
+                    "text": "Alice,alice@example.com,\nAlice,alice@example.com,449-87-4100,4532015112830366\n,4532015112830366"
+                  },
+                  "startLine": 2
+                },
+                "region": {
+                  "endColumn": 36,
+                  "snippet": {
+                    "text": "Alice,alice@example.com,449-87-4100,4532015112830366"
+                  },
+                  "startColumn": 25,
+                  "startLine": 2
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Social Security Number Detected in people.csv at line 2 (confidence: 85.0% - MEDIUM). Matched text: '449-87-4100'"
+          },
+          "properties": {
+            "confidence": 85,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 20,
+              "context_confidence": 1,
+              "context_doctype": "CSV",
+              "context_domain": "HR_Payroll",
+              "context_impact": -20,
+              "original_confidence": 65,
+              "original_file": "<TMPDIR>/people.csv",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0.1
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "digits": true,
+                "format": true,
+                "not_common_pattern": true,
+                "not_repeating": true,
+                "not_sequential": true,
+                "not_test_number": true,
+                "valid_area": true
+              },
+              "validation_path": "document"
+            },
+            "negativeKeywords": [
+              "example"
+            ],
+            "positiveKeywords": [
+              "ssn"
+            ],
+            "validator": "ssn"
+          },
+          "rank": 92.5,
+          "ruleId": "SSN"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/people.csv"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "Bob,bob@example.org,\nBob,bob@example.org,529-11-2233,5425233430109903\n,5425233430109903"
+                  },
+                  "startLine": 3
+                },
+                "region": {
+                  "endColumn": 32,
+                  "snippet": {
+                    "text": "Bob,bob@example.org,529-11-2233,5425233430109903"
+                  },
+                  "startColumn": 21,
+                  "startLine": 3
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Social Security Number Detected in people.csv at line 3 (confidence: 85.0% - MEDIUM). Matched text: '529-11-2233'"
+          },
+          "properties": {
+            "confidence": 85,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 20,
+              "context_confidence": 1,
+              "context_doctype": "CSV",
+              "context_domain": "HR_Payroll",
+              "context_impact": -20,
+              "original_confidence": 65,
+              "original_file": "<TMPDIR>/people.csv",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0.1
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "digits": true,
+                "format": true,
+                "not_common_pattern": true,
+                "not_repeating": true,
+                "not_sequential": true,
+                "not_test_number": true,
+                "valid_area": true
+              },
+              "validation_path": "document"
+            },
+            "negativeKeywords": [
+              "example"
+            ],
+            "positiveKeywords": [
+              "ssn"
+            ],
+            "validator": "ssn"
+          },
+          "rank": 92.5,
+          "ruleId": "SSN"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/people.csv"
+                },
+                "contextRegion": {
+                  "snippet": {
                     "text": "Alice,\nAlice,alice@example.com,449-87-4100,4532015112830366\n,449-87-4100,4532015112830366"
                   },
                   "startLine": 2
@@ -144,138 +282,6 @@
           },
           "rank": 62.5,
           "ruleId": "BUSINESS"
-        },
-        {
-          "level": "error",
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "file://<TMPDIR>/people.csv"
-                },
-                "contextRegion": {
-                  "snippet": {
-                    "text": "Alice,alice@example.com,\nAlice,alice@example.com,449-87-4100,4532015112830366\n,4532015112830366"
-                  },
-                  "startLine": 2
-                },
-                "region": {
-                  "endColumn": 36,
-                  "snippet": {
-                    "text": "Alice,alice@example.com,449-87-4100,4532015112830366"
-                  },
-                  "startColumn": 25,
-                  "startLine": 2
-                }
-              }
-            }
-          ],
-          "message": {
-            "text": "Social Security Number Detected in people.csv at line 2 (confidence: 75.0% - MEDIUM). Matched text: '449-87-4100'"
-          },
-          "properties": {
-            "confidence": 75,
-            "confidenceLevel": "MEDIUM",
-            "metadata": {
-              "confidence_adjustment": 20,
-              "context_confidence": 1,
-              "context_doctype": "CSV",
-              "context_domain": "HR_Payroll",
-              "context_impact": -30,
-              "original_confidence": 55,
-              "original_file": "<TMPDIR>/people.csv",
-              "semantic_context": {
-                "FinancialData": 0,
-                "MedicalData": 0,
-                "PersonalData": 0,
-                "Production": 0,
-                "TestData": 0.1
-              },
-              "source": "preprocessed_content",
-              "validation_checks": {
-                "digits": true,
-                "format": true,
-                "not_common_pattern": true,
-                "not_repeating": true,
-                "not_sequential": true,
-                "not_test_number": true,
-                "valid_area": true
-              },
-              "validation_path": "document"
-            },
-            "negativeKeywords": [
-              "example"
-            ],
-            "validator": "ssn"
-          },
-          "rank": 87.5,
-          "ruleId": "SSN"
-        },
-        {
-          "level": "error",
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "file://<TMPDIR>/people.csv"
-                },
-                "contextRegion": {
-                  "snippet": {
-                    "text": "Bob,bob@example.org,\nBob,bob@example.org,529-11-2233,5425233430109903\n,5425233430109903"
-                  },
-                  "startLine": 3
-                },
-                "region": {
-                  "endColumn": 32,
-                  "snippet": {
-                    "text": "Bob,bob@example.org,529-11-2233,5425233430109903"
-                  },
-                  "startColumn": 21,
-                  "startLine": 3
-                }
-              }
-            }
-          ],
-          "message": {
-            "text": "Social Security Number Detected in people.csv at line 3 (confidence: 75.0% - MEDIUM). Matched text: '529-11-2233'"
-          },
-          "properties": {
-            "confidence": 75,
-            "confidenceLevel": "MEDIUM",
-            "metadata": {
-              "confidence_adjustment": 20,
-              "context_confidence": 1,
-              "context_doctype": "CSV",
-              "context_domain": "HR_Payroll",
-              "context_impact": -30,
-              "original_confidence": 55,
-              "original_file": "<TMPDIR>/people.csv",
-              "semantic_context": {
-                "FinancialData": 0,
-                "MedicalData": 0,
-                "PersonalData": 0,
-                "Production": 0,
-                "TestData": 0.1
-              },
-              "source": "preprocessed_content",
-              "validation_checks": {
-                "digits": true,
-                "format": true,
-                "not_common_pattern": true,
-                "not_repeating": true,
-                "not_sequential": true,
-                "not_test_number": true,
-                "valid_area": true
-              },
-              "validation_path": "document"
-            },
-            "negativeKeywords": [
-              "example"
-            ],
-            "validator": "ssn"
-          },
-          "rank": 87.5,
-          "ruleId": "SSN"
         },
         {
           "level": "error",

--- a/internal/goldencorpus/testdata/golden/file_csv_tabular_pii.txt
+++ b/internal/goldencorpus/testdata/golden/file_csv_tabular_pii.txt
@@ -1,8 +1,8 @@
 LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH             FILE
 -------------------------------------------------------------------------------------------
+[MEDIUM] ssn          SSN                    85.00% line     2 449-87-4100       people.csv
+[MEDIUM] ssn          SSN                    85.00% line     3 529-11-2233       people.csv
 [MEDIUM] email        BUSINESS               75.00% line     2 alice@example.com people.csv
 [MEDIUM] email        BUSINESS               75.00% line     3 bob@example.org   people.csv
-[MEDIUM] ssn          SSN                    75.00% line     2 449-87-4100       people.csv
-[MEDIUM] ssn          SSN                    75.00% line     3 529-11-2233       people.csv
 [LOW   ] creditcard   MASTERCARD             25.00% line     3 5425233430109903  people.csv
 [LOW   ] creditcard   VISA                   25.00% line     2 4532015112830366  people.csv

--- a/internal/goldencorpus/testdata/golden/file_csv_tabular_pii.yaml
+++ b/internal/goldencorpus/testdata/golden/file_csv_tabular_pii.yaml
@@ -1,4 +1,66 @@
 results:
+    - text: 449-87-4100
+      line_number: 2
+      type: SSN
+      confidence: 85
+      confidence_level: MEDIUM
+      filename: <TMPDIR>/people.csv
+      validator: ssn
+      metadata:
+        confidence_adjustment: 20
+        context_confidence: 1
+        context_doctype: CSV
+        context_domain: HR_Payroll
+        context_impact: -20
+        original_confidence: 65
+        original_file: <TMPDIR>/people.csv
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0.125
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            format: true
+            not_common_pattern: true
+            not_repeating: true
+            not_sequential: true
+            not_test_number: true
+            valid_area: true
+        validation_path: document
+    - text: 529-11-2233
+      line_number: 3
+      type: SSN
+      confidence: 85
+      confidence_level: MEDIUM
+      filename: <TMPDIR>/people.csv
+      validator: ssn
+      metadata:
+        confidence_adjustment: 20
+        context_confidence: 1
+        context_doctype: CSV
+        context_domain: HR_Payroll
+        context_impact: -20
+        original_confidence: 65
+        original_file: <TMPDIR>/people.csv
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0.125
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            format: true
+            not_common_pattern: true
+            not_repeating: true
+            not_sequential: true
+            not_test_number: true
+            valid_area: true
+        validation_path: document
     - text: alice@example.com
       line_number: 2
       type: BUSINESS
@@ -70,68 +132,6 @@ results:
             valid_format: true
             valid_tld: true
             valid_username: true
-        validation_path: document
-    - text: 449-87-4100
-      line_number: 2
-      type: SSN
-      confidence: 75
-      confidence_level: MEDIUM
-      filename: <TMPDIR>/people.csv
-      validator: ssn
-      metadata:
-        confidence_adjustment: 20
-        context_confidence: 1
-        context_doctype: CSV
-        context_domain: HR_Payroll
-        context_impact: -30
-        original_confidence: 55
-        original_file: <TMPDIR>/people.csv
-        semantic_context:
-            FinancialData: 0
-            MedicalData: 0
-            PersonalData: 0
-            Production: 0
-            TestData: 0.125
-        source: preprocessed_content
-        validation_checks:
-            digits: true
-            format: true
-            not_common_pattern: true
-            not_repeating: true
-            not_sequential: true
-            not_test_number: true
-            valid_area: true
-        validation_path: document
-    - text: 529-11-2233
-      line_number: 3
-      type: SSN
-      confidence: 75
-      confidence_level: MEDIUM
-      filename: <TMPDIR>/people.csv
-      validator: ssn
-      metadata:
-        confidence_adjustment: 20
-        context_confidence: 1
-        context_doctype: CSV
-        context_domain: HR_Payroll
-        context_impact: -30
-        original_confidence: 55
-        original_file: <TMPDIR>/people.csv
-        semantic_context:
-            FinancialData: 0
-            MedicalData: 0
-            PersonalData: 0
-            Production: 0
-            TestData: 0.125
-        source: preprocessed_content
-        validation_checks:
-            digits: true
-            format: true
-            not_common_pattern: true
-            not_repeating: true
-            not_sequential: true
-            not_test_number: true
-            valid_area: true
         validation_path: document
     - text: "5425233430109903"
       line_number: 3

--- a/internal/scorecorpus/testdata/baseline.json
+++ b/internal/scorecorpus/testdata/baseline.json
@@ -133,8 +133,8 @@
       "tp_high_medium": 154,
       "fn_missed": 0,
       "fn_band": 0,
-      "fp_high_medium": 45,
-      "fp_low": 0,
+      "fp_high_medium": 12,
+      "fp_low": 33,
       "extra_same_span": 0
     },
     "VIN": {

--- a/internal/validators/ssn/tabular_header_test.go
+++ b/internal/validators/ssn/tabular_header_test.go
@@ -1,0 +1,242 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ssn
+
+import (
+	stdctx "context"
+	"strings"
+	"testing"
+)
+
+// A value's column header must count as context for that value.
+//
+// Keyword scanning is per-LINE, so a CSV header row — which is a different line
+// from the values it labels — was invisible to it. Measured on identical text
+// before this change:
+//
+//	"Phone: 130-07-5728"                       ->  55  (negative keyword seen)
+//	"a,phone,c" / "x,130-07-5728,z"            -> 100  (header unseen)
+//
+// Same word, same validator, 45 points apart, decided purely by whether the label
+// sat beside the value or above it. The keyword list already covered
+// tracking/invoice/sku/serial/account/phone/zip; it simply never got to read the
+// header.
+
+// csvWith builds a 3-column CSV with the given header on the middle column.
+//
+// Three columns because tabular.Analyze requires >= 3 fields: two is commonly
+// ordinary prose carrying one comma ("Smith, John"), and treating that as a table
+// would be worse than missing it.
+func csvWith(header string) string {
+	return "a," + header + ",c\n" +
+		"x1,130-07-5728,y\n" +
+		"x2,214-89-6712,y\n" +
+		"x3,301-45-7788,y\n"
+}
+
+func scanCSV(t *testing.T, header string) (conf float64, count int) {
+	t.Helper()
+	ms, err := NewValidator().ValidateContentCtx(stdctx.Background(), csvWith(header), "t.csv")
+	if err != nil {
+		t.Fatalf("ValidateContentCtx: %v", err)
+	}
+	if len(ms) == 0 {
+		return 0, 0
+	}
+	return ms[0].Confidence, len(ms)
+}
+
+// TestContradictingHeaderDemotesButStillReports is the core contract.
+//
+// Demoted below MEDIUM so the value leaves the default review surface and stops
+// blocking a pre-commit hook — but STILL REPORTED, because only reported findings
+// reach the redactor. A dropped finding would be cleartext in the redacted output,
+// which is the worst failure this tool has.
+func TestContradictingHeaderDemotesButStillReports(t *testing.T) {
+	// Headers the validator's own negativeKeywords already cover. Nothing here is
+	// new vocabulary; the fix is that the header is now readable at all.
+	for _, header := range []string{
+		"tracking_number", "phone", "zip_code", "account_number", "invoice_number",
+		"part_number", "product_code", "routing_number", "serial_number", "sku",
+		"transaction_id",
+	} {
+		t.Run(header, func(t *testing.T) {
+			conf, n := scanCSV(t, header)
+
+			if n == 0 {
+				t.Fatalf("no finding at all under a %q column. The demotion must never "+
+					"delete the finding: an unreported value is never handed to the "+
+					"redactor, so it stays in cleartext in the output.", header)
+			}
+			if n != 3 {
+				t.Errorf("got %d findings, want 3 — every row must still be reported "+
+					"and therefore redactable", n)
+			}
+			if conf >= 60 {
+				t.Errorf("confidence %.0f under a %q column is still >= MEDIUM, so it "+
+					"remains on the default review surface and still blocks a pre-commit "+
+					"hook. The same keywords inline score 55.", conf, header)
+			}
+			if conf <= 0 {
+				t.Errorf("confidence %.0f means the finding was effectively erased", conf)
+			}
+		})
+	}
+}
+
+// TestSupportingHeaderIsUnaffected — recall must not move.
+//
+// This is the half that matters most: a column that says "ssn" must stay HIGH. The
+// national-identifier headers are included because the SSN validator's own
+// positiveKeywords contain "national id", "government id", "federal id" and
+// "tax id" — it was built to fire on them, and the score corpus labels them TRUE
+// POSITIVES.
+func TestSupportingHeaderIsUnaffected(t *testing.T) {
+	for _, header := range []string{
+		"ssn", "employee_ssn", "social_security_number", "taxpayer_id",
+		"national_id", "govt_id", "sin", "nino", "socsec", "personnummer",
+	} {
+		t.Run(header, func(t *testing.T) {
+			conf, n := scanCSV(t, header)
+			if n != 3 {
+				t.Fatalf("got %d findings under a %q column, want 3", n, header)
+			}
+			if conf < 90 {
+				t.Errorf("confidence %.0f under a %q column: an identifier column must "+
+					"stay HIGH. Losing recall here is a cleartext leak, not a cosmetic "+
+					"regression.", conf, header)
+			}
+		})
+	}
+}
+
+// TestHeaderCarryingBothSignalsIsNotDemoted — a supporting header wins.
+//
+// "employee_ssn" contains "employee id"-adjacent vocabulary, and some exports use
+// headers that match a negative token incidentally. A column that says it holds
+// SSNs must never be demoted for also matching something else.
+func TestHeaderCarryingBothSignalsIsNotDemoted(t *testing.T) {
+	// "account" is a negative keyword; "ssn" is positive. Support must win.
+	for _, header := range []string{"ssn_account", "account_ssn", "payroll_account_ssn"} {
+		t.Run(header, func(t *testing.T) {
+			conf, n := scanCSV(t, header)
+			if n == 0 {
+				t.Fatalf("no finding under %q", header)
+			}
+			if conf < 60 {
+				t.Errorf("confidence %.0f under %q: the header names it as an SSN column, "+
+					"so the positive signal must outrank the incidental negative one", conf, header)
+			}
+		})
+	}
+}
+
+// TestOnlyTheMatchesOwnColumnCounts — scoping.
+//
+// The header consulted is the one for THIS match's column, never the whole header
+// row. Without that scoping a "zip_code" column would suppress the "employee_ssn"
+// column beside it, turning a precision fix into a recall bug.
+func TestOnlyTheMatchesOwnColumnCounts(t *testing.T) {
+	// zip_code (negative) in column 1, employee_ssn (positive) in column 2. The
+	// SSN-shaped values live in column 2 and must NOT be demoted by column 1.
+	content := "zip_code,employee_ssn,dept\n" +
+		"90210,130-07-5728,ops\n" +
+		"10001,214-89-6712,fin\n" +
+		"60601,301-45-7788,hr\n"
+
+	ms, err := NewValidator().ValidateContentCtx(stdctx.Background(), content, "t.csv")
+	if err != nil {
+		t.Fatalf("ValidateContentCtx: %v", err)
+	}
+	if len(ms) == 0 {
+		t.Fatal("no findings")
+	}
+	for _, m := range ms {
+		if m.Confidence < 90 {
+			t.Errorf("value %q in the employee_ssn column scored %.0f: a negative header "+
+				"on a DIFFERENT column must not demote it, or this precision fix becomes "+
+				"a recall bug", m.Text, m.Confidence)
+		}
+	}
+}
+
+// TestNonTabularContentIsUnchanged — the conservative-recognizer guarantee.
+//
+// tabular.Analyze rejects anything that is not clearly delimited data: fewer than
+// three fields, header cells that do not look like column names, ragged rows,
+// unbalanced quotes. Everything it rejects must score exactly as it did before, so
+// this change cannot reach ordinary prose.
+func TestNonTabularContentIsUnchanged(t *testing.T) {
+	cases := map[string]string{
+		"prose":                "Employee SSN: 130-07-5728 on file.\n",
+		"two fields only":      "tracking_number,130-07-5728\n",
+		"prose with a comma":   "Smith, John has SSN 130-07-5728 in the record.\n",
+		"ragged rows":          "a,tracking_number,c\nx,130-07-5728\ny,214-89-6712,z,extra\n",
+		"no letters in header": "1,2,3\nx,130-07-5728,y\nz,214-89-6712,w\n",
+	}
+
+	for name, content := range cases {
+		t.Run(name, func(t *testing.T) {
+			ms, err := NewValidator().ValidateContentCtx(stdctx.Background(), content, "t.txt")
+			if err != nil {
+				t.Fatalf("ValidateContentCtx: %v", err)
+			}
+			if len(ms) == 0 {
+				t.Fatalf("no finding: %q should still detect its SSN", content)
+			}
+			// The prose case carries an explicit "SSN:" label and must stay HIGH.
+			if name == "prose" && ms[0].Confidence < 90 {
+				t.Errorf("labelled prose SSN scored %.0f, want >= 90 — the header logic "+
+					"must not reach non-tabular content", ms[0].Confidence)
+			}
+		})
+	}
+}
+
+// TestDelimiterCoverageIsHonest records which delimiters the fix reaches.
+//
+// Measured: comma, tab, semicolon and pipe are recognised (and markdown tables come
+// free via pipe). Colon, fixed-width alignment, caret and tilde are NOT, so a
+// contradicted column in those layouts is still reported at its undemoted score.
+//
+// This is pinned rather than left implicit so the limit is discoverable from the
+// tests, and so the day someone adds a delimiter the expectations move visibly.
+// Fixed-width is the notable gap: it is alignment-based rather than delimited, so
+// it needs column-position logic rather than another entry in a list.
+func TestDelimiterCoverageIsHonest(t *testing.T) {
+	demoted := map[string]bool{
+		",":  true,
+		"\t": true,
+		";":  true,
+		"|":  true,
+		":":  false,
+		"^":  false,
+		"~":  false,
+	}
+
+	for delim, wantDemoted := range demoted {
+		t.Run("delim_"+strings.TrimSpace(delim), func(t *testing.T) {
+			content := "name" + delim + "tracking_number" + delim + "dept\n" +
+				"a" + delim + "130-07-5728" + delim + "x\n" +
+				"b" + delim + "214-89-6712" + delim + "y\n" +
+				"c" + delim + "301-45-7788" + delim + "z\n"
+
+			ms, err := NewValidator().ValidateContentCtx(stdctx.Background(), content, "t.txt")
+			if err != nil {
+				t.Fatalf("ValidateContentCtx: %v", err)
+			}
+			if len(ms) == 0 {
+				t.Fatalf("no finding for delimiter %q", delim)
+			}
+
+			gotDemoted := ms[0].Confidence < 60
+			if gotDemoted != wantDemoted {
+				t.Errorf("delimiter %q: demoted=%v (conf %.0f), want demoted=%v.\n"+
+					"If a delimiter was just added, update this map — it exists to keep the "+
+					"supported set explicit rather than folklore.",
+					delim, gotDemoted, ms[0].Confidence, wantDemoted)
+			}
+		})
+	}
+}

--- a/internal/validators/ssn/validator.go
+++ b/internal/validators/ssn/validator.go
@@ -12,6 +12,7 @@ import (
 	"github.com/awslabs/ferret-scan/v2/internal/detector"
 	"github.com/awslabs/ferret-scan/v2/internal/execguard"
 	"github.com/awslabs/ferret-scan/v2/internal/observability"
+	"github.com/awslabs/ferret-scan/v2/internal/tabular"
 	"github.com/awslabs/ferret-scan/v2/internal/validators/kwmatch"
 )
 
@@ -74,6 +75,76 @@ const (
 	encodedDataPenalty     = 40.0
 	encodedDataStrongFloor = 60.0
 )
+
+// confidenceCeilingKey is the Match.Metadata key a validator sets to declare a hard
+// upper bound that downstream adjustment stages must respect.
+//
+// Clamping inside the validator is NOT sufficient on its own. The dual-path bridge
+// applies a document-level context adjustment AFTER the validator returns —
+// tabular_boost is +20 for a CSV — which took a value capped at 55 back to 75, above
+// the MEDIUM bar the cap exists to put it below. Measured end to end before this:
+// validator 55, CLI 75.
+//
+// The bridge calls clampToCeiling immediately after that adjustment, so publishing
+// the bound here is what makes it hold. The secrets validator already does exactly
+// this for unlabelled hex identifiers, and its comment records the same 55 -> 80
+// surprise.
+//
+// The string must match validators.ConfidenceCeilingKey. It is duplicated rather
+// than imported because internal/validators imports this package, so depending on it
+// here would be a cycle — the same reason the secrets validator duplicates it.
+const confidenceCeilingKey = "confidence_ceiling"
+
+// buildSSNMetadata assembles a match's metadata, publishing a confidence ceiling
+// when the column header contradicted the finding.
+func buildSSNMetadata(checks map[string]bool, contextImpact float64, originalPath string, capByHeader bool) map[string]any {
+	meta := map[string]any{
+		"validation_checks": checks,
+		"context_impact":    contextImpact,
+		"source":            "preprocessed_content",
+		"original_file":     originalPath,
+	}
+	if capByHeader {
+		meta[confidenceCeilingKey] = contradictingHeaderCap
+	}
+	return meta
+}
+
+// contradictingHeaderCap bounds a tabular match whose own column header names the
+// column as something other than an identifier.
+//
+// 55 sits below the MEDIUM boundary of 60, so the value leaves the default review
+// surface and stops blocking a pre-commit hook, while remaining REPORTED and
+// therefore redacted. It matches what the same keywords already produce inline
+// ("tracking_number 130-07-5728" scores 55), so a value is not judged differently
+// according to whether its label sits beside it or above it — which was the entire
+// defect this addresses.
+const contradictingHeaderCap = 55.0
+
+// headerContradicts reports whether a column header names the column as something
+// that is not an identifier.
+func (v *Validator) headerContradicts(header string) bool {
+	for _, kw := range v.negativeKeywords {
+		if containsKeyword(header, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// headerSupports reports whether a column header names the column as an identifier.
+//
+// Checked so a header carrying BOTH signals is not capped: "employee_ssn" contains
+// "employee id"-adjacent vocabulary in some exports, and a column that says "ssn"
+// must never be demoted for also matching a negative token.
+func (v *Validator) headerSupports(header string) bool {
+	for _, kw := range v.positiveKeywords {
+		if containsKeyword(header, kw) {
+			return true
+		}
+	}
+	return false
+}
 
 // Validator implements the detector.Validator interface for detecting
 // Social Security Numbers using regex patterns and contextual analysis.
@@ -198,6 +269,22 @@ type lineContext struct {
 	isEnhancedTab bool            // v.isEnhancedTabularData(line, ...) — value arg is unused
 	isEncoded     bool            // v.isEncodedData(line, ...) — match arg is unused
 	keywordOnLine map[string]bool // containsKeyword(line, kw) for every keyword we test
+
+	// columnHeader is the header cell naming THIS match's column, lowercased, or
+	// "" when the document is not a delimited table.
+	//
+	// Unlike every field above it varies per MATCH rather than per line, because
+	// the column changes along a row. It exists because keyword scanning is
+	// per-LINE, so a CSV header row is invisible to it — and that single fact was
+	// the whole bug. Measured on identical text:
+	//
+	//	"Phone: 130-07-5728"          -> 55  (negative keyword seen)
+	//	"a,phone,c" / "x,130-07-5728" -> 100 (header on another line, unseen)
+	//
+	// Same word, same validator, 45 points apart. The keyword list already covers
+	// tracking/invoice/sku/serial/account/phone/zip; it simply never got to read
+	// the header. Nothing here adds a new suppression mechanism.
+	columnHeader string
 }
 
 // newLineContext precomputes the per-line-global analysis values once. Every map
@@ -251,6 +338,16 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 
 	isDocx := strings.Contains(originalPath, ".docx")
 
+	// Recognise a delimited table ONCE per document, so each match can be resolved
+	// to the header cell naming its column.
+	//
+	// tabular.Analyze is conservative by construction — it requires >=3 fields, a
+	// header whose cells look like column names, and >=80% of sampled rows agreeing
+	// on the field count. Ragged rows, unbalanced quotes, or a comma-rich sentence
+	// all yield a non-table, which leaves every score exactly as it was. That is
+	// why this can be wired into the keyword path without a new suppression rule.
+	table := tabular.Analyze(content)
+
 	for lineNum, line := range lines {
 		// Cooperative cancellation: stop promptly if the scan's deadline fired
 		// or it was cancelled, returning what we have plus the reason.
@@ -302,8 +399,31 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 			lc = v.newLineContext(line)
 		}
 
+		// Field offsets for THIS line, computed once and reused for every match on
+		// it, so resolving a match to its column stays a binary search rather than a
+		// per-match rescan — this validator has been audited for exactly that
+		// O(matches x lineLength) shape. Nil when the document is not tabular, and
+		// on the header row itself, where a cell is a label rather than a value.
+		var lineBounds *tabular.LineBounds
+		if len(foundMatches) > 0 && table.IsTable() && lineNum != table.HeaderLine() {
+			lineBounds = table.Bounds(line)
+		}
+
 		for _, ms := range foundMatches {
 			match := ms.text
+
+			// Resolve THIS match's column header. Set per match because the column
+			// changes along a row.
+			//
+			// ms.start is -1 for the synthesized concatenated-number candidates, which
+			// have no real offset on the line; those stay headerless rather than being
+			// attributed to whatever column offset 0 happens to be.
+			if lc != nil {
+				lc.columnHeader = ""
+				if lineBounds != nil && ms.start >= 0 {
+					lc.columnHeader = table.HeaderAt(lineBounds, ms.start)
+				}
+			}
 			// Clean the SSN for validation
 			cleanMatch := v.cleanSSN(match)
 
@@ -392,6 +512,11 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 			// Check if this is tabular data first - this is more reliable than keyword detection
 			isTabular := lc.isTabular
 
+			// capByHeader records that this match's own column header contradicted it,
+			// so the ceiling can be published in Metadata below and survive the
+			// document-level adjustment applied after this validator returns.
+			capByHeader := false
+
 			// Adjust confidence based on context, prioritizing tabular data detection
 			if isTabular {
 				// For tabular data, don't cap confidence regardless of keywords
@@ -400,6 +525,31 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 					confidence -= 10 // Very mild penalty for negative context in tabular data
 				}
 				// Don't cap confidence for tabular data - let the base confidence stand
+
+				// A COLUMN HEADER naming the column as something other than an
+				// identifier is a stronger signal than an incidental word elsewhere on
+				// the row, so it gets a ceiling rather than only the -10 above.
+				//
+				// This is an ACCURACY judgement, not a safety one: a value under
+				// "tracking_number" genuinely is weaker evidence for "this is an SSN"
+				// than the same value under "ssn". The inline path already scores it that
+				// way — "tracking_number 130-07-5728" is 55 — so a value should not be
+				// judged differently according to whether its label sits beside it or
+				// above it. That inconsistency was the entire defect.
+				//
+				// The -10 alone is not enough. It is deliberately gentle ("don't cap
+				// confidence for tabular data"), which is right for a word that merely
+				// shares a row; measured, it leaves a contradicted column at 92, still
+				// HIGH and still blocking a pre-commit hook.
+				//
+				// headerSupports is checked too, so a header carrying BOTH signals is
+				// never demoted: a column that says "ssn" must win over a coincidental
+				// negative token.
+				capByHeader = lc.columnHeader != "" &&
+					v.headerContradicts(lc.columnHeader) && !v.headerSupports(lc.columnHeader)
+				if capByHeader && confidence > contradictingHeaderCap {
+					confidence = contradictingHeaderCap
+				}
 			} else if len(contextInfo.PositiveKeywords) == 0 {
 				// For non-tabular data without positive keywords, be more restrictive.
 				if len(contextInfo.NegativeKeywords) > 0 {
@@ -452,12 +602,7 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 				Filename:   originalPath,
 				Validator:  "ssn",
 				Context:    contextInfo,
-				Metadata: map[string]any{
-					"validation_checks": checks,
-					"context_impact":    contextImpact,
-					"source":            "preprocessed_content",
-					"original_file":     originalPath,
-				},
+				Metadata:   buildSSNMetadata(checks, contextImpact, originalPath, capByHeader),
 			})
 		}
 	}
@@ -489,6 +634,13 @@ const junctionWindowLen = 64
 // regions need scanning here.
 func (v *Validator) keywordInFullContext(keyword, before, after string, lc *lineContext) bool {
 	if lc.keywordOnLine[keyword] {
+		return true
+	}
+	// The header cell naming this match's column is context for the value even
+	// though it sits on a different line. Scoped to THIS column's header, never
+	// the whole header row, so a "zip_code" column cannot suppress the
+	// "employee_ssn" column beside it.
+	if lc.columnHeader != "" && containsKeyword(lc.columnHeader, keyword) {
 		return true
 	}
 	// A SINGLE-WORD keyword absent from the line cannot appear in
@@ -748,6 +900,12 @@ func (v *Validator) findKeywordsCached(lc *lineContext, keywords []string) []str
 	var found []string
 	for _, keyword := range keywords {
 		if lc.keywordOnLine[keyword] {
+			found = append(found, keyword)
+			continue
+		}
+		// See lineContext.columnHeader: a CSV header row is on a different line
+		// than the value it labels, so per-line scanning alone never sees it.
+		if lc.columnHeader != "" && containsKeyword(lc.columnHeader, keyword) {
 			found = append(found, keyword)
 		}
 	}


### PR DESCRIPTION
A CSV header row sits on a different line from the values it labels, and keyword scanning is per-**line** — so the header was invisible to it. Measured on identical text:

| input | confidence |
|---|---|
| `Phone: 130-07-5728` (label beside the value) | **55** |
| `a,phone,c` / `x,130-07-5728,z` (label above it) | **100** |

Same word, same validator, 45 points apart, decided only by whether the label sat beside the value or above it.

The keyword list already covered `tracking`/`invoice`/`sku`/`serial`/`account`/`phone`/`zip` — **11 of the 15** false-positive headers in the score corpus. It simply never got to read the header. This is not a new suppression mechanism: it wires `internal/tabular`'s column resolution into the existing keyword path.

## Measured end to end (`make score`)

| metric | before | after |
|---|---|---|
| SSN FP ≥ MEDIUM | 45 | **12** |
| SSN FP LOW | 0 | 33 *(demoted, still reported)* |
| SSN precision | 0.7739 | **0.9277** |
| overall precision | 0.7920 | **0.9275** |
| recall_all | 1.0000 | **1.0000** |
| recall_hm | 0.9944 | **0.9944** |
| whole_leak | 0 | **0** |

**33 of 45 false positives leave the review surface with zero recall lost.** All 45 findings are still *reported*, so still redacted — the demotion moves them out of view, never out of coverage.

## Two mechanisms, because one was not enough

The validator caps a contradicted column at 55, matching what the same keywords produce inline. But the dual-path bridge applies a document-level `tabular_boost` of **+20 after** the validator returns, which took a capped 55 back to **75** — above the MEDIUM bar the cap exists to clear.

So the ceiling is also published in `Match.Metadata` under `confidence_ceiling`, which `clampToCeiling` (called immediately after that adjustment) enforces. The `secrets` validator already does exactly this for unlabelled hex identifiers, and its comment records the same 55 → 80 surprise.

## Justification is accuracy, not threat model

A value under `tracking_number` genuinely is weaker evidence for "this is an SSN" than the same value under `ssn` — which is how the inline path already scores it.

An earlier draft argued the cap prevented an attacker hiding an SSN by renaming a column. **That reasoning is wrong and is deliberately absent from the code:** the document is one artifact from one author, and someone hiding a value would simply omit it. The genuine confusion case is metadata-vs-body — two *channels*, where forged content in one routes past the validators applied to the other.

## Scoping

The header consulted is the one for **this match's column**, never the whole header row, so a `zip_code` column cannot suppress the `employee_ssn` column beside it. A header carrying both signals is not demoted — a column that says `ssn` outranks an incidental negative token.

## Golden impact: one case, and it is an improvement

`file_csv_tabular_pii`: SSNs under an `ssn` header went **75 → 85**, because the header now registers as a **positive** keyword too. Same six detections, reordered by the confidence change. Read line by line — a recall improvement, not a regression.

## Delimiter coverage is honest and pinned

Comma, tab, semicolon and pipe are recognised (markdown tables come free via pipe). **Colon, fixed-width alignment, caret and tilde are not**, so a contradicted column in those layouts still reports undemoted. `TestDelimiterCoverageIsHonest` asserts the supported set so the limit is discoverable rather than folklore. Fixed-width is the notable gap — it is alignment-based, so it needs column-position logic rather than another list entry.

## Testing

- **6 new tests:** demote-but-still-report, supporting headers unaffected (incl. the national-identifier headers the corpus labels TP), both-signals, per-column scoping, non-tabular content unchanged, delimiter set.
- **Non-vacuity via a COMPILING mutation:** disabling header resolution makes the contradicted columns score 100 again and fails with the intended message.
- The baseline is **re-locked at 12 FPs**, and the mutation now *also* fails the corpus gate (`PRECISION REGRESSION SSN: FP(H+M) 12 -> 45`), so the win is ratcheted rather than given back for free.
- **Timing A/B**, median of 4: 4000-row CSV **112.9ms → 155.1ms (+37%)**, 64KB single line 119.5ms → 125.7ms (+5%). The CSV cost is real and buys 33 fewer false positives at unchanged recall.
- **O(n²) check**, 1k…32k rows over three runs: **1.85–2.24× per doubling**. Linear is 2.0×, quadratic 4.0×; 32× the input costs 32× the time. `Analyze` runs once per document, `Bounds` once per line, `HeaderAt` is a binary search per match.
- Full suite rc=0 / 65 packages; `-race` rc=0; golden **186 = 186**; complexity guard PASS for all 19 validators plus both redaction targets; gofmt/vet clean.
- **Union-tested** with #276 and #277 merged onto `main` together: builds, 65 packages green, `-race` clean, golden 186, score PASS. That union run found and fixed a real regression in #277 (see its thread).

`internal/tabular/header.go` (`Classify`/`ColumnSupport`) is deliberately **not** included: the validator's own keyword lists are richer than anything that API would take, so it would be dead code.