### PR TITLE
feat(validators,suppressions): record match context in secrets, personname and cloud_resources

### DIFF
--- a/internal/detector/line_context.go
+++ b/internal/detector/line_context.go
@@ -1,0 +1,73 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package detector
+
+import "unicode/utf8"
+
+// LineContextWindow is how many bytes of surrounding text LineContext keeps on
+// each side of a match. It matches ContextExtractor's default (50), which is the
+// wider of the two widths already in use across the validators.
+const LineContextWindow = 50
+
+// LineContext builds the ContextInfo for a match occupying [matchStart, matchEnd)
+// of line.
+//
+// It exists so a validator that already has the line and the match offsets can
+// record context without restating the window arithmetic, which is currently
+// open-coded per validator at two different widths and, in the older copies, with
+// a strings.Index rescan that resolves to the wrong occurrence when a value
+// repeats on the line.
+//
+// The windows are clamped to the line and then pulled back to rune boundaries, so
+// BeforeText and AfterText never begin or end inside a multi-byte character.
+// (pkg/scan repairs that at its own boundary for the older validators; new
+// callers get it right at the source instead.) Both exclude the match itself:
+// BeforeText ends where the match starts and AfterText begins where it ends, so
+// BeforeText+match+AfterText is always a contiguous span of the line.
+//
+// Offsets outside the line yield a ContextInfo carrying only FullLine, on the
+// principle that a wrong window is worse than no window: the caller's offsets
+// disagree with the caller's line, and guessing which is authoritative would
+// attach text that never surrounded the match.
+func LineContext(line string, matchStart, matchEnd int) ContextInfo {
+	info := ContextInfo{FullLine: line}
+	if matchStart < 0 || matchEnd > len(line) || matchStart > matchEnd {
+		return info
+	}
+
+	before := line[max(0, matchStart-LineContextWindow):matchStart]
+	after := line[matchEnd:min(len(line), matchEnd+LineContextWindow)]
+
+	info.BeforeText = TrimLeadingRuneFragment(before)
+	info.AfterText = TrimTrailingRuneFragment(after)
+	return info
+}
+
+// TrimLeadingRuneFragment drops the tail of a rune the window's outer edge cut
+// through. Only a leading run of continuation bytes can be such a tail, and a cut
+// leaves at most utf8.UTFMax-1 of them, so the bound keeps this a boundary repair
+// rather than a sanitizer: malformed bytes that were genuinely in the line are
+// left for the caller to see.
+func TrimLeadingRuneFragment(s string) string {
+	i := 0
+	for i < len(s) && i < utf8.UTFMax-1 && s[i]&0xC0 == 0x80 {
+		i++
+	}
+	return s[i:]
+}
+
+// TrimTrailingRuneFragment is the mirror of TrimLeadingRuneFragment for the far
+// edge of AfterText, where a cut leaves a rune's leading byte without its
+// continuation bytes. A validly encoded U+FFFD decodes with a size greater than
+// one and is kept; only an incomplete encoding is removed.
+func TrimTrailingRuneFragment(s string) string {
+	for i := 0; i < utf8.UTFMax-1 && s != ""; i++ {
+		r, size := utf8.DecodeLastRuneInString(s)
+		if r != utf8.RuneError || size > 1 {
+			break
+		}
+		s = s[:len(s)-size]
+	}
+	return s
+}

--- a/internal/detector/line_context_test.go
+++ b/internal/detector/line_context_test.go
@@ -1,0 +1,161 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package detector
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestLineContextBracketsTheMatch(t *testing.T) {
+	const line = "Bucket arn:aws:s3:::prod-customer-exports listed here"
+	const match = "arn:aws:s3:::prod-customer-exports"
+	start := strings.Index(line, match)
+
+	got := LineContext(line, start, start+len(match))
+
+	if got.FullLine != line {
+		t.Errorf("FullLine = %q, want %q", got.FullLine, line)
+	}
+	if want := "Bucket "; got.BeforeText != want {
+		t.Errorf("BeforeText = %q, want %q", got.BeforeText, want)
+	}
+	if want := " listed here"; got.AfterText != want {
+		t.Errorf("AfterText = %q, want %q", got.AfterText, want)
+	}
+	// The defining property callers rely on: before+match+after reconstructs a
+	// contiguous span of the line, so the match is bracketed and never restated.
+	if rebuilt := got.BeforeText + match + got.AfterText; !strings.Contains(line, rebuilt) {
+		t.Errorf("before+match+after = %q is not a span of %q", rebuilt, line)
+	}
+	if strings.Contains(got.BeforeText, match) || strings.Contains(got.AfterText, match) {
+		t.Errorf("context must exclude the match (before=%q after=%q)", got.BeforeText, got.AfterText)
+	}
+}
+
+func TestLineContextClampsToWindowAndLine(t *testing.T) {
+	match := "SECRET"
+	long := strings.Repeat("a", 300) + match + strings.Repeat("b", 300)
+
+	got := LineContext(long, 300, 300+len(match))
+
+	if len(got.BeforeText) != LineContextWindow {
+		t.Errorf("len(BeforeText) = %d, want the window %d", len(got.BeforeText), LineContextWindow)
+	}
+	if len(got.AfterText) != LineContextWindow {
+		t.Errorf("len(AfterText) = %d, want the window %d", len(got.AfterText), LineContextWindow)
+	}
+
+	// At the very start and end of a line the window clamps rather than
+	// underflowing the slice bounds.
+	short := match + "!"
+	got = LineContext(short, 0, len(match))
+	if got.BeforeText != "" {
+		t.Errorf("BeforeText = %q, want empty at line start", got.BeforeText)
+	}
+	if got.AfterText != "!" {
+		t.Errorf("AfterText = %q, want %q", got.AfterText, "!")
+	}
+}
+
+// TestLineContextIsRuneAligned is the reason this helper exists rather than each
+// caller slicing for itself: a fixed byte window lands mid-rune on non-ASCII
+// text, and a public consumer converts these to a platform string.
+func TestLineContextIsRuneAligned(t *testing.T) {
+	const match = "4111-1111-1111-1111"
+	// Runs of 3-byte runes on both sides, long enough that a 50-byte window
+	// cannot land on a rune boundary by luck.
+	cjk := strings.Repeat("機密資料", 12)
+	line := cjk + " " + match + " " + cjk
+	start := strings.Index(line, match)
+
+	got := LineContext(line, start, start+len(match))
+
+	if !utf8.ValidString(got.BeforeText) {
+		t.Errorf("BeforeText is not valid UTF-8: %q", got.BeforeText)
+	}
+	if !utf8.ValidString(got.AfterText) {
+		t.Errorf("AfterText is not valid UTF-8: %q", got.AfterText)
+	}
+	// Trimming only ever removes bytes, so both remain spans of the line.
+	if !strings.Contains(line, got.BeforeText) || !strings.Contains(line, got.AfterText) {
+		t.Error("trimming produced text that is not a span of the input line")
+	}
+}
+
+// TestLineContextRejectsInconsistentOffsets covers the deliberate choice to
+// return FullLine only rather than guess. Offsets that do not fit the line mean
+// the caller passed a mismatched pair, and inventing a window would attach text
+// that never surrounded the match.
+func TestLineContextRejectsInconsistentOffsets(t *testing.T) {
+	const line = "short line"
+	cases := []struct {
+		name       string
+		start, end int
+	}{
+		{"end past line", 0, len(line) + 5},
+		{"negative start", -1, 4},
+		{"inverted", 6, 2},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := LineContext(line, tc.start, tc.end)
+			if got.FullLine != line {
+				t.Errorf("FullLine = %q, want it preserved", got.FullLine)
+			}
+			if got.BeforeText != "" || got.AfterText != "" {
+				t.Errorf("want no window for inconsistent offsets, got before=%q after=%q",
+					got.BeforeText, got.AfterText)
+			}
+		})
+	}
+}
+
+func TestTrimRuneFragments(t *testing.T) {
+	const cjk = "資料" // 3 bytes per rune
+
+	cases := []struct {
+		name         string
+		in, wantHead string
+		wantTail     string
+	}{
+		{"empty", "", "", ""},
+		{"ascii untouched", "abc", "abc", "abc"},
+		{"clean multibyte untouched", cjk, cjk, cjk},
+		{"encoded replacement char kept", "�", "�", "�"},
+		// A window cut one byte into a 3-byte rune leaves two continuation
+		// bytes at the head; cut two bytes in, one leading byte at the tail.
+		{"head fragment trimmed", cjk[1:], cjk[3:], cjk[1:]},
+		{"tail fragment trimmed", cjk[:4], cjk[:4], cjk[:3]},
+		{"tail lead byte trimmed", cjk[:5], cjk[:5], cjk[:3]},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := TrimLeadingRuneFragment(tc.in); got != tc.wantHead {
+				t.Errorf("TrimLeadingRuneFragment(%q) = %q, want %q", tc.in, got, tc.wantHead)
+			}
+			if got := TrimTrailingRuneFragment(tc.in); got != tc.wantTail {
+				t.Errorf("TrimTrailingRuneFragment(%q) = %q, want %q", tc.in, got, tc.wantTail)
+			}
+		})
+	}
+}
+
+// TestTrimIsBoundedNotSanitizing pins the deliberate limit on the repair: it
+// fixes a cut edge, it does not scrub malformed input. Content that was genuinely
+// mis-encoded in the source still reaches the caller.
+func TestTrimIsBoundedNotSanitizing(t *testing.T) {
+	const inner = "ok\xff\xfe more text"
+	if got := TrimLeadingRuneFragment(inner); got != inner {
+		t.Errorf("TrimLeadingRuneFragment(%q) = %q, want it unchanged", inner, got)
+	}
+	longRun := strings.Repeat("\x80", 16)
+	if got := TrimLeadingRuneFragment(longRun); len(longRun)-len(got) > utf8.UTFMax-1 {
+		t.Errorf("trimmed %d bytes from the head, want at most %d", len(longRun)-len(got), utf8.UTFMax-1)
+	}
+	if got := TrimTrailingRuneFragment(longRun); len(longRun)-len(got) > utf8.UTFMax-1 {
+		t.Errorf("trimmed %d bytes from the tail, want at most %d", len(longRun)-len(got), utf8.UTFMax-1)
+	}
+}

