### PR TITLE
feat(scan): expose the match's surrounding text on Finding

### DIFF
--- a/pkg/scan/context_test.go
+++ b/pkg/scan/context_test.go
@@ -1,0 +1,283 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package scan
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// findByValidator returns the first finding produced by the named validator.
+// Tests select on the validator rather than indexing Findings, because the
+// order of the slice is the order validators complete, not source order.
+func findByValidator(t *testing.T, findings []Finding, validator string) Finding {
+	t.Helper()
+	for _, f := range findings {
+		if f.Validator == validator {
+			return f
+		}
+	}
+	t.Fatalf("no finding from validator %q in %d findings", validator, len(findings))
+	return Finding{}
+}
+
+// TestContextExposedOnBothEntryPoints locks the context fields on the two public
+// scan paths. Both go through mapResult, so this is really asserting that the
+// mapping keeps the data rather than dropping it as it did before.
+func TestContextExposedOnBothEntryPoints(t *testing.T) {
+	const line = "Corporate card 4111-1111-1111-1111 expires soon\n"
+
+	path := filepath.Join(t.TempDir(), "ctx.txt")
+	if err := os.WriteFile(path, []byte(line), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	fileResult, err := ScanFile(context.Background(), path, FileOptions{Checks: []string{"CREDIT_CARD"}})
+	if err != nil {
+		t.Fatalf("ScanFile: %v", err)
+	}
+	textResult, err := ScanText(context.Background(), line, TextOptions{Checks: []string{"CREDIT_CARD"}})
+	if err != nil {
+		t.Fatalf("ScanText: %v", err)
+	}
+
+	for _, tc := range []struct {
+		entry    string
+		findings []Finding
+	}{
+		{"ScanFile", fileResult.Findings},
+		{"ScanText", textResult.Findings},
+	} {
+		t.Run(tc.entry, func(t *testing.T) {
+			f := findByValidator(t, tc.findings, "creditcard")
+
+			if !strings.Contains(f.ContextBefore, "Corporate card") {
+				t.Errorf("ContextBefore = %q, want it to contain the preceding text", f.ContextBefore)
+			}
+			if !strings.Contains(f.ContextAfter, "expires soon") {
+				t.Errorf("ContextAfter = %q, want it to contain the following text", f.ContextAfter)
+			}
+			if got, want := f.FullLine, strings.TrimSuffix(line, "\n"); got != want {
+				t.Errorf("FullLine = %q, want %q", got, want)
+			}
+
+			// The context brackets the match; it never restates it. A caller
+			// that concatenated before+text+after must not get the value twice.
+			if strings.Contains(f.ContextBefore, f.Text) {
+				t.Errorf("ContextBefore %q must exclude the matched value %q", f.ContextBefore, f.Text)
+			}
+			if strings.Contains(f.ContextAfter, f.Text) {
+				t.Errorf("ContextAfter %q must exclude the matched value %q", f.ContextAfter, f.Text)
+			}
+			if !strings.Contains(f.FullLine, f.Text) {
+				t.Errorf("FullLine %q must contain the matched value %q", f.FullLine, f.Text)
+			}
+			if got := f.ContextBefore + f.Text + f.ContextAfter; !strings.Contains(f.FullLine, got) {
+				t.Errorf("before+text+after = %q is not a span of FullLine %q", got, f.FullLine)
+			}
+		})
+	}
+}
+
+// TestContextDoesNotSpanLines guards the documented single-line contract. A
+// caller building an LLM prompt from context needs to know the blast radius of
+// what it is about to send; "the neighbouring lines too" is a different and much
+// larger promise than the one this package makes.
+func TestContextDoesNotSpanLines(t *testing.T) {
+	body := strings.Join([]string{
+		"UNRELATED-PRECEDING-LINE",
+		"Corporate card 4111-1111-1111-1111 expires soon",
+		"UNRELATED-FOLLOWING-LINE",
+	}, "\n") + "\n"
+
+	r, err := ScanText(context.Background(), body, TextOptions{Checks: []string{"CREDIT_CARD"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := findByValidator(t, r.Findings, "creditcard")
+
+	for name, got := range map[string]string{
+		"ContextBefore": f.ContextBefore,
+		"ContextAfter":  f.ContextAfter,
+		"FullLine":      f.FullLine,
+	} {
+		if strings.Contains(got, "\n") {
+			t.Errorf("%s = %q contains a newline; context is documented as single-line", name, got)
+		}
+		for _, leaked := range []string{"PRECEDING", "FOLLOWING"} {
+			if strings.Contains(got, leaked) {
+				t.Errorf("%s = %q leaked text from a neighbouring line", name, got)
+			}
+		}
+	}
+	if f.LineNumber != 2 {
+		t.Errorf("LineNumber = %d, want 2", f.LineNumber)
+	}
+}
+
+// TestContextIsValidUTF8 covers the reason the mapping trims rune fragments.
+// Validators cut their context windows at byte offsets, so a run of multi-byte
+// runes before the match gets sliced mid-rune. Handing that to a gomobile
+// consumer means a mangled Java/Swift string, and to json.Marshal means a silent
+// U+FFFD substitution, so the public fields are repaired at the boundary.
+func TestContextIsValidUTF8(t *testing.T) {
+	// Long enough that the window boundary lands inside the run of CJK runes
+	// rather than before it.
+	const line = "請注意這張公司信用卡的號碼是機密資料絕對不可以外流給任何人知道 4111-1111-1111-1111 這是機密資料絕對不可以外流給任何人知道請注意\n"
+
+	r, err := ScanText(context.Background(), line, TextOptions{Checks: []string{"CREDIT_CARD"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := findByValidator(t, r.Findings, "creditcard")
+
+	if f.ContextBefore == "" || f.ContextAfter == "" {
+		t.Fatalf("fixture produced no context to check (before=%q after=%q)", f.ContextBefore, f.ContextAfter)
+	}
+	for name, got := range map[string]string{
+		"ContextBefore": f.ContextBefore,
+		"ContextAfter":  f.ContextAfter,
+	} {
+		if !utf8.ValidString(got) {
+			t.Errorf("%s = %q is not valid UTF-8", name, got)
+		}
+	}
+	// The repair trims, never pads: what survives is still a suffix/prefix of
+	// the line's own bytes.
+	if !strings.Contains(line, f.ContextBefore) {
+		t.Errorf("ContextBefore %q is not a substring of the input line", f.ContextBefore)
+	}
+	if !strings.Contains(line, f.ContextAfter) {
+		t.Errorf("ContextAfter %q is not a substring of the input line", f.ContextAfter)
+	}
+}
+
+func TestTrimRuneFragments(t *testing.T) {
+	const cjk = "資料" // 3 bytes per rune
+
+	cases := []struct {
+		name         string
+		in, wantHead string
+		wantTail     string
+	}{
+		{"empty", "", "", ""},
+		{"ascii untouched", "abc", "abc", "abc"},
+		{"clean multibyte untouched", cjk, cjk, cjk},
+		{"encoded replacement char kept", "�", "�", "�"},
+		// A window cut one byte into a 3-byte rune leaves two continuation
+		// bytes at the head; cut two bytes in, one leading byte at the tail.
+		{"head fragment trimmed", cjk[1:], cjk[3:], cjk[1:]},
+		{"tail fragment trimmed", cjk[:4], cjk[:4], cjk[:3]},
+		{"tail lead byte trimmed", cjk[:5], cjk[:5], cjk[:3]},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := trimLeadingRuneFragment(tc.in); got != tc.wantHead {
+				t.Errorf("trimLeadingRuneFragment(%q) = %q, want %q", tc.in, got, tc.wantHead)
+			}
+			if got := trimTrailingRuneFragment(tc.in); got != tc.wantTail {
+				t.Errorf("trimTrailingRuneFragment(%q) = %q, want %q", tc.in, got, tc.wantTail)
+			}
+		})
+	}
+}
+
+// TestTrimIsBoundedNotSanitizing pins the deliberate limit on the repair: it
+// fixes a cut edge, it does not scrub malformed input. A caller scanning
+// genuinely mis-encoded content still sees that content.
+func TestTrimIsBoundedNotSanitizing(t *testing.T) {
+	// Invalid bytes sitting past the boundary region survive.
+	const inner = "ok\xff\xfe more text"
+	if got := trimLeadingRuneFragment(inner); got != inner {
+		t.Errorf("trimLeadingRuneFragment(%q) = %q, want it unchanged", inner, got)
+	}
+	// At most utf8.UTFMax-1 bytes come off either edge.
+	longRun := strings.Repeat("\x80", 16)
+	if got := trimLeadingRuneFragment(longRun); len(longRun)-len(got) > utf8.UTFMax-1 {
+		t.Errorf("trimmed %d bytes from the head, want at most %d", len(longRun)-len(got), utf8.UTFMax-1)
+	}
+	if got := trimTrailingRuneFragment(longRun); len(longRun)-len(got) > utf8.UTFMax-1 {
+		t.Errorf("trimmed %d bytes from the tail, want at most %d", len(longRun)-len(got), utf8.UTFMax-1)
+	}
+}
+
+// TestContextExcludedFromJSON locks the `json:"-"` decision. Finding carries no
+// tags on its other fields, so an existing caller's marshaled output is a
+// stable shape it may already be persisting or shipping; three new raw-content
+// fields must not appear in it just because the struct grew.
+func TestContextExcludedFromJSON(t *testing.T) {
+	r, err := ScanText(context.Background(),
+		"Corporate card 4111-1111-1111-1111 expires soon\n",
+		TextOptions{Checks: []string{"CREDIT_CARD"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := findByValidator(t, r.Findings, "creditcard")
+	if f.ContextBefore == "" {
+		t.Fatal("fixture produced no context, so the exclusion is not actually being tested")
+	}
+
+	encoded, err := json.Marshal(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, unwanted := range []string{"ContextBefore", "ContextAfter", "FullLine", "Corporate card"} {
+		if strings.Contains(string(encoded), unwanted) {
+			t.Errorf("marshaled Finding contains %q; context must not widen the JSON surface:\n%s",
+				unwanted, encoded)
+		}
+	}
+	// The pre-existing shape is untouched.
+	if !strings.Contains(string(encoded), `"Text":"4111-1111-1111-1111"`) {
+		t.Errorf("marshaled Finding lost its existing fields:\n%s", encoded)
+	}
+}
+
+// TestValidatorsWithoutContextAreDocumented locks the gap the doc comment
+// promises, in both directions.
+//
+// SECRETS, PERSON_NAME and CLOUD_RESOURCES never populate Match.Context, so
+// their findings report blank context however much text surrounds them. That is
+// worth a test rather than a footnote: it is the case where a caller is most
+// likely to mistake "not recorded" for "the value stood alone", and SECRETS is
+// where the real-vs-example question is hardest.
+//
+// If a change starts populating context for one of these, this test fails on
+// purpose. The fix is to update the Finding doc comment and drop the validator
+// from this list — and to check the suppression finding-hash first, since
+// Context participates in it and attaching context silently rewrites the
+// identity of every finding of that type.
+func TestValidatorsWithoutContextAreDocumented(t *testing.T) {
+	cases := []struct {
+		validator string
+		input     string
+	}{
+		{"secrets", "AWS key AKIAIOSFODNN7EXAMPLE rotate quarterly\n"},
+		{"PERSON_NAME", "Owner is Michael Thompson per HR record\n"},
+		{"cloud_resources", "Bucket arn:aws:s3:::prod-customer-exports listed here\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.validator, func(t *testing.T) {
+			r, err := ScanText(context.Background(), tc.input, TextOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			f := findByValidator(t, r.Findings, tc.validator)
+
+			if f.ContextBefore != "" || f.ContextAfter != "" || f.FullLine != "" {
+				t.Errorf("validator %q now populates context (before=%q after=%q fullline=%q).\n"+
+					"This is an improvement, but it changes the documented contract: update the "+
+					"Finding doc comment and confirm the suppression finding-hash impact "+
+					"(internal/suppressions.findingHashVersion reads all three fields, so existing "+
+					"rules for %s findings stop matching once they are populated).",
+					tc.validator, f.ContextBefore, f.ContextAfter, f.FullLine, f.Type)
+			}
+		})
+	}
+}

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"unicode/utf8"
 
 	"github.com/awslabs/ferret-scan/v2/internal/config"
 	"github.com/awslabs/ferret-scan/v2/internal/core"
@@ -83,6 +84,45 @@ type Finding struct {
 	Rationale    string  // plain-language "why flagged" (empty unless Explain=true)
 	Verdict      string  // "likely_real" | "likely_test" | "uncertain" (empty unless Explain)
 	SuppressedBy string  // non-empty if this finding was suppressed
+
+	// ContextBefore and ContextAfter are the text on either side of the match,
+	// excluding the match itself; FullLine is the whole line the match sits on.
+	// They answer "how was this value used?", which is the signal that separates
+	// a live value from a documentation example — the same signal the validators
+	// already score against internally.
+	//
+	// What is and is not promised:
+	//
+	//   - Single line. These never span lines, even in multi-line documents:
+	//     ContextBefore stops at the start of the match's own line.
+	//   - The window width is the validator's own, chosen for its confidence
+	//     scoring (currently 30–50 bytes per side depending on the validator).
+	//     It is not part of this package's compatibility surface and will move
+	//     as validators are tuned. Do not parse against a fixed width.
+	//   - MAY BE EMPTY, and empty means "this validator does not record
+	//     context", NOT "the match had no surrounding text". As of this
+	//     release SECRETS, PERSON_NAME and CLOUD_RESOURCES never populate
+	//     them, so a SECRETS finding always reports blank context even when
+	//     the line around it is full of text. Callers that reason over context
+	//     must branch on the empty case instead of concluding the match stood
+	//     alone. (Populating those three is deliberately deferred: their
+	//     context participates in the suppression finding-hash, so attaching
+	//     it would silently invalidate operators' existing rules for those
+	//     types. See the package's upstream notes.)
+	//   - Rune-aligned. The validators cut their windows at byte offsets, which
+	//     can slice a multi-byte rune in half; the fragment is trimmed here, so
+	//     these fields can differ from the internal value by up to three bytes
+	//     and are always valid UTF-8 when the underlying line is.
+	//
+	// Sensitivity: raw content copied out of the scanned input, exactly as
+	// sensitive as Text and frequently more revealing, since a line of prose
+	// around a value can identify the person the value belongs to. They carry
+	// `json:"-"` so that adding them cannot silently widen an existing
+	// serialization sink — a caller already marshaling Finding keeps its old
+	// output and has to opt in explicitly to emit context.
+	ContextBefore string `json:"-"`
+	ContextAfter  string `json:"-"`
+	FullLine      string `json:"-"`
 }
 
 // Result holds the output of a scan.
@@ -176,6 +216,13 @@ func mapResult(r *core.ScanResult) *Result {
 			LineNumber: m.LineNumber,
 			Text:       m.Text,
 			Filename:   m.Filename,
+
+			// Trim on the cut edge only: the window's outer boundary is the one
+			// the validator sliced at a byte offset, while the inner boundary is
+			// the match itself and is already rune-aligned.
+			ContextBefore: trimLeadingRuneFragment(m.Context.BeforeText),
+			ContextAfter:  trimTrailingRuneFragment(m.Context.AfterText),
+			FullLine:      m.Context.FullLine,
 		}
 		if ex, ok := explain.FromMatch(m); ok {
 			f.Rationale = ex.Rationale
@@ -195,4 +242,34 @@ func normalizeChecks(checks []string) []string {
 		return []string{"all"}
 	}
 	return checks
+}
+
+// trimLeadingRuneFragment drops the tail of a multi-byte rune that a validator's
+// fixed-width context window cut through at the start of BeforeText.
+//
+// Only a leading run of continuation bytes (0b10xxxxxx) can be such a tail, and a
+// cut can leave at most utf8.UTFMax-1 of them, so the bound keeps this a
+// boundary repair rather than a general sanitizer: genuinely malformed bytes
+// further into the line are left alone for the caller to see.
+func trimLeadingRuneFragment(s string) string {
+	i := 0
+	for i < len(s) && i < utf8.UTFMax-1 && s[i]&0xC0 == 0x80 {
+		i++
+	}
+	return s[i:]
+}
+
+// trimTrailingRuneFragment is trimLeadingRuneFragment for the far edge of
+// AfterText, where a cut leaves a rune's leading byte without its continuation
+// bytes. A validly encoded U+FFFD decodes with a size greater than one and is
+// kept; only an incomplete encoding is removed.
+func trimTrailingRuneFragment(s string) string {
+	for i := 0; i < utf8.UTFMax-1 && s != ""; i++ {
+		r, size := utf8.DecodeLastRuneInString(s)
+		if r != utf8.RuneError || size > 1 {
+			break
+		}
+		s = s[:len(s)-size]
+	}
+	return s
 }


### PR DESCRIPTION
## What

Adds `ContextBefore`, `ContextAfter` and `FullLine` to `pkg/scan.Finding` and populates them in `mapResult`, so the text around a match is reachable from outside the module.

Requested by the **ferret-scan-mobile** team (iOS + Android). `pkg/scan` already covers everything else their facade needs; match context was the last thing only reachable via `internal/detector`, and therefore the last reason their build has to compile inside a checkout of this repo instead of importing it as a normal Go module. This package's own doc comment names the gomobile facade as an intended consumer.

Their use case: the surrounding line is what distinguishes a live value from a form example, and it's the prompt they give an on-device model for a second opinion on a finding the engine already flagged.

```
Corporate card ⟦value⟧ expires soon        → probably real
Example: ⟦value⟧ (do not use)              → probably a placeholder
```

## The change

Three fields, three assignments, one mapping point — `mapResult` is the only place internal matches become public findings, so `ScanText` and `ScanFile` are both covered by one edit. No new detection logic, no validator touched, no output format touched. The golden corpus is unchanged and needed no regeneration.

Two things measured while implementing it changed *how* the fields are exposed. Both are the reason this is a little larger than the 3+3 line diff that was requested.

### 1. The raw values can be invalid UTF-8

Validators cut their context windows with byte arithmetic — `line[matchStart-30 : matchStart]` in creditcard, ±50 in ssn — which slices through a multi-byte rune whenever the neighbouring text isn't ASCII. Forwarding it verbatim, measured on CJK text either side of a test card number:

| field | value | valid UTF-8 |
|---|---|---|
| `ContextBefore` | `"\x8f\xaf以外流給任何人知道 "` | ❌ |
| `ContextAfter` | `" 這是機密資料絕對不\xe5\x8f"` | ❌ |

Harmless internally (the value only feeds keyword matching), but a *public* field gets converted to a Java/Swift `String` by gomobile and to U+FFFD by `json.Marshal`. The fragment is trimmed at the mapping point, bounded to the ≤3 bytes a cut can leave — a boundary repair, not a sanitizer, so genuinely mis-encoded content further into the line still reaches the caller intact.

### 2. `Finding` has no JSON tags, so new fields would silently widen an existing sink

Nothing in this repo marshals `Finding`, but third-party callers are why the type is public, and Go serializes untagged exported fields by name. Adding three raw-content fields would have appended the surrounding line to whatever an existing caller already writes to a file or ships to a log — no code change on their side, nothing in a diff to notice.

The three fields carry `json:"-"`. The previously marshaled shape is byte-identical; a caller who wants context in JSON has to opt in. **Flagging this as the one judgment call a maintainer might want to reverse** — it's a one-word change if you'd rather they serialize by default.

The doc comment states only the contract the fields can actually keep: single line, window width owned by the validator and explicitly *not* part of the compatibility surface (30–50 bytes today, will move as validators are tuned), same sensitivity as `Text`, may be empty.

## What I deliberately left out, and why

**Three validators record no context at all**, so their findings report blank context however much text surrounds them: `SECRETS`, `PERSON_NAME`, `CLOUD_RESOURCES`. `Match.Context` is populated per-validator with no central backfill. Verified on both entry points:

```
ctx-OK    creditcard/VISA          before="Corporate card "  after=" expires soon"
ctx-OK    ssn/SSN, email, phone, dob, passport, vin, bank_account, address, ...
ctx-NONE  secrets/AWS_ACCESS_KEY   before="" after="" fullline=""
ctx-NONE  PERSON_NAME/PERSON_NAME  before="" after="" fullline=""
ctx-NONE  cloud_resources/AWS_ARN  before="" after="" fullline=""
```

SECRETS is the worst of the three to lose — "real key or documentation example" is precisely the question the field exists to answer. (The fixture in the test is `AKIAIOSFODNN7EXAMPLE`, the key from AWS's own docs.)

I intended to close this gap in the same PR. **It isn't the two-line change it looks like.** `suppressions.findingHashVersion` reads `Context.FullLine`, `BeforeText` and `AfterText` as part of a finding's *identity*:

```
AWS_ACCESS_KEY, no context (today)   ed3217d2a07c46a9...
AWS_ACCESS_KEY, context attached     54ba6fe7b2da4db6...
```

Suppression matching is purely hash-indexed (`rulesByHash`) with no structural fallback, and the version candidates cover only the confidence axis. So attaching context would make **every existing operator rule for a SECRETS, PERSON_NAME or CLOUD_RESOURCES finding stop matching** — turning reviewed-and-accepted findings back into noise, and in a pre-commit gate back into a block. That's the exact failure mode the comment on `findingHashVersion` exists to prevent ("an operator's suppression file is a record of decisions they already made, not a cache we may invalidate").

Closing it properly needs a hash-compatibility version, which loosens suppression identity for *every* finding — a maintainer call, and a security-relevant one, not a rider on an API addition. So instead:

- the gap is documented on the field, with empty defined as **"not recorded"**, never "the match stood alone" (a caller reading it the second way draws a conclusion about a secret that the data doesn't support);
- `TestValidatorsWithoutContextAreDocumented` fails if a validator starts populating context, and points the next person at the hash question before they ship it.

Tracked in #286, which lays out four options for closing it with the measurements behind each. Happy to implement whichever you pick — it needs a decision from you first.

## Also noticed (not addressed here)

1. **`Finding.SuppressedBy` is dead and silently lies.** `mapResult` never sets it, and it can't: `core.ScanFile` returns `Matches: unsuppressed`, so a suppressed finding never appears in `Findings` at all, and `SuppressedBy` lives on `detector.SuppressedMatch`, a different type. A caller checking `f.SuppressedBy != ""` always concludes nothing was suppressed. This is the same shape as the `SOCIAL_MEDIA` / `ValidCheckNames()` fix in the current changelog — a public field reporting a clean state it can't actually observe. Populating it means surfacing `SuppressedMatches` (an API addition); dropping it is breaking but honest. Left alone here since either direction is a separate decision; tracked in #287.
2. **`docs/upstream-asks.md` has two contradictory `## Status` tables** (lines 111–138) — ask #8 is `Done` in one and `Not started` in the other. Untouched to keep this diff focused.
3. **TM-11 applies to the consumer's design.** Worth passing back to the mobile team rather than fixing here: the threat model already documents that attacker-authored context is a suppression oracle. Feeding it to an LLM that decides keep-vs-discard rebuilds that oracle at the prompt layer, where `Example: ⟦value⟧ (do not use)` also becomes an injection surface. Their prompt needs the same "checksum-valid values keep a floor" discipline the engine adopted.

## Verification

- `go test ./...` clean (65 packages), `go vet ./...` clean, `make build` succeeds.
- Golden corpus unchanged, no regeneration — no detection, confidence or format change.
- Additive: existing callers' compiled behaviour *and* marshaled output are identical. No unkeyed `Finding` literals in the tree.
- Both non-obvious decisions are mutation-tested: removing the trim fails the UTF-8 test, removing the tags fails the JSON test.
- New tests: exposure on both entry points, single-line contract, valid UTF-8, trim helpers (table + bounded-not-sanitizing), JSON exclusion, and the documented-gap lock.
