### PR TITLE
docs(preprocessors): correct the false claim that nesting depth is bounded

### DIFF
--- a/internal/preprocessors/base_metadata_preprocessor.go
+++ b/internal/preprocessors/base_metadata_preprocessor.go
@@ -207,13 +207,29 @@ func (bmp *BaseMetadataPreprocessor) ProcessEmbeddedMedia(originalFilePath strin
 		// Create context showing original file relationship
 		embeddedPath := bmp.utilities.RouterHelper.CreateEmbeddedMediaPath(originalFilePath, media.OriginalName)
 
-		// Reprocess embedded media through router
-		// The router tracks nesting depth itself, keyed on the temp path it handed
-		// out for this embedded item -- see FileRouter.noteEmbeddedChild. The
-		// preprocessor cannot construct a router ProcessingContext (router imports
-		// preprocessors, so the reverse would be an import cycle) and its Process
-		// method takes no context to thread one through, so depth is owned on the
-		// router side rather than plumbed through every preprocessor signature.
+		// Reprocess embedded media through the router.
+		//
+		// NOTHING BOUNDS THE NESTING DEPTH HERE. This comment used to claim the
+		// router tracked depth "keyed on the temp path it handed out, see
+		// FileRouter.noteEmbeddedChild". No such method exists, and no
+		// nesting-depth tracking exists anywhere in internal/router or
+		// internal/preprocessors — the only guards are the size caps
+		// MaxFileSize (100MB) and MaxEmbeddedMediaSize (50MB), and a
+		// deep-nesting bomb is small on disk.
+		//
+		// That mattered because this call site is exactly where someone would look
+		// before admitting embedded OOXML documents in
+		// meta-extract-officelib.embeddedMediaType, which is currently the other
+		// half of the nesting leak (an embedded .docx is never scanned; see #297).
+		// A reader who trusted the old comment would have concluded a bound was
+		// already in place and shipped unbounded recursion.
+		//
+		// Recursion is bounded TODAY only because the admitted types are leaves:
+		// images and audio route to extractors that follow nothing, and the legacy
+		// .doc/.xls/.ppt extractor reads OLE streams directly without following
+		// embeddings. Admitting .docx/.xlsx/.pptx routes back into this same
+		// function, so it requires a real depth cap first — and a cap must DISCLOSE
+		// when it truncates, or it replaces a silent miss with a different one.
 		if processed, err := bmp.router.ProcessFile(media.TempFilePath, nil); err == nil && processed != nil && processed.Success {
 			// Update processed content to show original file relationship
 			processed.OriginalPath = embeddedPath

--- a/internal/preprocessors/meta-extractors/meta-extract-officelib/office-extractor.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-officelib/office-extractor.go
@@ -737,14 +737,25 @@ func embeddedMediaType(ext string) string {
 		// detection gap for a decompression-bomb amplifier, which is a worse
 		// trade for a tool that runs on untrusted input.
 		//
-		// The bound cannot be added here cheaply: depth cannot live on the
-		// preprocessor (one instance is shared across concurrent workers), cannot
-		// travel in a router ProcessingContext (router imports preprocessors, so
-		// the reverse is an import cycle), and cannot live on the router (one
-		// instance, shared). It needs a context parameter on the preprocessor
-		// Process interface, which is a change of its own size. Tracked
-		// separately; this comment is the reason the case is missing, so nobody
-		// "fixes" it by adding the extension.
+		// A bound is needed FIRST, and note that none exists today: the claim
+		// that the router already tracks depth (formerly in
+		// BaseMetadataPreprocessor.processEmbeddedMedia, citing a
+		// FileRouter.noteEmbeddedChild that was never written) was false. The only
+		// guards are the size caps above, and a deep-nesting bomb is small on disk.
+		//
+		// Depth cannot live on the preprocessor (one instance is shared across
+		// concurrent workers) nor on the router (also one instance), and the
+		// concrete router ProcessingContext type is unreachable from here (router
+		// imports preprocessors, so the reverse is an import cycle). What IS
+		// reachable: RouterInterface has exactly one real implementor, so a
+		// depth-carrying entry point beside ProcessFile is additive rather than a
+		// signature change across every preprocessor.
+		//
+		// Tracked in #297, which carries the measured repro and that design. This
+		// comment is the reason the case is missing, so nobody "fixes" it by adding
+		// the extension: doing that without the cap trades a detection gap for a
+		// decompression-bomb amplifier, which is the worse trade for a tool that
+		// runs on untrusted input.
 		return ""
 	}
 }


### PR DESCRIPTION
Split out of #297 because it stands alone and is the dangerous half to leave in place.

## The problem

`processEmbeddedMedia` claimed a safety net that does not exist:

> *"The router tracks nesting depth itself, keyed on the temp path it handed out for this embedded item — see `FileRouter.noteEmbeddedChild`."*

**`noteEmbeddedChild` does not exist.** That comment was its only occurrence in the repository, and `grep` finds no nesting-depth tracking anywhere in `internal/router/` or `internal/preprocessors/`. The only guards are size caps:

```
MaxFileSize          = 100MB
MaxEmbeddedMediaSize = 50MB
```

Neither bounds depth, and a deep-nesting bomb is small on disk.

## Why this is worth its own PR

Because of **where** the comment sits: directly above the recursion call site, which is exactly where someone would look before admitting embedded OOXML documents in `embeddedMediaType` — the other half of the nesting leak (#297), where a `.docx` inside a `.docx` is never scanned, reports clean, exits 0, and stays silent even under `--fail-on-incomplete`.

A reader who trusted the old comment would conclude a bound was already in place and ship unbounded recursion, trading a detection gap for a decompression-bomb amplifier. That is a worse trade for a tool that runs on untrusted input.

Recursion is bounded **today** only because every admitted type is a **leaf** — images and audio route to extractors that follow nothing, and the legacy `.doc/.xls/.ppt` extractor reads OLE streams directly without following embeddings. That is a property of the admitted set, not a mechanism, and nothing enforces it.

## Also corrected

The sibling comment in `embeddedMediaType` called the fix infeasible:

> *"needs a context parameter on the preprocessor `Process` interface, which is a change of its own size"*

Measured: `RouterInterface` has exactly **one** real implementor (`FileRouter`), so a depth-carrying entry point beside `ProcessFile` is **additive** rather than a signature change across every preprocessor. Both comments now point at #297, which carries the measured repro and that design.

## Verification

Comments only:

```
2 files changed, 42 insertions(+), 15 deletions(-)
added lines: 42
added NON-comment lines: 0
```

Test plan — change kind is *pure docs* touching `.go` files, so dimensions 1 and 2:

- **1 build/vet/format** — `go build ./...` clean, `go vet` clean, `gofmt -l` empty
- **2 full suite** — `rc=0`, **65 packages**
- **3 golden** — 0 files move (asserted, not assumed)
- 4–13 — N/A: no executable line changed, so no sink is reachable from this diff

Does not fix the leak. #297 tracks that, with the repro and the depth-cap design, including the requirement that a cap must **disclose** when it truncates rather than replacing a silent miss with a different one.