--- a/internal/formatters/gitlab-sast/sanitizer.go
+++ b/internal/formatters/gitlab-sast/sanitizer.go
@@ -77,11 +77,13 @@ func (s *DataSanitizer) SanitizeDescription(match detector.Match, showMatch bool
 	} else if showMatch && match.Text != "" {
 		// Validator-independent reveal path. SanitizeMessage always emits
 		// "[HIDDEN]", so the Context line above is normally the only place the
-		// matched value can surface — but some validators (e.g. secrets/AWS
-		// keys) never populate Context.FullLine, so --show-match would reveal
-		// nothing for them, contradicting the flag's contract. Fall back to the
-		// matched value itself so every validator honors --show-match, while the
-		// deny-by-default branch (no --show-match) still emits nothing here.
+		// matched value can surface — but a match that spans lines has no single
+		// line to report and leaves Context.FullLine empty (the multi-line SECRETS
+		// types: SSH_PRIVATE_KEY, CERTIFICATE, PGP_PRIVATE_KEY), so --show-match
+		// would reveal nothing for them, contradicting the flag's contract. Fall
+		// back to the matched value itself so every validator honors --show-match,
+		// while the deny-by-default branch (no --show-match) still emits nothing
+		// here.
 		description.WriteString(fmt.Sprintf("\n**Matched value:**\n```\n%s\n```\n", match.Text))
 	}
 

--- a/internal/goldencorpus/testdata/golden/cloud_resources_test_context.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/cloud_resources_test_context.gitlab-sast.json
@@ -29,7 +29,7 @@
     {
       "category": "sast",
       "confidence": "High",
-      "description": "Ferret Scan detected sensitive data (aws arn) in this file.\n\n**Location:** <golden:cloud_resources_test_context> (line 1)\n**Confidence:** HIGH (95.0%)\n**Detected by:** cloud_resources validator\n\n**Matched value:**\n```\narn:aws:iam::123456789012:role/PaymentsAdmin\n```\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "description": "Ferret Scan detected sensitive data (aws arn) in this file.\n\n**Location:** <golden:cloud_resources_test_context> (line 1)\n**Confidence:** HIGH (95.0%)\n**Detected by:** cloud_resources validator\n\n**Context:**\n```\nprod arn:aws:iam::123456789012:role/PaymentsAdmin\n```\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {
@@ -55,7 +55,7 @@
     {
       "category": "sast",
       "confidence": "Medium",
-      "description": "Ferret Scan detected sensitive data (aws arn) in this file.\n\n**Location:** <golden:cloud_resources_test_context> (line 2)\n**Confidence:** MEDIUM (75.0%)\n**Detected by:** cloud_resources validator\n\n**Matched value:**\n```\narn:aws:iam::123456789012:role/PaymentsAdmin\n```\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "description": "Ferret Scan detected sensitive data (aws arn) in this file.\n\n**Location:** <golden:cloud_resources_test_context> (line 2)\n**Confidence:** MEDIUM (75.0%)\n**Detected by:** cloud_resources validator\n\n**Context:**\n```\nexample arn:aws:iam::123456789012:role/PaymentsAdmin\n```\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {

--- a/internal/goldencorpus/testdata/golden/cloud_resources_test_context.sarif.json
+++ b/internal/goldencorpus/testdata/golden/cloud_resources_test_context.sarif.json
@@ -11,7 +11,18 @@
                 "artifactLocation": {
                   "uri": "<golden:cloud_resources_test_context>"
                 },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "prod \nprod arn:aws:iam::123456789012:role/PaymentsAdmin"
+                  },
+                  "startLine": 1
+                },
                 "region": {
+                  "endColumn": 50,
+                  "snippet": {
+                    "text": "prod arn:aws:iam::123456789012:role/PaymentsAdmin"
+                  },
+                  "startColumn": 6,
                   "startLine": 1
                 }
               }
@@ -59,7 +70,18 @@
                 "artifactLocation": {
                   "uri": "<golden:cloud_resources_test_context>"
                 },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "example \nexample arn:aws:iam::123456789012:role/PaymentsAdmin"
+                  },
+                  "startLine": 2
+                },
                 "region": {
+                  "endColumn": 53,
+                  "snippet": {
+                    "text": "example arn:aws:iam::123456789012:role/PaymentsAdmin"
+                  },
+                  "startColumn": 9,
                   "startLine": 2
                 }
               }

--- a/internal/goldencorpus/testdata/golden/context_decoys_personname.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/context_decoys_personname.gitlab-sast.json
@@ -29,7 +29,7 @@
     {
       "category": "sast",
       "confidence": "High",
-      "description": "Ferret Scan detected sensitive data (person name) in this file.\n\n**Location:** <golden:context_decoys_personname> (line 3)\n**Confidence:** HIGH (92.0%)\n**Detected by:** PERSON_NAME validator\n\n**Matched value:**\n```\nJames Whitfield\n```\n\n**Additional Information:**\n- context_impact: 0\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "description": "Ferret Scan detected sensitive data (person name) in this file.\n\n**Location:** <golden:context_decoys_personname> (line 3)\n**Confidence:** HIGH (92.0%)\n**Detected by:** PERSON_NAME validator\n\n**Context:**\n```\nPlease forward the report to James Whitfield by Friday\n```\n\n**Additional Information:**\n- context_impact: 0\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {
@@ -55,7 +55,7 @@
     {
       "category": "sast",
       "confidence": "High",
-      "description": "Ferret Scan detected sensitive data (person name) in this file.\n\n**Location:** <golden:context_decoys_personname> (line 5)\n**Confidence:** HIGH (92.0%)\n**Detected by:** PERSON_NAME validator\n\n**Matched value:**\n```\nSarah Okonkwo\n```\n\n**Additional Information:**\n- context_impact: 0\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "description": "Ferret Scan detected sensitive data (person name) in this file.\n\n**Location:** <golden:context_decoys_personname> (line 5)\n**Confidence:** HIGH (92.0%)\n**Detected by:** PERSON_NAME validator\n\n**Context:**\n```\nSarah Okonkwo will present the quarterly results\n```\n\n**Additional Information:**\n- context_impact: 0\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {
@@ -81,7 +81,7 @@
     {
       "category": "sast",
       "confidence": "High",
-      "description": "Ferret Scan detected sensitive data (person name) in this file.\n\n**Location:** <golden:context_decoys_personname> (line 7)\n**Confidence:** HIGH (92.0%)\n**Detected by:** PERSON_NAME validator\n\n**Matched value:**\n```\nDaniel Moreau\n```\n\n**Additional Information:**\n- context_impact: 0\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "description": "Ferret Scan detected sensitive data (person name) in this file.\n\n**Location:** <golden:context_decoys_personname> (line 7)\n**Confidence:** HIGH (92.0%)\n**Detected by:** PERSON_NAME validator\n\n**Context:**\n```\nSchedule a review with Daniel Moreau next week\n```\n\n**Additional Information:**\n- context_impact: 0\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {
@@ -107,7 +107,7 @@
     {
       "category": "sast",
       "confidence": "High",
-      "description": "Ferret Scan detected sensitive data (person name) in this file.\n\n**Location:** <golden:context_decoys_personname> (line 9)\n**Confidence:** HIGH (92.0%)\n**Detected by:** PERSON_NAME validator\n\n**Matched value:**\n```\nPriya Raghavan\n```\n\n**Additional Information:**\n- context_impact: 0\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "description": "Ferret Scan detected sensitive data (person name) in this file.\n\n**Location:** <golden:context_decoys_personname> (line 9)\n**Confidence:** HIGH (92.0%)\n**Detected by:** PERSON_NAME validator\n\n**Context:**\n```\nPriya Raghavan approved the budget request\n```\n\n**Additional Information:**\n- context_impact: 0\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {
@@ -133,7 +133,7 @@
     {
       "category": "sast",
       "confidence": "High",
-      "description": "Ferret Scan detected sensitive data (person name) in this file.\n\n**Location:** <golden:context_decoys_personname> (line 1)\n**Confidence:** MEDIUM (80.0%)\n**Detected by:** PERSON_NAME validator\n\n**Matched value:**\n```\nContact Maria Delgado\n```\n\n**Additional Information:**\n- context_impact: 12\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "description": "Ferret Scan detected sensitive data (person name) in this file.\n\n**Location:** <golden:context_decoys_personname> (line 1)\n**Confidence:** MEDIUM (80.0%)\n**Detected by:** PERSON_NAME validator\n\n**Context:**\n```\nContact Maria Delgado for approval\n```\n\n**Additional Information:**\n- context_impact: 12\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {

--- a/internal/goldencorpus/testdata/golden/context_decoys_personname.sarif.json
+++ b/internal/goldencorpus/testdata/golden/context_decoys_personname.sarif.json
@@ -11,7 +11,18 @@
                 "artifactLocation": {
                   "uri": "<golden:context_decoys_personname>"
                 },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "Please forward the report to \nPlease forward the report to James Whitfield by Friday\n by Friday"
+                  },
+                  "startLine": 3
+                },
                 "region": {
+                  "endColumn": 45,
+                  "snippet": {
+                    "text": "Please forward the report to James Whitfield by Friday"
+                  },
+                  "startColumn": 30,
                   "startLine": 3
                 }
               }
@@ -89,7 +100,18 @@
                 "artifactLocation": {
                   "uri": "<golden:context_decoys_personname>"
                 },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "Sarah Okonkwo will present the quarterly results\n will present the quarterly results"
+                  },
+                  "startLine": 5
+                },
                 "region": {
+                  "endColumn": 14,
+                  "snippet": {
+                    "text": "Sarah Okonkwo will present the quarterly results"
+                  },
+                  "startColumn": 1,
                   "startLine": 5
                 }
               }
@@ -167,7 +189,18 @@
                 "artifactLocation": {
                   "uri": "<golden:context_decoys_personname>"
                 },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "Schedule a review with \nSchedule a review with Daniel Moreau next week\n next week"
+                  },
+                  "startLine": 7
+                },
                 "region": {
+                  "endColumn": 37,
+                  "snippet": {
+                    "text": "Schedule a review with Daniel Moreau next week"
+                  },
+                  "startColumn": 24,
                   "startLine": 7
                 }
               }
@@ -245,7 +278,18 @@
                 "artifactLocation": {
                   "uri": "<golden:context_decoys_personname>"
                 },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "Priya Raghavan approved the budget request\n approved the budget request"
+                  },
+                  "startLine": 9
+                },
                 "region": {
+                  "endColumn": 15,
+                  "snippet": {
+                    "text": "Priya Raghavan approved the budget request"
+                  },
+                  "startColumn": 1,
                   "startLine": 9
                 }
               }
