### PR TITLE
feat(formatters): disclose unexamined files in junit, sarif and gitlab-sast

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2003,6 +2003,23 @@ func main() {
 		Duration:         elapsed.Seconds(),
 	}
 
+	// The same disclosure, in structured form, for formats that cannot carry prose.
+	//
+	// Set unconditionally beside Stats and from the SAME slice, so the count in
+	// stats.files_not_examined and the per-file entries can never disagree. Deriving
+	// them independently is how a report comes to say "2 not examined" and then list
+	// three files.
+	//
+	// Note this is set BEFORE the text footer is built below: the machine formats
+	// must disclose even when the text renderer declines to (it is skipped entirely
+	// in pre-commit mode).
+	formatterOptions.NotExamined = toFormatterNotExamined(unscannedEntries)
+
+	// The JUnit formatter reads this to decide the VALENCE of the not-examined
+	// entries (<skipped> vs <error>), so one flag governs both the XML verdict and
+	// the exit code instead of the two disagreeing.
+	formatterOptions.FailOnIncomplete = *failOnIncomplete
+
 	// Render the not-examined detail into the summary block rather than printing it
 	// separately. Text format only: structured formats carry the same facts as data,
 	// and pre-commit owns a strict output contract. Building it here means the whole

--- a/cmd/unscanned_report.go
+++ b/cmd/unscanned_report.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/awslabs/ferret-scan/v2/internal/formatters"
 	"github.com/awslabs/ferret-scan/v2/internal/parallel"
 )
 
@@ -73,6 +74,50 @@ type unscannedEntry struct {
 	Path   string
 	Cause  unscannedCause
 	Detail string
+}
+
+// toFormatterNotExamined converts the cmd-side entries into the formatter-facing
+// type, so machine formats can carry the disclosure as DATA.
+//
+// The classification stays HERE rather than moving into internal/formatters. The
+// reason is not tidiness: classifyReason and describeUnparseable perform filesystem
+// I/O (describeUnparseable calls os.Open to sniff a file's real magic bytes), and
+// the formatters package is reachable from the web server's /export handler with
+// user-supplied filenames. Moving path-touching code into it would put file reads
+// behind an HTTP surface. Only this small pure mapping crosses the boundary.
+//
+// The two cause enums are mapped explicitly rather than by numeric conversion.
+// unscannedCause and formatters.NotExaminedCause happen to share an order today, so
+// int(c) would compile and pass — and would silently mis-label every file the day
+// either list grows a member. The switch fails to compile on a new cmd-side cause
+// only if the default is removed, so the default deliberately maps to the most
+// conservative option: "cannot read" claims the least about what was scanned.
+func toFormatterNotExamined(entries []unscannedEntry) []formatters.NotExaminedFile {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]formatters.NotExaminedFile, 0, len(entries))
+	for _, e := range entries {
+		var cause formatters.NotExaminedCause
+		switch e.Cause {
+		case causeUnreadable:
+			cause = formatters.NotExaminedUnreadable
+		case causeUnparseable:
+			cause = formatters.NotExaminedUnparseable
+		case causeNoText:
+			cause = formatters.NotExaminedNoText
+		case causeCutShort:
+			cause = formatters.NotExaminedCutShort
+		default:
+			cause = formatters.NotExaminedUnreadable
+		}
+		out = append(out, formatters.NotExaminedFile{
+			Path:   e.Path,
+			Cause:  cause,
+			Detail: e.Detail,
+		})
+	}
+	return out
 }
 
 // humanizeReason turns an internal reason string into something actionable.

--- a/docs/COVERAGE_DISCLOSURE.md
+++ b/docs/COVERAGE_DISCLOSURE.md
@@ -1,0 +1,162 @@
+# Coverage disclosure: files that were not examined
+
+A file the scanner could not read is **not** a file with no findings. This document
+records where each output format says so, and the one place it cannot.
+
+## Why this exists
+
+Only reported facts reach the consumer. If a scan cannot open a file and says nothing
+about it, a pipeline parsing the output concludes the file is clean — and it may hold
+anything. That is the same class of harm as a missed detection, arriving by a
+different route.
+
+Measured on a directory holding one findings-bearing `.txt`, one unreadable file and
+one `.docx` whose body could not be extracted, the in-band signal on **stdout** was:
+
+| format | before | now |
+|---|---|---|
+| `text` | in-band summary footer | unchanged |
+| `json` | `stats.files_not_examined` | unchanged |
+| `yaml` | `filesnotexamined` | unchanged |
+| `csv` | **nothing** | stderr only (see below) |
+| `junit` | **nothing** | `<testsuite name="not-examined">` |
+| `sarif` | **nothing** | `runs[].invocations[].toolExecutionNotifications[]` |
+| `gitlab-sast` | **nothing** | `scan.messages[]` |
+
+The human-readable report was always produced for the machine formats — it went to
+**stderr**, which pipelines routinely discard.
+
+## The four causes
+
+| cause | meaning | were findings possible? |
+|---|---|---|
+| `cannot read` | permissions, vanished path, I/O error | nothing about the file is known |
+| `cannot parse` | bytes do not match the declared type | no text was recovered |
+| `no body text (metadata still scanned)` | opened and parsed, no body text found | **yes** — metadata was scanned and may already have produced findings |
+| `coverage cut short` | a budget, size cap or timeout fired | **yes** — the file is partly scanned |
+
+The third and fourth never claim the file was unread. A `.docx` with an empty body but
+PII in its author field appears both as findings *and* in this list, and saying its
+contents were never read would contradict the same report.
+
+## Per-format details
+
+### gitlab-sast — `scan.messages[]`
+
+A first-class schema field, not an extension. Level is `warn`, whose schema
+description is this case exactly: *"a potentially recoverable problem, or a partial
+error"*.
+
+```json
+"scan": {
+  "status": "success",
+  "messages": [
+    { "level": "warn", "value": "NOT FULLY EXAMINED: 2 file(s) — findings may be missing" },
+    { "level": "warn", "value": "NOT EXAMINED (cannot read): /scan/noperm.txt — permission denied" }
+  ]
+}
+```
+
+`status` stays `success`: the scan *succeeded*, its coverage was partial. The enum is
+only `success|failure`, so `failure` would claim the analyzer broke. Unexamined files
+are never injected into `vulnerabilities[]` — that would put fabricated findings on a
+security dashboard.
+
+### sarif — `invocations[].toolExecutionNotifications[]`
+
+The spec's description of this array *is* the semantics: "runtime conditions detected
+by the tool during the analysis". Level is `warning` (SARIF's enum is
+`none/note/warning/error`).
+
+```json
+"invocations": [{
+  "executionSuccessful": true,
+  "toolExecutionNotifications": [
+    { "descriptor": { "id": "ferret-scan/not-examined" },
+      "level": "warning",
+      "message": { "text": "NOT EXAMINED (cannot read): /scan/noperm.txt — permission denied" } }
+  ]
+}]
+```
+
+> **Note the enums differ.** GitLab uses `warn`; SARIF uses `warning`. Each is invalid
+> in the other's schema, and an invalid report is rejected in full — losing every
+> finding. They are not interchangeable.
+
+`executionSuccessful` is always `true` for the same reason GitLab's status is
+`success`.
+
+**Known limitation:** GitHub's code-scanning UI does not display
+`toolExecutionNotifications`, so this disclosure is machine-readable only. The
+alternative — emitting unexamined files as `results` — would create dismissable
+"alerts" for files that were never read, i.e. fabricated findings. A quiet valid
+statement was preferred over a visible false one.
+
+### junit — a separate `not-examined` suite
+
+```xml
+<testsuite name="not-examined" tests="2" failures="0" errors="0">
+  <testcase name="noperm.txt" classname="not-examined">
+    <skipped message="NOT EXAMINED (cannot read): /scan/noperm.txt — permission denied">...</skipped>
+  </testcase>
+  <system-out>NOT FULLY EXAMINED: 2 file(s) — findings may be missing</system-out>
+</testsuite>
+```
+
+A separate suite, so the `security-scan` suite's `tests=` attribute keeps meaning
+"files examined".
+
+**Valence follows `--fail-on-incomplete`:**
+
+| | element | build verdict |
+|---|---|---|
+| default | `<skipped>` | unchanged — a disclosure alone never turns a green build red |
+| `--fail-on-incomplete` | `<error>` | fails, agreeing with exit code 3 |
+
+Unexamined files are never `<failure>`: a failure means something was found wrong *in*
+the file, and reporting "cannot read" that way fabricates a finding.
+
+### csv — stderr only, by design
+
+`csv` keeps this disclosure **out of band**, on stderr, for the same reason the
+`--limit` note does: the format is a fixed row grammar with no metadata channel.
+Every in-band option corrupts something.
+
+- A leading `# NOT EXAMINED` comment makes Go's `encoding/csv` reject the document on
+  field count, and Python's `DictReader` adopt the comment as the only fieldname — so
+  every real row parses as garbage.
+- A synthetic row with `Type=NOT_EXAMINED` is indistinguishable from a finding to
+  every consumer.
+
+**Residual gap, stated plainly:** a `--output report.csv` artifact read away from the
+terminal *cannot* tell you coverage was incomplete. If you need machine-readable
+coverage data, use `json`, `yaml`, `sarif` or `gitlab-sast`.
+
+## Caps
+
+Machine formats enumerate at most **50** entries and then state the total, so
+truncation is never silent:
+
+```
+NOT FULLY EXAMINED: 312 file(s) — findings may be missing; 50 listed here, 262 omitted
+```
+
+The cap exists because an unbounded list is a denial of service against the consumer
+— a tree with thousands of unreadable files would push a SARIF upload toward GitHub's
+size-rejection limit, losing the whole report and defeating the point.
+
+## Exit codes
+
+The disclosure is independent of the exit code. Coverage gaps exit `0` by default; add
+`--fail-on-incomplete` to exit `3`. That flag is also what switches the JUnit valence,
+so one decision governs every channel.
+
+## Testing
+
+`internal/formatters/notexamined_disclosure_test.go` covers all four formats in one
+file, because the property is cross-cutting: the regression to catch is *adding a
+format without the disclosure*.
+
+**The golden corpus cannot gate this.** Its harness builds `FormatterOptions` without
+`Stats` or `NotExamined`, so every golden passes whether the feature works or not. A
+green golden run is not evidence here.

