### PR TITLE
fix(preprocessors): disclose a PDF whose text could not be extracted

### DIFF
--- a/cmd/checks_parity_test.go
+++ b/cmd/checks_parity_test.go
@@ -1,0 +1,174 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/core"
+)
+
+// --checks must mean the same thing whatever the input source.
+//
+// It did not. File mode ran the value through parseChecksToRun, which upper-cased it
+// and exited 1 on an unrecognized name. Stdin mode ran it through parseChecksList,
+// which did neither and handed the raw strings to core.ParseChecksToRun — whose loop
+// has no else branch, so an unknown name is discarded with no error and no warning.
+// Measured on the same fixture and the same binary:
+//
+//	--checks ssn --file fx.txt   -> 1 finding      --stdin -> 0 findings, rc 0, silent
+//	--checks BOGUS --file fx.txt -> rc 1           --stdin -> 0 findings, rc 0, silent
+//	--checks ALL --file fx.txt   -> rc 1           --stdin -> 0 findings, rc 0, silent
+//
+// Running zero validators and reporting clean is the worst outcome a scanner has. The
+// documented streaming gateway made it worse still: with --stdin --enable-redaction,
+// a typo'd check name echoed the input back BYTE-IDENTICAL at rc 0, so a pipeline
+// built on that pattern passed cleartext through while appearing to redact.
+//
+// Both paths now share normalizeChecksArg. These tests exist because a shared helper
+// is only a convention until something asserts the two callers still agree.
+
+// checksCases is the table both parsers must agree on.
+var checksCases = []struct {
+	arg      string
+	wantErr  bool
+	wantAll  bool     // nil result: every validator
+	wantList []string // canonical names, when not wantAll and not wantErr
+	why      string
+}{
+	{arg: "", wantAll: true, why: "no flag means every check"},
+	{arg: "all", wantAll: true, why: "the documented sentinel"},
+	{arg: "ALL", wantAll: true, why: "the sentinel is case-insensitive; uppercase used to select NOTHING"},
+	{arg: "  all  ", wantAll: true, why: "surrounding whitespace must not defeat the sentinel"},
+	{arg: "SSN", wantList: []string{"SSN"}, why: "canonical name"},
+	{arg: "ssn", wantList: []string{"SSN"}, why: "lowercase is accepted and upper-cased, as file mode always did"},
+	{arg: " ssn , email ", wantList: []string{"SSN", "EMAIL"}, why: "whitespace around names is trimmed"},
+	{arg: "SSN,SSN", wantList: []string{"SSN", "SSN"}, why: "a repeat is harmless: the result seeds a presence map"},
+
+	{arg: "BOGUS_CHECK", wantErr: true, why: "an unknown name must never mean 'scan nothing'"},
+	{arg: "ADDRESS", wantErr: true, why: "plausible-but-wrong: the real id is PHYSICAL_ADDRESS"},
+	{arg: "CARD", wantErr: true, why: "plausible-but-wrong: the real id is CREDIT_CARD"},
+	{arg: "NAME", wantErr: true, why: "plausible-but-wrong: the real id is PERSON_NAME"},
+	{arg: "SSN,BOGUS", wantErr: true, why: "one bad name in a list must fail the whole list, not silently drop half"},
+	{arg: "all,SSN", wantErr: true, why: "'all' mixed with names used to silently select only SSN"},
+	{arg: "ALL,ssn", wantErr: true, why: "same, in the case that previously selected nothing at all"},
+}
+
+func TestNormalizeChecksArg(t *testing.T) {
+	for _, tc := range checksCases {
+		t.Run(strings.ReplaceAll(tc.arg, " ", "_"), func(t *testing.T) {
+			got, err := normalizeChecksArg(tc.arg)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("normalizeChecksArg(%q) returned nil error and %v.\n%s\n"+
+						"Accepting this silently runs zero validators and reports clean.",
+						tc.arg, got, tc.why)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("normalizeChecksArg(%q) errored: %v\n%s", tc.arg, err, tc.why)
+			}
+			if tc.wantAll {
+				if got != nil {
+					t.Errorf("normalizeChecksArg(%q) = %v, want nil (every check).\n%s", tc.arg, got, tc.why)
+				}
+				return
+			}
+			if len(got) != len(tc.wantList) {
+				t.Fatalf("normalizeChecksArg(%q) = %v, want %v\n%s", tc.arg, got, tc.wantList, tc.why)
+			}
+			for i := range got {
+				if got[i] != tc.wantList[i] {
+					t.Errorf("normalizeChecksArg(%q)[%d] = %q, want %q\n%s",
+						tc.arg, i, got[i], tc.wantList[i], tc.why)
+				}
+			}
+		})
+	}
+}
+
+// TestFileAndStdinParsersAgree is the parity gate.
+//
+// parseChecksToRun (file mode) exits the process on a bad name, so it cannot be
+// called with invalid input from a test. What CAN be asserted is that both parsers
+// derive from the same function and produce the same SELECTION for every input that
+// is valid — which is the half a silent divergence would break.
+func TestFileAndStdinParsersAgree(t *testing.T) {
+	for _, tc := range checksCases {
+		if tc.wantErr {
+			// Both reject via the same normalizeChecksArg call; the error path is
+			// covered above. parseChecksToRun would os.Exit(1) here.
+			continue
+		}
+		t.Run(strings.ReplaceAll(tc.arg, " ", "_"), func(t *testing.T) {
+			fileSel := parseChecksToRun(tc.arg)
+
+			stdinList, err := parseChecksList(tc.arg)
+			if err != nil {
+				t.Fatalf("parseChecksList(%q) errored where file mode accepted: %v", tc.arg, err)
+			}
+
+			// Reduce the stdin list to the same shape as the file-mode map.
+			stdinSel := map[string]bool{}
+			for _, c := range core.CheckNames() {
+				stdinSel[c] = false
+			}
+			if stdinList == nil {
+				for c := range stdinSel {
+					stdinSel[c] = true
+				}
+			} else {
+				for _, c := range stdinList {
+					stdinSel[c] = true
+				}
+			}
+
+			for _, c := range core.CheckNames() {
+				if fileSel[c] != stdinSel[c] {
+					t.Errorf("--checks %q: check %s is %v in file mode but %v on stdin.\n"+
+						"The same flag must select the same validators whatever the input source.",
+						tc.arg, c, fileSel[c], stdinSel[c])
+				}
+			}
+		})
+	}
+}
+
+// TestEveryCanonicalNameIsAccepted — the recall half.
+//
+// A validation gate that rejects a legitimate name is worse than the fail-open it
+// replaced: it stops a scan that would have found something. Every name the engine
+// publishes must survive its own validator, in both cases.
+func TestEveryCanonicalNameIsAccepted(t *testing.T) {
+	names := core.CheckNames()
+	if len(names) == 0 {
+		t.Fatal("core.CheckNames() is empty; this test would pass vacuously")
+	}
+	for _, name := range names {
+		for _, spelling := range []string{name, strings.ToLower(name)} {
+			got, err := normalizeChecksArg(spelling)
+			if err != nil {
+				t.Errorf("normalizeChecksArg(%q) rejected a name core.CheckNames() publishes: %v",
+					spelling, err)
+				continue
+			}
+			if len(got) != 1 || got[0] != name {
+				t.Errorf("normalizeChecksArg(%q) = %v, want exactly [%s]", spelling, got, name)
+			}
+		}
+	}
+
+	// And the whole list at once, which is what a --checks line generated from
+	// CheckNames() looks like.
+	all, err := normalizeChecksArg(strings.Join(names, ","))
+	if err != nil {
+		t.Fatalf("the full published list was rejected: %v", err)
+	}
+	if len(all) != len(names) {
+		t.Errorf("full list round-tripped to %d names, want %d", len(all), len(names))
+	}
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2564,40 +2564,97 @@ func isFlagSet(name string) bool {
 	return found
 }
 
+// normalizeChecksArg turns the raw --checks value into the canonical check names,
+// or returns an error naming the first unrecognized one.
+//
+// This is the ONE place the flag's vocabulary is decided, because it previously had
+// two and they disagreed. File mode validated and upper-cased here; stdin mode used
+// cmd/stdin.go's parseChecksList, which did neither and handed the raw strings to
+// core.ParseChecksToRun — whose loop silently drops any name it does not recognise.
+// So the same flag, in the same binary, behaved differently by input source:
+//
+//	--checks ssn --file fx.txt   -> 1 finding   (upper-cased here)
+//	--checks ssn --stdin         -> 0 findings, rc 0, nothing on stderr
+//	--checks BOGUS --file fx.txt -> rc 1, "Unknown check type"
+//	--checks BOGUS --stdin       -> 0 findings, rc 0, silent
+//
+// Silently running zero validators is the worst available outcome for a scanner: it
+// reports clean. With --stdin --enable-redaction it also emitted the input back
+// BYTE-IDENTICAL at rc 0, so the documented streaming-gateway pattern passed
+// cleartext through while looking like it had redacted.
+//
+// Returning ([]string, error) rather than exiting keeps this usable from both call
+// sites — the CLI boundary decides how to report, and neither path can quietly skip
+// the check.
+//
+// A nil slice means "every check", which is what core.ParseChecksToRun treats an
+// empty list as.
+func normalizeChecksArg(checks string) ([]string, error) {
+	// Available checks come from the single source of truth (core.CheckNames,
+	// derived from validatorConstructors) so this list cannot drift from the
+	// validators that actually exist.
+	valid := make(map[string]bool, len(core.CheckNames()))
+	for _, c := range core.CheckNames() {
+		valid[c] = true
+	}
+
+	trimmed := strings.TrimSpace(checks)
+	if trimmed == "" {
+		return nil, nil
+	}
+	// The "all" sentinel, case-insensitively. core.ParseChecksToRun only honours a
+	// lowercase, single-element "all", so "ALL" reached it as an unknown name and
+	// selected NOTHING. Normalising here means the sentinel behaves the way every
+	// other check name does.
+	if strings.EqualFold(trimmed, "all") {
+		return nil, nil
+	}
+
+	var out []string
+	for _, check := range strings.Split(trimmed, ",") {
+		checkStr := strings.ToUpper(strings.TrimSpace(check))
+		if checkStr == "" {
+			continue
+		}
+		// "all" mixed with other names is rejected rather than silently winning or
+		// silently losing. core.ParseChecksToRun's sentinel requires a single-element
+		// list, so "all,SSN" previously selected only SSN — a reasonable reader
+		// expects the opposite, and guessing either way is worse than saying so.
+		if checkStr == "ALL" {
+			return nil, fmt.Errorf("'all' cannot be combined with other check names (got %q)", checks)
+		}
+		if !valid[checkStr] {
+			return nil, fmt.Errorf("unknown check type '%s'\nAvailable checks: %s",
+				checkStr, strings.Join(core.CheckNames(), ", "))
+		}
+		out = append(out, checkStr)
+	}
+	return out, nil
+}
+
 // parseChecksToRun converts a comma-separated string of check names
 // into a map of enabled checks
 func parseChecksToRun(checks string) map[string]bool {
-	// Available checks come from the single source of truth (core.CheckNames,
-	// derived from validatorConstructors) so this list cannot drift from the
-	// validators that actually exist. Order is irrelevant here — it only seeds
-	// a presence map. The validate-and-exit-on-unknown semantics below are
-	// intentionally kept (distinct from core.ParseChecksToRun's fail-open).
-	availableChecks := core.CheckNames()
-
 	result := make(map[string]bool)
-	for _, check := range availableChecks {
+	for _, check := range core.CheckNames() {
 		result[check] = false
 	}
 
-	if checks == "all" {
+	selected, err := normalizeChecksArg(checks)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	// nil means "every check".
+	if selected == nil {
 		for key := range result {
 			result[key] = true
 		}
 		return result
 	}
-
-	// Parse comma-separated list of checks
-	for _, check := range strings.Split(checks, ",") {
-		checkStr := strings.ToUpper(strings.TrimSpace(check))
-		if _, exists := result[checkStr]; exists {
-			result[checkStr] = true
-		} else if checkStr != "" {
-			fmt.Fprintf(os.Stderr, "Error: Unknown check type '%s'\n", checkStr)
-			fmt.Fprintf(os.Stderr, "Available checks: %s\n", strings.Join(core.CheckNames(), ", "))
-			os.Exit(1)
-		}
+	for _, c := range selected {
+		result[c] = true
 	}
-
 	return result
 }
 

--- a/cmd/stdin.go
+++ b/cmd/stdin.go
@@ -171,7 +171,15 @@ func runStdinScan(in stdinScanInputs) int {
 	suppressionManager := suppressions.NewSuppressionManager(finalCfg.suppressionFile)
 
 	// Parse checks list into a []string for ScanContent.
-	checks := parseChecksList(finalCfg.checksToRun)
+	//
+	// An unrecognized name is a hard error, matching file mode. Failing open here
+	// meant running ZERO validators and reporting clean — and under
+	// --enable-redaction, streaming the input back byte-identical at rc 0.
+	checks, err := parseChecksList(finalCfg.checksToRun)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
 
 	scanCfg := core.ContentScanConfig{
 		VirtualPath:        in.stdinName,
@@ -577,18 +585,15 @@ func writeStdinOutput(outputFile, formatted string, precommitConfig *precommit.P
 }
 
 // parseChecksList turns "all" or "CHECK1,CHECK2" into a slice for ScanContent.
-func parseChecksList(checks string) []string {
-	if checks == "" || checks == "all" {
-		return nil // empty means "all" in core.ParseChecksToRun
-	}
-	parts := strings.Split(checks, ",")
-	out := make([]string, 0, len(parts))
-	for _, p := range parts {
-		if t := strings.TrimSpace(p); t != "" {
-			out = append(out, t)
-		}
-	}
-	return out
+//
+// Delegates to normalizeChecksArg so stdin mode and file mode share one vocabulary.
+// This function used to do its own thing: no upper-casing and no validation, handing
+// the raw strings to core.ParseChecksToRun, whose loop silently discards any name it
+// does not recognise. The result was that "--checks ssn" found an SSN via --file and
+// nothing via --stdin, and "--checks BOGUS" reported clean at rc 0 instead of the
+// rc 1 file mode gives. See normalizeChecksArg for the measurements.
+func parseChecksList(checks string) ([]string, error) {
+	return normalizeChecksArg(checks)
 }
 
 // highestConfidenceLevel returns "high"/"medium"/"low"/"" for use with

--- a/internal/preprocessors/base_metadata_preprocessor.go
+++ b/internal/preprocessors/base_metadata_preprocessor.go
@@ -207,13 +207,29 @@ func (bmp *BaseMetadataPreprocessor) ProcessEmbeddedMedia(originalFilePath strin
 		// Create context showing original file relationship
 		embeddedPath := bmp.utilities.RouterHelper.CreateEmbeddedMediaPath(originalFilePath, media.OriginalName)
 
-		// Reprocess embedded media through router
-		// The router tracks nesting depth itself, keyed on the temp path it handed
-		// out for this embedded item -- see FileRouter.noteEmbeddedChild. The
-		// preprocessor cannot construct a router ProcessingContext (router imports
-		// preprocessors, so the reverse would be an import cycle) and its Process
-		// method takes no context to thread one through, so depth is owned on the
-		// router side rather than plumbed through every preprocessor signature.
+		// Reprocess embedded media through the router.
+		//
+		// NOTHING BOUNDS THE NESTING DEPTH HERE. This comment used to claim the
+		// router tracked depth "keyed on the temp path it handed out, see
+		// FileRouter.noteEmbeddedChild". No such method exists, and no
+		// nesting-depth tracking exists anywhere in internal/router or
+		// internal/preprocessors — the only guards are the size caps
+		// MaxFileSize (100MB) and MaxEmbeddedMediaSize (50MB), and a
+		// deep-nesting bomb is small on disk.
+		//
+		// That mattered because this call site is exactly where someone would look
+		// before admitting embedded OOXML documents in
+		// meta-extract-officelib.embeddedMediaType, which is currently the other
+		// half of the nesting leak (an embedded .docx is never scanned; see #297).
+		// A reader who trusted the old comment would have concluded a bound was
+		// already in place and shipped unbounded recursion.
+		//
+		// Recursion is bounded TODAY only because the admitted types are leaves:
+		// images and audio route to extractors that follow nothing, and the legacy
+		// .doc/.xls/.ppt extractor reads OLE streams directly without following
+		// embeddings. Admitting .docx/.xlsx/.pptx routes back into this same
+		// function, so it requires a real depth cap first — and a cap must DISCLOSE
+		// when it truncates, or it replaces a silent miss with a different one.
 		if processed, err := bmp.router.ProcessFile(media.TempFilePath, nil); err == nil && processed != nil && processed.Success {
 			// Update processed content to show original file relationship
 			processed.OriginalPath = embeddedPath

--- a/internal/preprocessors/meta-extractors/meta-extract-officelib/office-extractor.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-officelib/office-extractor.go
@@ -737,14 +737,25 @@ func embeddedMediaType(ext string) string {
 		// detection gap for a decompression-bomb amplifier, which is a worse
 		// trade for a tool that runs on untrusted input.
 		//
-		// The bound cannot be added here cheaply: depth cannot live on the
-		// preprocessor (one instance is shared across concurrent workers), cannot
-		// travel in a router ProcessingContext (router imports preprocessors, so
-		// the reverse is an import cycle), and cannot live on the router (one
-		// instance, shared). It needs a context parameter on the preprocessor
-		// Process interface, which is a change of its own size. Tracked
-		// separately; this comment is the reason the case is missing, so nobody
-		// "fixes" it by adding the extension.
+		// A bound is needed FIRST, and note that none exists today: the claim
+		// that the router already tracks depth (formerly in
+		// BaseMetadataPreprocessor.processEmbeddedMedia, citing a
+		// FileRouter.noteEmbeddedChild that was never written) was false. The only
+		// guards are the size caps above, and a deep-nesting bomb is small on disk.
+		//
+		// Depth cannot live on the preprocessor (one instance is shared across
+		// concurrent workers) nor on the router (also one instance), and the
+		// concrete router ProcessingContext type is unreachable from here (router
+		// imports preprocessors, so the reverse is an import cycle). What IS
+		// reachable: RouterInterface has exactly one real implementor, so a
+		// depth-carrying entry point beside ProcessFile is additive rather than a
+		// signature change across every preprocessor.
+		//
+		// Tracked in #297, which carries the measured repro and that design. This
+		// comment is the reason the case is missing, so nobody "fixes" it by adding
+		// the extension: doing that without the cap trades a detection gap for a
+		// decompression-bomb amplifier, which is the worse trade for a tool that
+		// runs on untrusted input.
 		return ""
 	}
 }

--- a/internal/preprocessors/pdf_extraction_warning_test.go
+++ b/internal/preprocessors/pdf_extraction_warning_test.go
@@ -1,0 +1,229 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package preprocessors
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A PDF whose text could not be extracted must SAY so.
+//
+// The Error alone never reaches the operator. pdf_metadata runs on the same file and
+// succeeds even when the bytes are not a PDF at all, so FileRouter's combine step sees
+// one successful preprocessor, stamps Success: true, and discards the text extractor's
+// error. Only ExtractionWarning survives that step — it is gathered regardless of
+// pResult.err, precisely for this shape.
+//
+// Measured before this change, on a valid PDF truncated at its xref while still
+// holding a recoverable SSN in a FlateDecode stream:
+//
+//	valid.pdf     -> 1 finding
+//	truncated.pdf -> 0 findings, exit 0, 0 bytes of stderr, exit 0 under
+//	                 --fail-on-incomplete
+//
+// The same corruption in a .docx printed "NOT FULLY EXAMINED ... cannot parse" and
+// exited 3, because the Office branch already carried its extractor's note across the
+// error return. See #294.
+
+// TestProcessPDFSetsExtractionWarningOnFailure is the core contract.
+func TestProcessPDFSetsExtractionWarningOnFailure(t *testing.T) {
+	tp := NewTextPreprocessor()
+
+	for _, tc := range []struct {
+		name string
+		body []byte
+	}{
+		{"not a pdf at all", []byte("this is plain text, not a PDF\n")},
+		{"pdf header then garbage", append([]byte("%PDF-1.4\n"), []byte("\x00\x01\x02 not a real pdf")...)},
+		{"empty file", []byte{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "doc.pdf")
+			if err := os.WriteFile(path, tc.body, 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			content := &ProcessedContent{OriginalPath: path, Filename: "doc.pdf"}
+			got, err := tp.processPDF(path, content)
+			if err == nil && strings.TrimSpace(got.Text) != "" {
+				t.Skipf("this fixture extracted text (%d bytes); it does not exercise the failure path",
+					len(got.Text))
+			}
+
+			if got.ExtractionWarning == "" {
+				t.Errorf("processPDF produced no ExtractionWarning (err=%v).\n"+
+					"Without it, pdf_metadata's success makes the router stamp the file "+
+					"Success: true and the operator is told nothing — the file reads as "+
+					"scanned and clean.", err)
+			}
+			if !strings.Contains(got.ExtractionWarning, "NOT scanned") {
+				t.Errorf("ExtractionWarning = %q; it must state the consequence, so a reader "+
+					"who sees only this line knows content was missed", got.ExtractionWarning)
+			}
+		})
+	}
+}
+
+// TestProcessPDFWarnsWhenItParsesButYieldsNoText covers the other half of the silence.
+//
+// A PDF that parses to zero text is indistinguishable from a genuinely empty document.
+// A scanned-image PDF with no text layer lands here too, and the operator needs to
+// know the pages were not read rather than assume they were clean.
+func TestProcessPDFWarnsWhenItParsesButYieldsNoText(t *testing.T) {
+	// A STRUCTURALLY VALID PDF -- proper xref AND startxref -- with a page whose
+	// content stream is empty. Both matter: my first fixture omitted startxref, so
+	// the extractor returned "missing final startxref" and the ERROR branch set the
+	// warning. The test passed for the wrong reason, and a mutation deleting this
+	// branch entirely still passed. Verified reachable: err=nil, textLen=0.
+	path := filepath.Join(t.TempDir(), "notext.pdf")
+	if err := os.WriteFile(path, []byte(validPDFNoText()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	content := &ProcessedContent{OriginalPath: path, Filename: "notext.pdf"}
+	got, err := tpForTest().processPDF(path, content)
+
+	// Assert the fixture really exercises this path rather than skipping, so the
+	// test cannot go quietly vacuous again.
+	if err != nil {
+		t.Fatalf("fixture errored (%v); it must PARSE so the no-text branch is the one "+
+			"under test, not the error branch", err)
+	}
+	if strings.TrimSpace(got.Text) != "" {
+		t.Fatalf("fixture yielded text (%q); it must yield none", got.Text)
+	}
+
+	if got.ExtractionWarning == "" {
+		t.Error("a PDF that parsed to ZERO text produced no ExtractionWarning, so it is " +
+			"indistinguishable from a genuinely empty document. A scanned-image PDF with " +
+			"no text layer lands here too.")
+	}
+	if strings.Contains(got.ExtractionWarning, "startxref") {
+		t.Errorf("warning %q came from the error path; the no-text branch is not being tested",
+			got.ExtractionWarning)
+	}
+}
+
+// validPDFNoText builds a structurally valid PDF with a page and an empty content
+// stream, so extraction SUCCEEDS and returns no text.
+func validPDFNoText() string {
+	objs := []string{
+		"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n",
+		"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n",
+		"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R >>\nendobj\n",
+		"4 0 obj\n<< /Length 0 >>\nstream\n\nendstream\nendobj\n",
+	}
+	return assemblePDF(objs)
+}
+
+// TestPDFWarningIsPayloadFree — the string reaches stderr, the text summary and every
+// machine format, so it must never carry document content.
+func TestPDFWarningIsPayloadFree(t *testing.T) {
+	const secret = "536-90-4271"
+	warning := pdfExtractionWarning("/tmp/x/report.pdf",
+		errors.New("malformed xref near "+secret))
+
+	// The extractor's own diagnostics are passed through, so a caller could in
+	// principle embed content in an error. Assert the shape we control: the helper
+	// adds no content of its own, and names only the extension.
+	if !strings.Contains(warning, ".pdf") {
+		t.Errorf("warning %q does not name the extension", warning)
+	}
+	if strings.Contains(warning, "/tmp/x/report.pdf") {
+		t.Errorf("warning %q embeds the full path; the report already names the file, "+
+			"and repeating it is what made the old WARNING lines unreadable", warning)
+	}
+	if !strings.Contains(warning, "NOT scanned") {
+		t.Errorf("warning %q must state the consequence", warning)
+	}
+
+	// A nil error must not panic or produce an empty note.
+	if got := pdfExtractionWarning("/tmp/a.pdf", nil); got == "" || !strings.Contains(got, "NOT scanned") {
+		t.Errorf("pdfExtractionWarning with a nil error = %q, want a usable note", got)
+	}
+}
+
+// TestValidPDFGetsNoWarning — the fix must not cry wolf.
+//
+// A warning on every PDF would be worse than none: an operator learns to ignore it,
+// and the signal that matters disappears into noise.
+func TestValidPDFGetsNoWarning(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ok.pdf")
+	if err := os.WriteFile(path, []byte(validPDFWithText()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	content := &ProcessedContent{OriginalPath: path, Filename: "ok.pdf"}
+	got, err := tpForTest().processPDF(path, content)
+	if err != nil {
+		t.Skipf("fixture did not extract (%v); cannot assert the clean path here", err)
+	}
+	if strings.TrimSpace(got.Text) == "" {
+		t.Skip("fixture extracted no text; cannot assert the clean path here")
+	}
+	if got.ExtractionWarning != "" {
+		t.Errorf("a PDF that extracted %d bytes of text carries a warning: %q",
+			len(got.Text), got.ExtractionWarning)
+	}
+}
+
+func tpForTest() *TextPreprocessor { return NewTextPreprocessor() }
+
+// validPDFWithText builds a small PDF whose content stream holds readable text.
+func validPDFWithText() string {
+	const content = "BT /F1 12 Tf 72 700 Td (Employee SSN: 536-90-4271) Tj ET\n"
+	return assemblePDF([]string{
+		"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n",
+		"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n",
+		"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R " +
+			"/Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n",
+		"4 0 obj\n<< /Length " + itoa(len(content)) + " >>\nstream\n" + content + "endstream\nendobj\n",
+		"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n",
+	})
+}
+
+// assemblePDF writes objects with a correct xref table AND startxref offset. Both are
+// required: without startxref the extractor errors instead of parsing, which silently
+// redirects a no-text test onto the error path.
+func assemblePDF(objs []string) string {
+	var sb strings.Builder
+	sb.WriteString("%PDF-1.4\n")
+	offsets := make([]int, 0, len(objs))
+	for _, o := range objs {
+		offsets = append(offsets, sb.Len())
+		sb.WriteString(o)
+	}
+	xref := sb.Len()
+	sb.WriteString("xref\n0 " + itoa(len(objs)+1) + "\n0000000000 65535 f \n")
+	for _, off := range offsets {
+		sb.WriteString(pad10(off) + " 00000 n \n")
+	}
+	sb.WriteString("trailer\n<< /Size " + itoa(len(objs)+1) + " /Root 1 0 R >>\nstartxref\n" +
+		itoa(xref) + "\n%%EOF\n")
+	return sb.String()
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}
+
+func pad10(n int) string {
+	s := itoa(n)
+	for len(s) < 10 {
+		s = "0" + s
+	}
+	return s
+}

--- a/internal/preprocessors/text_preprocessor.go
+++ b/internal/preprocessors/text_preprocessor.go
@@ -122,10 +122,54 @@ func (tp *TextPreprocessor) Process(filePath string) (*ProcessedContent, error) 
 	return result, err
 }
 
+// pdfExtractionWarning turns a PDF text-extraction failure into a short,
+// payload-free note for the operator.
+//
+// Payload-free is a requirement, not a nicety: this string reaches stderr, the
+// text summary and the machine formats, so it must never carry a byte of document
+// content. The extractor's own error text is header/structure diagnostics
+// ("not a PDF file: invalid header", "malformed xref"), which is safe and is the
+// most actionable part, so it is passed through unmodified rather than replaced
+// with prose that might describe a failure that did not happen.
+//
+// The wording leads with the consequence, matching the Office extractor's
+// noteEmptyExtraction, so an operator comparing a PDF and a DOCX failure from the
+// same run reads the same sentence shape.
+func pdfExtractionWarning(filePath string, err error) string {
+	detail := "unknown error"
+	if err != nil {
+		detail = err.Error()
+	}
+	return fmt.Sprintf(
+		"no text extracted from %s: %s, so document content was NOT scanned",
+		filepath.Ext(filePath), detail)
+}
+
 // processPDF extracts text from PDF documents
 func (tp *TextPreprocessor) processPDF(filePath string, content *ProcessedContent) (*ProcessedContent, error) {
 	pdfContent, err := textextractpdftextlib.ExtractText(filePath)
 	if err != nil {
+		// Record the failure as an ExtractionWarning, not only as an Error.
+		//
+		// The Error alone does not reach the operator. pdf_metadata runs on the same
+		// file and SUCCEEDS even when the bytes are not a PDF at all, so
+		// FileRouter's combine step sees one successful preprocessor, stamps
+		// Success: true, and discards this error. Only ExtractionWarning survives
+		// that step (it is gathered regardless of pResult.err, precisely for this
+		// shape).
+		//
+		// Measured before this change, on a valid PDF truncated at its xref while
+		// still holding a recoverable SSN in a FlateDecode stream:
+		//
+		//	valid.pdf     -> 1 finding
+		//	truncated.pdf -> 0 findings, exit 0, 0 bytes of stderr,
+		//	                 still exit 0 under --fail-on-incomplete
+		//
+		// The same corruption in a .docx correctly printed "NOT FULLY EXAMINED ...
+		// cannot parse" and exited 3, because the Office branch below already
+		// carries its extractor's note across the error return. This is that same
+		// fix for the PDF branch. See #294.
+		content.ExtractionWarning = pdfExtractionWarning(filePath, err)
 		content.Error = fmt.Errorf("failed to extract text from PDF: %w", err)
 		return content, content.Error
 	}
@@ -137,6 +181,17 @@ func (tp *TextPreprocessor) processPDF(filePath string, content *ProcessedConten
 	content.WordCount = pdfContent.WordCount
 	content.CharCount = pdfContent.CharCount
 	content.LineCount = pdfContent.LineCount
+
+	// A PDF that parsed but yielded no text is the other half of the same silence.
+	// It is indistinguishable from a genuinely empty document unless we say so, and
+	// a scanned-image PDF (no text layer) lands here too — the operator needs to
+	// know the pages were not read rather than assume they were clean.
+	if strings.TrimSpace(content.Text) == "" {
+		content.ExtractionWarning = fmt.Sprintf(
+			"no text extracted from %s: the file parsed but held no document text, "+
+				"so page content was NOT scanned", filepath.Ext(filePath))
+	}
+
 	content.Success = true
 
 	// Enable position tracking for PDF documents

--- a/pkg/scan/checks_validation_test.go
+++ b/pkg/scan/checks_validation_test.go
@@ -1,0 +1,231 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package scan
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// An unrecognized check name must be an error, never "scan for nothing".
+//
+// normalizeChecks used to pass the caller's slice through untouched, and
+// core.ParseChecksToRun's loop has no else branch, so a name it does not recognise is
+// discarded silently. A caller who misspelled one got zero validators, a nil error,
+// and an empty finding list indistinguishable from a clean input. Measured before:
+//
+//	Checks=["BOGUS_CHECK"] -> 0 findings, err=nil
+//	Checks=["ADDRESS"]     -> 0 findings, err=nil   (real id: PHYSICAL_ADDRESS)
+//	Checks=["ssn"]         -> 0 findings, err=nil   (case-sensitive)
+//	Checks=["ALL"]         -> 0 findings, err=nil   (only lowercase "all" was the sentinel)
+//	Checks=[" all"]        -> 0 findings, err=nil   (what strings.Split leaves behind)
+//	Checks=["all","SSN"]   -> 1 finding             (sentinel needs a 1-element list)
+//
+// pkg/redact already fails closed on the same mistake ("redact: no validators
+// enabled"), so this brings the sibling package into line rather than inventing a
+// policy.
+
+const validationBody = "Employee SSN: 452-11-9384\nCard: 4111 1111 1111 1111\n"
+
+func TestUnknownCheckIsAnError(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		check []string
+		why   string
+	}{
+		{"bogus", []string{"BOGUS_CHECK"}, "a name no validator answers to"},
+		{"plausible ADDRESS", []string{"ADDRESS"}, "the real id is PHYSICAL_ADDRESS"},
+		{"plausible CARD", []string{"CARD"}, "the real id is CREDIT_CARD"},
+		{"plausible NAME", []string{"NAME"}, "the real id is PERSON_NAME"},
+		{"one bad in a list", []string{"SSN", "BOGUS"}, "half a list silently dropped is worse than an error"},
+		{"all mixed with names", []string{"all", "SSN"}, "the sentinel used to select only the OTHER names"},
+		{"ALL mixed with names", []string{"ALL", "ssn"}, "same, in the case that previously selected nothing"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r, err := ScanText(context.Background(), validationBody, TextOptions{Checks: tc.check})
+			if err == nil {
+				got := 0
+				if r != nil {
+					got = len(r.Findings)
+				}
+				t.Errorf("ScanText(Checks=%v) returned nil error and %d findings.\n%s\n"+
+					"Silently running zero validators reports the input CLEAN.",
+					tc.check, got, tc.why)
+			}
+		})
+	}
+}
+
+// TestEveryCheckSpellingThatShouldWorkDoes is the recall half, and it matters more.
+//
+// A validation gate that rejects a legitimate name is worse than the fail-open it
+// replaces: it stops a scan that would have found something.
+func TestEveryCheckSpellingThatShouldWorkDoes(t *testing.T) {
+	// The sentinel, in every shape a caller plausibly produces.
+	for _, tc := range [][]string{
+		nil,
+		{},
+		{"all"},
+		{"ALL"},
+		{" all"},
+		{"all "},
+		{""},
+		{" "},
+	} {
+		r, err := ScanText(context.Background(), validationBody, TextOptions{Checks: tc})
+		if err != nil {
+			t.Errorf("ScanText(Checks=%#v) errored: %v — all of these mean \"every validator\"", tc, err)
+			continue
+		}
+		if len(r.Findings) < 2 {
+			t.Errorf("ScanText(Checks=%#v) found %d findings, want the same as nil (>=2). "+
+				"This spelling silently selected nothing.", tc, len(r.Findings))
+		}
+	}
+
+	// Every canonical name, in both cases.
+	names := CheckNames()
+	if len(names) == 0 {
+		t.Fatal("CheckNames() is empty; this test would pass vacuously")
+	}
+	for _, n := range names {
+		for _, spelling := range []string{n, strings.ToLower(n)} {
+			if _, err := ScanText(context.Background(), validationBody,
+				TextOptions{Checks: []string{spelling}}); err != nil {
+				t.Errorf("ScanText(Checks=[%q]) rejected a name CheckNames() publishes: %v", spelling, err)
+			}
+		}
+	}
+
+	// And the whole published list at once.
+	if _, err := ScanText(context.Background(), validationBody, TextOptions{Checks: names}); err != nil {
+		t.Errorf("the full CheckNames() list was rejected: %v", err)
+	}
+}
+
+// TestLowercaseCheckActuallySelectsTheValidator — normalizing must not be cosmetic.
+//
+// Accepting "ssn" without upper-casing it would pass the error-path test above while
+// still selecting nothing, so assert the finding comes back.
+func TestLowercaseCheckActuallySelectsTheValidator(t *testing.T) {
+	upper, err := ScanText(context.Background(), validationBody, TextOptions{Checks: []string{"SSN"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lower, err := ScanText(context.Background(), validationBody, TextOptions{Checks: []string{"ssn"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(upper.Findings) == 0 {
+		t.Fatal(`Checks=["SSN"] found nothing; the fixture is broken`)
+	}
+	if len(lower.Findings) != len(upper.Findings) {
+		t.Errorf(`Checks=["ssn"] found %d findings but ["SSN"] found %d: the name was accepted `+
+			`but not canonicalized, so it still selects nothing`, len(lower.Findings), len(upper.Findings))
+	}
+}
+
+// TestRedactFileRejectsUnknownCheckBeforeWriting is THE SINK, and the reason this is
+// a leak rather than a nuisance.
+//
+// Measured before this change, with Checks=["BOGUS_CHECK"]:
+//
+//	err                            = nil
+//	RedactionCount                 = 0
+//	output byte-identical to input = true
+//	cleartext SSN in output file   = TRUE
+//
+// The API's own doc comment describes that path as the redacted copy. A caller has
+// nothing to branch on — RedactionCount 0 is also what a genuinely clean input
+// produces — so they would hand the file on believing it was scrubbed.
+func TestRedactFileRejectsUnknownCheckBeforeWriting(t *testing.T) {
+	dir := t.TempDir()
+	in := filepath.Join(dir, "in.txt")
+	if err := os.WriteFile(in, []byte(validationBody), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	outDir := filepath.Join(dir, "redacted")
+
+	res, err := RedactFile(in, RedactFileOptions{OutputDir: outDir, Checks: []string{"BOGUS_CHECK"}})
+	if err == nil {
+		count := -1
+		if res != nil {
+			count = res.RedactionCount
+		}
+		t.Errorf("RedactFile(Checks=[BOGUS_CHECK]) returned nil error (RedactionCount=%d). "+
+			"It previously wrote an output file byte-identical to the input, with the SSN "+
+			"in cleartext, in a path the API calls the redacted copy.", count)
+	}
+
+	// Nothing may be written on the rejected path: a file that exists and is
+	// unredacted is worse than no file, because the caller can ship it.
+	var written []string
+	_ = filepath.Walk(outDir, func(p string, fi os.FileInfo, walkErr error) error {
+		if walkErr == nil && fi != nil && !fi.IsDir() {
+			written = append(written, p)
+		}
+		return nil
+	})
+	for _, p := range written {
+		b, readErr := os.ReadFile(p)
+		if readErr != nil {
+			continue
+		}
+		if strings.Contains(string(b), "452-11-9384") {
+			t.Errorf("a file was written at %s containing the cleartext SSN despite the "+
+				"rejected check name", p)
+		}
+	}
+	if len(written) > 0 {
+		t.Errorf("RedactFile wrote %d file(s) on the error path: %v", len(written), written)
+	}
+}
+
+// TestRedactFileStillWorksWithAValidCheck — the fix must not break redaction.
+func TestRedactFileStillWorksWithAValidCheck(t *testing.T) {
+	dir := t.TempDir()
+	in := filepath.Join(dir, "in.txt")
+	if err := os.WriteFile(in, []byte(validationBody), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	outDir := filepath.Join(dir, "redacted")
+
+	for _, checks := range [][]string{nil, {"SSN"}, {"ssn"}, {"all"}} {
+		res, err := RedactFile(in, RedactFileOptions{OutputDir: outDir, Checks: checks})
+		if err != nil {
+			t.Errorf("RedactFile(Checks=%#v) errored: %v", checks, err)
+			continue
+		}
+		if res == nil || res.RedactionCount == 0 {
+			t.Errorf("RedactFile(Checks=%#v) reported no redactions on content holding an SSN", checks)
+			continue
+		}
+		var sawRedacted, sawCleartext bool
+		_ = filepath.Walk(outDir, func(p string, fi os.FileInfo, walkErr error) error {
+			if walkErr != nil || fi == nil || fi.IsDir() {
+				return nil
+			}
+			b, readErr := os.ReadFile(p)
+			if readErr != nil {
+				return nil
+			}
+			if strings.Contains(string(b), "452-11-9384") {
+				sawCleartext = true
+			}
+			if strings.Contains(string(b), "*") {
+				sawRedacted = true
+			}
+			return nil
+		})
+		if sawCleartext {
+			t.Errorf("Checks=%#v: the redacted output still contains the cleartext SSN", checks)
+		}
+		if !sawRedacted {
+			t.Errorf("Checks=%#v: no redaction token found in the output", checks)
+		}
+	}
+}

--- a/pkg/scan/redactfile.go
+++ b/pkg/scan/redactfile.go
@@ -57,11 +57,18 @@ func RedactFile(path string, opts RedactFileOptions) (*RedactFileResult, error) 
 		strategy = "synthetic"
 	}
 
+	// Reject an unknown check BEFORE any output file is created. Failing after the
+	// write would leave a file the API calls a redacted copy holding cleartext.
+	checks, err := normalizeChecks(opts.Checks)
+	if err != nil {
+		return nil, err
+	}
+
 	result, err := core.RedactFile(core.RedactConfig{
 		FilePath:  path,
 		OutputDir: opts.OutputDir,
 		Strategy:  strategy,
-		Checks:    normalizeChecks(opts.Checks),
+		Checks:    checks,
 		Config:    config.LoadConfigOrDefault(""),
 		LogWriter: logWriter,
 	})

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/awslabs/ferret-scan/v2/internal/config"
 	"github.com/awslabs/ferret-scan/v2/internal/core"
@@ -154,9 +155,14 @@ func ScanText(_ context.Context, text string, opts TextOptions) (*Result, error)
 		logWriter = io.Discard
 	}
 
+	checks, err := normalizeChecks(opts.Checks)
+	if err != nil {
+		return nil, err
+	}
+
 	coreResult, err := core.ScanContent(text, core.ContentScanConfig{
 		VirtualPath: label,
-		Checks:      normalizeChecks(opts.Checks),
+		Checks:      checks,
 		Explain:     opts.Explain,
 		Config:      config.LoadConfigOrDefault(""),
 		LogWriter:   logWriter,
@@ -187,9 +193,14 @@ func ScanFile(_ context.Context, path string, opts FileOptions) (*Result, error)
 		logWriter = io.Discard
 	}
 
+	checks, err := normalizeChecks(opts.Checks)
+	if err != nil {
+		return nil, err
+	}
+
 	coreResult, err := core.ScanFile(core.ScanConfig{
 		FilePath:            path,
-		Checks:              normalizeChecks(opts.Checks),
+		Checks:              checks,
 		EnablePreprocessors: true,
 		Explain:             opts.Explain,
 		Config:              config.LoadConfigOrDefault(""),
@@ -243,9 +254,73 @@ func mapResult(r *core.ScanResult) *Result {
 	}
 }
 
-func normalizeChecks(checks []string) []string {
-	if len(checks) == 0 {
-		return []string{"all"}
+// normalizeChecks canonicalizes the caller's Checks and rejects a name no
+// validator answers to.
+//
+// It used to pass the slice through untouched, and core.ParseChecksToRun's loop has
+// no else branch — an unrecognized name is discarded silently. So a caller who
+// misspelled one got ZERO validators, a nil error, and an empty finding list
+// indistinguishable from a clean input. Measured before this change:
+//
+//	Checks=[]              -> 2 findings   (correct)
+//	Checks=["SSN"]         -> 1 finding    (correct)
+//	Checks=["BOGUS_CHECK"] -> 0 findings, err=nil
+//	Checks=["ADDRESS"]     -> 0 findings, err=nil   (the real id is PHYSICAL_ADDRESS)
+//	Checks=["ssn"]         -> 0 findings, err=nil   (case-sensitive)
+//	Checks=["ALL"]         -> 0 findings, err=nil   (only lowercase "all" was the sentinel)
+//	Checks=[" all"]        -> 0 findings, err=nil   (what strings.Split leaves behind)
+//	Checks=["all","SSN"]   -> 1 finding             (the sentinel needs a 1-element list)
+//
+// RedactFile is where that became a leak rather than a nuisance. With
+// Checks=["BOGUS_CHECK"] it returned err=nil and RedactionCount=0, and wrote an
+// output file BYTE-IDENTICAL to the input — the SSN sitting in it in cleartext, in a
+// file the API's own doc comment describes as the redacted copy. A caller has nothing
+// to branch on: RedactionCount 0 is also what a genuinely clean input produces.
+//
+// pkg/redact already fails closed on the same mistake, returning
+// "redact: no validators enabled (Checks=%v)" (engine.go). This brings pkg/scan into
+// line with its sibling rather than inventing a policy.
+//
+// A nil/empty slice still means "every validator", which is the documented contract.
+func normalizeChecks(checks []string) ([]string, error) {
+	// Trim and drop empties first, so [" "] and [""] behave like [].
+	cleaned := make([]string, 0, len(checks))
+	for _, c := range checks {
+		if t := strings.TrimSpace(c); t != "" {
+			cleaned = append(cleaned, t)
+		}
 	}
-	return checks
+	if len(cleaned) == 0 {
+		return []string{"all"}, nil
+	}
+
+	// The "all" sentinel, case-insensitively and whitespace-tolerantly. core's
+	// sentinel requires a lowercase single-element list, so "ALL" and " all"
+	// previously selected nothing at all.
+	if len(cleaned) == 1 && strings.EqualFold(cleaned[0], "all") {
+		return []string{"all"}, nil
+	}
+
+	valid := make(map[string]bool, len(core.CheckNames()))
+	for _, n := range core.CheckNames() {
+		valid[n] = true
+	}
+
+	out := make([]string, 0, len(cleaned))
+	for _, c := range cleaned {
+		name := strings.ToUpper(c)
+		// "all" mixed with other names is rejected rather than silently resolving
+		// to one of the two readings. core's sentinel would have selected only the
+		// OTHER names, which is the opposite of what the word means.
+		if name == "ALL" {
+			return nil, fmt.Errorf("scan: %q cannot be combined with other check names; "+
+				"pass nil or []string{\"all\"} alone for every validator", c)
+		}
+		if !valid[name] {
+			return nil, fmt.Errorf("scan: unknown check %q; valid checks are %s",
+				c, strings.Join(core.CheckNames(), ", "))
+		}
+		out = append(out, name)
+	}
+	return out, nil
 }


### PR DESCRIPTION
Closes #294.

## The bug

A `.pdf` whose text extraction failed was reported as **scanned and clean**. The extractor's error never reached the operator: `pdf_metadata` runs on the same file and succeeds *even when the bytes are not a PDF at all*, so `FileRouter`'s combine step saw one successful preprocessor, stamped `Success: true`, and discarded the error.

Measured on a valid PDF truncated at its xref, still holding a **recoverable** SSN in a FlateDecode stream:

```
valid.pdf      rc=0  findings=1
truncated.pdf  rc=0  findings=0  stderr=0B     <- reported CLEAN
  + --fail-on-incomplete:  rc=0, stderr=0B     <- still silent
```

The same corruption in a `.docx` already printed `NOT FULLY EXAMINED ... cannot parse` and exited 3 — because the Office branch carries its extractor's note across the error return. The PDF branch returned with nothing set.

## The fix

Only `ExtractionWarning` survives the combine step — it's gathered regardless of `pResult.err`, precisely for this shape (the router's own comment says so, describing the `.docx` case). So the fix is to **set it**, not to change how success is decided.

Two paths now warn:

- **extraction errored** — the extractor's own diagnostics pass through unmodified (`not a PDF file: invalid header`, `malformed xref`). They're structure diagnostics, payload-free, and the most actionable part; inventing prose instead risks describing a failure that didn't happen.
- **extraction succeeded but yielded no text** — indistinguishable from a genuinely empty document unless we say so. A scanned-image PDF with no text layer lands here, and the operator needs to know the pages weren't read rather than assume they were clean.

## After

```
truncated.pdf            -> "NOT FULLY EXAMINED: 1 of 1 file", rc 3 under --fail-on-incomplete
random bytes named .pdf  -> same
valid.pdf                -> unchanged, no warning
```

## Real-world A/B — 1859 files, 310 real PDFs

```
no body text (metadata still scanned):  14 -> 41   (+27 newly disclosed)
cannot parse:                           22 -> 22   (no new false alarms)
coverage cut short:                    259 -> 259
FINDINGS:                             1963 -> 1963 (IDENTICAL)
```

**Pure disclosure.** 27 PDFs that previously read as clean now say coverage was incomplete, and not one finding changed.

## Non-vacuity

Four mutations, each verified to **compile**:

| mutation | caught |
|---|---|
| error-path warning removed (the original bug) | ✓ |
| parsed-but-no-text warning removed | ✓ |
| warns on every PDF (cries wolf) | ✓ |
| full path embedded in the warning | ✓ |

**My first parsed-but-no-text mutation compiled and PASSED — vacuous.** Cause was the fixture: it omitted `startxref`, so the extractor *errored* and the error branch set the warning, meaning the test never exercised the branch it named. Replaced with a structurally valid PDF (correct xref **and** startxref) holding an empty content stream, and the test now asserts `err == nil` and `textLen == 0` up front so it cannot go quietly vacuous again.

## Test plan

- **1** build / vet / gofmt clean
- **2** full suite `rc=0`, **65 packages**
- **3** golden **0 moved**; **3b** score corpus unchanged
- **9** real-world A/B above
- **13** `-race` clean on the changed package
- **4** N/A — no new loop over line/match
- **5, 6, 7** N/A — no offset, span, suppression-hash or formatter surface touched; the warning rides the existing `ExtractionWarning` channel that text/json/yaml/sarif/gitlab/junit already render

## Union-tested against all three open PRs

`main` + #298 + #299 + #300 + this branch:

```
conflicts:     0
all 4 markers present (verified)
union build:   exit 0
union suite:   rc=0, 65 packages
```

## One deliberate imprecision

A corrupt PDF is classified `no body text (metadata still scanned)` rather than `cannot parse`. That is **accurate** — the metadata *was* read and scanned — and reclassifying would mean changing the shared cause taxonomy for every format. Flagged rather than silently reshaped.