@@ -323,7 +367,18 @@
                 "artifactLocation": {
                   "uri": "<golden:context_decoys_personname>"
                 },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "Contact Maria Delgado for approval\n for approval"
+                  },
+                  "startLine": 1
+                },
                 "region": {
+                  "endColumn": 22,
+                  "snippet": {
+                    "text": "Contact Maria Delgado for approval"
+                  },
+                  "startColumn": 1,
                   "startLine": 1
                 }
               }

--- a/internal/goldencorpus/testdata/golden/file_source_code_secrets.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_source_code_secrets.gitlab-sast.json
@@ -29,7 +29,7 @@
     {
       "category": "sast",
       "confidence": "Medium",
-      "description": "Ferret Scan detected aws access key in this file.\n\n**Location:** <TMPDIR>/config.go (line 4)\n**Confidence:** MEDIUM (69.0%)\n**Detected by:** secrets validator\n\n**Matched value:**\n```\nAKIAIOSFODNN7EXAMPLE\n```\n\n**Additional Information:**\n- source: preprocessed_content\n\n**Remediation:**\nRemove AWS credentials immediately and rotate them. Use IAM roles or environment variables instead.",
+      "description": "Ferret Scan detected aws access key in this file.\n\n**Location:** <TMPDIR>/config.go (line 4)\n**Confidence:** MEDIUM (69.0%)\n**Detected by:** secrets validator\n\n**Context:**\n```\nconst AWSKey = \"AKIAIOSFODNN7EXAMPLE\"\n```\n\n**Additional Information:**\n- source: preprocessed_content\n\n**Remediation:**\nRemove AWS credentials immediately and rotate them. Use IAM roles or environment variables instead.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {
@@ -55,7 +55,7 @@
     {
       "category": "sast",
       "confidence": "Medium",
-      "description": "Ferret Scan detected sensitive data (aws secret access key) in this file.\n\n**Location:** <TMPDIR>/config.go (line 5)\n**Confidence:** MEDIUM (65.0%)\n**Detected by:** secrets validator\n\n**Matched value:**\n```\nwJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n```\n\n**Additional Information:**\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "description": "Ferret Scan detected sensitive data (aws secret access key) in this file.\n\n**Location:** <TMPDIR>/config.go (line 5)\n**Confidence:** MEDIUM (65.0%)\n**Detected by:** secrets validator\n\n**Context:**\n```\nconst Secret = \"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\"\n```\n\n**Additional Information:**\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {

--- a/internal/goldencorpus/testdata/golden/file_source_code_secrets.sarif.json
+++ b/internal/goldencorpus/testdata/golden/file_source_code_secrets.sarif.json
@@ -11,7 +11,18 @@
                 "artifactLocation": {
                   "uri": "file://<TMPDIR>/config.go"
                 },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "const AWSKey = \"\nconst AWSKey = \"AKIAIOSFODNN7EXAMPLE\"\n\""
+                  },
+                  "startLine": 4
+                },
                 "region": {
+                  "endColumn": 37,
+                  "snippet": {
+                    "text": "const AWSKey = \"AKIAIOSFODNN7EXAMPLE\""
+                  },
+                  "startColumn": 17,
                   "startLine": 4
                 }
               }
@@ -65,7 +76,18 @@
                 "artifactLocation": {
                   "uri": "file://<TMPDIR>/config.go"
                 },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "const Secret = \"\nconst Secret = \"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\"\n\""
+                  },
+                  "startLine": 5
+                },
                 "region": {
+                  "endColumn": 57,
+                  "snippet": {
+                    "text": "const Secret = \"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\""
+                  },
+                  "startColumn": 17,
                   "startLine": 5
                 }
               }

--- a/internal/goldencorpus/testdata/golden/file_txt_mixed_pii.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_txt_mixed_pii.gitlab-sast.json
@@ -107,7 +107,7 @@
     {
       "category": "sast",
       "confidence": "Medium",
-      "description": "Ferret Scan detected aws access key in this file.\n\n**Location:** <TMPDIR>/notes.txt (line 2)\n**Confidence:** MEDIUM (69.0%)\n**Detected by:** secrets validator\n\n**Matched value:**\n```\nAKIAIOSFODNN7EXAMPLE\n```\n\n**Additional Information:**\n- source: preprocessed_content\n\n**Remediation:**\nRemove AWS credentials immediately and rotate them. Use IAM roles or environment variables instead.",
+      "description": "Ferret Scan detected aws access key in this file.\n\n**Location:** <TMPDIR>/notes.txt (line 2)\n**Confidence:** MEDIUM (69.0%)\n**Detected by:** secrets validator\n\n**Context:**\n```\nAWS key AKIAIOSFODNN7EXAMPLE in the config.\n```\n\n**Additional Information:**\n- source: preprocessed_content\n\n**Remediation:**\nRemove AWS credentials immediately and rotate them. Use IAM roles or environment variables instead.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {

--- a/internal/goldencorpus/testdata/golden/file_txt_mixed_pii.sarif.json
+++ b/internal/goldencorpus/testdata/golden/file_txt_mixed_pii.sarif.json
@@ -218,7 +218,18 @@
                 "artifactLocation": {
                   "uri": "file://<TMPDIR>/notes.txt"
                 },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "AWS key \nAWS key AKIAIOSFODNN7EXAMPLE in the config.\n in the config."
+                  },
+                  "startLine": 2
+                },
                 "region": {
+                  "endColumn": 29,
+                  "snippet": {
+                    "text": "AWS key AKIAIOSFODNN7EXAMPLE in the config."
+                  },
+                  "startColumn": 9,
                   "startLine": 2
                 }
               }

