### PR TITLE
fix(legacy-office): scan every OLE stream for body text, not four allowlisted names

### DIFF
--- a/internal/preprocessors/meta-extractors/meta-extract-officelib/legacy-ole-extractor.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-officelib/legacy-ole-extractor.go
@@ -45,10 +45,33 @@ import (
 // 50MB per-entry cap the OOXML paths already use. An OLE container declares its
 // own stream sizes, so an unbounded io.ReadAll here would be the same
 // decompression-bomb hole that cap exists to close.
-const maxLegacyStreamBytes = 50 * 1024 * 1024
+// A var, not a const, so a test can lower it and assert the truncation actually
+// happens. It was a const and nothing asserted it — a mutation raising it to 1<<62
+// compiled and every test still passed. That is precisely the guard that must not be
+// silently removable, because scanning every stream (see below) applies it to far more
+// bytes than the previous four-name allowlist did.
+var maxLegacyStreamBytes int64 = 50 * 1024 * 1024
 
-// legacyBodyStreams are the streams that hold document character data, by
-// format. Names are exact and case-sensitive, as written by Office.
+// legacyBodyStreams names the streams KNOWN to hold document character data.
+//
+// Retained for documentation and for the ordering guarantee below, NOT as a gate:
+// body text is now recovered from every stream that is not a property stream. The
+// allowlist was a detection hole, because a .doc keeps a large fraction of its text
+// outside WordDocument:
+//
+//	1Table / 0Table   revision marks, comments, fast-save text
+//	Data              embedded content
+//	ObjectPool/*      embedded objects
+//
+// Measured on a real 690KB .doc: 1Table held 14 recoverable printable runs that no
+// validator ever saw, and a fixture with an SSN placed only in 1Table produced zero
+// findings — so the value survived into the "redacted" copy in cleartext, since only
+// reported findings are redacted. That is the normal on-disk layout of an edited Word
+// document; it needs no attacker.
+//
+// recoverPrintableRuns was already name-agnostic and conservative (a minimum run
+// length, single-byte and UTF-16 passes), so the allowlist bought nothing on the body
+// side while excluding most of the document. See #266.
 var legacyBodyStreams = map[string]bool{
 	"WordDocument":        true, // .doc
 	"Workbook":            true, // .xls (Excel 97+)
@@ -83,20 +106,37 @@ func extractLegacyOfficeMetadata(filePath string, metadata *Metadata) (*Metadata
 
 	var body strings.Builder
 	for entry, err := doc.Next(); err == nil; entry, err = doc.Next() {
+		// Property streams are PARSED as properties; everything else is scavenged for
+		// printable runs.
+		//
+		// Inverted from an allowlist of four body-stream names, which silently
+		// excluded 1Table/0Table/Data/ObjectPool — where an edited .doc keeps its
+		// revision marks, comments and fast-save text. A value living only there was
+		// never reported and therefore never redacted (#266).
+		//
+		// Deliberately a default-scan rather than a longer allowlist: the failure mode
+		// being fixed is "a stream nobody thought of", so a list of names we thought of
+		// cannot close it. recoverPrintableRuns is conservative enough to run on
+		// arbitrary bytes — it emits only runs of printable characters at or above a
+		// minimum length, so structural bookkeeping yields nothing.
+		//
+		// The per-stream io.LimitReader cap is unchanged and now matters more, since it
+		// applies to more streams: an OLE container declares its own stream sizes, so
+		// this stays bounded per stream rather than becoming a bomb amplifier.
 		switch {
-		case legacyBodyStreams[entry.Name]:
-			buf, rerr := io.ReadAll(io.LimitReader(entry, maxLegacyStreamBytes))
-			if rerr != nil {
-				continue
-			}
-			body.WriteString(recoverPrintableRuns(buf))
-
 		case legacyPropertyStreams[entry.Name]:
 			buf, rerr := io.ReadAll(io.LimitReader(entry, maxLegacyStreamBytes))
 			if rerr != nil {
 				continue
 			}
 			applyLegacyProperties(buf, metadata)
+
+		default:
+			buf, rerr := io.ReadAll(io.LimitReader(entry, maxLegacyStreamBytes))
+			if rerr != nil {
+				continue
+			}
+			body.WriteString(recoverPrintableRuns(buf))
 		}
 	}
 

--- a/internal/preprocessors/meta-extractors/meta-extract-officelib/ole_stream_coverage_test.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-officelib/ole_stream_coverage_test.go
@@ -1,0 +1,198 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package metaextractofficelib
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/olefixture"
+)
+
+// Body text must be recovered from EVERY stream, not four allowlisted names.
+//
+// A .doc keeps a large fraction of its text outside WordDocument: 1Table/0Table hold
+// revision marks, comments and fast-save text; Data and ObjectPool hold embedded
+// content. The extractor allowlisted WordDocument/Workbook/Book/PowerPoint Document,
+// so a value living anywhere else was never reported — and since only reported
+// findings are redacted, it survived into the "redacted" copy in cleartext.
+//
+// Measured on a real 690KB .doc: 1Table held 14 recoverable printable runs no
+// validator ever saw. That is the normal on-disk layout of an edited Word document,
+// not a constructed attack. See #266.
+
+// buildDoc writes an OLE compound file with the given streams.
+//
+// NOTE the fixture builder fits 3 streams plus the root in one directory sector, so
+// tests stay at or below three.
+func buildDoc(t *testing.T, streams []olefixture.Stream) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "legacy.doc")
+	if err := os.WriteFile(path, olefixture.MustBuild(streams), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func extractBody(t *testing.T, path string) string {
+	t.Helper()
+	md := &Metadata{Properties: map[string]string{}}
+	_, body, err := extractLegacyOfficeMetadata(path, md)
+	if err != nil {
+		t.Fatalf("extractLegacyOfficeMetadata: %v", err)
+	}
+	return body
+}
+
+// TestNonAllowlistedStreamsAreScanned is the regression.
+func TestNonAllowlistedStreamsAreScanned(t *testing.T) {
+	const (
+		inBody   = "Cover page. Nothing sensitive in the main body stream at all."
+		inTable  = "Reviewer comment: Employee SSN: 447-62-9183 confidential"
+		inData   = "Embedded blob: contact sarah.morgan@example.com here"
+		ssn      = "447-62-9183"
+		email    = "sarah.morgan@example.com"
+		bodyText = "Cover page"
+	)
+
+	body := extractBody(t, buildDoc(t, []olefixture.Stream{
+		{Name: "WordDocument", Data: []byte(inBody)},
+		{Name: "1Table", Data: []byte(inTable)},
+		{Name: "Data", Data: []byte(inData)},
+	}))
+
+	if !strings.Contains(body, bodyText) {
+		t.Errorf("WordDocument text missing from the recovered body; the allowlist removal "+
+			"must not cost the streams that already worked. Got %d bytes.", len(body))
+	}
+	if !strings.Contains(body, ssn) {
+		t.Errorf("the SSN in 1Table did not reach the recovered body. It is therefore never "+
+			"reported, and an unreported value is never redacted — it stays in the output "+
+			"file the report calls redacted. Body was %d bytes.", len(body))
+	}
+	if !strings.Contains(body, email) {
+		t.Errorf("the value in the Data stream did not reach the recovered body")
+	}
+}
+
+// TestOtherUnnamedStreamsAreAlsoScanned — the point is default-scan, not a longer list.
+//
+// The failure mode being fixed is "a stream nobody thought of", so a test that only
+// covers 1Table and Data would let the next allowlist through.
+func TestOtherUnnamedStreamsAreAlsoScanned(t *testing.T) {
+	for _, name := range []string{"0Table", "ObjectPool", "Ctls", "MsoDataStore", "Xyzzy"} {
+		t.Run(name, func(t *testing.T) {
+			body := extractBody(t, buildDoc(t, []olefixture.Stream{
+				{Name: "WordDocument", Data: []byte("Cover page only, nothing here.")},
+				{Name: name, Data: []byte("Hidden away: Employee SSN: 447-62-9183 end")},
+			}))
+			if !strings.Contains(body, "447-62-9183") {
+				t.Errorf("a value in the %q stream was not recovered. Body scanning must not "+
+					"depend on recognising the stream name.", name)
+			}
+		})
+	}
+}
+
+// TestPropertyStreamsStillParseAsProperties — the inversion must not swallow them.
+//
+// A property stream must reach applyLegacyProperties, not the printable-run
+// scavenger. If it fell through to the default branch, the author would stop
+// appearing as AUTHOR_INFO metadata and instead surface as loose body text with no
+// field attribution.
+func TestPropertyStreamsStillParseAsProperties(t *testing.T) {
+	const author = "Margaret Chen"
+	path := buildDoc(t, []olefixture.Stream{
+		{Name: "WordDocument", Data: []byte("Cover page only.")},
+		{Name: "\x05SummaryInformation", Data: olefixture.SummaryInformation(map[uint32]string{4: author})},
+	})
+
+	md := &Metadata{Properties: map[string]string{}}
+	got, _, err := extractLegacyOfficeMetadata(path, md)
+	if err != nil {
+		t.Fatalf("extractLegacyOfficeMetadata: %v", err)
+	}
+	if got.Author != author {
+		t.Errorf("Author = %q, want %q: the property stream must still be PARSED as "+
+			"properties rather than scavenged as body text", got.Author, author)
+	}
+}
+
+// TestStructuralBytesYieldNothing — the conservative-scavenger guarantee.
+//
+// Scanning every stream is only safe because recoverPrintableRuns emits nothing for
+// bookkeeping bytes. If it started emitting them, every legacy document would gain
+// junk findings, which is its own kind of harm.
+func TestStructuralBytesYieldNothing(t *testing.T) {
+	// Binary noise with no printable run at or above the minimum length.
+	noise := make([]byte, 4096)
+	for i := range noise {
+		noise[i] = byte(i % 7) // all below 0x20, never printable
+	}
+	body := extractBody(t, buildDoc(t, []olefixture.Stream{
+		{Name: "WordDocument", Data: []byte("Real content here for the body.")},
+		{Name: "Data", Data: noise},
+	}))
+	if strings.Count(body, "\n") > 3 {
+		t.Errorf("binary noise produced %d lines of recovered text; the scavenger must stay "+
+			"conservative or every legacy document gains junk findings:\n%q",
+			strings.Count(body, "\n"), body)
+	}
+}
+
+// TestPerStreamSizeCapIsEnforced guards the bomb bound.
+//
+// An OLE container declares its own stream sizes, so an unbounded io.ReadAll here
+// would be a decompression-bomb hole. That bound matters MORE now that every stream is
+// scanned rather than four allowlisted names.
+//
+// Nothing asserted it before: raising the cap to 1<<62 compiled and the whole suite
+// still passed. The constant became a var purely so this test can lower it and observe
+// the truncation, rather than needing a 50MB fixture.
+func TestPerStreamSizeCapIsEnforced(t *testing.T) {
+	original := maxLegacyStreamBytes
+	t.Cleanup(func() { maxLegacyStreamBytes = original })
+
+	// A stream far larger than the cap we are about to set.
+	const marker = "TAIL-MARKER-SHOULD-NOT-APPEAR"
+	big := strings.Repeat("A", 4096) + marker
+	path := buildDoc(t, []olefixture.Stream{
+		{Name: "WordDocument", Data: []byte("Cover page only.")},
+		{Name: "1Table", Data: []byte(big)},
+	})
+
+	// Uncapped first, to prove the fixture's tail IS reachable.
+	if body := extractBody(t, path); !strings.Contains(body, marker) {
+		t.Fatalf("the fixture's tail is not recoverable even uncapped; this test would " +
+			"pass vacuously")
+	}
+
+	maxLegacyStreamBytes = 64
+	body := extractBody(t, path)
+	if strings.Contains(body, marker) {
+		t.Errorf("with the cap at 64 bytes the stream tail still reached the body, so the "+
+			"per-stream io.LimitReader is not bounding the read. Body was %d bytes.", len(body))
+	}
+}
+
+// TestDefaultStreamCapIsSane asserts the shipped VALUE, not just the mechanism.
+//
+// TestPerStreamSizeCapIsEnforced lowers the cap to observe truncation, which proves
+// io.LimitReader is wired — but because it sets the value explicitly, it keeps passing
+// when the DEFAULT is raised. Measured: a mutation setting the default to 1<<62
+// compiled and that test still passed. Both assertions are needed.
+func TestDefaultStreamCapIsSane(t *testing.T) {
+	const (
+		floor   = int64(1 << 20)   // 1MB: below this, real documents get truncated
+		ceiling = int64(512 << 20) // 512MB: above this it is not a bound worth having
+	)
+	if maxLegacyStreamBytes < floor || maxLegacyStreamBytes > ceiling {
+		t.Errorf("maxLegacyStreamBytes = %d, want between %d and %d. An OLE container "+
+			"declares its own stream sizes, so this is the only thing standing between a "+
+			"crafted .doc and an unbounded read — and it now applies to EVERY stream, not "+
+			"the four the old allowlist named.", maxLegacyStreamBytes, floor, ceiling)
+	}
+}


### PR DESCRIPTION
Closes #266.

## The leak

The legacy Office extractor recovered body text only from `WordDocument`, `Workbook`, `Book`, `PowerPoint Document`. A `.doc` keeps a large fraction of its text **outside** `WordDocument` — `1Table`/`0Table` hold revision marks, comments and fast-save text; `Data` and `ObjectPool` hold embedded content. A value there was never reported, and **only reported findings are redacted**, so it survived into the "redacted" copy in cleartext.

Verified with an SSN placed only in `1Table` and an email only in `Data`:

```
before:  recovered body 55 bytes
         WordDocument text present: true
         1Table SSN present:        FALSE
         Data value present:        FALSE

after:   recovered body 157 bytes, all three present
```

End to end through the CLI:

```
scan   -> [HIGH] SSN 100.00% line 2  447-62-9183
redact -> cleartext SSN in the redacted .doc:   false
          cleartext email in the redacted .doc: false
          redaction tokens present:             true
```

Confirmed by **reading the OLE bytes** of the output, not by grepping — a container hides content from grep, which is the trap the test plan calls out.

The redaction side already mapped and overwrote every stream (`streammap.go`, #265), so it removes whatever the extractor now reports.

## Inverted, not extended

Property streams are **parsed** as properties; everything else is **scavenged** for printable runs. A longer allowlist cannot close this, because the failure mode is *"a stream nobody thought of"*. `recoverPrintableRuns` was already name-agnostic and conservative — minimum run length, single-byte and UTF-16 passes — so the allowlist bought nothing on the body side while excluding most of the document.

`TestOtherUnnamedStreamsAreAlsoScanned` covers `0Table`, `ObjectPool`, `Ctls`, `MsoDataStore` **and a made-up name**, for exactly that reason.

## The bomb bound was untested

`maxLegacyStreamBytes` was a `const` and **nothing asserted it** — a mutation raising it to `1<<62` compiled and the whole suite passed. It's now the only thing between a crafted `.doc` and an unbounded read, and it applies to far more bytes than before.

It's now gated two ways, and **both are needed**:

| test | proves |
|---|---|
| `TestPerStreamSizeCapIsEnforced` | lowers the cap, observes truncation → `io.LimitReader` is wired on the new default branch |
| `TestDefaultStreamCapIsSane` | asserts the shipped **value** |

The first keeps passing when the default is raised, because it sets the value itself. My cap mutation was **vacuous twice** — once because no test existed, once because the test overrode the value it was meant to check. Both gaps are closed.

## Non-vacuity

Three mutations, each verified to **compile**:

| mutation | caught |
|---|---|
| allowlist restored (the original bug) | ✓ |
| property streams scavenged instead of parsed | ✓ |
| default cap raised to `1<<62` | ✓ |

The property-stream mutation matters: falling through would lose `Author` as `AUTHOR_INFO` metadata and surface it as loose body text with no field attribution.

Also pinned: `TestStructuralBytesYieldNothing`. Scanning every stream is only safe because the scavenger emits nothing for bookkeeping bytes; if it started emitting them, every legacy document would gain junk findings — its own kind of harm.

## Test plan

- **1** build / vet / gofmt clean
- **2** full suite `rc=0`, **65 packages**
- **3** golden **0 moved**; **3b** score corpus unchanged
- **5** redaction verified **by reading the OLE stream inside the output**
- **13** `-race` clean on the changed package
- **9 could NOT be run on real data** — this machine has no `.doc`/`.xls`/`.ppt` to A/B against, so the evidence is the synthetic fixture plus the end-to-end CLI run. Stating the limit rather than implying coverage I don't have.

## Residual

Recall on `.doc` is still approximate rather than equal to `.docx`: this is printable-run scavenging, not a piece-table parser. The extractor's header comment already says so, and that remains true — this change widens *which streams* are read, not how well any one is parsed.