--- a/internal/formatters/formatter.go
+++ b/internal/formatters/formatter.go
@@ -36,9 +36,38 @@ type FormatterOptions struct {
 	// as a detached box after a blank line, and a piped stdout ended with a summary
 	// whose frame was closed by content the pipe never received.
 	//
-	// Text format only: structured formats carry the same information as data (see
-	// the unscanned key), not as decorated prose.
+	// Text format only: structured formats carry the same information as data via
+	// NotExamined below, not as decorated prose.
 	NotExaminedFooter string
+
+	// NotExamined is the STRUCTURED form of the same disclosure, for machine
+	// formats. Empty means every file was fully examined.
+	//
+	// Separate from NotExaminedFooter because that field is rendered prose — box
+	// rules, column padding, a flag hint — which a JUnit or SARIF consumer cannot
+	// use. A machine format needs the path and the cause as distinct fields.
+	//
+	// Deliberately NOT part of ScanStats: stats is marshalled directly into the
+	// json/yaml output, and putting an int-backed enum there would put an ordinal on
+	// the wire as a number, which would then be an output contract. The count that
+	// belongs in stats is already there (ScanStats.FilesNotExamined).
+	//
+	// Formatters must guard on len(NotExamined) > 0 AND treat a nil Stats as
+	// legitimate: the golden harness constructs FormatterOptions without either.
+	NotExamined []NotExaminedFile
+
+	// FailOnIncomplete mirrors --fail-on-incomplete, which makes incomplete coverage
+	// a non-zero exit.
+	//
+	// Only the JUnit formatter reads it, and only to decide the VALENCE of the
+	// not-examined entries: <skipped> by default, <error> when the flag is set. That
+	// keeps one decision in one place — a JUnit widget's verdict then agrees with the
+	// process exit code instead of contradicting it.
+	//
+	// Default-false matters: emitting <error> unconditionally would turn currently
+	// green pipelines red on the first unreadable file, which is a behaviour change
+	// nobody asked for, dressed up as a disclosure.
+	FailOnIncomplete bool
 
 	// StreamWriter, when non-nil, causes the text formatter to write output
 	// directly to this writer instead of buffering into a returned string.

--- a/internal/formatters/gitlab-sast/formatter.go
+++ b/internal/formatters/gitlab-sast/formatter.go
@@ -110,6 +110,21 @@ func (f *Formatter) Format(matches []detector.Match, suppressedMatches []detecto
 		},
 	}
 