--- a/internal/goldencorpus/testdata/golden/file_wav_metadata_pii.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_wav_metadata_pii.gitlab-sast.json
@@ -29,7 +29,7 @@
     {
       "category": "sast",
       "confidence": "High",
-      "description": "Ferret Scan detected aws access key in this file.\n\n**Location:** <TMPDIR>/clip.wav (line 7)\n**Confidence:** MEDIUM (84.0%)\n**Detected by:** secrets validator\n\n**Matched value:**\n```\nAKIAIOSFODNN7EXAMPLE\n```\n\n**Additional Information:**\n- source: preprocessed_content\n\n**Remediation:**\nRemove AWS credentials immediately and rotate them. Use IAM roles or environment variables instead.",
+      "description": "Ferret Scan detected aws access key in this file.\n\n**Location:** <TMPDIR>/clip.wav (line 7)\n**Confidence:** MEDIUM (84.0%)\n**Detected by:** secrets validator\n\n**Context:**\n```\nComment: contact 212-555-0142 or AKIAIOSFODNN7EXAMPLE\n```\n\n**Additional Information:**\n- source: preprocessed_content\n\n**Remediation:**\nRemove AWS credentials immediately and rotate them. Use IAM roles or environment variables instead.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {

--- a/internal/goldencorpus/testdata/golden/file_wav_metadata_pii.sarif.json
+++ b/internal/goldencorpus/testdata/golden/file_wav_metadata_pii.sarif.json
@@ -11,7 +11,18 @@
                 "artifactLocation": {
                   "uri": "file://<TMPDIR>/clip.wav"
                 },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "Comment: contact 212-555-0142 or \nComment: contact 212-555-0142 or AKIAIOSFODNN7EXAMPLE"
+                  },
+                  "startLine": 7
+                },
                 "region": {
+                  "endColumn": 54,
+                  "snippet": {
+                    "text": "Comment: contact 212-555-0142 or AKIAIOSFODNN7EXAMPLE"
+                  },
+                  "startColumn": 34,
                   "startLine": 7
                 }
               }

--- a/internal/goldencorpus/testdata/golden/mixed_pii_basic.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/mixed_pii_basic.gitlab-sast.json
@@ -107,7 +107,7 @@
     {
       "category": "sast",
       "confidence": "Medium",
-      "description": "Ferret Scan detected aws access key in this file.\n\n**Location:** <golden:mixed_pii_basic> (line 2)\n**Confidence:** MEDIUM (69.0%)\n**Detected by:** secrets validator\n\n**Matched value:**\n```\nAKIAIOSFODNN7EXAMPLE\n```\n\n**Additional Information:**\n- source: preprocessed_content\n\n**Remediation:**\nRemove AWS credentials immediately and rotate them. Use IAM roles or environment variables instead.",
+      "description": "Ferret Scan detected aws access key in this file.\n\n**Location:** <golden:mixed_pii_basic> (line 2)\n**Confidence:** MEDIUM (69.0%)\n**Detected by:** secrets validator\n\n**Context:**\n```\nAWS key AKIAIOSFODNN7EXAMPLE in the config.\n```\n\n**Additional Information:**\n- source: preprocessed_content\n\n**Remediation:**\nRemove AWS credentials immediately and rotate them. Use IAM roles or environment variables instead.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {

--- a/internal/goldencorpus/testdata/golden/mixed_pii_basic.sarif.json
+++ b/internal/goldencorpus/testdata/golden/mixed_pii_basic.sarif.json
@@ -218,7 +218,18 @@
                 "artifactLocation": {
                   "uri": "<golden:mixed_pii_basic>"
                 },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "AWS key \nAWS key AKIAIOSFODNN7EXAMPLE in the config.\n in the config."
+                  },
+                  "startLine": 2
+                },
                 "region": {
+                  "endColumn": 29,
+                  "snippet": {
+                    "text": "AWS key AKIAIOSFODNN7EXAMPLE in the config."
+                  },
+                  "startColumn": 9,
                   "startLine": 2
                 }
               }

--- a/internal/goldencorpus/testdata/golden/secrets_aws.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/secrets_aws.gitlab-sast.json
@@ -29,7 +29,7 @@
     {
       "category": "sast",
       "confidence": "High",
-      "description": "Ferret Scan detected aws access key in this file.\n\n**Location:** <golden:secrets_aws> (line 1)\n**Confidence:** MEDIUM (84.0%)\n**Detected by:** secrets validator\n\n**Matched value:**\n```\nAKIAIOSFODNN7EXAMPLE\n```\n\n**Additional Information:**\n- source: preprocessed_content\n\n**Remediation:**\nRemove AWS credentials immediately and rotate them. Use IAM roles or environment variables instead.",
+      "description": "Ferret Scan detected aws access key in this file.\n\n**Location:** <golden:secrets_aws> (line 1)\n**Confidence:** MEDIUM (84.0%)\n**Detected by:** secrets validator\n\n**Context:**\n```\nAWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE\n```\n\n**Additional Information:**\n- source: preprocessed_content\n\n**Remediation:**\nRemove AWS credentials immediately and rotate them. Use IAM roles or environment variables instead.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {
@@ -55,7 +55,7 @@
     {
       "category": "sast",
       "confidence": "Medium",
-      "description": "Ferret Scan detected sensitive data (aws secret access key) in this file.\n\n**Location:** <golden:secrets_aws> (line 2)\n**Confidence:** MEDIUM (65.0%)\n**Detected by:** secrets validator\n\n**Matched value:**\n```\nwJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n```\n\n**Additional Information:**\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "description": "Ferret Scan detected sensitive data (aws secret access key) in this file.\n\n**Location:** <golden:secrets_aws> (line 2)\n**Confidence:** MEDIUM (65.0%)\n**Detected by:** secrets validator\n\n**Context:**\n```\nAWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n```\n\n**Additional Information:**\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {

--- a/internal/goldencorpus/testdata/golden/secrets_aws.sarif.json
+++ b/internal/goldencorpus/testdata/golden/secrets_aws.sarif.json
@@ -11,7 +11,18 @@
                 "artifactLocation": {
                   "uri": "<golden:secrets_aws>"
                 },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "AWS_ACCESS_KEY_ID=\nAWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE"
+                  },
+                  "startLine": 1
+                },
                 "region": {
+                  "endColumn": 39,
+                  "snippet": {
+                    "text": "AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE"
+                  },
+                  "startColumn": 19,
                   "startLine": 1
                 }
               }
@@ -66,7 +77,18 @@
                 "artifactLocation": {
                   "uri": "<golden:secrets_aws>"
                 },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "AWS_SECRET_ACCESS_KEY=\nAWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+                  },
+                  "startLine": 2
+                },
                 "region": {
+                  "endColumn": 63,
+                  "snippet": {
+                    "text": "AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+                  },
+                  "startColumn": 23,
                   "startLine": 2
                 }
               }

--- a/internal/suppressions/contextless_hash_test.go
+++ b/internal/suppressions/contextless_hash_test.go
@@ -1,0 +1,139 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package suppressions
+
+import (
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+)
+
+// contextlessFinding is a finding as secrets / personname / cloudresources used to
+// emit it: no ContextInfo at all.
+func contextlessFinding(validator, findingType, text string) detector.Match {
+	return detector.Match{
+		Type:       findingType,
+		Text:       text,
+		Filename:   "config/app.env",
+		LineNumber: 4,
+		Validator:  validator,
+		Confidence: 90,
+	}
+}
+
+// withContext is the same finding once its validator started recording context.
+func withContext(m detector.Match) detector.Match {
+	m.Context = detector.ContextInfo{
+		FullLine:   "AWS key AKIAIOSFODNN7EXAMPLE rotate quarterly",
+		BeforeText: "AWS key ",
+		AfterText:  " rotate quarterly",
+	}
+	return m
+}
+
+func ruleManager(hashes ...string) *SuppressionManager {
+	rules := make([]SuppressionRule, 0, len(hashes))
+	for _, h := range hashes {
+		rules = append(rules, SuppressionRule{
+			Hash:    h,
+			Enabled: true,
+			Reason:  "reviewed: documentation example",
+		})
+	}
+	return &SuppressionManager{enabled: true, config: &SuppressionConfig{Rules: rules}}
+}
+
+// TestExistingRulesSurviveContextRecording is the whole point of the contextless
+// hash variants. An operator's rule file records decisions already made; a
+// validator gaining context must not quietly turn those accepted findings back
+// into noise (and, in a pre-commit gate, back into a block).
+func TestExistingRulesSurviveContextRecording(t *testing.T) {
+	for _, tc := range []struct {
+		validator   string
+		findingType string
+		text        string
+	}{
+		{"secrets", "AWS_ACCESS_KEY", "AKIAIOSFODNN7EXAMPLE"},
+		{"PERSON_NAME", "PERSON_NAME", "Michael Thompson"},
+		{"cloud_resources", "AWS_ARN", "arn:aws:s3:::prod-customer-exports"},
+	} {
+		t.Run(tc.validator, func(t *testing.T) {
+			before := contextlessFinding(tc.validator, tc.findingType, tc.text)
+			after := withContext(before)
+
+			sm := ruleManager()
+
+			// Both legacy formulas are covered: a rule file may predate the
+			// confidence change as well as the context change.
+			for _, version := range []hashVersion{hashVersionNoConfidence, hashVersionLegacyConfidence} {
+				oldHash := sm.findingHashVersion(before, version)
+				mgr := ruleManager(oldHash)
+
+				if ok, _ := mgr.IsSuppressed(before); !ok {
+					t.Fatalf("precondition: rule under formula %d should suppress the pre-change finding", version)
+				}
+				if ok, rule := mgr.IsSuppressed(after); !ok {
+					t.Errorf("rule written under formula %d stopped matching once context was recorded", version)
+				} else if rule.Reason != "reviewed: documentation example" {
+					t.Errorf("matched the wrong rule: %q", rule.Reason)
+				}
+			}
+		})
+	}
+}
+
+// TestContextlessVariantsAreScopedToTheAffectedValidators guards the deliberate
+// narrowness. Offering an empty-context identity to every validator would weaken
+// suppression identity across the board — two findings agreeing on type, basename,
+// line and value but sitting on different line content would become
+// indistinguishable, so a rule could keep suppressing after the line changed.
+func TestContextlessVariantsAreScopedToTheAffectedValidators(t *testing.T) {
+	sm := ruleManager()
+
+	affected := contextlessFinding("secrets", "AWS_ACCESS_KEY", "AKIAIOSFODNN7EXAMPLE")
+	if got, want := len(sm.findingHashCandidates(withContext(affected))), 4; got != want {
+		t.Errorf("affected validator: %d hash candidates, want %d", got, want)
+	}
+
+	// A validator that always recorded context has no pre-existing contextless
+	// rules, so it keeps exactly the two candidates it had.
+	unaffected := contextlessFinding("creditcard", "VISA", "4111-1111-1111-1111")
+	if got, want := len(sm.findingHashCandidates(withContext(unaffected))), 2; got != want {
+		t.Errorf("unaffected validator: %d hash candidates, want %d", got, want)
+	}
+
+	// And the loosening does not leak: a contextful finding from an unaffected
+	// validator is not suppressed by a rule recorded against its context-free form.
+	contextfulHash := sm.findingHashVersion(withContext(unaffected), hashVersionNoConfidence)
+	contextlessHash := sm.findingHashVersion(unaffected, hashVersionNoConfidence)
+	if contextfulHash == contextlessHash {
+		t.Fatal("fixture error: hashes should differ with and without context")
+	}
+	if ok, _ := ruleManager(contextlessHash).IsSuppressed(withContext(unaffected)); ok {
+		t.Error("an unaffected validator's finding was suppressed by a contextless hash; " +
+			"identity for the other validators must be unchanged")
+	}
+}
+
+// TestNewRulesAreWrittenWithContext confirms the compatibility is read-only: rules
+// generated from now on carry the current, context-bearing identity, so a rule
+// file migrates as it is regenerated rather than pinning the weaker form forever.
+func TestNewRulesAreWrittenWithContext(t *testing.T) {
+	sm := ruleManager()
+	finding := withContext(contextlessFinding("secrets", "AWS_ACCESS_KEY", "AKIAIOSFODNN7EXAMPLE"))
+
+	written := sm.generateFindingHash(finding)
+	if want := sm.findingHashVersion(finding, hashVersionNoConfidence); written != want {
+		t.Errorf("generateFindingHash = %s, want the current formula %s", written, want)
+	}
+	for _, legacy := range []hashVersion{
+		hashVersionNoConfidenceContextless,
+		hashVersionLegacyConfidenceContextless,
+		hashVersionLegacyConfidence,
+	} {
+		if written == sm.findingHashVersion(finding, legacy) {
+			t.Errorf("new rules must not be written under compatibility formula %d", legacy)
+		}
+	}
+}

