### PR TITLE
fix(scan): reject an unknown check name instead of silently scanning for nothing

### DIFF
--- a/pkg/scan/checks_validation_test.go
+++ b/pkg/scan/checks_validation_test.go
@@ -1,0 +1,231 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package scan
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// An unrecognized check name must be an error, never "scan for nothing".
+//
+// normalizeChecks used to pass the caller's slice through untouched, and
+// core.ParseChecksToRun's loop has no else branch, so a name it does not recognise is
+// discarded silently. A caller who misspelled one got zero validators, a nil error,
+// and an empty finding list indistinguishable from a clean input. Measured before:
+//
+//	Checks=["BOGUS_CHECK"] -> 0 findings, err=nil
+//	Checks=["ADDRESS"]     -> 0 findings, err=nil   (real id: PHYSICAL_ADDRESS)
+//	Checks=["ssn"]         -> 0 findings, err=nil   (case-sensitive)
+//	Checks=["ALL"]         -> 0 findings, err=nil   (only lowercase "all" was the sentinel)
+//	Checks=[" all"]        -> 0 findings, err=nil   (what strings.Split leaves behind)
+//	Checks=["all","SSN"]   -> 1 finding             (sentinel needs a 1-element list)
+//
+// pkg/redact already fails closed on the same mistake ("redact: no validators
+// enabled"), so this brings the sibling package into line rather than inventing a
+// policy.
+
+const validationBody = "Employee SSN: 452-11-9384\nCard: 4111 1111 1111 1111\n"
+
+func TestUnknownCheckIsAnError(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		check []string
+		why   string
+	}{
+		{"bogus", []string{"BOGUS_CHECK"}, "a name no validator answers to"},
+		{"plausible ADDRESS", []string{"ADDRESS"}, "the real id is PHYSICAL_ADDRESS"},
+		{"plausible CARD", []string{"CARD"}, "the real id is CREDIT_CARD"},
+		{"plausible NAME", []string{"NAME"}, "the real id is PERSON_NAME"},
+		{"one bad in a list", []string{"SSN", "BOGUS"}, "half a list silently dropped is worse than an error"},
+		{"all mixed with names", []string{"all", "SSN"}, "the sentinel used to select only the OTHER names"},
+		{"ALL mixed with names", []string{"ALL", "ssn"}, "same, in the case that previously selected nothing"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r, err := ScanText(context.Background(), validationBody, TextOptions{Checks: tc.check})
+			if err == nil {
+				got := 0
+				if r != nil {
+					got = len(r.Findings)
+				}
+				t.Errorf("ScanText(Checks=%v) returned nil error and %d findings.\n%s\n"+
+					"Silently running zero validators reports the input CLEAN.",
+					tc.check, got, tc.why)
+			}
+		})
+	}
+}
+
+// TestEveryCheckSpellingThatShouldWorkDoes is the recall half, and it matters more.
+//
+// A validation gate that rejects a legitimate name is worse than the fail-open it
+// replaces: it stops a scan that would have found something.
+func TestEveryCheckSpellingThatShouldWorkDoes(t *testing.T) {
+	// The sentinel, in every shape a caller plausibly produces.
+	for _, tc := range [][]string{
+		nil,
+		{},
+		{"all"},
+		{"ALL"},
+		{" all"},
+		{"all "},
+		{""},
+		{" "},
+	} {
+		r, err := ScanText(context.Background(), validationBody, TextOptions{Checks: tc})
+		if err != nil {
+			t.Errorf("ScanText(Checks=%#v) errored: %v — all of these mean \"every validator\"", tc, err)
+			continue
+		}
+		if len(r.Findings) < 2 {
+			t.Errorf("ScanText(Checks=%#v) found %d findings, want the same as nil (>=2). "+
+				"This spelling silently selected nothing.", tc, len(r.Findings))
+		}
+	}
+
+	// Every canonical name, in both cases.
+	names := CheckNames()
+	if len(names) == 0 {
+		t.Fatal("CheckNames() is empty; this test would pass vacuously")
+	}
+	for _, n := range names {
+		for _, spelling := range []string{n, strings.ToLower(n)} {
+			if _, err := ScanText(context.Background(), validationBody,
+				TextOptions{Checks: []string{spelling}}); err != nil {
+				t.Errorf("ScanText(Checks=[%q]) rejected a name CheckNames() publishes: %v", spelling, err)
+			}
+		}
+	}
+
+	// And the whole published list at once.
+	if _, err := ScanText(context.Background(), validationBody, TextOptions{Checks: names}); err != nil {
+		t.Errorf("the full CheckNames() list was rejected: %v", err)
+	}
+}
+
+// TestLowercaseCheckActuallySelectsTheValidator — normalizing must not be cosmetic.
+//
+// Accepting "ssn" without upper-casing it would pass the error-path test above while
+// still selecting nothing, so assert the finding comes back.
+func TestLowercaseCheckActuallySelectsTheValidator(t *testing.T) {
+	upper, err := ScanText(context.Background(), validationBody, TextOptions{Checks: []string{"SSN"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lower, err := ScanText(context.Background(), validationBody, TextOptions{Checks: []string{"ssn"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(upper.Findings) == 0 {
+		t.Fatal(`Checks=["SSN"] found nothing; the fixture is broken`)
+	}
+	if len(lower.Findings) != len(upper.Findings) {
+		t.Errorf(`Checks=["ssn"] found %d findings but ["SSN"] found %d: the name was accepted `+
+			`but not canonicalized, so it still selects nothing`, len(lower.Findings), len(upper.Findings))
+	}
+}
+
+// TestRedactFileRejectsUnknownCheckBeforeWriting is THE SINK, and the reason this is
+// a leak rather than a nuisance.
+//
+// Measured before this change, with Checks=["BOGUS_CHECK"]:
+//
+//	err                            = nil
+//	RedactionCount                 = 0
+//	output byte-identical to input = true
+//	cleartext SSN in output file   = TRUE
+//
+// The API's own doc comment describes that path as the redacted copy. A caller has
+// nothing to branch on — RedactionCount 0 is also what a genuinely clean input
+// produces — so they would hand the file on believing it was scrubbed.
+func TestRedactFileRejectsUnknownCheckBeforeWriting(t *testing.T) {
+	dir := t.TempDir()
+	in := filepath.Join(dir, "in.txt")
+	if err := os.WriteFile(in, []byte(validationBody), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	outDir := filepath.Join(dir, "redacted")
+
+	res, err := RedactFile(in, RedactFileOptions{OutputDir: outDir, Checks: []string{"BOGUS_CHECK"}})
+	if err == nil {
+		count := -1
+		if res != nil {
+			count = res.RedactionCount
+		}
+		t.Errorf("RedactFile(Checks=[BOGUS_CHECK]) returned nil error (RedactionCount=%d). "+
+			"It previously wrote an output file byte-identical to the input, with the SSN "+
+			"in cleartext, in a path the API calls the redacted copy.", count)
+	}
+
+	// Nothing may be written on the rejected path: a file that exists and is
+	// unredacted is worse than no file, because the caller can ship it.
+	var written []string
+	_ = filepath.Walk(outDir, func(p string, fi os.FileInfo, walkErr error) error {
+		if walkErr == nil && fi != nil && !fi.IsDir() {
+			written = append(written, p)
+		}
+		return nil
+	})
+	for _, p := range written {
+		b, readErr := os.ReadFile(p)
+		if readErr != nil {
+			continue
+		}
+		if strings.Contains(string(b), "452-11-9384") {
+			t.Errorf("a file was written at %s containing the cleartext SSN despite the "+
+				"rejected check name", p)
+		}
+	}
+	if len(written) > 0 {
+		t.Errorf("RedactFile wrote %d file(s) on the error path: %v", len(written), written)
+	}
+}
+
+// TestRedactFileStillWorksWithAValidCheck — the fix must not break redaction.
+func TestRedactFileStillWorksWithAValidCheck(t *testing.T) {
+	dir := t.TempDir()
+	in := filepath.Join(dir, "in.txt")
+	if err := os.WriteFile(in, []byte(validationBody), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	outDir := filepath.Join(dir, "redacted")
+
+	for _, checks := range [][]string{nil, {"SSN"}, {"ssn"}, {"all"}} {
+		res, err := RedactFile(in, RedactFileOptions{OutputDir: outDir, Checks: checks})
+		if err != nil {
+			t.Errorf("RedactFile(Checks=%#v) errored: %v", checks, err)
+			continue
+		}
+		if res == nil || res.RedactionCount == 0 {
+			t.Errorf("RedactFile(Checks=%#v) reported no redactions on content holding an SSN", checks)
+			continue
+		}
+		var sawRedacted, sawCleartext bool
+		_ = filepath.Walk(outDir, func(p string, fi os.FileInfo, walkErr error) error {
+			if walkErr != nil || fi == nil || fi.IsDir() {
+				return nil
+			}
+			b, readErr := os.ReadFile(p)
+			if readErr != nil {
+				return nil
+			}
+			if strings.Contains(string(b), "452-11-9384") {
+				sawCleartext = true
+			}
+			if strings.Contains(string(b), "*") {
+				sawRedacted = true
+			}
+			return nil
+		})
+		if sawCleartext {
+			t.Errorf("Checks=%#v: the redacted output still contains the cleartext SSN", checks)
+		}
+		if !sawRedacted {
+			t.Errorf("Checks=%#v: no redaction token found in the output", checks)
+		}
+	}
+}

--- a/pkg/scan/redactfile.go
+++ b/pkg/scan/redactfile.go
@@ -57,11 +57,18 @@ func RedactFile(path string, opts RedactFileOptions) (*RedactFileResult, error) 
 		strategy = "synthetic"
 	}
 
+	// Reject an unknown check BEFORE any output file is created. Failing after the
+	// write would leave a file the API calls a redacted copy holding cleartext.
+	checks, err := normalizeChecks(opts.Checks)
+	if err != nil {
+		return nil, err
+	}
+
 	result, err := core.RedactFile(core.RedactConfig{
 		FilePath:  path,
 		OutputDir: opts.OutputDir,
 		Strategy:  strategy,
-		Checks:    normalizeChecks(opts.Checks),
+		Checks:    checks,
 		Config:    config.LoadConfigOrDefault(""),
 		LogWriter: logWriter,
 	})

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/awslabs/ferret-scan/v2/internal/config"
 	"github.com/awslabs/ferret-scan/v2/internal/core"
@@ -154,9 +155,14 @@ func ScanText(_ context.Context, text string, opts TextOptions) (*Result, error)
 		logWriter = io.Discard
 	}
 
+	checks, err := normalizeChecks(opts.Checks)
+	if err != nil {
+		return nil, err
+	}
+
 	coreResult, err := core.ScanContent(text, core.ContentScanConfig{
 		VirtualPath: label,
-		Checks:      normalizeChecks(opts.Checks),
+		Checks:      checks,
 		Explain:     opts.Explain,
 		Config:      config.LoadConfigOrDefault(""),
 		LogWriter:   logWriter,
@@ -187,9 +193,14 @@ func ScanFile(_ context.Context, path string, opts FileOptions) (*Result, error)
 		logWriter = io.Discard
 	}
 
+	checks, err := normalizeChecks(opts.Checks)
+	if err != nil {
+		return nil, err
+	}
+
 	coreResult, err := core.ScanFile(core.ScanConfig{
 		FilePath:            path,
-		Checks:              normalizeChecks(opts.Checks),
+		Checks:              checks,
 		EnablePreprocessors: true,
 		Explain:             opts.Explain,
 		Config:              config.LoadConfigOrDefault(""),
@@ -243,9 +254,73 @@ func mapResult(r *core.ScanResult) *Result {
 	}
 }
 
-func normalizeChecks(checks []string) []string {
-	if len(checks) == 0 {
-		return []string{"all"}
+// normalizeChecks canonicalizes the caller's Checks and rejects a name no
+// validator answers to.
+//
+// It used to pass the slice through untouched, and core.ParseChecksToRun's loop has
+// no else branch — an unrecognized name is discarded silently. So a caller who
+// misspelled one got ZERO validators, a nil error, and an empty finding list
+// indistinguishable from a clean input. Measured before this change:
+//
+//	Checks=[]              -> 2 findings   (correct)
+//	Checks=["SSN"]         -> 1 finding    (correct)
+//	Checks=["BOGUS_CHECK"] -> 0 findings, err=nil
+//	Checks=["ADDRESS"]     -> 0 findings, err=nil   (the real id is PHYSICAL_ADDRESS)
+//	Checks=["ssn"]         -> 0 findings, err=nil   (case-sensitive)
+//	Checks=["ALL"]         -> 0 findings, err=nil   (only lowercase "all" was the sentinel)
+//	Checks=[" all"]        -> 0 findings, err=nil   (what strings.Split leaves behind)
+//	Checks=["all","SSN"]   -> 1 finding             (the sentinel needs a 1-element list)
+//
+// RedactFile is where that became a leak rather than a nuisance. With
+// Checks=["BOGUS_CHECK"] it returned err=nil and RedactionCount=0, and wrote an
+// output file BYTE-IDENTICAL to the input — the SSN sitting in it in cleartext, in a
+// file the API's own doc comment describes as the redacted copy. A caller has nothing
+// to branch on: RedactionCount 0 is also what a genuinely clean input produces.
+//
+// pkg/redact already fails closed on the same mistake, returning
+// "redact: no validators enabled (Checks=%v)" (engine.go). This brings pkg/scan into
+// line with its sibling rather than inventing a policy.
+//
+// A nil/empty slice still means "every validator", which is the documented contract.
+func normalizeChecks(checks []string) ([]string, error) {
+	// Trim and drop empties first, so [" "] and [""] behave like [].
+	cleaned := make([]string, 0, len(checks))
+	for _, c := range checks {
+		if t := strings.TrimSpace(c); t != "" {
+			cleaned = append(cleaned, t)
+		}
 	}
-	return checks
+	if len(cleaned) == 0 {
+		return []string{"all"}, nil
+	}
+
+	// The "all" sentinel, case-insensitively and whitespace-tolerantly. core's
+	// sentinel requires a lowercase single-element list, so "ALL" and " all"
+	// previously selected nothing at all.
+	if len(cleaned) == 1 && strings.EqualFold(cleaned[0], "all") {
+		return []string{"all"}, nil
+	}
+
+	valid := make(map[string]bool, len(core.CheckNames()))
+	for _, n := range core.CheckNames() {
+		valid[n] = true
+	}
+
+	out := make([]string, 0, len(cleaned))
+	for _, c := range cleaned {
+		name := strings.ToUpper(c)
+		// "all" mixed with other names is rejected rather than silently resolving
+		// to one of the two readings. core's sentinel would have selected only the
+		// OTHER names, which is the opposite of what the word means.
+		if name == "ALL" {
+			return nil, fmt.Errorf("scan: %q cannot be combined with other check names; "+
+				"pass nil or []string{\"all\"} alone for every validator", c)
+		}
+		if !valid[name] {
+			return nil, fmt.Errorf("scan: unknown check %q; valid checks are %s",
+				c, strings.Join(core.CheckNames(), ", "))
+		}
+		out = append(out, name)
+	}
+	return out, nil
 }


### PR DESCRIPTION
Follows #295, which recorded these measurements while fixing the CLI half. This is the library half.

## The bug

`normalizeChecks` passed the caller's `Checks` through untouched, and `core.ParseChecksToRun`'s loop has **no else branch** — an unrecognized name is discarded silently. Measured on `main`:

```
Checks=[]              -> 2 findings   (correct)
Checks=["SSN"]         -> 1 finding    (correct)
Checks=["BOGUS_CHECK"] -> 0 findings, err=nil
Checks=["ADDRESS"]     -> 0 findings, err=nil   (real id: PHYSICAL_ADDRESS)
Checks=["ssn"]         -> 0 findings, err=nil   (case-sensitive)
Checks=["ALL"]         -> 0 findings, err=nil   (only lowercase "all" was the sentinel)
Checks=[" all"]        -> 0 findings, err=nil   (what strings.Split leaves behind)
Checks=["all","SSN"]   -> 1 finding             (sentinel needs a 1-element list)
```

## Why it's a leak, not a nuisance

`RedactFile` with `Checks=["BOGUS_CHECK"]`, measured by **reading the written file**:

```
err                            = nil
RedactionCount                 = 0
output byte-identical to input = true
cleartext SSN in output file   = TRUE
```

The API's own doc comment describes that path as the redacted copy. The caller has nothing to branch on — `RedactionCount` 0 is also what a genuinely clean input produces — so they hand the file on believing it was scrubbed.

The `[" all"]` row is the one that would actually bite: a caller doing `strings.Split(userInput, ",")` on `"all, SSN"` gets a leading space, and the documented sentinel then selects **nothing**.

## The fix

`normalizeChecks` now trims, drops empties, treats `all` case-insensitively, upper-cases canonical names, and returns an error for an unknown name or for `all` combined with other names. Validation runs **before** `core.RedactFile`, so the error path writes **no file** — an unredacted file that exists is worse than no file, because the caller can ship it.

**Not a new policy.** `pkg/redact` already fails closed on the same mistake (`engine.go:105`, `"redact: no validators enabled (Checks=%v)"`). `pkg/scan` was the sibling that didn't — and it's the package consumers are being pointed at: #285 exists so the mobile facade can import it as a normal module rather than compiling inside a checkout of this repo.

## The recall half is tested deliberately

A gate that rejects a **legitimate** name is worse than the fail-open it replaces — it stops a scan that would have found something. `TestEveryCheckSpellingThatShouldWorkDoes` covers `nil`, `{}`, `{""}`, `{" "}`, `{"all"}`, `{"ALL"}`, `{" all"}`, `{"all "}`, every published name in both cases, and the whole `CheckNames()` list at once.

`TestLowercaseCheckActuallySelectsTheValidator` asserts that accepting `"ssn"` also **finds** the SSN — so a cosmetic normalize that accepts the name without canonicalizing it cannot pass.

## Breaking change

For a caller currently passing an unrecognized name and silently getting nothing. **That caller is already broken and has no way to notice**; an error is how they find out.

## Non-vacuity

Four mutations, each verified to **compile** first:

| mutation | caught |
|---|---|
| `normalizeChecks` reverted to pass-through | ✓ |
| unknown names skipped instead of erroring | ✓ |
| `RedactFile` ignores the validation error | ✓ |
| `all` sentinel case-sensitive again | ✓ |

My first attempt at the revert mutation **did not compile** (unused import) and therefore proved nothing — it was redone.

## Test plan

- **1** build / vet / gofmt clean
- **2** full suite `rc=0`, **65 packages**
- **3** golden **0 files moved**; **3b** score corpus unchanged
- **5** redaction, on the sink: valid checks still write a redaction token with **0** cleartext occurrences; the rejected path writes **no file**
- 4, 6–13 — N/A: no loop, offset, suppression-hash, format, web or concurrency surface is touched

## Union-tested against the open PRs

Merged `main` + #298 + #299 + this branch:

```
conflicts:            0
union build:          exit 0
union suite:          rc=0, 65 packages
goldens moved:        0
file vs stdin parity: 5/5 inputs agree (rc identical)
pkg/scan rejection:   still enforced
```

File-disjointness alone would not have been evidence — a rename in one PR plus the old name in another gives 0 conflicts and a build failure, so the union was built and run.