+	// The not-examined disclosure, BEFORE the zero-matches early return below.
+	//
+	// Placement is the whole correctness argument here. A scan that found nothing
+	// AND could not read some of its files is the single most dangerous report this
+	// tool can produce — an empty vulnerabilities array that looks like a clean bill
+	// of health — and it is exactly the path that returns early. Attaching this
+	// alongside the `truncated` block further down (which runs only when there are
+	// matches) would make the signal vanish in the one case it exists for.
+	//
+	// Status deliberately stays "success": the scan DID succeed. The enum is only
+	// success|failure, so reporting "failure" would claim the analyzer broke, which
+	// is a different and false statement. Coverage is reported through messages, and
+	// the exit code (with --fail-on-incomplete) carries the verdict.
+	addNotExaminedMessages(report, options)
+
 	// Handle empty results - return valid empty GitLab report structure
 	if len(matches) == 0 {
 		if options.Verbose {

--- a/internal/formatters/gitlab-sast/models.go
+++ b/internal/formatters/gitlab-sast/models.go
@@ -77,6 +77,36 @@ type GitLabScanInfo struct {
 	// that field would make a correct report look like a failed one.
 	Truncated            bool `json:"truncated,omitempty"`
 	TotalVulnerabilities int  `json:"total_vulnerabilities,omitempty"`
+
+	// Messages carries the not-examined disclosure: files the tool could not read,
+	// parse or extract text from, and which therefore cannot be called clean.
+	//
+	// This is a FIRST-CLASS schema field, not an extension. Verified by fetching the
+	// v15.0.4 schema this formatter declares (GitLabSASTSchemaVersion) from
+	// gitlab-org/security-products/security-report-schemas: scan.messages is present
+	// under properties.scan.properties, its items require {level, value}, level is
+	// the enum [info, warn, fatal], and value has minLength 1.
+	//
+	// The schema's own description of "warn" is this case exactly: "a potentially
+	// recoverable problem, or a partial error".
+	//
+	// omitempty, so a scan that examined everything is byte-for-byte unchanged.
+	Messages []GitLabScanMessage `json:"messages,omitempty"`
+}
+
+// GitLabScanMessage is one scan.messages[] entry.
+//
+// Exactly {level, value} and nothing more. The schema does not close
+// additionalProperties on these items, so an extra key would validate — but GitLab
+// would ignore it, so it would be output nobody reads, and the two fields already
+// carry everything the consumer can act on.
+//
+// Level must be one of info/warn/fatal. NOTE the difference from SARIF, whose
+// notification level enum is none/note/warning/error: "warn" here, "warning" there.
+// The two are not interchangeable and each is invalid in the other's schema.
+type GitLabScanMessage struct {
+	Level string `json:"level"`
+	Value string `json:"value"`
 }
 
 // GitLabAnalyzer represents the analyzer information

--- a/internal/formatters/gitlab-sast/notexamined.go
+++ b/internal/formatters/gitlab-sast/notexamined.go
@@ -1,0 +1,51 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package gitlabsast
+
+import "github.com/awslabs/ferret-scan/v2/internal/formatters"
+
+// scanMessageLevelWarn is the GitLab schema's level for a partial error.
+//
+// The v15.0.4 enum is [info, warn, fatal] and the schema describes "warn" as "a
+// potentially recoverable problem, or a partial error" — which is what an
+// unexamined file is. NOT "warning": that is SARIF's spelling and is invalid here,
+// and the reverse is equally true. Both enums exist in this codebase, so the
+// constant is named to make a copy-paste between them fail visibly.
+const scanMessageLevelWarn = "warn"
+
+// addNotExaminedMessages appends the not-examined disclosure to scan.messages.
+//
+// Called BEFORE the formatter's zero-matches early return: a clean-looking report
+// over unreadable files is the case this exists for, and that is the path that
+// returns early.
+//
+// Emits a leading summary line and then one line per file, capped. The summary
+// comes first so a consumer that shows only the first message still learns coverage
+// was incomplete, and it states the TOTAL, so the cap can never hide the scale.
+func addNotExaminedMessages(report *GitLabSecurityReport, options formatters.FormatterOptions) {
+	if report == nil || len(options.NotExamined) == 0 {
+		return
+	}
+
+	shown, total := formatters.CapNotExamined(options.NotExamined)
+
+	// Non-nil so the field marshals as [] rather than null if anything later
+	// truncates it; omitempty on the field keeps a complete scan unchanged.
+	msgs := make([]GitLabScanMessage, 0, len(shown)+1)
+	msgs = append(msgs, GitLabScanMessage{
+		Level: scanMessageLevelWarn,
+		Value: formatters.NotExaminedSummary(len(shown), total),
+	})
+	for _, f := range shown {
+		// f.Message() guarantees a non-empty string, which the schema requires
+		// (value has minLength 1). A zero-valued NotExaminedFile still yields a
+		// valid message rather than an empty one that would fail validation.
+		msgs = append(msgs, GitLabScanMessage{
+			Level: scanMessageLevelWarn,
+			Value: f.Message(),
+		})
+	}
+
+	report.Scan.Messages = append(report.Scan.Messages, msgs...)
+}

--- a/internal/formatters/junit/formatter.go
+++ b/internal/formatters/junit/formatter.go
@@ -51,6 +51,19 @@ type TestCase struct {
 	ClassName string   `xml:"classname,attr"`
 	Time      string   `xml:"time,attr"`
 	Failure   *Failure `xml:"failure,omitempty"`
+
+	// Skipped marks a file that was NOT examined: the standard, non-failing JUnit
+	// element. Used by default for unexamined files so a disclosure cannot turn a
+	// green pipeline red on its own.
+	Skipped *Skipped `xml:"skipped,omitempty"`
+
+	// Error marks an unexamined file when --fail-on-incomplete is set, so the XML
+	// verdict agrees with the process exit code (3) instead of contradicting it.
+	//
+	// Distinct from Failure: a failure means the tool found something wrong IN the
+	// file; an error means the tool could not evaluate the file at all. Reporting
+	// "cannot read" as a PII finding would be a fabricated finding.
+	Error *Failure `xml:"error,omitempty"`
 	// SystemOut carries informational, non-failing detail (the standard JUnit
 	// <system-out> element). Suppressed findings use it so they convey their
 	// detail without being reported as failures.
@@ -60,6 +73,18 @@ type TestCase struct {
 type Failure struct {
 	Message string `xml:"message,attr"`
 	Type    string `xml:"type,attr"`
+	Content string `xml:",chardata"`
+}
+
+// Skipped is the standard non-failing JUnit element, used for files that were not
+// examined.
+//
+// No `type` attribute: the JUnit 10 XSD declares only `message` on <skipped>, unlike
+// <failure> and <error> which also carry `type`. Adding one would make the document
+// fail schema validation, and Jenkins' xunit-plugin validates against that XSD and
+// rejects the WHOLE file rather than the offending element.
+type Skipped struct {
+	Message string `xml:"message,attr"`
 	Content string `xml:",chardata"`
 }
 
@@ -185,6 +210,24 @@ func (f *Formatter) Format(matches []detector.Match, suppressedMatches []detecto
 	testSuites.TestSuites = append(testSuites.TestSuites, securitySuite)
 	testSuites.Tests += securitySuite.Tests
 	testSuites.Failures += securitySuite.Failures
+
+	// Declare the files that were NOT examined, as their own suite.
+	//
+	// Appended AFTER the security suite so the findings stay first in the report,
+	// and unconditionally — a scan with zero findings and unreadable files is
+	// exactly the case where this must appear.
+	//
+	// Rolls up Tests and Errors ONLY. There is deliberately no `skipped` attribute
+	// on <testsuites>: the JUnit 10 XSD does not declare one there (it exists on
+	// <testsuite>), so adding it makes the document fail validation — measured, and
+	// Jenkins' xunit-plugin rejects the whole file rather than the bad attribute.
+	// The skipped count therefore lives on the suite alone, which is both valid and
+	// where consumers look for it.
+	if notExaminedSuite, ok := buildNotExaminedSuite(options); ok {
+		testSuites.TestSuites = append(testSuites.TestSuites, notExaminedSuite)
+		testSuites.Tests += notExaminedSuite.Tests
+		testSuites.Errors += notExaminedSuite.Errors
+	}
 
 	// Generate XML
 	xmlData, err := xml.MarshalIndent(testSuites, "", "  ")

--- a/internal/formatters/junit/notexamined.go
+++ b/internal/formatters/junit/notexamined.go
@@ -1,0 +1,96 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package junit
+
+import (
+	"encoding/xml"
+	"fmt"
+	"path/filepath"
+
+	"github.com/awslabs/ferret-scan/v2/internal/formatters"
+)
+
+// notExaminedSuiteName is the suite that holds unexamined files.
+//
+// A SEPARATE suite, not extra cases in the findings suite, so that suite's tests=
+// attribute keeps meaning "files examined". Mixing the two makes a dashboard's test
+// count a number that answers no question. This follows the existing
+// suppressed-findings suite, which solved the same problem the same way.
+const notExaminedSuiteName = "not-examined"
+
+// buildNotExaminedSuite renders the not-examined disclosure as a JUnit suite.
+//
+// Returns false when there is nothing to disclose, so a complete scan is
+// byte-for-byte unchanged.
+//
+// VALENCE, which is the whole design question here:
+//
+//   - default: <skipped>. Universal JUnit vocabulary, and non-failing in every
+//     consumer — Jenkins, GitLab and the xunit family all count skipped separately
+//     from failures. A file nobody could read is genuinely "not run", which is what
+//     skipped means.
+//   - --fail-on-incomplete: <error>. The operator has declared incomplete coverage a
+//     failure and the process already exits 3, so the XML agrees with the exit code
+//     rather than contradicting it.
+//
+// Emitting <error> unconditionally was rejected: it turns currently-green pipelines
+// red on the first unreadable file. A disclosure that changes a build verdict without
+// being asked is a behaviour change wearing a disclosure's clothes.
+func buildNotExaminedSuite(options formatters.FormatterOptions) (TestSuite, bool) {
+	if len(options.NotExamined) == 0 {
+		return TestSuite{}, false
+	}
+
+	shown, total := formatters.CapNotExamined(options.NotExamined)
+
+	suite := TestSuite{
+		XMLName:   xml.Name{Local: "testsuite"},
+		Name:      notExaminedSuiteName,
+		Time:      "0.000",
+		TestCases: make([]TestCase, 0, len(shown)),
+		// The summary states the TOTAL, so the cap above can never make the report
+		// understate how much was missed.
+		SystemOut: formatters.NotExaminedSummary(len(shown), total),
+	}
+
+	for _, nf := range shown {
+		tc := TestCase{
+			XMLName: xml.Name{Local: "testcase"},
+			// The base name keeps the case list readable; the full path is in the
+			// message, so nothing is lost.
+			Name:      filepath.Base(nf.Path),
+			ClassName: notExaminedSuiteName,
+			Time:      "0.000",
+		}
+		msg := nf.Message()
+		if options.FailOnIncomplete {
+			tc.Error = &Failure{
+				Message: msg,
+				Type:    "NotExamined",
+				Content: notExaminedContent(nf),
+			}
+			suite.Errors++
+		} else {
+			tc.Skipped = &Skipped{
+				Message: msg,
+				Content: notExaminedContent(nf),
+			}
+		}
+		suite.TestCases = append(suite.TestCases, tc)
+	}
+	suite.Tests = len(suite.TestCases)
+
+	return suite, true
+}
+
+// notExaminedContent is the element body: the detail a reader needs to act, and the
+// explicit statement that silence here is not a clean bill of health.
+//
+// Deliberately does NOT begin with "Line ", because the shared limit-parity test
+// counts finding lines by that prefix and these are not findings.
+func notExaminedContent(nf formatters.NotExaminedFile) string {
+	return fmt.Sprintf("%s\nCause: %s\nFindings may be missing for this file; "+
+		"the absence of findings is not evidence that it contains no sensitive data.",
+		nf.Path, nf.Cause)
+}

--- a/internal/formatters/notexamined.go
+++ b/internal/formatters/notexamined.go
@@ -1,0 +1,155 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package formatters
+
+import "fmt"
+
+// The not-examined disclosure, as DATA rather than prose.
+//
+// A file the tool could not read is not a file with no findings, but on four of the
+// six output formats those two states were byte-identical. Measured on a directory
+// holding one findings-bearing .txt, one unreadable file and one body-less .docx:
+//
+//	format       in-band signal on stdout
+//	text         "NOT FULLY EXAMINED: 2 of 3 files" inside the summary block
+//	json         stats.files_not_examined = 2
+//	yaml         filesnotexamined: 2
+//	csv          NONE
+//	junit        NONE
+//	sarif        NONE
+//	gitlab-sast  NONE
+//
+// The human-readable report IS produced for the machine formats — it goes to
+// STDERR, which pipelines routinely discard. So a CI job parsing stdout concludes
+// those files are clean. They were never opened.
+//
+// That is the same class of harm as a missed detection: only reported facts reach
+// the consumer, and an undisclosed gap reads as a pass.
+//
+// This file carries the STRUCTURED form into the formatters. FormatterOptions
+// already had NotExaminedFooter, but that is a rendered string with box-drawing
+// characters and column alignment — useless to a machine format, which needs the
+// path and the cause as separate fields.
+
+// NotExaminedCause is a coarse, user-facing reason a file was not examined.
+//
+// An INT enum, not a string, for two reasons found while designing this:
+//
+//  1. The four causes have a deliberate presentation ORDER (unreadable, unparseable,
+//     no-text, cut-short — least to most partial coverage). String values would sort
+//     lexicographically and permute it.
+//  2. The zero value of a string is "", and the GitLab SAST schema requires
+//     minLength 1 on the message value. An int zero is a VALID cause, so a
+//     partially-populated struct cannot emit a schema-invalid document.
+//
+// Deliberately coarse: the point is what the operator must DO, not which internal
+// component reported the failure. It mirrors the cmd-side taxonomy exactly; see
+// cmd/unscanned_report.go, which keeps the classification logic because it does
+// filesystem I/O that must not migrate into a package the web export handler calls.
+type NotExaminedCause int
+
+const (
+	// NotExaminedUnreadable — the bytes could not be read at all (permissions,
+	// vanished path, I/O error). Nothing about this file is known.
+	NotExaminedUnreadable NotExaminedCause = iota
+
+	// NotExaminedUnparseable — the file was read but its bytes do not match its
+	// declared type, so no text could be recovered.
+	NotExaminedUnparseable
+
+	// NotExaminedNoText — opened and parsed, but no body text was found. NOTE: the
+	// file's METADATA was still extracted and scanned through a separate channel and
+	// may already have produced findings in this same report. Never claim this file
+	// was unread.
+	NotExaminedNoText
+
+	// NotExaminedCutShort — a budget, size cap or timeout fired, so the file is
+	// PARTLY scanned. Findings from it may be present and incomplete.
+	NotExaminedCutShort
+)
+
+// String returns the operator-facing cause label.
+//
+// These strings are consumed by machine formats, so they are part of the output
+// contract; changing one changes every report. They match the text renderer's
+// wording exactly, because an operator comparing a human report against a JUnit
+// artifact from the same run must not have to translate.
+func (c NotExaminedCause) String() string {
+	switch c {
+	case NotExaminedUnreadable:
+		return "cannot read"
+	case NotExaminedUnparseable:
+		return "cannot parse"
+	case NotExaminedNoText:
+		// Names the BODY specifically. "no text" alone reads as "nothing was
+		// scanned" on a file whose metadata may have produced findings in this very
+		// report — a contradiction the reader cannot resolve.
+		return "no body text (metadata still scanned)"
+	case NotExaminedCutShort:
+		return "coverage cut short"
+	default:
+		return "unknown"
+	}
+}
+
+// NotExaminedFile is one file that was not fully examined.
+type NotExaminedFile struct {
+	// Path is the file as the user named it.
+	Path string
+	// Cause is the coarse reason.
+	Cause NotExaminedCause
+	// Detail is a short actionable explanation ("permission denied"), already
+	// stripped of internal vocabulary and of the redundant path. May be empty;
+	// Message() supplies a fallback so no format can emit an empty string into a
+	// field whose schema requires minLength 1.
+	Detail string
+}
+
+// Message renders one entry as a single self-describing line.
+//
+// Shared by every machine format so the wording cannot drift between them, and so
+// the minLength-1 guarantee lives in exactly one place. The leading claim is the
+// consequence, not the cause: a consumer that truncates the string still learns
+// that coverage is incomplete.
+func (f NotExaminedFile) Message() string {
+	detail := f.Detail
+	if detail == "" {
+		detail = "no further detail available"
+	}
+	return fmt.Sprintf("NOT EXAMINED (%s): %s — %s", f.Cause, f.Path, detail)
+}
+
+// NotExaminedSummary is the aggregate line, used when per-file entries are capped.
+//
+// Truncation is never silent: the count of what was dropped is stated. This is the
+// same idiom the --limit disclosure uses.
+func NotExaminedSummary(shown, total int) string {
+	if total <= shown {
+		return fmt.Sprintf("NOT FULLY EXAMINED: %d file(s) — findings may be missing", total)
+	}
+	return fmt.Sprintf("NOT FULLY EXAMINED: %d file(s) — findings may be missing; "+
+		"%d listed here, %d omitted", total, shown, total-shown)
+}
+
+// MaxNotExaminedEntries caps how many per-file entries a machine format emits.
+//
+// Larger than the terminal renderer's inlineDetailLimit (8), which is tuned for
+// something a person reads: a machine artifact can carry more, and the consumer
+// usually wants the list. Capped at all because an unbounded list is a denial of
+// service against the consumer — a tree with 10,000 unreadable files would push a
+// SARIF upload toward GitHub's 10 MB gzipped rejection limit, which would lose the
+// whole report and so defeat the purpose of disclosing anything.
+//
+// When the cap bites, NotExaminedSummary states the total, so the disclosure remains
+// complete even when the enumeration is not.
+const MaxNotExaminedEntries = 50
+
+// CapNotExamined returns the entries to enumerate plus the full total.
+func CapNotExamined(files []NotExaminedFile) (shown []NotExaminedFile, total int) {
+	total = len(files)
+	if total > MaxNotExaminedEntries {
+		return files[:MaxNotExaminedEntries], total
+	}
+	return files, total
+}

--- a/internal/formatters/notexamined_disclosure_test.go
+++ b/internal/formatters/notexamined_disclosure_test.go
@@ -1,0 +1,468 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package formatters_test
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/formatters"
+	csvfmt "github.com/awslabs/ferret-scan/v2/internal/formatters/csv"
+	gitlabsast "github.com/awslabs/ferret-scan/v2/internal/formatters/gitlab-sast"
+	"github.com/awslabs/ferret-scan/v2/internal/formatters/junit"
+	"github.com/awslabs/ferret-scan/v2/internal/formatters/sarif"
+)
+
+// A file the tool could not read must never read as a file with no findings.
+//
+// Measured before this change, on a directory with one findings-bearing file and two
+// unexaminable ones — the in-band signal on STDOUT was:
+//
+//	json         stats.files_not_examined = 2   PRESENT
+//	yaml         filesnotexamined: 2            PRESENT
+//	csv          NONE
+//	junit        NONE
+//	sarif        NONE
+//	gitlab-sast  NONE
+//
+// The human report was produced for all of them, on STDERR, which pipelines
+// discard. A CI job parsing stdout concluded those files were clean.
+//
+// These tests live in one file, across all four formats, because the property is
+// cross-cutting: adding a format without the disclosure is the regression to catch,
+// and a per-package test would not notice.
+//
+// NOTE the golden corpus CANNOT gate any of this: its harness constructs
+// FormatterOptions without Stats or NotExamined, so every golden passes whether the
+// feature works or not. All coverage is here.
+
+// twoUnexamined is the standard fixture: one unreadable file, one whose body could
+// not be extracted.
+func twoUnexamined() []formatters.NotExaminedFile {
+	return []formatters.NotExaminedFile{
+		{Path: "/scan/noperm.txt", Cause: formatters.NotExaminedUnreadable, Detail: "permission denied"},
+		{Path: "/scan/broken.docx", Cause: formatters.NotExaminedNoText, Detail: "no document body part"},
+	}
+}
+
+func optsWith(files []formatters.NotExaminedFile) formatters.FormatterOptions {
+	return formatters.FormatterOptions{
+		ConfidenceLevel: map[string]bool{"high": true, "medium": true, "low": true},
+		NotExamined:     files,
+	}
+}
+
+func oneMatch() []detector.Match {
+	return []detector.Match{{
+		Text: "130-07-5728", Type: "SSN", Confidence: 100,
+		Filename: "good.txt", LineNumber: 1, Validator: "ssn",
+	}}
+}
+
+// TestZeroFindingsStillDisclosesNotExamined is the single most important test here.
+//
+// A scan that finds nothing AND could not read some files is the most dangerous
+// report this tool can emit: an empty findings list that looks like a clean bill of
+// health. It is also the path that returns EARLY in two of these formatters, so a
+// disclosure attached next to the truncation logic (which runs only when there are
+// matches) would vanish in exactly the case it exists for.
+func TestZeroFindingsStillDisclosesNotExamined(t *testing.T) {
+	opts := optsWith(twoUnexamined())
+
+	for _, tc := range []struct {
+		name string
+		out  func() (string, error)
+	}{
+		{"gitlab-sast", func() (string, error) {
+			return gitlabsast.NewFormatter().Format(nil, nil, opts)
+		}},
+		{"sarif", func() (string, error) {
+			return sarif.NewFormatter().Format(nil, nil, opts)
+		}},
+		{"junit", func() (string, error) {
+			return junit.NewFormatter().Format(nil, nil, opts)
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := tc.out()
+			if err != nil {
+				t.Fatalf("Format: %v", err)
+			}
+			if !strings.Contains(out, "NOT EXAMINED") && !strings.Contains(out, "NOT FULLY EXAMINED") {
+				t.Errorf("a scan with ZERO findings and 2 unexaminable files produced no "+
+					"in-band disclosure. This output is indistinguishable from a clean "+
+					"scan, which is the worst report this tool can emit:\n%s", out)
+			}
+		})
+	}
+}
+
+// TestGitLabDisclosesViaScanMessages pins the slot and the schema constraints.
+func TestGitLabDisclosesViaScanMessages(t *testing.T) {
+	out, err := gitlabsast.NewFormatter().Format(oneMatch(), nil, optsWith(twoUnexamined()))
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+	var doc struct {
+		Scan struct {
+			Status   string `json:"status"`
+			Messages []struct {
+				Level string `json:"level"`
+				Value string `json:"value"`
+			} `json:"messages"`
+		} `json:"scan"`
+		Vulnerabilities []map[string]any `json:"vulnerabilities"`
+	}
+	if err := json.Unmarshal([]byte(out), &doc); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	if len(doc.Scan.Messages) == 0 {
+		t.Fatal("scan.messages is empty; the disclosure is missing")
+	}
+	for i, m := range doc.Scan.Messages {
+		// The v15.0.4 enum is [info, warn, fatal]. "warning" is SARIF's spelling and
+		// is INVALID here — GitLab rejects an invalid report in full, losing every
+		// finding, so this assertion protects the findings, not the disclosure.
+		if m.Level != "warn" {
+			t.Errorf("messages[%d].level = %q, want %q (the schema enum is info/warn/fatal; "+
+				"%q is SARIF's spelling and invalid here)", i, m.Level, "warn", "warning")
+		}
+		// value has minLength 1 in the schema.
+		if m.Value == "" {
+			t.Errorf("messages[%d].value is empty, but the schema requires minLength 1", i)
+		}
+	}
+
+	// The scan SUCCEEDED; only its coverage was partial. The enum is success|failure,
+	// so "failure" would claim the analyzer broke.
+	if doc.Scan.Status != "success" {
+		t.Errorf("scan.status = %q, want \"success\": incomplete COVERAGE is not a failed "+
+			"scan, and the exit code carries the verdict", doc.Scan.Status)
+	}
+
+	// Never fabricate findings to report a gap.
+	if len(doc.Vulnerabilities) != 1 {
+		t.Errorf("vulnerabilities has %d entries, want exactly the 1 real finding: "+
+			"unexamined files must NOT be injected as synthetic vulnerabilities, which "+
+			"would put fake findings on a security dashboard", len(doc.Vulnerabilities))
+	}
+}
+
+// TestSARIFDisclosesViaToolExecutionNotifications pins the slot and its schema rules.
+func TestSARIFDisclosesViaToolExecutionNotifications(t *testing.T) {
+	out, err := sarif.NewFormatter().Format(oneMatch(), nil, optsWith(twoUnexamined()))
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(out), &doc); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	run := doc["runs"].([]any)[0].(map[string]any)
+
+	// run.additionalProperties is FALSE in SARIF 2.1.0, so a bespoke run-level key
+	// is not merely unconventional — it invalidates the document, and GitLab rejects
+	// an invalid SARIF report whole.
+	for _, forbidden := range []string{"notExamined", "unscanned", "filesNotExamined"} {
+		if _, present := run[forbidden]; present {
+			t.Errorf("run has a non-standard key %q; run.additionalProperties is false, "+
+				"so this makes the whole document schema-invalid", forbidden)
+		}
+	}
+
+	invs, ok := run["invocations"].([]any)
+	if !ok || len(invs) == 0 {
+		t.Fatalf("run.invocations is missing; the disclosure has nowhere to live: %v", run["invocations"])
+	}
+	inv := invs[0].(map[string]any)
+
+	// executionSuccessful is the object's only required member, and false tells
+	// consumers the analysis failed — grounds to discard the results.
+	if inv["executionSuccessful"] != true {
+		t.Errorf("invocations[0].executionSuccessful = %v, want true: the run succeeded, "+
+			"its coverage was partial, and false may make a consumer discard the results",
+			inv["executionSuccessful"])
+	}
+
+	notes, ok := inv["toolExecutionNotifications"].([]any)
+	if !ok || len(notes) == 0 {
+		t.Fatal("toolExecutionNotifications is empty; the disclosure is missing")
+	}
+	for i, raw := range notes {
+		n := raw.(map[string]any)
+		// The SARIF enum is none/note/warning/error. "warn" is GitLab's spelling.
+		if n["level"] != "warning" {
+			t.Errorf("notification[%d].level = %v, want \"warning\" (the SARIF enum is "+
+				"none/note/warning/error; \"warn\" is GitLab's and invalid here)", i, n["level"])
+		}
+		// notification.additionalProperties IS false here — the opposite of GitLab's
+		// messages — so only the spec's own members may appear.
+		for k := range n {
+			switch k {
+			case "descriptor", "level", "message", "locations", "properties",
+				"associatedRule", "exception", "threadId", "timeUtc":
+			default:
+				t.Errorf("notification[%d] has key %q, which is not a spec member; "+
+					"notification.additionalProperties is false", i, k)
+			}
+		}
+	}
+
+	// The descriptor must be declared exactly once: driver.notifications has
+	// uniqueItems:true, so a per-file descriptor would duplicate and invalidate.
+	driver := run["tool"].(map[string]any)["driver"].(map[string]any)
+	descs, _ := driver["notifications"].([]any)
+	if len(descs) != 1 {
+		t.Errorf("driver.notifications has %d entries, want exactly 1 shared descriptor "+
+			"(the array is uniqueItems:true)", len(descs))
+	}
+
+	// Unexamined files must not become results: GitHub renders results as
+	// dismissable code-scanning alerts, so this would fabricate PII alerts.
+	if got := len(run["results"].([]any)); got != 1 {
+		t.Errorf("results has %d entries, want exactly the 1 real finding: an unexamined "+
+			"file must never be reported as a finding", got)
+	}
+}
+
+// TestJUnitDisclosureIsNonFailingByDefault is the CI-safety half.
+func TestJUnitDisclosureIsNonFailingByDefault(t *testing.T) {
+	out, err := junit.NewFormatter().Format(oneMatch(), nil, optsWith(twoUnexamined()))
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+
+	var suites struct {
+		Errors   int `xml:"errors,attr"`
+		Failures int `xml:"failures,attr"`
+		Tests    int `xml:"tests,attr"`
+		Suites   []struct {
+			Name    string `xml:"name,attr"`
+			Errors  int    `xml:"errors,attr"`
+			Skipped int    `xml:"skipped,attr"`
+			Cases   []struct {
+				Name    string `xml:"name,attr"`
+				Skipped *struct {
+					Message string `xml:"message,attr"`
+				} `xml:"skipped"`
+				Error *struct {
+					Message string `xml:"message,attr"`
+				} `xml:"error"`
+				Failure *struct {
+					Message string `xml:"message,attr"`
+				} `xml:"failure"`
+			} `xml:"testcase"`
+		} `xml:"testsuite"`
+	}
+	if err := xml.Unmarshal([]byte(out), &suites); err != nil {
+		t.Fatalf("invalid XML: %v", err)
+	}
+
+	// Without --fail-on-incomplete the report must not turn a green pipeline red.
+	if suites.Errors != 0 {
+		t.Errorf("testsuites errors=%d without --fail-on-incomplete. A disclosure must "+
+			"not change a build's verdict unless asked: that is a behaviour change "+
+			"dressed as a disclosure.", suites.Errors)
+	}
+
+	var found bool
+	for _, s := range suites.Suites {
+		if s.Name != "not-examined" {
+			continue
+		}
+		found = true
+		if len(s.Cases) != 2 {
+			t.Errorf("not-examined suite has %d cases, want one PER FILE (2)", len(s.Cases))
+		}
+		for _, c := range s.Cases {
+			if c.Skipped == nil {
+				t.Errorf("case %q has no <skipped>; that is the standard non-failing element", c.Name)
+			}
+			if c.Failure != nil {
+				t.Errorf("case %q reports <failure>: an unexamined file is not a PII "+
+					"finding, and reporting it as one fabricates a finding", c.Name)
+			}
+		}
+	}
+	if !found {
+		t.Error("no 'not-examined' suite. A separate suite keeps the security suite's " +
+			"tests= attribute meaning 'files examined'.")
+	}
+
+	// The JUnit 10 XSD declares no `skipped` attribute on <testsuites> (only on
+	// <testsuite>). Jenkins' xunit-plugin validates against that XSD and rejects the
+	// WHOLE file, so this would lose the entire report.
+	if strings.Contains(out, "<testsuites") {
+		head := out[strings.Index(out, "<testsuites"):]
+		head = head[:strings.Index(head, ">")]
+		if strings.Contains(head, "skipped=") {
+			t.Errorf("<testsuites> carries a skipped attribute: the JUnit 10 XSD does not "+
+				"declare one there, and Jenkins rejects the whole file. Got: %s", head)
+		}
+	}
+}
+
+// TestJUnitDisclosureFailsUnderFailOnIncomplete is the flag half.
+//
+// When the operator declares incomplete coverage a failure, every channel must agree
+// with the exit code rather than contradict it.
+func TestJUnitDisclosureFailsUnderFailOnIncomplete(t *testing.T) {
+	opts := optsWith(twoUnexamined())
+	opts.FailOnIncomplete = true
+
+	out, err := junit.NewFormatter().Format(oneMatch(), nil, opts)
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+	if !strings.Contains(out, "<error ") {
+		t.Error("--fail-on-incomplete produced no <error> element: the XML verdict would " +
+			"say the run was fine while the process exits 3")
+	}
+	if strings.Contains(out, "<skipped ") {
+		t.Error("--fail-on-incomplete still emits <skipped>; the valence must switch, not double up")
+	}
+
+	var suites struct {
+		Errors int `xml:"errors,attr"`
+	}
+	if err := xml.Unmarshal([]byte(out), &suites); err != nil {
+		t.Fatalf("invalid XML: %v", err)
+	}
+	if suites.Errors != 2 {
+		t.Errorf("testsuites errors=%d, want 2: the roll-up must count the errored cases, "+
+			"or a consumer reading only the top-level attributes sees a clean run", suites.Errors)
+	}
+}
+
+// TestCompleteScanIsByteIdentical — the disclosure must be purely additive.
+func TestCompleteScanIsByteIdentical(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		fn   func(formatters.FormatterOptions) (string, error)
+	}{
+		{"gitlab-sast", func(o formatters.FormatterOptions) (string, error) {
+			return gitlabsast.NewFormatter().Format(oneMatch(), nil, o)
+		}},
+		{"sarif", func(o formatters.FormatterOptions) (string, error) {
+			return sarif.NewFormatter().Format(oneMatch(), nil, o)
+		}},
+		{"junit", func(o formatters.FormatterOptions) (string, error) {
+			return junit.NewFormatter().Format(oneMatch(), nil, o)
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// nil and empty must both mean "nothing to disclose".
+			withNil, err := tc.fn(optsWith(nil))
+			if err != nil {
+				t.Fatalf("Format: %v", err)
+			}
+			withEmpty, err := tc.fn(optsWith([]formatters.NotExaminedFile{}))
+			if err != nil {
+				t.Fatalf("Format: %v", err)
+			}
+			if withNil != withEmpty {
+				t.Error("a nil and an empty NotExamined produced different output; both mean " +
+					"every file was examined")
+			}
+			for _, marker := range []string{"NOT EXAMINED", "not-examined", "notifications", "messages"} {
+				if strings.Contains(withNil, marker) {
+					t.Errorf("a complete scan's output mentions %q; the disclosure must be "+
+						"omitted entirely so existing consumers see no change", marker)
+				}
+			}
+		})
+	}
+}
+
+// TestCapIsDisclosedNotSilent — truncation must never hide the scale.
+func TestCapIsDisclosedNotSilent(t *testing.T) {
+	many := make([]formatters.NotExaminedFile, formatters.MaxNotExaminedEntries+25)
+	for i := range many {
+		many[i] = formatters.NotExaminedFile{
+			Path:   "/scan/f.txt",
+			Cause:  formatters.NotExaminedUnreadable,
+			Detail: "permission denied",
+		}
+	}
+	shown, total := formatters.CapNotExamined(many)
+	if len(shown) != formatters.MaxNotExaminedEntries {
+		t.Errorf("cap returned %d entries, want %d", len(shown), formatters.MaxNotExaminedEntries)
+	}
+	if total != len(many) {
+		t.Errorf("total = %d, want %d: the cap must report the true total", total, len(many))
+	}
+
+	summary := formatters.NotExaminedSummary(len(shown), total)
+	if !strings.Contains(summary, "omitted") {
+		t.Errorf("the summary does not say anything was omitted, so a capped list reads as "+
+			"complete: %q", summary)
+	}
+
+	out, err := gitlabsast.NewFormatter().Format(nil, nil, optsWith(many))
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+	if !strings.Contains(out, "omitted") {
+		t.Error("the emitted report does not disclose that the list was capped")
+	}
+}
+
+// TestMessageIsNeverEmpty guards the minLength-1 schema constraint at its source.
+func TestMessageIsNeverEmpty(t *testing.T) {
+	// A zero-valued entry is the worst case: empty path, empty detail, zero cause.
+	var zero formatters.NotExaminedFile
+	if zero.Message() == "" {
+		t.Error("a zero-valued NotExaminedFile renders an empty message, which violates " +
+			"the GitLab schema's minLength:1 and would invalidate the whole report")
+	}
+	// The int zero value must be a real cause, not "unknown": that is why the enum
+	// is an int rather than a string.
+	if got := zero.Cause.String(); got == "unknown" || got == "" {
+		t.Errorf("the zero cause renders %q; the int zero must be a valid cause", got)
+	}
+}
+
+// TestCSVStaysOutOfBand records a deliberate LIMITATION, not an omission.
+//
+// csv is a fixed-grammar row format. Every in-band option corrupts something:
+//
+//   - a leading "# NOT EXAMINED" comment makes Go's encoding/csv fail the document
+//     (wrong field count) and makes Python's DictReader adopt the comment as the
+//     sole fieldname, so all real rows parse as garbage;
+//   - a synthetic row with Type="NOT_EXAMINED" is indistinguishable from a finding
+//     to every consumer, and inflates the row counts two committed tests assert.
+//
+// So csv keeps its disclosure on STDERR, exactly as PR #274 decided for the --limit
+// note on the same grounds ("csv cannot carry metadata"). This test pins that
+// decision so a future change cannot quietly corrupt the grammar in the name of
+// completeness — and documents the residual gap: a --output x.csv artifact, read
+// away from the terminal, cannot self-describe. Callers who need machine-readable
+// coverage data should use json, yaml, sarif or gitlab-sast.
+func TestCSVStaysOutOfBand(t *testing.T) {
+	out, err := csvfmt.NewFormatter().Format(oneMatch(), nil, optsWith(twoUnexamined()))
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	// Header + exactly one finding row. Nothing else.
+	if len(lines) != 2 {
+		t.Errorf("csv emitted %d lines, want 2 (header + 1 finding). Extra rows for "+
+			"unexamined files are indistinguishable from findings:\n%s", len(lines), out)
+	}
+	if strings.HasPrefix(lines[0], "#") {
+		t.Error("csv output starts with a # comment: encoding/csv fails such a document " +
+			"and DictReader adopts the comment as the only fieldname")
+	}
+	for _, marker := range []string{"NOT EXAMINED", "NOT_EXAMINED", "not-examined"} {
+		if strings.Contains(out, marker) {
+			t.Errorf("csv output contains %q. The disclosure belongs on stderr for this "+
+				"format; in band it corrupts the grammar or fakes a finding.", marker)
+		}
+	}
+}

--- a/internal/formatters/sarif/formatter.go
+++ b/internal/formatters/sarif/formatter.go
@@ -144,6 +144,14 @@ func (f *Formatter) buildReport(mapper *VulnerabilityMapper, ruleManager *RuleMa
 		}
 	}
 
+	// Declare the files that were NOT examined.
+	//
+	// Unconditional — outside the `truncated` branch above and reached on every
+	// path, including a scan that produced zero results. A clean-looking report over
+	// unreadable files is the most dangerous document this tool can emit, so the
+	// disclosure must not sit behind a has-findings condition.
+	attachNotExamined(&run, options)
+
 	// Create the top-level SARIF report
 	report := &SARIFReport{
 		Schema:  SARIFSchemaURL,

--- a/internal/formatters/sarif/models.go
+++ b/internal/formatters/sarif/models.go
@@ -17,6 +17,10 @@ type SARIFRun struct {
 	Results                  []SARIFResult         `json:"results"`
 	VersionControlProvenance []SARIFVersionControl `json:"versionControlProvenance,omitempty"`
 
+	// Invocations carries the not-examined disclosure. omitempty, so a scan that
+	// examined every file emits nothing new and existing consumers see no change.
+	Invocations []SARIFInvocation `json:"invocations,omitempty"`
+
 	// Properties carries run-level metadata. It is currently used for one thing:
 	// declaring that --limit truncated the results, and what the true total was.
 	//
@@ -53,6 +57,56 @@ type SARIFDriver struct {
 	SemanticVersion string      `json:"semanticVersion,omitempty"`
 	InformationURI  string      `json:"informationUri,omitempty"`
 	Rules           []SARIFRule `json:"rules,omitempty"`
+
+	// Notifications declares the descriptors that toolExecutionNotifications refer
+	// to. A notification's descriptor is a reference, so without the descriptor
+	// declared here the reference dangles.
+	//
+	// uniqueItems is true on this array in the schema, so a descriptor must be
+	// emitted at most once no matter how many notifications cite it.
+	Notifications []SARIFRule `json:"notifications,omitempty"`
+}
+
+// SARIFInvocation describes the tool run itself.
+//
+// Added to carry the not-examined disclosure through toolExecutionNotifications,
+// whose spec description IS this semantics: "runtime conditions detected by the tool
+// during the analysis". No other slot fits — run.additionalProperties is false in
+// SARIF 2.1.0, so a bespoke run-level key is not merely non-standard but INVALID,
+// and expressing it as a result would manufacture dismissable "PII alerts" in
+// GitHub's UI for files that were never read.
+//
+// ExecutionSuccessful has no omitempty and is deliberately always true: it is the
+// object's only REQUIRED member per the schema, and false tells consumers the
+// analysis failed, which may cause them to discard the results. The scan succeeded;
+// its COVERAGE was incomplete. Those are different claims.
+type SARIFInvocation struct {
+	ExecutionSuccessful        bool                `json:"executionSuccessful"`
+	ToolExecutionNotifications []SARIFNotification `json:"toolExecutionNotifications,omitempty"`
+}
+
+// SARIFNotification is one runtime condition detected during the run.
+//
+// Exactly {descriptor, level, message} — notification.additionalProperties IS false
+// in the 2.1.0 schema (verified against the OASIS schema), so any extra key makes
+// the whole document invalid. That is the opposite of GitLab's scan.messages, which
+// leaves additionalProperties open; the two must not share a struct.
+//
+// Per-file paths ride in the message text rather than in locations[], because
+// SARIFLocation embeds a non-pointer Region whose StartLine lacks omitempty and
+// would therefore serialise startLine:0 against the schema's minimum of 1.
+type SARIFNotification struct {
+	Descriptor *SARIFReportingDescriptorRef `json:"descriptor,omitempty"`
+	// Level must be one of none/note/warning/error. NOTE: "warning", not "warn" —
+	// GitLab's enum uses "warn" and the two are not interchangeable.
+	Level   string       `json:"level,omitempty"`
+	Message SARIFMessage `json:"message"`
+}
+
+// SARIFReportingDescriptorRef points a notification at its descriptor in
+// tool.driver.notifications.
+type SARIFReportingDescriptorRef struct {
+	ID string `json:"id"`
 }
 
 // SARIFRule represents a reporting descriptor for a rule

--- a/internal/formatters/sarif/notexamined.go
+++ b/internal/formatters/sarif/notexamined.go
@@ -1,0 +1,89 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package sarif
+
+import "github.com/awslabs/ferret-scan/v2/internal/formatters"
+
+// notExaminedNotificationID is the descriptor id shared by every not-examined
+// notification.
+//
+// One descriptor for the whole class, cited by each notification, because
+// tool.driver.notifications has uniqueItems:true — a per-file descriptor would
+// duplicate the object and invalidate the document on a run with two unreadable
+// files of the same cause.
+const notExaminedNotificationID = "ferret-scan/not-examined"
+
+// attachNotExamined adds the not-examined disclosure to a SARIF run.
+//
+// Slot choice: run.invocations[].toolExecutionNotifications[], whose spec
+// description is precisely this ("runtime conditions detected by the tool during the
+// analysis"). The alternatives were rejected on evidence, not taste:
+//
+//   - a new run-level key ("notExamined"): run.additionalProperties is FALSE in
+//     SARIF 2.1.0, so this is invalid, and GitLab rejects an invalid report whole.
+//   - a result with kind:"informational": GitHub renders results as dismissable code
+//     scanning alerts, so files that were never read would appear as PII findings —
+//     fabricating findings to report a gap is worse than the gap.
+//   - artifacts[].roles: a closed 23-value enum with no member meaning "not
+//     examined".
+//
+// The disclosure is machine-readable only: GitHub's UI does not surface
+// toolExecutionNotifications. That is the accepted trade — a valid, quiet,
+// programmatically-checkable statement beats a visible fake alert.
+func attachNotExamined(run *SARIFRun, options formatters.FormatterOptions) {
+	if run == nil || len(options.NotExamined) == 0 {
+		return
+	}
+
+	shown, total := formatters.CapNotExamined(options.NotExamined)
+
+	notifications := make([]SARIFNotification, 0, len(shown)+1)
+
+	// Summary first, so a consumer that reads only the first notification still
+	// learns coverage was incomplete, and so the total survives the cap.
+	notifications = append(notifications, newNotExaminedNotification(
+		formatters.NotExaminedSummary(len(shown), total)))
+	for _, f := range shown {
+		notifications = append(notifications, newNotExaminedNotification(f.Message()))
+	}
+
+	run.Invocations = append(run.Invocations, SARIFInvocation{
+		// True, always. This is the object's only required member, and false means
+		// "the analysis did not complete", which consumers may treat as grounds to
+		// discard the results. The run succeeded; its coverage was partial.
+		ExecutionSuccessful:        true,
+		ToolExecutionNotifications: notifications,
+	})
+
+	// Declare the descriptor the notifications reference, exactly once.
+	for _, existing := range run.Tool.Driver.Notifications {
+		if existing.ID == notExaminedNotificationID {
+			return
+		}
+	}
+	run.Tool.Driver.Notifications = append(run.Tool.Driver.Notifications, SARIFRule{
+		ID: notExaminedNotificationID,
+		ShortDescription: SARIFMessage{
+			Text: "A file could not be fully examined, so findings may be missing",
+		},
+		FullDescription: SARIFMessage{
+			Text: "The scanner could not read, parse or extract text from this file. " +
+				"Its contents were not examined, so the absence of findings for it is " +
+				"not evidence that it contains no sensitive data.",
+		},
+	})
+}
+
+// newNotExaminedNotification builds one notification.
+//
+// Level "warning" — the SARIF enum is none/note/warning/error. NOT "warn", which is
+// GitLab's spelling and invalid here. Both formats are emitted by this codebase, so
+// the distinction is called out at every site that could be copy-pasted.
+func newNotExaminedNotification(text string) SARIFNotification {
+	return SARIFNotification{
+		Descriptor: &SARIFReportingDescriptorRef{ID: notExaminedNotificationID},
+		Level:      LevelWarning,
+		Message:    SARIFMessage{Text: text},
+	}
+}


### PR DESCRIPTION
A file the scanner could not read is **not** a file with no findings — but on four of the six formats those two states were byte-identical on stdout.

Measured on a directory with one findings-bearing `.txt`, one unreadable file and one body-less `.docx`:

| format | in-band signal (stdout) |
|---|---|
| `json` | `stats.files_not_examined` = 2 ✅ |
| `yaml` | `filesnotexamined: 2` ✅ |
| `csv` | **nothing** |
| `junit` | **nothing** |
| `sarif` | **nothing** |
| `gitlab-sast` | **nothing** |

The human report *was* produced for the machine formats — on **stderr**, which pipelines routinely discard. A CI job parsing stdout concluded those files were clean.

## Slots, chosen against the published schemas

**gitlab-sast → `scan.messages[]`, level `warn`.** A first-class field, verified by fetching the v15.0.4 schema this formatter declares: `scan.messages` lives under `properties.scan.properties`, items require `{level,value}`, enum is `[info,warn,fatal]`, `value` has `minLength 1`. The schema's own wording for `warn` is this case: *"a potentially recoverable problem, or a partial error"*.

**sarif → `runs[].invocations[].toolExecutionNotifications[]`, level `warning`**, plus the descriptor in `tool.driver.notifications`. Verified against the OASIS 2.1.0 schema: `run.additionalProperties` is **false**, so a bespoke run-level key would be *invalid*, not merely unconventional — and GitLab rejects an invalid SARIF report in full, losing every finding.

> **The enums are inverted.** GitLab wants `warn`, SARIF wants `warning`, and each is invalid in the other's schema. The extension rules are opposite too (SARIF's `notification` closes `additionalProperties`; GitLab's items do not), so they deliberately do not share a struct.

**junit → separate `<testsuite name="not-examined">`.** Valence follows the flag:

| | element | verdict |
|---|---|---|
| default | `<skipped>` | unchanged — `errors="0"` |
| `--fail-on-incomplete` | `<error>` | fails, agreeing with exit 3 |

Emitting `<error>` unconditionally would turn green pipelines red on the first unreadable file — a behaviour change dressed as a disclosure. No `skipped` attr on `<testsuites>`: the JUnit 10 XSD doesn't declare one there and Jenkins rejects the **whole file**.

**csv → stays out of band**, extending #274's precedent. A `#` comment makes Go's `encoding/csv` reject the document and Python's `DictReader` adopt it as the only fieldname; a synthetic `NOT_EXAMINED` row is indistinguishable from a finding. The residual gap (a `--output x.csv` artifact can't self-describe) is **documented**, not papered over.

## Placement is the load-bearing detail

The gitlab and sarif calls sit **before** their formatters' zero-matches early return. A scan that finds nothing *and* couldn't read some files is the most dangerous report this tool emits — an empty findings list that reads as a clean bill of health — and that is exactly the path that returns early. Attaching it beside the existing `truncated` block (which runs only when there *are* matches) would have made the signal vanish in the one case it exists for.

## Safety properties

- **Additive**: every new field is `omitempty`, so a complete scan is byte-for-byte unchanged. **Zero golden files move.**
- `status` stays `success`, `executionSuccessful` stays `true` — incomplete *coverage* is not a failed scan; the exit code carries that verdict.
- Unexamined files are **never** emitted as vulnerabilities, SARIF results, or `<failure>`. Fabricating a finding to report a gap is worse than the gap.
- Entries capped at 50 with the total always stated, so truncation is never silent. An unbounded list would push a SARIF upload toward GitHub's size-rejection limit and lose the whole report.

## Verification

```
suite:    rc=0, 65 packages, -race clean
goldens:  0 moved
real binary, zero findings + unreadable file:
  gitlab-sast  2 disclosure lines   sarif  3   junit  2   csv  stderr only
junit default:              errors="0"
junit --fail-on-incomplete: errors="2"
```

**Six mutations, each verified to compile and then fail:** relocating the gitlab call; `warn`↔`warning` in both directions; `executionSuccessful: false`; junit `<skipped>`→`<failure>`; junit ignoring the flag; a silently-truncating cap.

My first cap mutation compiled and **passed** — so it was vacuous and I replaced it with one that genuinely removes the omitted-count.

## One caveat worth stating

**The golden corpus cannot gate any of this.** Both harnesses build `FormatterOptions` without `Stats` or `NotExamined`, so every golden passes whether the feature works or not. That's why 0 goldens move — and equally why a green golden run is *not* evidence here. All coverage is in `internal/formatters/notexamined_disclosure_test.go`.

## Known limitation

GitHub's code-scanning UI does not display `toolExecutionNotifications`, so the SARIF disclosure is machine-readable only. The alternative — emitting unexamined files as `results` — would create dismissable "PII alerts" for files that were never read. A quiet valid statement beats a visible false one.

Depends on #283 (`results: null`), which must merge first.