--- a/internal/suppressions/suppression.go
+++ b/internal/suppressions/suppression.go
@@ -231,16 +231,72 @@ const (
 	// hashVersionNoConfidence drops confidence from the identity.
 	hashVersionNoConfidence hashVersion = 2
 
+	// hashVersionNoConfidenceContextless and hashVersionLegacyConfidenceContextless
+	// reproduce the two formulas above as they were computed for a finding whose
+	// Context was empty.
+	//
+	// They exist for the validators that used to emit no context at all (see
+	// contextlessHashValidators). A rule an operator wrote against one of those
+	// findings recorded a hash over an empty FullLine and an empty before/after
+	// pair; once the validator starts attaching context, the current formula
+	// produces a different hash and that rule would stop matching. Computing the
+	// empty-context variant as an additional MATCHING candidate keeps the rule
+	// working. Never written.
+	hashVersionNoConfidenceContextless     hashVersion = 3
+	hashVersionLegacyConfidenceContextless hashVersion = 4
+
 	// hashVersionCurrent is what new rules are written with.
 	hashVersionCurrent = hashVersionNoConfidence
 )
 
+// includesConfidence reports whether this formula folds Confidence into the
+// identity. Only the two legacy formulas do.
+func (v hashVersion) includesConfidence() bool {
+	return v == hashVersionLegacyConfidence || v == hashVersionLegacyConfidenceContextless
+}
+
+// contextless reports whether this formula computes the identity as though the
+// finding carried no Context.
+func (v hashVersion) contextless() bool {
+	return v == hashVersionNoConfidenceContextless || v == hashVersionLegacyConfidenceContextless
+}
+
+// contextlessHashValidators names the validators that emitted findings with an
+// empty ContextInfo before context recording was added to them, keyed by
+// Match.Validator.
+//
+// The empty-context hash variants are offered as matching candidates for these
+// validators ONLY. Offering them for every validator would weaken suppression
+// identity across the board: with context excluded, two findings that agree on
+// type, basename, line number and value but sit on different line content become
+// indistinguishable, so a rule could keep suppressing after the line around the
+// value changed -- which is how a stale suppression hides a newly introduced
+// secret. Scoping the compatibility to the validators that actually need it keeps
+// the identity of the other sixteen exactly as it was.
+//
+// This list is closed. A validator added later starts out recording context, so it
+// has no pre-existing contextless rules to be compatible with, and adding it here
+// would weaken its identity for nothing.
+var contextlessHashValidators = map[string]bool{
+	"secrets":         true,
+	"PERSON_NAME":     true,
+	"cloud_resources": true,
+}
+
 // findingHashVersion computes a finding's hash under a specific formula version.
 func (sm *SuppressionManager) findingHashVersion(match detector.Match, version hashVersion) string {
+	// A contextless formula reads the context components as though the finding
+	// carried none, reproducing the hash this finding had before its validator
+	// began recording context.
+	ctx := match.Context
+	if version.contextless() {
+		ctx = detector.ContextInfo{}
+	}
+
 	// Bound the FullLine contribution (see maxHashLineLen). TrimSpace first so a
 	// short line padded with whitespace still hashes identically; the cap only
 	// engages for genuinely long lines.
-	fullLine := strings.TrimSpace(match.Context.FullLine)
+	fullLine := strings.TrimSpace(ctx.FullLine)
 	if len(fullLine) > maxHashLineLen {
 		fullLine = fullLine[:maxHashLineLen]
 	}
@@ -250,7 +306,7 @@ func (sm *SuppressionManager) findingHashVersion(match detector.Match, version h
 	// component order or separator would alter every v1 hash and defeat the
 	// compatibility this version switch exists to provide.
 	components := []string{match.Type}
-	if version == hashVersionLegacyConfidence {
+	if version.includesConfidence() {
 		components = append(components, fmt.Sprintf("%.2f", match.Confidence))
 	}
 	components = append(components,
@@ -260,7 +316,7 @@ func (sm *SuppressionManager) findingHashVersion(match detector.Match, version h
 	)
 
 	// Add context for uniqueness but hash it for privacy
-	contextHash := sm.hashSensitiveData(match.Context.BeforeText + match.Context.AfterText)
+	contextHash := sm.hashSensitiveData(ctx.BeforeText + ctx.AfterText)
 	components = append(components, contextHash)
 
 	// Hash the match text separately for privacy
@@ -280,11 +336,22 @@ func (sm *SuppressionManager) findingHashVersion(match detector.Match, version h
 // newly written rules use only the current formula and stop being confidence-sensitive.
 // A rule file therefore migrates as it is regenerated rather than needing a conversion
 // step, and an operator who never regenerates loses nothing.
+//
+// For the validators in contextlessHashValidators the empty-context variants of both
+// formulas are candidates too, because those validators used to emit findings with no
+// context and rules were written against those hashes.
 func (sm *SuppressionManager) findingHashCandidates(match detector.Match) []string {
-	return []string{
+	candidates := []string{
 		sm.findingHashVersion(match, hashVersionNoConfidence),
 		sm.findingHashVersion(match, hashVersionLegacyConfidence),
 	}
+	if contextlessHashValidators[match.Validator] {
+		candidates = append(candidates,
+			sm.findingHashVersion(match, hashVersionNoConfidenceContextless),
+			sm.findingHashVersion(match, hashVersionLegacyConfidenceContextless),
+		)
+	}
+	return candidates
 }
 
 // hashMatchesFinding reports whether a stored rule hash identifies this finding under

--- a/internal/validators/cloudresources/cloudresources.go
+++ b/internal/validators/cloudresources/cloudresources.go
@@ -290,6 +290,11 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 			Filename:   originalPath,
 			Validator:  "cloud_resources",
 			Metadata:   v.buildMetadata(text, resourceType, factors),
+			// Record the surrounding text. scoreMatch already consulted this
+			// line (via cachedLineHasNegKw), so attaching it changes no score —
+			// it only stops the finding from reaching a caller stripped of the
+			// context this validator itself used to judge it.
+			Context: detector.LineContext(cachedLine, start-lineStart, start-lineStart+len(text)),
 		})
 		if provider != "" {
 			providerCounts[provider]++

--- a/internal/validators/personname/validator.go
+++ b/internal/validators/personname/validator.go
@@ -216,6 +216,10 @@ func (v *Validator) findNamesInLine(line string, lineNum int, filePath string) [
 					"context_impact":    contextImpact,
 					"name_components":   nameComponents,
 				},
+				// analyzeContextCached already scored against this line; recording
+				// it changes no confidence, it just stops the finding reaching a
+				// caller without the context used to judge it.
+				Context: detector.LineContext(line, patternMatch.StartIndex, patternMatch.StartIndex+len(nameText)),
 			}
 			matches = append(matches, detectorMatch)
 		}
@@ -292,6 +296,9 @@ func (v *Validator) findNamesInLineWithContext(line string, lineNum int, filePat
 					"domain":                  contextInsights.Domain,
 					"name_components":         nameComponents,
 				},
+				// See the sibling emitter in findNamesInLine: the line has already
+				// been scored against, so this is a record of it, not an input.
+				Context: detector.LineContext(line, patternMatch.StartIndex, patternMatch.StartIndex+len(nameText)),
 			}
 			matches = append(matches, detectorMatch)
 		}

--- a/internal/validators/secrets/validator.go
+++ b/internal/validators/secrets/validator.go
@@ -1332,6 +1332,10 @@ func (v *Validator) findAWSSecretKeys(line, prevLine, nextLine string, lineNum i
 					"secret_type":      "AWS_SECRET_ACCESS_KEY",
 					"example_embedded": exampleEmbedded,
 				},
+				// The line is already an input to the confidence above (the
+				// reAWSSecretKeyName gate), so recording it is inert for scoring
+				// and only preserves what a reviewer needs to judge the finding.
+				Context: detector.LineContext(line, start, end),
 			},
 		})
 	}
