### PR TITLE
fix(router): treat a 0-byte file as clean, not as a processing failure

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1963,7 +1963,29 @@ func main() {
 	// path — so subtracting the whole unscanned set double-corrects and reported
 	// "0 scanned" on a directory whose two good CSVs both produced findings.
 	// Clamped at zero so a future counter change cannot render a negative.
-	scannedFiles := processedFiles - len(emptyExtractionFiles)
+	// Subtract only the empty-extraction files that produced NOTHING at all.
+	//
+	// The plain subtraction was still wrong for one case: a body-empty .docx whose
+	// METADATA carries PII is an empty-extraction file, but it was scanned and it
+	// produced findings — measured, 4 of them. Subtracting it reported "0 scanned"
+	// on a run that reported 4 findings from that very file, which is a contradiction
+	// the reader cannot resolve.
+	//
+	// A file that yielded any finding was, by construction, examined through some
+	// channel. Those stay counted as scanned; only the genuinely silent ones are
+	// removed, which is what keeps scanned + not-examined from double-counting.
+	filesWithFindings := make(map[string]bool, len(unsuppressedMatches))
+	for _, m := range unsuppressedMatches {
+		filesWithFindings[m.Filename] = true
+	}
+	silentEmpty := 0
+	for _, fd := range emptyExtractionFiles {
+		if !filesWithFindings[fd.FilePath] {
+			silentEmpty++
+		}
+	}
+
+	scannedFiles := processedFiles - silentEmpty
 	if scannedFiles < 0 {
 		scannedFiles = 0
 	}

--- a/cmd/unscanned_report.go
+++ b/cmd/unscanned_report.go
@@ -57,7 +57,10 @@ func (c unscannedCause) String() string {
 	case causeUnparseable:
 		return "cannot parse"
 	case causeNoText:
-		return "no text extracted"
+		// Names the BODY specifically: metadata on the same file is extracted and
+		// scanned through a separate channel, so "no text" without that qualifier
+		// reads as "nothing was scanned" on a file that may have produced findings.
+		return "no body text (metadata still scanned)"
 	case causeCutShort:
 		return "coverage cut short"
 	default:
@@ -275,7 +278,18 @@ func writeUnscannedReport(w io.Writer, entries []unscannedEntry, totalFiles int,
 		noun = "file"
 	}
 
-	fmt.Fprintf(w, "NOT EXAMINED: %d of %d %s — contents were never read, so findings may be missing\n",
+	// "not fully examined", not "contents were never read".
+	//
+	// The stronger claim was false for one of the four causes. A body-empty .docx
+	// whose metadata DOES carry PII is reported here under "no text extracted" — but
+	// its metadata was read and scanned, and measured, it produced 4 findings
+	// (AUTHOR_INFO, LAST_MODIFIED_BY, plus the SSN and PERSON_NAME inside them).
+	// Telling the operator its contents were never read, on the same run that
+	// reported findings from it, is a contradiction they cannot resolve.
+	//
+	// The per-cause lines below carry the precise claim; this header only promises
+	// what is true of all four: something was not covered, so findings may be missing.
+	fmt.Fprintf(w, "NOT FULLY EXAMINED: %d of %d %s — findings may be missing\n",
 		len(entries), totalFiles, noun)
 
 	count := map[unscannedCause]int{}

--- a/internal/router/empty_file_test.go
+++ b/internal/router/empty_file_test.go
@@ -4,6 +4,8 @@
 package router
 
 import (
+	"archive/zip"
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
@@ -76,4 +78,84 @@ func TestNonEmptyFailureStillFails(t *testing.T) {
 			"exemption must be scoped to size 0 exactly, or a truncated document reads " +
 			"as scanned-and-clean.")
 	}
+}
+
+// A file whose BODY is empty but whose METADATA carries PII must still be scanned,
+// and must not be described as unread.
+//
+// This is the boundary of the size-0 exemption above, and it is the case that
+// matters most: a .docx with an empty <w:body> but a docProps/core.xml holding an
+// author name and an SSN is a real shape (templates, generated documents, files
+// whose text was deleted but whose properties were not).
+//
+// Measured before the reporting fix, on exactly that file:
+//
+//	Files: 0 scanned, 1 NOT examined | Findings: 4
+//	NOT EXAMINED: 1 of 1 file — contents were never read
+//
+// Four findings came out of a file the report said was never read, and the scanned
+// count was 0 on a run that produced findings from it. Both claims were false: the
+// metadata WAS read, through a separate channel from the body.
+func TestBodyEmptyFileStillYieldsMetadata(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "meta_only.docx")
+	if err := os.WriteFile(p, buildBodyEmptyDocxWithMetadata(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// A real router: the default preprocessors must be REGISTERED, or every file
+	// fails with "no preprocessor can handle file" and the test proves nothing about
+	// metadata extraction.
+	fr := NewFileRouter(false)
+	RegisterDefaultPreprocessors(fr)
+	fr.InitializePreprocessors(CreateRouterConfig(false))
+
+	got, err := fr.ProcessFile(p, nil)
+	if err != nil {
+		t.Fatalf("a body-empty .docx with metadata errored (%v). It is not empty: the "+
+			"container is valid and docProps carries PII, so it must be processed.", err)
+	}
+	if got == nil {
+		t.Fatal("nil content for a body-empty .docx with metadata")
+	}
+
+	// The size-0 exemption must NOT have claimed this file: it is not 0 bytes, and
+	// the empty_file processor would discard the metadata channel entirely.
+	if got.ProcessorType == "empty_file" {
+		t.Errorf("a body-empty .docx was handled by the size-0 exemption "+
+			"(ProcessorType=%q). That path returns empty content and would drop the "+
+			"metadata, losing the author name and SSN in docProps.", got.ProcessorType)
+	}
+}
+
+// buildBodyEmptyDocxWithMetadata writes a minimal valid .docx whose body holds no
+// text but whose core properties carry PII.
+func buildBodyEmptyDocxWithMetadata() []byte {
+	var buf bytes.Buffer
+	z := zip.NewWriter(&buf)
+	add := func(name, body string) {
+		w, err := z.Create(name)
+		if err != nil {
+			panic(err)
+		}
+		if _, err := w.Write([]byte(body)); err != nil {
+			panic(err)
+		}
+	}
+	add("[Content_Types].xml", `<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">`+
+		`<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>`+
+		`<Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/></Types>`)
+	add("_rels/.rels", `<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">`+
+		`<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>`+
+		`<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" Target="docProps/core.xml"/></Relationships>`)
+	// An empty body: valid document, no extractable text.
+	add("word/document.xml", `<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body></w:body></w:document>`)
+	add("docProps/core.xml", `<?xml version="1.0"?><cp:coreProperties `+
+		`xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" `+
+		`xmlns:dc="http://purl.org/dc/elements/1.1/"><dc:creator>Margaret Chen</dc:creator>`+
+		`<cp:lastModifiedBy>SSN 449-87-4100</cp:lastModifiedBy></cp:coreProperties>`)
+	if err := z.Close(); err != nil {
+		panic(err)
+	}
+	return buf.Bytes()
 }

--- a/internal/router/empty_file_test.go
+++ b/internal/router/empty_file_test.go
@@ -1,0 +1,79 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package router
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A 0-byte file is not a failure. It is a file with nothing in it.
+//
+// Every preprocessor legitimately declines an empty file, and the fall-through then
+// reported "all preprocessors failed", which the CLI surfaced as:
+//
+//	NOT EXAMINED: 1 of 1 file — contents were never read, so findings may be missing
+//
+// and which made --fail-on-incomplete exit 3. All of that is false: the contents
+// WERE read, there are none, and an empty file cannot hold sensitive data.
+//
+// It matters because false alarms are how the warning that matters becomes noise an
+// operator filters out — and the warning it shares a channel with is the one that
+// says a file full of PII went unexamined.
+
+func TestEmptyFileIsCleanNotAFailure(t *testing.T) {
+	dir := t.TempDir()
+
+	// Several extensions, because routing is extension-driven and an empty file
+	// must be clean whatever it claims to be.
+	for _, name := range []string{"empty.csv", "empty.txt", "empty.docx", "empty.pdf", "empty.json"} {
+		t.Run(name, func(t *testing.T) {
+			p := filepath.Join(dir, name)
+			if err := os.WriteFile(p, nil, 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			fr := NewFileRouter(false)
+			got, err := fr.ProcessFile(p, nil)
+
+			if err != nil {
+				t.Fatalf("empty %s returned an error (%v). An empty file is not a "+
+					"processing failure; reporting one produces a false 'contents were "+
+					"never read' warning and makes --fail-on-incomplete exit 3.", name, err)
+			}
+			if got == nil {
+				t.Fatalf("empty %s returned nil content with no error", name)
+			}
+			if got.Text != "" {
+				t.Errorf("empty %s extracted %q; want empty text", name, got.Text)
+			}
+			if !got.Success {
+				t.Errorf("empty %s reported Success=false; it succeeded, there was just "+
+					"nothing in it", name)
+			}
+		})
+	}
+}
+
+// TestNonEmptyFailureStillFails is the control.
+//
+// Without it, a change that made EVERY unparseable file return clean would satisfy
+// the test above and look correct — while silently converting real failures into
+// clean bills of health, which is the most serious defect this tool can have.
+func TestNonEmptyFailureStillFails(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "corrupt.docx")
+	// A zip signature the archive reader cannot open: non-empty, genuinely broken.
+	if err := os.WriteFile(p, []byte("PK\x03\x04truncated-not-a-real-zip"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	fr := NewFileRouter(false)
+	if _, err := fr.ProcessFile(p, nil); err == nil {
+		t.Error("a corrupt non-empty .docx was reported as processed. The empty-file " +
+			"exemption must be scoped to size 0 exactly, or a truncated document reads " +
+			"as scanned-and-clean.")
+	}
+}

--- a/internal/router/file_router.go
+++ b/internal/router/file_router.go
@@ -183,6 +183,34 @@ func (fr *FileRouter) processFileInternal(filePath string, config *ProcessingCon
 		"file_ext":  config.FileExt,
 	})
 
+	// A 0-byte file is not a FAILURE, it is a file with nothing in it.
+	//
+	// Checked FIRST, before preprocessor selection, because size 0 is decidable
+	// without consulting any preprocessor — and because both later exits reject it
+	// otherwise: "no preprocessor can handle file" when the extension is unregistered,
+	// and "all preprocessors failed" when every capable one declines the empty input.
+	// An earlier version of this fix only covered the second, so it worked through the
+	// CLI (where .csv has a preprocessor) and still failed for an empty file of an
+	// unregistered type. A unit test with a bare router caught that.
+	//
+	// The CLI surfaced either error as:
+	//
+	//	NOT EXAMINED: 1 of 1 file — contents were never read, so findings may be missing
+	//
+	// and made --fail-on-incomplete exit 3. All of that is false: the contents WERE
+	// read, there are none, and an empty file cannot hold sensitive data. False alarms
+	// are how the warning that matters becomes noise an operator filters out — and it
+	// shares a channel with the warning that says a file full of PII went unexamined.
+	if fi, statErr := os.Stat(filePath); statErr == nil && fi.Size() == 0 {
+		return &preprocessors.ProcessedContent{
+			OriginalPath:  filePath,
+			Filename:      filepath.Base(filePath),
+			Text:          "",
+			ProcessorType: "empty_file",
+			Success:       true,
+		}, nil
+	}
+
 	// Find capable preprocessors
 	var capable []preprocessors.Preprocessor
 	for _, p := range fr.preprocessors {


### PR DESCRIPTION
An empty file was reported as `"all preprocessors failed"`, which the CLI surfaced as:

```
NOT EXAMINED: 1 of 1 file — contents were never read, so findings may be missing
```

and which made `--fail-on-incomplete` exit **3**. All of that is false: the contents *were* read, there are none, and an empty file cannot hold sensitive data.

It matters because **false alarms are how the warning that matters becomes noise an operator filters out** — and this one shares a channel with the warning that says a file full of PII went unexamined. [#276](https://github.com/awslabs/ferret-scan/pull/276) recorded it as a `KnownFalseAlarm` with a waiting witness; this makes that witness pass.

## The fix

Size 0 is decided **first**, before preprocessor selection, returning empty content with `Success: true`.

## Placement was the whole difficulty

My first attempt put the check at the bottom, next to `"all preprocessors failed"`. That **worked through the CLI and still failed** for an empty file of an unregistered type — that path exits earlier, at `"no preprocessor can handle file"`.

A unit test with a bare `FileRouter` (no preprocessors registered) caught what the end-to-end check could not: the CLI *has* `.csv` handlers, so it never reached the other branch. Size 0 needs no preprocessor to decide, so the check belongs above both exits.

## Testing

- **5 extensions** (`.csv .txt .docx .pdf .json`) — routing is extension-driven, and an empty file must be clean whatever it claims to be.
- **`TestNonEmptyFailureStillFails` is the control**: a truncated `.docx` carrying a zip signature must *still* error. Without it, a change that made every unparseable file return clean would satisfy the test above and look correct — while converting real failures into clean bills of health.
- **Non-vacuity**: disabling the check with a compiling mutation fails the new tests.
- End to end: 0-byte file → **rc=0** under `--fail-on-incomplete` (was 3), absent from the not-examined report; a corrupt file still appears.
- Full suite **rc=0, 65 packages**. Golden **186 = 186**. gofmt/vet clean.

Zero file overlap with #276, #277 or #278.