### PR TITLE
fix(cli): validate --checks on stdin too, so a typo cannot silently scan for nothing

### DIFF
--- a/cmd/checks_parity_test.go
+++ b/cmd/checks_parity_test.go
@@ -1,0 +1,174 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/core"
+)
+
+// --checks must mean the same thing whatever the input source.
+//
+// It did not. File mode ran the value through parseChecksToRun, which upper-cased it
+// and exited 1 on an unrecognized name. Stdin mode ran it through parseChecksList,
+// which did neither and handed the raw strings to core.ParseChecksToRun — whose loop
+// has no else branch, so an unknown name is discarded with no error and no warning.
+// Measured on the same fixture and the same binary:
+//
+//	--checks ssn --file fx.txt   -> 1 finding      --stdin -> 0 findings, rc 0, silent
+//	--checks BOGUS --file fx.txt -> rc 1           --stdin -> 0 findings, rc 0, silent
+//	--checks ALL --file fx.txt   -> rc 1           --stdin -> 0 findings, rc 0, silent
+//
+// Running zero validators and reporting clean is the worst outcome a scanner has. The
+// documented streaming gateway made it worse still: with --stdin --enable-redaction,
+// a typo'd check name echoed the input back BYTE-IDENTICAL at rc 0, so a pipeline
+// built on that pattern passed cleartext through while appearing to redact.
+//
+// Both paths now share normalizeChecksArg. These tests exist because a shared helper
+// is only a convention until something asserts the two callers still agree.
+
+// checksCases is the table both parsers must agree on.
+var checksCases = []struct {
+	arg      string
+	wantErr  bool
+	wantAll  bool     // nil result: every validator
+	wantList []string // canonical names, when not wantAll and not wantErr
+	why      string
+}{
+	{arg: "", wantAll: true, why: "no flag means every check"},
+	{arg: "all", wantAll: true, why: "the documented sentinel"},
+	{arg: "ALL", wantAll: true, why: "the sentinel is case-insensitive; uppercase used to select NOTHING"},
+	{arg: "  all  ", wantAll: true, why: "surrounding whitespace must not defeat the sentinel"},
+	{arg: "SSN", wantList: []string{"SSN"}, why: "canonical name"},
+	{arg: "ssn", wantList: []string{"SSN"}, why: "lowercase is accepted and upper-cased, as file mode always did"},
+	{arg: " ssn , email ", wantList: []string{"SSN", "EMAIL"}, why: "whitespace around names is trimmed"},
+	{arg: "SSN,SSN", wantList: []string{"SSN", "SSN"}, why: "a repeat is harmless: the result seeds a presence map"},
+
+	{arg: "BOGUS_CHECK", wantErr: true, why: "an unknown name must never mean 'scan nothing'"},
+	{arg: "ADDRESS", wantErr: true, why: "plausible-but-wrong: the real id is PHYSICAL_ADDRESS"},
+	{arg: "CARD", wantErr: true, why: "plausible-but-wrong: the real id is CREDIT_CARD"},
+	{arg: "NAME", wantErr: true, why: "plausible-but-wrong: the real id is PERSON_NAME"},
+	{arg: "SSN,BOGUS", wantErr: true, why: "one bad name in a list must fail the whole list, not silently drop half"},
+	{arg: "all,SSN", wantErr: true, why: "'all' mixed with names used to silently select only SSN"},
+	{arg: "ALL,ssn", wantErr: true, why: "same, in the case that previously selected nothing at all"},
+}
+
+func TestNormalizeChecksArg(t *testing.T) {
+	for _, tc := range checksCases {
+		t.Run(strings.ReplaceAll(tc.arg, " ", "_"), func(t *testing.T) {
+			got, err := normalizeChecksArg(tc.arg)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("normalizeChecksArg(%q) returned nil error and %v.\n%s\n"+
+						"Accepting this silently runs zero validators and reports clean.",
+						tc.arg, got, tc.why)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("normalizeChecksArg(%q) errored: %v\n%s", tc.arg, err, tc.why)
+			}
+			if tc.wantAll {
+				if got != nil {
+					t.Errorf("normalizeChecksArg(%q) = %v, want nil (every check).\n%s", tc.arg, got, tc.why)
+				}
+				return
+			}
+			if len(got) != len(tc.wantList) {
+				t.Fatalf("normalizeChecksArg(%q) = %v, want %v\n%s", tc.arg, got, tc.wantList, tc.why)
+			}
+			for i := range got {
+				if got[i] != tc.wantList[i] {
+					t.Errorf("normalizeChecksArg(%q)[%d] = %q, want %q\n%s",
+						tc.arg, i, got[i], tc.wantList[i], tc.why)
+				}
+			}
+		})
+	}
+}
+
+// TestFileAndStdinParsersAgree is the parity gate.
+//
+// parseChecksToRun (file mode) exits the process on a bad name, so it cannot be
+// called with invalid input from a test. What CAN be asserted is that both parsers
+// derive from the same function and produce the same SELECTION for every input that
+// is valid — which is the half a silent divergence would break.
+func TestFileAndStdinParsersAgree(t *testing.T) {
+	for _, tc := range checksCases {
+		if tc.wantErr {
+			// Both reject via the same normalizeChecksArg call; the error path is
+			// covered above. parseChecksToRun would os.Exit(1) here.
+			continue
+		}
+		t.Run(strings.ReplaceAll(tc.arg, " ", "_"), func(t *testing.T) {
+			fileSel := parseChecksToRun(tc.arg)
+
+			stdinList, err := parseChecksList(tc.arg)
+			if err != nil {
+				t.Fatalf("parseChecksList(%q) errored where file mode accepted: %v", tc.arg, err)
+			}
+
+			// Reduce the stdin list to the same shape as the file-mode map.
+			stdinSel := map[string]bool{}
+			for _, c := range core.CheckNames() {
+				stdinSel[c] = false
+			}
+			if stdinList == nil {
+				for c := range stdinSel {
+					stdinSel[c] = true
+				}
+			} else {
+				for _, c := range stdinList {
+					stdinSel[c] = true
+				}
+			}
+
+			for _, c := range core.CheckNames() {
+				if fileSel[c] != stdinSel[c] {
+					t.Errorf("--checks %q: check %s is %v in file mode but %v on stdin.\n"+
+						"The same flag must select the same validators whatever the input source.",
+						tc.arg, c, fileSel[c], stdinSel[c])
+				}
+			}
+		})
+	}
+}
+
+// TestEveryCanonicalNameIsAccepted — the recall half.
+//
+// A validation gate that rejects a legitimate name is worse than the fail-open it
+// replaced: it stops a scan that would have found something. Every name the engine
+// publishes must survive its own validator, in both cases.
+func TestEveryCanonicalNameIsAccepted(t *testing.T) {
+	names := core.CheckNames()
+	if len(names) == 0 {
+		t.Fatal("core.CheckNames() is empty; this test would pass vacuously")
+	}
+	for _, name := range names {
+		for _, spelling := range []string{name, strings.ToLower(name)} {
+			got, err := normalizeChecksArg(spelling)
+			if err != nil {
+				t.Errorf("normalizeChecksArg(%q) rejected a name core.CheckNames() publishes: %v",
+					spelling, err)
+				continue
+			}
+			if len(got) != 1 || got[0] != name {
+				t.Errorf("normalizeChecksArg(%q) = %v, want exactly [%s]", spelling, got, name)
+			}
+		}
+	}
+
+	// And the whole list at once, which is what a --checks line generated from
+	// CheckNames() looks like.
+	all, err := normalizeChecksArg(strings.Join(names, ","))
+	if err != nil {
+		t.Fatalf("the full published list was rejected: %v", err)
+	}
+	if len(all) != len(names) {
+		t.Errorf("full list round-tripped to %d names, want %d", len(all), len(names))
+	}
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2564,40 +2564,97 @@ func isFlagSet(name string) bool {
 	return found
 }
 
+// normalizeChecksArg turns the raw --checks value into the canonical check names,
+// or returns an error naming the first unrecognized one.
+//
+// This is the ONE place the flag's vocabulary is decided, because it previously had
+// two and they disagreed. File mode validated and upper-cased here; stdin mode used
+// cmd/stdin.go's parseChecksList, which did neither and handed the raw strings to
+// core.ParseChecksToRun — whose loop silently drops any name it does not recognise.
+// So the same flag, in the same binary, behaved differently by input source:
+//
+//	--checks ssn --file fx.txt   -> 1 finding   (upper-cased here)
+//	--checks ssn --stdin         -> 0 findings, rc 0, nothing on stderr
+//	--checks BOGUS --file fx.txt -> rc 1, "Unknown check type"
+//	--checks BOGUS --stdin       -> 0 findings, rc 0, silent
+//
+// Silently running zero validators is the worst available outcome for a scanner: it
+// reports clean. With --stdin --enable-redaction it also emitted the input back
+// BYTE-IDENTICAL at rc 0, so the documented streaming-gateway pattern passed
+// cleartext through while looking like it had redacted.
+//
+// Returning ([]string, error) rather than exiting keeps this usable from both call
+// sites — the CLI boundary decides how to report, and neither path can quietly skip
+// the check.
+//
+// A nil slice means "every check", which is what core.ParseChecksToRun treats an
+// empty list as.
+func normalizeChecksArg(checks string) ([]string, error) {
+	// Available checks come from the single source of truth (core.CheckNames,
+	// derived from validatorConstructors) so this list cannot drift from the
+	// validators that actually exist.
+	valid := make(map[string]bool, len(core.CheckNames()))
+	for _, c := range core.CheckNames() {
+		valid[c] = true
+	}
+
+	trimmed := strings.TrimSpace(checks)
+	if trimmed == "" {
+		return nil, nil
+	}
+	// The "all" sentinel, case-insensitively. core.ParseChecksToRun only honours a
+	// lowercase, single-element "all", so "ALL" reached it as an unknown name and
+	// selected NOTHING. Normalising here means the sentinel behaves the way every
+	// other check name does.
+	if strings.EqualFold(trimmed, "all") {
+		return nil, nil
+	}
+
+	var out []string
+	for _, check := range strings.Split(trimmed, ",") {
+		checkStr := strings.ToUpper(strings.TrimSpace(check))
+		if checkStr == "" {
+			continue
+		}
+		// "all" mixed with other names is rejected rather than silently winning or
+		// silently losing. core.ParseChecksToRun's sentinel requires a single-element
+		// list, so "all,SSN" previously selected only SSN — a reasonable reader
+		// expects the opposite, and guessing either way is worse than saying so.
+		if checkStr == "ALL" {
+			return nil, fmt.Errorf("'all' cannot be combined with other check names (got %q)", checks)
+		}
+		if !valid[checkStr] {
+			return nil, fmt.Errorf("unknown check type '%s'\nAvailable checks: %s",
+				checkStr, strings.Join(core.CheckNames(), ", "))
+		}
+		out = append(out, checkStr)
+	}
+	return out, nil
+}
+
 // parseChecksToRun converts a comma-separated string of check names
 // into a map of enabled checks
 func parseChecksToRun(checks string) map[string]bool {
-	// Available checks come from the single source of truth (core.CheckNames,
-	// derived from validatorConstructors) so this list cannot drift from the
-	// validators that actually exist. Order is irrelevant here — it only seeds
-	// a presence map. The validate-and-exit-on-unknown semantics below are
-	// intentionally kept (distinct from core.ParseChecksToRun's fail-open).
-	availableChecks := core.CheckNames()
-
 	result := make(map[string]bool)
-	for _, check := range availableChecks {
+	for _, check := range core.CheckNames() {
 		result[check] = false
 	}
 
-	if checks == "all" {
+	selected, err := normalizeChecksArg(checks)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	// nil means "every check".
+	if selected == nil {
 		for key := range result {
 			result[key] = true
 		}
 		return result
 	}
-
-	// Parse comma-separated list of checks
-	for _, check := range strings.Split(checks, ",") {
-		checkStr := strings.ToUpper(strings.TrimSpace(check))
-		if _, exists := result[checkStr]; exists {
-			result[checkStr] = true
-		} else if checkStr != "" {
-			fmt.Fprintf(os.Stderr, "Error: Unknown check type '%s'\n", checkStr)
-			fmt.Fprintf(os.Stderr, "Available checks: %s\n", strings.Join(core.CheckNames(), ", "))
-			os.Exit(1)
-		}
+	for _, c := range selected {
+		result[c] = true
 	}
-
 	return result
 }
 

--- a/cmd/stdin.go
+++ b/cmd/stdin.go
@@ -171,7 +171,15 @@ func runStdinScan(in stdinScanInputs) int {
 	suppressionManager := suppressions.NewSuppressionManager(finalCfg.suppressionFile)
 
 	// Parse checks list into a []string for ScanContent.
-	checks := parseChecksList(finalCfg.checksToRun)
+	//
+	// An unrecognized name is a hard error, matching file mode. Failing open here
+	// meant running ZERO validators and reporting clean — and under
+	// --enable-redaction, streaming the input back byte-identical at rc 0.
+	checks, err := parseChecksList(finalCfg.checksToRun)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
 
 	scanCfg := core.ContentScanConfig{
 		VirtualPath:        in.stdinName,
@@ -577,18 +585,15 @@ func writeStdinOutput(outputFile, formatted string, precommitConfig *precommit.P
 }
 
 // parseChecksList turns "all" or "CHECK1,CHECK2" into a slice for ScanContent.
-func parseChecksList(checks string) []string {
-	if checks == "" || checks == "all" {
-		return nil // empty means "all" in core.ParseChecksToRun
-	}
-	parts := strings.Split(checks, ",")
-	out := make([]string, 0, len(parts))
-	for _, p := range parts {
-		if t := strings.TrimSpace(p); t != "" {
-			out = append(out, t)
-		}
-	}
-	return out
+//
+// Delegates to normalizeChecksArg so stdin mode and file mode share one vocabulary.
+// This function used to do its own thing: no upper-casing and no validation, handing
+// the raw strings to core.ParseChecksToRun, whose loop silently discards any name it
+// does not recognise. The result was that "--checks ssn" found an SSN via --file and
+// nothing via --stdin, and "--checks BOGUS" reported clean at rc 0 instead of the
+// rc 1 file mode gives. See normalizeChecksArg for the measurements.
+func parseChecksList(checks string) ([]string, error) {
+	return normalizeChecksArg(checks)
 }
 
 // highestConfidenceLevel returns "high"/"medium"/"low"/"" for use with


### PR DESCRIPTION
Closes #295.

## The bug

The same `--checks` flag, in the same binary, behaved differently by input source. Measured on one fixture:

| `--checks` | `--file` | `--stdin` |
|---|---|---|
| `ssn` | 1 finding | **0 findings, rc 0, silent** |
| `BOGUS_CHECK` | rc 1 | **0 findings, rc 0, silent** |
| `ADDRESS` | rc 1 | **0 findings, rc 0, silent** |
| `ALL` | rc 1 | **0 findings, rc 0, silent** |
| `all,SSN` | rc 1 | 1 finding (sentinel defeated) |

File mode used `parseChecksToRun` — upper-cases, exits 1 on an unknown name. Stdin used `parseChecksList`, which did neither and handed raw strings to `core.ParseChecksToRun`, whose loop has **no else branch**:

```go
if _, exists := result[checkStr]; exists {
    result[checkStr] = true
}
// unknown name silently discarded
```

## Why it matters more than a flag typo

**The documented streaming gateway passed cleartext through while appearing to redact:**

```console
$ cat fx.txt | ferret-scan --stdin --enable-redaction --checks SSN
SSN: ***-**-9384

$ cat fx.txt | ferret-scan --stdin --enable-redaction --checks BOGUS_CHECK
SSN: 452-11-9384          # byte-identical to input, rc=0, nothing on stderr
```

66 bytes in, the same 66 bytes out. And `docs/PRE_COMMIT_INTEGRATION.md` configures hooks with an explicit `--checks LIST` — exactly the shape that degraded to "check nothing" and exited 0, so the gate silently stopped blocking.

## The fix

Both paths now share `normalizeChecksArg`, the one place the flag's vocabulary is decided. It:

- **upper-cases**, so `ssn` works everywhere it already worked in file mode
- treats `all` **case-insensitively**, so `ALL` no longer selects nothing
- **rejects** an unknown name, with the available list, rather than dropping it
- **rejects `all` combined with other names** instead of silently letting one win — the sentinel requires a single-element list, so `all,SSN` previously selected only `SSN`; a reader expects the opposite, and guessing either way is worse than saying so

Returning `([]string, error)` rather than exiting keeps it usable from both call sites: the CLI boundary decides how to report, and neither path can quietly skip the check.

## After

**All 8 probed inputs now agree** between file and stdin, and the gateway writes **0 bytes and exits 1** instead of passing cleartext.

## The recall half is tested too

A validation gate that rejects a *legitimate* name is worse than the fail-open it replaces — it stops a scan that would have found something. `TestEveryCanonicalNameIsAccepted` round-trips every name `core.CheckNames()` publishes, in both upper and lower case, plus the whole list at once.

## Non-vacuity

Three mutations, each verified to **compile** and then fail:

| mutation | caught by |
|---|---|
| stdin parser reverted to fail-open | parity + normalize tests |
| unknown names silently dropped | normalize tests |
| `all` sentinel case-sensitive again | normalize tests |

## Test plan

- **1** build / vet / gofmt — clean
- **2** full suite — `rc=0`, **65 packages**
- **3** golden — **0 files moved**; **3b** score corpus unchanged (valid inputs behave identically)
- **5** redaction — verified in **both** modes: file mode writes `***-**-9384` with **0** cleartext occurrences; stdin likewise
- **7** all seven formats produce output on stdin with a valid check
- **exit codes** — pre-commit still returns 1 on a real finding, and now returns non-zero (was **0**) on a bad check name
- 4, 6, 8–13 — N/A: no loop, offset, suppression-hash, web or concurrency surface is touched; the change is flag parsing at the CLI boundary

## Note on scope

`pkg/scan.normalizeChecks` has the same fail-open shape (`["BOGUS_CHECK"]` → 0 findings, nil error) and is **not** fixed here — it is a library API change and deserves its own decision. #295 records the measurements; this PR closes the CLI half, which is where the documented patterns live.