@@ -1578,6 +1582,10 @@ func (v *Validator) processScopedCandidates(matches []scopedCandidate, line stri
 					Filename:   originalPath,
 					Validator:  "secrets",
 					Metadata:   meta,
+					// calculateEnhancedConfidenceWithCacheAndEnvAndLine and
+					// unlabelledHexIdentifierCap both already read this line, so
+					// this records the context they judged against.
+					Context: detector.LineContext(line, cand.start, cand.end),
 				},
 			})
 		}
@@ -1666,6 +1674,15 @@ func (v *Validator) looksLikeVariableName(match string) bool {
 }
 
 // findMultiLineSecretsWithContext finds multi-line secrets with enhanced context analysis
+//
+// The matches emitted here deliberately carry no Context. ContextInfo describes a
+// match's position within one line -- FullLine plus the text either side of it --
+// and a PEM block spans dozens, so there is no line for the value to sit in and no
+// honest way to fill the fields. A caller reading empty context on an
+// SSH_PRIVATE_KEY / CERTIFICATE / PGP_PRIVATE_KEY finding is seeing "not
+// applicable", which is the same thing the field's doc comment already tells them
+// empty means. Single-line secrets, which are the overwhelming majority, do record
+// it -- see findAWSSecretKeys and processScopedCandidates.
 func (v *Validator) findMultiLineSecretsWithContext(content, filePath string, contextInsights context.ContextInsights, isShellScript bool, envType string) []detector.Match {
 	var matches []detector.Match
 

--- a/pkg/scan/context_test.go
+++ b/pkg/scan/context_test.go
@@ -158,55 +158,6 @@ func TestContextIsValidUTF8(t *testing.T) {
 	}
 }
 
-func TestTrimRuneFragments(t *testing.T) {
-	const cjk = "資料" // 3 bytes per rune
-
-	cases := []struct {
-		name         string
-		in, wantHead string
-		wantTail     string
-	}{
-		{"empty", "", "", ""},
-		{"ascii untouched", "abc", "abc", "abc"},
-		{"clean multibyte untouched", cjk, cjk, cjk},
-		{"encoded replacement char kept", "�", "�", "�"},
-		// A window cut one byte into a 3-byte rune leaves two continuation
-		// bytes at the head; cut two bytes in, one leading byte at the tail.
-		{"head fragment trimmed", cjk[1:], cjk[3:], cjk[1:]},
-		{"tail fragment trimmed", cjk[:4], cjk[:4], cjk[:3]},
-		{"tail lead byte trimmed", cjk[:5], cjk[:5], cjk[:3]},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := trimLeadingRuneFragment(tc.in); got != tc.wantHead {
-				t.Errorf("trimLeadingRuneFragment(%q) = %q, want %q", tc.in, got, tc.wantHead)
-			}
-			if got := trimTrailingRuneFragment(tc.in); got != tc.wantTail {
-				t.Errorf("trimTrailingRuneFragment(%q) = %q, want %q", tc.in, got, tc.wantTail)
-			}
-		})
-	}
-}
-
-// TestTrimIsBoundedNotSanitizing pins the deliberate limit on the repair: it
-// fixes a cut edge, it does not scrub malformed input. A caller scanning
-// genuinely mis-encoded content still sees that content.
-func TestTrimIsBoundedNotSanitizing(t *testing.T) {
-	// Invalid bytes sitting past the boundary region survive.
-	const inner = "ok\xff\xfe more text"
-	if got := trimLeadingRuneFragment(inner); got != inner {
-		t.Errorf("trimLeadingRuneFragment(%q) = %q, want it unchanged", inner, got)
-	}
-	// At most utf8.UTFMax-1 bytes come off either edge.
-	longRun := strings.Repeat("\x80", 16)
-	if got := trimLeadingRuneFragment(longRun); len(longRun)-len(got) > utf8.UTFMax-1 {
-		t.Errorf("trimmed %d bytes from the head, want at most %d", len(longRun)-len(got), utf8.UTFMax-1)
-	}
-	if got := trimTrailingRuneFragment(longRun); len(longRun)-len(got) > utf8.UTFMax-1 {
-		t.Errorf("trimmed %d bytes from the tail, want at most %d", len(longRun)-len(got), utf8.UTFMax-1)
-	}
-}
-
 // TestContextExcludedFromJSON locks the `json:"-"` decision. Finding carries no
 // tags on its other fields, so an existing caller's marshaled output is a
 // stable shape it may already be persisting or shipping; three new raw-content
@@ -239,28 +190,24 @@ func TestContextExcludedFromJSON(t *testing.T) {
 	}
 }
 
-// TestValidatorsWithoutContextAreDocumented locks the gap the doc comment
-// promises, in both directions.
+// TestEverySingleLineValidatorRecordsContext is the coverage floor: a validator
+// that finds a value on one line must report the text around it.
 //
