### PR TITLE
docs(scan): deprecate Finding.SuppressedBy and document that pkg/scan applies no suppression

### DIFF
--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -75,15 +75,25 @@ type FileOptions struct {
 
 // Finding is one piece of sensitive data detected.
 type Finding struct {
-	Type         string  // validator-assigned classification (e.g. "SSN", "VISA", "EMAIL")
-	Validator    string  // which validator produced it
-	Confidence   float64 // 0–100
-	LineNumber   int     // 1-based
-	Text         string  // the matched substring (handle with care)
-	Filename     string  // source file or label
-	Rationale    string  // plain-language "why flagged" (empty unless Explain=true)
-	Verdict      string  // "likely_real" | "likely_test" | "uncertain" (empty unless Explain)
-	SuppressedBy string  // non-empty if this finding was suppressed
+	Type       string  // validator-assigned classification (e.g. "SSN", "VISA", "EMAIL")
+	Validator  string  // which validator produced it
+	Confidence float64 // 0–100
+	LineNumber int     // 1-based
+	Text       string  // the matched substring (handle with care)
+	Filename   string  // source file or label
+	Rationale  string  // plain-language "why flagged" (empty unless Explain=true)
+	Verdict    string  // "likely_real" | "likely_test" | "uncertain" (empty unless Explain)
+
+	// SuppressedBy is always the empty string.
+	//
+	// Deprecated: this package applies no suppression, so nothing can ever set
+	// this field — see the note on Result about suppression. It has read as ""
+	// for every finding since the package was introduced, and the check it
+	// invites, `if f.SuppressedBy != ""`, therefore answers "nothing was
+	// suppressed" for a package that never asked the question. Do not branch on
+	// it. It is kept only so existing callers keep compiling and will be removed
+	// in the next major version.
+	SuppressedBy string
 
 	// ContextBefore and ContextAfter are the text on either side of the match,
 	// excluding the match itself; FullLine is the whole line the match sits on.
@@ -124,6 +134,23 @@ type Finding struct {
 }
 
 // Result holds the output of a scan.
+//
+// Suppression is NOT applied. Findings is every match the selected validators
+// produced; no suppression rule is consulted, and no finding is filtered or
+// annotated as suppressed. This differs from the CLI, which does apply a
+// suppressions file, so a caller that assumes this package honors the project's
+// `.ferret-scan-suppressions.yaml` will see findings an operator has already
+// reviewed and accepted. That is the safe direction for a detection API — it
+// reports everything and lets the caller decide — but it is worth knowing before
+// wiring this into a gate.
+//
+// Suppression in the engine is opt-in at the internal layer
+// (core.ScanConfig.SuppressionManager), which this package deliberately does not
+// set: filtering findings by default would let a stale rule silently hide a real
+// value from a caller who never asked for it. Callers wanting rule-based
+// suppression today can express it over the returned Findings, or use
+// pkg/redact, whose Engine matches caller-supplied rules and reports what they
+// suppressed.
 type Result struct {
 	Findings         []Finding
 	Incomplete       bool // true if coverage was cut short (timeout, cancellation)

--- a/pkg/scan/suppression_test.go
+++ b/pkg/scan/suppression_test.go
@@ -1,0 +1,62 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package scan
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestSuppressedByIsAlwaysEmpty pins the claim the deprecation notice makes.
+//
+// This package never sets core.ScanConfig.SuppressionManager, so the suppression
+// stage does not run: nothing is filtered and nothing can populate SuppressedBy.
+// The field is retained only for compilation compatibility.
+//
+// If suppression is ever wired into this package, this test fails and that is the
+// right outcome — it is the prompt to undeprecate the field, populate it from
+// detector.SuppressedMatch, and rewrite the note on Result. Deleting the test to
+// make a change pass would put the docs back into the state this replaced, where
+// a public field described behaviour the package did not have.
+func TestSuppressedByIsAlwaysEmpty(t *testing.T) {
+	const body = "Employee SSN 796-58-4123 on file\n" +
+		"Corporate card 4111-1111-1111-1111 expires soon\n" +
+		"AWS key AKIAIOSFODNN7EXAMPLE rotate quarterly\n"
+
+	path := filepath.Join(t.TempDir(), "findings.txt")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	textResult, err := ScanText(context.Background(), body, TextOptions{Explain: true})
+	if err != nil {
+		t.Fatalf("ScanText: %v", err)
+	}
+	fileResult, err := ScanFile(context.Background(), path, FileOptions{Explain: true})
+	if err != nil {
+		t.Fatalf("ScanFile: %v", err)
+	}
+
+	for _, tc := range []struct {
+		entry    string
+		findings []Finding
+	}{
+		{"ScanText", textResult.Findings},
+		{"ScanFile", fileResult.Findings},
+	} {
+		if len(tc.findings) == 0 {
+			t.Fatalf("%s: fixture produced no findings, so the assertion is vacuous", tc.entry)
+		}
+		for _, f := range tc.findings {
+			if f.SuppressedBy != "" {
+				t.Errorf("%s: %s finding on line %d has SuppressedBy = %q; this package applies "+
+					"no suppression, so the field cannot be set. If suppression was just wired in, "+
+					"update the Finding and Result doc comments instead of relaxing this test.",
+					tc.entry, f.Type, f.LineNumber, f.SuppressedBy)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes #287. **Third in the stack** — base is #288's branch, so review order is #285 → #288 → this. Bases retarget automatically as each merges.

**No functional change.** Documentation, a deprecation marker, and a test. Nothing is removed, so nothing breaks.

## Why not remove the field

#287 originally recommended dropping `Finding.SuppressedBy`, and I argued for that on the strength of the `ValidCheckNames()` / `SOCIAL_MEDIA` precedent in the changelog. That precedent doesn't actually apply: it removed an item from a **returned list**, which breaks no compilation and changes runtime behaviour only for callers who explicitly passed `SOCIAL_MEDIA`. Removing an exported **struct field** breaks the build of any caller that so much as names it.

The field is unused in this repo and the one known downstream consumer explicitly doesn't read it, so removal would break no *behaviour* — but this package's compatibility is the entire reason it exists, and a build break is a poor trade for tidiness. `Deprecated:` is surfaced by staticcheck, `go doc` and editors, so callers get told without anything breaking, and the removal rides along free with the next major.

## What was actually wrong

`SuppressedBy` is documented as "non-empty if this finding was suppressed" and has read `""` for every finding since v2.1.0. It isn't an unmapped field — **this package never sets `core.ScanConfig.SuppressionManager`**, so the suppression stage doesn't run here at all. Nothing is filtered, `ScanResult.SuppressedMatches` is always empty, and there is nothing to report even in principle.

The cost is a wrong answer that looks like a right one: `if f.SuppressedBy != ""` is the obvious check and the one the comment invited, and it silently reports "nothing was suppressed" for a package that never asked.

## The larger gap, which was not the field

A caller had no way to know this package ignores suppression **entirely**. The CLI *does* apply a suppressions file, so assuming parity is the natural mistake — and it shows an operator findings they already reviewed and accepted.

`Result` now states it directly: suppression is not applied, `Findings` is every match the validators produced, and the engine's suppression is opt-in at the internal layer and deliberately not opted into here (filtering by default would let a stale rule hide a real value from a caller who never asked for it). It points at the two things a caller can actually do — filter the returned findings, or use `pkg/redact`, whose engine matches caller-supplied rules and reports what they suppressed.

That's the part I'd keep even if the field vanished tomorrow.

## Test

`TestSuppressedByIsAlwaysEmpty` pins the claim across `ScanText` and `ScanFile`, and fails loudly if suppression is ever wired in — which is the correct prompt to undeprecate the field, populate it from `detector.SuppressedMatch`, and rewrite both notes. The failure message says so, because the alternative failure mode is someone relaxing the test and putting the docs back into the state this replaced.

## Verification

`go test ./...` (65 packages), `go vet ./...`, `gofmt`, `make build` — all clean. Committed with Code Defender's hooks running.