-// SECRETS, PERSON_NAME and CLOUD_RESOURCES never populate Match.Context, so
-// their findings report blank context however much text surrounds them. That is
-// worth a test rather than a footnote: it is the case where a caller is most
-// likely to mistake "not recorded" for "the value stood alone", and SECRETS is
-// where the real-vs-example question is hardest.
-//
-// If a change starts populating context for one of these, this test fails on
-// purpose. The fix is to update the Finding doc comment and drop the validator
-// from this list — and to check the suppression finding-hash first, since
-// Context participates in it and attaching context silently rewrites the
-// identity of every finding of that type.
-func TestValidatorsWithoutContextAreDocumented(t *testing.T) {
+// These three were the exceptions, and SECRETS was the costly one — "real key or
+// documentation example" is the question context exists to answer, and the
+// fixture below is `AKIAIOSFODNN7EXAMPLE`, the key from AWS's own docs. A caller
+// reading blank context on a finding cannot tell "not recorded" from "the value
+// stood alone", so a silent regression here would quietly degrade every
+// context-dependent decision a consumer makes.
+func TestEverySingleLineValidatorRecordsContext(t *testing.T) {
 	cases := []struct {
-		validator string
-		input     string
+		validator     string
+		input         string
+		before, after string
 	}{
-		{"secrets", "AWS key AKIAIOSFODNN7EXAMPLE rotate quarterly\n"},
-		{"PERSON_NAME", "Owner is Michael Thompson per HR record\n"},
-		{"cloud_resources", "Bucket arn:aws:s3:::prod-customer-exports listed here\n"},
+		{"secrets", "AWS key AKIAIOSFODNN7EXAMPLE rotate quarterly\n", "AWS key ", " rotate quarterly"},
+		{"PERSON_NAME", "Owner is Michael Thompson per HR record\n", "Owner is ", " per HR record"},
+		{"cloud_resources", "Bucket arn:aws:s3:::prod-customer-exports listed here\n", "Bucket ", " listed here"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.validator, func(t *testing.T) {
@@ -270,14 +217,57 @@ func TestValidatorsWithoutContextAreDocumented(t *testing.T) {
 			}
 			f := findByValidator(t, r.Findings, tc.validator)
 
-			if f.ContextBefore != "" || f.ContextAfter != "" || f.FullLine != "" {
-				t.Errorf("validator %q now populates context (before=%q after=%q fullline=%q).\n"+
-					"This is an improvement, but it changes the documented contract: update the "+
-					"Finding doc comment and confirm the suppression finding-hash impact "+
-					"(internal/suppressions.findingHashVersion reads all three fields, so existing "+
-					"rules for %s findings stop matching once they are populated).",
-					tc.validator, f.ContextBefore, f.ContextAfter, f.FullLine, f.Type)
+			if !strings.Contains(f.ContextBefore, strings.TrimSpace(tc.before)) {
+				t.Errorf("ContextBefore = %q, want it to contain %q", f.ContextBefore, tc.before)
+			}
+			if !strings.Contains(f.ContextAfter, strings.TrimSpace(tc.after)) {
+				t.Errorf("ContextAfter = %q, want it to contain %q", f.ContextAfter, tc.after)
+			}
+			if got, want := f.FullLine, strings.TrimSuffix(tc.input, "\n"); got != want {
+				t.Errorf("FullLine = %q, want %q", got, want)
+			}
+			if strings.Contains(f.ContextBefore, f.Text) || strings.Contains(f.ContextAfter, f.Text) {
+				t.Errorf("context must exclude the matched value %q (before=%q after=%q)",
+					f.Text, f.ContextBefore, f.ContextAfter)
 			}
 		})
+	}
+}
+
+// TestMultiLineSecretReportsNoContext pins the one documented empty case, so
+// "empty" keeps meaning "not applicable to a match spanning lines" rather than
+// drifting back into "some validators just don't bother".
+func TestMultiLineSecretReportsNoContext(t *testing.T) {
+	// Synthetic, structurally-shaped PEM block: the detector keys on the armour,
+	// and no real key material is needed to exercise the path. Assembled from
+	// split literals at runtime, following the convention in
+	// internal/validators/secrets/validator_test.go (buildTestToken), so the
+	// armour never appears contiguously in source and static secret scanners in
+	// the pre-commit path do not flag this file.
+	armour := func(edge string) string {
+		return "-----" + edge + " OPENSSH " + "PRIVATE KEY" + "-----\n"
+	}
+	input := armour("BEGIN") +
+		strings.Repeat("b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2\n", 3) +
+		armour("END")
+
+	r, err := ScanText(context.Background(), input, TextOptions{Checks: []string{"SECRETS"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, f := range r.Findings {
+		if !strings.Contains(f.Text, "\n") {
+			continue // single-line finding; covered by the test above
+		}
+		found = true
+		if f.ContextBefore != "" || f.ContextAfter != "" || f.FullLine != "" {
+			t.Errorf("multi-line %s finding reports context (before=%q after=%q fullline=%q); "+
+				"a match spanning lines has no single line to describe",
+				f.Type, f.ContextBefore, f.ContextAfter, f.FullLine)
+		}
+	}
+	if !found {
+		t.Skip("fixture produced no multi-line finding; nothing to assert")
 	}
 }

--- a/pkg/scan/context_test.go
+++ b/pkg/scan/context_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 	"unicode/utf8"
+
+	"github.com/awslabs/ferret-scan/v2/internal/goldencorpus"
 )
 
 // findByValidator returns the first finding produced by the named validator.
@@ -190,16 +192,18 @@ func TestContextExcludedFromJSON(t *testing.T) {
 	}
 }
 
-// TestEverySingleLineValidatorRecordsContext is the coverage floor: a validator
-// that finds a value on one line must report the text around it.
+// TestBackfilledValidatorsRecordContext covers the three validators that used to
+// record no context at all.
 //
-// These three were the exceptions, and SECRETS was the costly one — "real key or
-// documentation example" is the question context exists to answer, and the
-// fixture below is `AKIAIOSFODNN7EXAMPLE`, the key from AWS's own docs. A caller
-// reading blank context on a finding cannot tell "not recorded" from "the value
-// stood alone", so a silent regression here would quietly degrade every
-// context-dependent decision a consumer makes.
-func TestEverySingleLineValidatorRecordsContext(t *testing.T) {
+// SECRETS was the costly one — "real key or documentation example" is the question
+// context exists to answer, and the fixture below is `AKIAIOSFODNN7EXAMPLE`, the
+// key from AWS's own docs. A caller reading blank context cannot tell "not
+// recorded" from "the value stood alone", so a silent regression here would
+// quietly degrade every context-dependent decision a consumer makes.
+//
+// This is deliberately not named for a universal claim: METADATA records FullLine
+// and never before/after, which TestMetadataRecordsFullLineOnly pins.
+func TestBackfilledValidatorsRecordContext(t *testing.T) {
 	cases := []struct {
 		validator     string
 		input         string
@@ -269,5 +273,54 @@ func TestMultiLineSecretReportsNoContext(t *testing.T) {
 	}
 	if !found {
 		t.Skip("fixture produced no multi-line finding; nothing to assert")
+	}
+}
+
+// TestMetadataRecordsFullLineOnly pins the third shape the Finding doc comment
+// describes: METADATA reports the document property it read, not an offset inside
+// a line, so it fills FullLine and leaves before/after permanently empty.
+//
+// Without this, a caller reading the doc comment's list of exceptions would
+// reasonably conclude METADATA carries before/after. It never has. Backfilling it
+// is tracked separately, and needs its own suppression-hash compatibility variant:
+// METADATA's existing identities already fold a POPULATED FullLine together with
+// an empty before/after pair, so it is a different migration from the one the
+// contextless validators needed.
+func TestMetadataRecordsFullLineOnly(t *testing.T) {
+	// A real .docx carrying document properties, built with the corpus helper so
+	// the metadata path runs exactly as it does in production.
+	docx := goldencorpus.BuildDOCX("Michael Thompson", "Michael Thompson",
+		[]string{"Quarterly summary. Nothing sensitive in the body."})
+
+	path := filepath.Join(t.TempDir(), "props.docx")
+	if err := os.WriteFile(path, docx, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := ScanFile(context.Background(), path, FileOptions{Checks: []string{"METADATA"}})
+	if err != nil {
+		t.Fatalf("ScanFile: %v", err)
+	}
+
+	var seen int
+	for _, f := range r.Findings {
+		if f.Validator != "metadata" {
+			continue
+		}
+		seen++
+		if f.FullLine == "" {
+			t.Errorf("%s finding has no FullLine; METADATA is documented as recording it", f.Type)
+		}
+		if f.ContextBefore != "" || f.ContextAfter != "" {
+			t.Errorf("%s finding now records before/after (before=%q after=%q). That is an "+
+				"improvement, but it changes the documented contract: update the Finding doc "+
+				"comment, and check the suppression finding-hash first — Context.BeforeText and "+
+				"AfterText are folded into a finding's identity, so populating them rewrites the "+
+				"hash of every METADATA finding and existing operator rules stop matching.",
+				f.Type, f.ContextBefore, f.ContextAfter)
+		}
+	}
+	if seen == 0 {
+		t.Fatal("fixture produced no METADATA findings, so the assertion is vacuous")
 	}
 }

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -99,14 +99,22 @@ type Finding struct {
 	//     scoring (currently 30–50 bytes per side depending on the validator).
 	//     It is not part of this package's compatibility surface and will move
 	//     as validators are tuned. Do not parse against a fixed width.
-	//   - MAY BE EMPTY, and empty means "no context was recorded for this
-	//     match", NOT "the match had no surrounding text". Every validator
-	//     records context for a match that sits on one line, but a match that
-	//     spans lines has no single line to describe and reports all three
-	//     blank — today that is the multi-line SECRETS types
-	//     (SSH_PRIVATE_KEY, CERTIFICATE, PGP_PRIVATE_KEY). Callers that reason
-	//     over context must branch on the empty case instead of concluding the
-	//     match stood alone.
+	//   - MAY BE EMPTY, field by field, and empty always means "not recorded" —
+	//     never "the match had no surrounding text". Three shapes exist:
+	//
+	//       * all three populated, for a validator that found the value at a
+	//         position inside a line it can point into. Most findings.
+	//       * FullLine only, with ContextBefore and ContextAfter always empty:
+	//         METADATA, which reports the document property it read
+	//         ("Author: Some Name") rather than an offset within a line, so
+	//         there is no before or after to give.
+	//       * all three empty, for a match that spans lines and therefore has
+	//         no single line to describe: the multi-line SECRETS types
+	//         (SSH_PRIVATE_KEY, CERTIFICATE, PGP_PRIVATE_KEY).
+	//
+	//     So branch on the specific field you read, not on "does this finding
+	//     have context", and do not read an empty ContextBefore as evidence
+	//     that the value stood alone on its line.
 	//   - Rune-aligned. Some validators cut their windows at byte offsets, which
 	//     can slice a multi-byte rune in half; the fragment is trimmed here, so
 	//     these fields can differ from the internal value by up to three bytes

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -22,10 +22,10 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"unicode/utf8"
 
 	"github.com/awslabs/ferret-scan/v2/internal/config"
 	"github.com/awslabs/ferret-scan/v2/internal/core"
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
 	"github.com/awslabs/ferret-scan/v2/internal/explain"
 )
 
@@ -99,17 +99,15 @@ type Finding struct {
 	//     scoring (currently 30–50 bytes per side depending on the validator).
 	//     It is not part of this package's compatibility surface and will move
 	//     as validators are tuned. Do not parse against a fixed width.
-	//   - MAY BE EMPTY, and empty means "this validator does not record
-	//     context", NOT "the match had no surrounding text". As of this
-	//     release SECRETS, PERSON_NAME and CLOUD_RESOURCES never populate
-	//     them, so a SECRETS finding always reports blank context even when
-	//     the line around it is full of text. Callers that reason over context
-	//     must branch on the empty case instead of concluding the match stood
-	//     alone. (Populating those three is deliberately deferred: their
-	//     context participates in the suppression finding-hash, so attaching
-	//     it would silently invalidate operators' existing rules for those
-	//     types. See the package's upstream notes.)
-	//   - Rune-aligned. The validators cut their windows at byte offsets, which
+	//   - MAY BE EMPTY, and empty means "no context was recorded for this
+	//     match", NOT "the match had no surrounding text". Every validator
+	//     records context for a match that sits on one line, but a match that
+	//     spans lines has no single line to describe and reports all three
+	//     blank — today that is the multi-line SECRETS types
+	//     (SSH_PRIVATE_KEY, CERTIFICATE, PGP_PRIVATE_KEY). Callers that reason
+	//     over context must branch on the empty case instead of concluding the
+	//     match stood alone.
+	//   - Rune-aligned. Some validators cut their windows at byte offsets, which
 	//     can slice a multi-byte rune in half; the fragment is trimmed here, so
 	//     these fields can differ from the internal value by up to three bytes
 	//     and are always valid UTF-8 when the underlying line is.
@@ -220,8 +218,8 @@ func mapResult(r *core.ScanResult) *Result {
 			// Trim on the cut edge only: the window's outer boundary is the one
 			// the validator sliced at a byte offset, while the inner boundary is
 			// the match itself and is already rune-aligned.
-			ContextBefore: trimLeadingRuneFragment(m.Context.BeforeText),
-			ContextAfter:  trimTrailingRuneFragment(m.Context.AfterText),
+			ContextBefore: detector.TrimLeadingRuneFragment(m.Context.BeforeText),
+			ContextAfter:  detector.TrimTrailingRuneFragment(m.Context.AfterText),
 			FullLine:      m.Context.FullLine,
 		}
 		if ex, ok := explain.FromMatch(m); ok {
@@ -242,34 +240,4 @@ func normalizeChecks(checks []string) []string {
 		return []string{"all"}
 	}
 	return checks
-}
-
-// trimLeadingRuneFragment drops the tail of a multi-byte rune that a validator's
-// fixed-width context window cut through at the start of BeforeText.
-//
-// Only a leading run of continuation bytes (0b10xxxxxx) can be such a tail, and a
-// cut can leave at most utf8.UTFMax-1 of them, so the bound keeps this a
-// boundary repair rather than a general sanitizer: genuinely malformed bytes
-// further into the line are left alone for the caller to see.
-func trimLeadingRuneFragment(s string) string {
-	i := 0
-	for i < len(s) && i < utf8.UTFMax-1 && s[i]&0xC0 == 0x80 {
-		i++
-	}
-	return s[i:]
-}
-
-// trimTrailingRuneFragment is trimLeadingRuneFragment for the far edge of
-// AfterText, where a cut leaves a rune's leading byte without its continuation
-// bytes. A validly encoded U+FFFD decodes with a size greater than one and is
-// kept; only an incomplete encoding is removed.
-func trimTrailingRuneFragment(s string) string {
-	for i := 0; i < utf8.UTFMax-1 && s != ""; i++ {
-		r, size := utf8.DecodeLastRuneInString(s)
-		if r != utf8.RuneError || size > 1 {
-			break
-		}
-		s = s[:len(s)-size]
-	}
-	return s
 }


### PR DESCRIPTION
Closes #286. **Stacked on #285** — base is that PR's branch, so review it second; the base will retarget to `main` automatically when #285 merges.

Implements **option 2** from #286: attach context in the three validators that never recorded it, with the compatibility candidate scoped per-validator rather than applied globally.

## What was wrong

`secrets`, `personname` and `cloud_resources` never populated `Match.Context`, so their findings carried no record of the text around the value. Context is populated per-validator with no central backfill, so this was a hole, not a policy — #285 could only document it.

`SECRETS` was the expensive one. "Real credential or documentation example" is the question surrounding text answers, and it matters most for a key — the fixture in these tests is `AKIAIOSFODNN7EXAMPLE`, the key from AWS's own docs. A reviewer, a SARIF consumer, and the gitlab-sast description all got a bare value with nothing to judge it by.

## No confidence score moves

`AnalyzeContext` is called by each validator on a locally built `ContextInfo`; nothing in the pipeline calls it over the `Context` attached to an emitted `Match`. All three validators here **already read the line while scoring** — the `reAWSSecretKeyName` gate in `findAWSSecretKeys`, `analyzeContextCached` in personname, `cachedLineHasNegKw` in cloud_resources — and then discarded it.

So this records what was already read. Every confidence in the golden corpus is byte-identical: 69.0, 84.0, 95.0, 92.0 and the rest unchanged.

New `detector.LineContext` helper supplies the windows instead of a fourth and fifth open-coded copy of the arithmetic. It clamps to the line, excludes the match so `BeforeText+match+AfterText` is a contiguous span, and pulls both edges to rune boundaries — the fault #285 repairs at the public boundary, avoided at the source. `pkg/scan` now shares that helper rather than carrying its own copy.

Multi-line secrets (`SSH_PRIVATE_KEY`, `CERTIFICATE`, `PGP_PRIVATE_KEY`) deliberately stay contextless: `ContextInfo` describes a match's position within one line and a PEM block spans dozens, so there's no line to report. That's now the only documented empty case, and a test pins it.

## The part that isn't free: suppression identity

`findingHashVersion` folds `Context.FullLine`, `BeforeText` and `AfterText` into a finding's identity, so attaching context rewrites the hash:

```
AWS_ACCESS_KEY, no context (before)   ed3217d2a07c46a9...
AWS_ACCESS_KEY, context attached      54ba6fe7b2da4db6...
```

Matching is purely hash-indexed with no structural fallback, so unaccompanied this would stop **every existing operator rule** for a SECRETS, PERSON_NAME or CLOUD_RESOURCES finding from matching — reviewed-and-accepted findings back to noise, and in a pre-commit gate back to a block.

Two compatibility formulas fix it, following the pattern the confidence change established: `hashVersionNoConfidenceContextless` and `hashVersionLegacyConfidenceContextless` recompute the identity as though the finding carried no context, offered as additional **matching** candidates. Never written — new rules carry the current context-bearing identity, so a rule file migrates as it's regenerated and an operator who never regenerates loses nothing. Both legacy formulas are covered, since a rule file may predate the confidence change as well as this one.

**Scoped to these three validators by `Match.Validator`, not applied globally** — this is the narrowing you asked for in option 2. A contextless identity is a weaker one: with the line excluded, two findings agreeing on type, basename, line number and value but sitting on different line content become indistinguishable, so a rule could keep suppressing after the line around the value changed, which is how a stale suppression hides a newly introduced secret. The other sixteen validators keep exactly the identity they had, and a test asserts they get 2 candidates while these three get 4. The list is closed: a validator added later starts out recording context.

## Golden corpus

Regenerated per CONTRIBUTING. The diff is confined to **sarif and gitlab-sast, 7 files each** — no text, json, yaml, csv or junit output moves, and no confidence or severity anywhere.

- **gitlab-sast**: these findings now take the primary `**Context:**` path instead of the `**Matched value:**` fallback — which existed *precisely because* these validators had no `FullLine`, and whose comment named secrets as the example. Both paths were already `--show-match` gated, so nothing newly reveals: with the flag the description shows the line rather than the bare value, as it already did for every other validator; without it, `[HIDDEN] (use --show-match …)` replaces silence. Comment updated to cite the multi-line case, now the only reason the fallback survives.
- **sarif**: results gain precise `region` `startColumn`/`endColumn` and a snippet where they previously carried only `startLine`.

## Pre-existing bug this makes more visible (not fixed here)

`buildContextRegion` composes its SARIF snippet as `BeforeText + "\n" + FullLine + "\n" + AfterText`, duplicating text already inside `FullLine`. It's in the committed goldens long before this change:

```
"SSN \nSSN 449-87-4100 on file.\n on file."
```

It affects every validator that records context; this change extends its reach from sixteen to nineteen. Worth its own fix rather than a rider here — happy to send it.

## Verification

- `go test ./...` (65 packages), `go vet ./...`, `make build` — all clean.
- The compatibility is **mutation-tested**: removing the contextless candidates fails `TestExistingRulesSurviveContextRecording` for all three validators under both legacy formulas.
- New tests: `detector.LineContext` (bracketing, clamping, rune alignment, inconsistent-offset rejection), the three suppression compatibility properties, a coverage floor asserting all three validators now record context, and the multi-line empty case.
- The multi-line PEM fixture is assembled from split literals at runtime, following the `buildTestToken` convention in `internal/validators/secrets/validator_test.go`, so Code Defender / static secret scanners don't flag the file.

## Note on #285

This replaces that PR's documented gap and the test that locked it. Its `Finding` doc comment now describes the multi-line case as the only reason context can be empty, and `TestValidatorsWithoutContextAreDocumented` becomes `TestEverySingleLineValidatorRecordsContext` — a coverage floor rather than a record of a hole.
