### PR TITLE
docs(scan): deprecate Finding.SuppressedBy and document that pkg/scan applies no suppression

### DIFF
--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -76,15 +76,25 @@ type FileOptions struct {
 
 // Finding is one piece of sensitive data detected.
 type Finding struct {
-	Type         string  // validator-assigned classification (e.g. "SSN", "VISA", "EMAIL")
-	Validator    string  // which validator produced it
-	Confidence   float64 // 0–100
-	LineNumber   int     // 1-based
-	Text         string  // the matched substring (handle with care)
-	Filename     string  // source file or label
-	Rationale    string  // plain-language "why flagged" (empty unless Explain=true)
-	Verdict      string  // "likely_real" | "likely_test" | "uncertain" (empty unless Explain)
-	SuppressedBy string  // non-empty if this finding was suppressed
+	Type       string  // validator-assigned classification (e.g. "SSN", "VISA", "EMAIL")
+	Validator  string  // which validator produced it
+	Confidence float64 // 0–100
+	LineNumber int     // 1-based
+	Text       string  // the matched substring (handle with care)
+	Filename   string  // source file or label
+	Rationale  string  // plain-language "why flagged" (empty unless Explain=true)
+	Verdict    string  // "likely_real" | "likely_test" | "uncertain" (empty unless Explain)
+
+	// SuppressedBy is always the empty string.
+	//
+	// Deprecated: this package applies no suppression, so nothing can ever set
+	// this field — see the note on Result about suppression. It has read as ""
+	// for every finding since the package was introduced, and the check it
+	// invites, `if f.SuppressedBy != ""`, therefore answers "nothing was
+	// suppressed" for a package that never asked the question. Do not branch on
+	// it. It is kept only so existing callers keep compiling and will be removed
+	// in the next major version.
+	SuppressedBy string
 
 	// ContextBefore and ContextAfter are the text on either side of the match,
 	// excluding the match itself; FullLine is the whole line the match sits on.
@@ -133,6 +143,23 @@ type Finding struct {
 }
 
 // Result holds the output of a scan.
+//
+// Suppression is NOT applied. Findings is every match the selected validators
+// produced; no suppression rule is consulted, and no finding is filtered or
+// annotated as suppressed. This differs from the CLI, which does apply a
+// suppressions file, so a caller that assumes this package honors the project's
+// `.ferret-scan-suppressions.yaml` will see findings an operator has already
+// reviewed and accepted. That is the safe direction for a detection API — it
+// reports everything and lets the caller decide — but it is worth knowing before
+// wiring this into a gate.
+//
+// Suppression in the engine is opt-in at the internal layer
+// (core.ScanConfig.SuppressionManager), which this package deliberately does not
+// set: filtering findings by default would let a stale rule silently hide a real
+// value from a caller who never asked for it. Callers wanting rule-based
+// suppression today can express it over the returned Findings, or use
+// pkg/redact, whose Engine matches caller-supplied rules and reports what they
+// suppressed.
 type Result struct {
 	Findings         []Finding
 	Incomplete       bool // true if coverage was cut short (timeout, cancellation)

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -153,13 +153,22 @@ type Finding struct {
 // reports everything and lets the caller decide — but it is worth knowing before
 // wiring this into a gate.
 //
-// Suppression in the engine is opt-in at the internal layer
-// (core.ScanConfig.SuppressionManager), which this package deliberately does not
-// set: filtering findings by default would let a stale rule silently hide a real
-// value from a caller who never asked for it. Callers wanting rule-based
-// suppression today can express it over the returned Findings, or use
-// pkg/redact, whose Engine matches caller-supplied rules and reports what they
-// suppressed.
+// This follows the engine's shape rather than departing from it. Detection itself
+// never suppresses: core is called with SuppressionManager nil by every consumer
+// — the CLI, the web server, the score corpus — and each applies suppression
+// itself once the scan returns, if it wants it. cmd/stdin.go states the reason at
+// the call site, "applied below so we can run --generate-suppressions on raw
+// matches": suppressing inside the scan would hide from rule generation the very
+// findings it exists to write rules for.
+//
+// So the difference between this package and the CLI is not that one opts in and
+// the other does not. It is that the CLI runs that post-pass and this package
+// leaves it to the caller, because filtering by default would let a stale rule
+// silently hide a real value from a caller who never asked for it.
+//
+// Callers wanting rule-based suppression can apply it over the returned Findings,
+// or use pkg/redact, whose Engine matches caller-supplied rules and reports what
+// they suppressed.
 type Result struct {
 	Findings         []Finding
 	Incomplete       bool // true if coverage was cut short (timeout, cancellation)

--- a/pkg/scan/suppression_test.go
+++ b/pkg/scan/suppression_test.go
@@ -1,0 +1,62 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package scan
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestSuppressedByIsAlwaysEmpty pins the claim the deprecation notice makes.
+//
+// This package never sets core.ScanConfig.SuppressionManager, so the suppression
+// stage does not run: nothing is filtered and nothing can populate SuppressedBy.
+// The field is retained only for compilation compatibility.
+//
+// If suppression is ever wired into this package, this test fails and that is the
+// right outcome — it is the prompt to undeprecate the field, populate it from
+// detector.SuppressedMatch, and rewrite the note on Result. Deleting the test to
+// make a change pass would put the docs back into the state this replaced, where
+// a public field described behaviour the package did not have.
+func TestSuppressedByIsAlwaysEmpty(t *testing.T) {
+	const body = "Employee SSN 796-58-4123 on file\n" +
+		"Corporate card 4111-1111-1111-1111 expires soon\n" +
+		"AWS key AKIAIOSFODNN7EXAMPLE rotate quarterly\n"
+
+	path := filepath.Join(t.TempDir(), "findings.txt")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	textResult, err := ScanText(context.Background(), body, TextOptions{Explain: true})
+	if err != nil {
+		t.Fatalf("ScanText: %v", err)
+	}
+	fileResult, err := ScanFile(context.Background(), path, FileOptions{Explain: true})
+	if err != nil {
+		t.Fatalf("ScanFile: %v", err)
+	}
+
+	for _, tc := range []struct {
+		entry    string
+		findings []Finding
+	}{
+		{"ScanText", textResult.Findings},
+		{"ScanFile", fileResult.Findings},
+	} {
+		if len(tc.findings) == 0 {
+			t.Fatalf("%s: fixture produced no findings, so the assertion is vacuous", tc.entry)
+		}
+		for _, f := range tc.findings {
+			if f.SuppressedBy != "" {
+				t.Errorf("%s: %s finding on line %d has SuppressedBy = %q; this package applies "+
+					"no suppression, so the field cannot be set. If suppression was just wired in, "+
+					"update the Finding and Result doc comments instead of relaxing this test.",
+					tc.entry, f.Type, f.LineNumber, f.SuppressedBy)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes #287. Base is `main`.

**Re-lands #292**, which merged into an intermediate stack branch *after* that branch had already reached `main` via #288 — so its contents never propagated. `pkg/scan/suppression_test.go` was absent from `main` and `SuppressedBy` still carried its original comment. My mistake: I retargeted #288 to `main` when its base merged, and left #292 pointing at the now-stale branch. Rebased onto current `main`, contents otherwise as reviewed, plus one accuracy fix below.

**No functional change.** Documentation, a deprecation marker, and a test. Nothing removed, so nothing breaks.

## The defect

`Finding.SuppressedBy` says "non-empty if this finding was suppressed" and has read `""` for every finding since v2.1.0. Nothing populates it and nothing can — the value lives on `detector.SuppressedMatch`, a different type from the `detector.Match` values in `ScanResult.Matches`, and suppressed findings are excluded from `Matches` regardless.

`if f.SuppressedBy != ""` is the obvious check and the one the comment invited. It silently reports "nothing was suppressed" for a package that never asked.

## Deprecated, not removed

The field is unused here and the one known downstream consumer doesn't read it, so removal breaks no *behaviour* — but it breaks the *build* of any caller that names it, and this package's compatibility is why it exists. `Deprecated:` is surfaced by staticcheck, `go doc` and editors, so callers get told without anything breaking, and removal rides along free with the next major.

## Accuracy fix over #292

#292 described suppression as "opt-in at the internal layer (`core.ScanConfig.SuppressionManager`), which this package deliberately does not set." That implies other consumers set it. **None do.** Every caller of core passes nil — `cmd/stdin.go`, `cmd/main.go`, `internal/web/server.go`, `internal/scorecorpus/score.go` — and applies suppression itself afterwards over the returned matches (`cmd/main.go:1879`, `cmd/stdin.go:238`).

`cmd/stdin.go` records why at the call site:

```go
SuppressionManager: nil, // applied below so we can run --generate-suppressions on raw matches
```

Suppressing inside the scan would hide from rule generation the very findings it exists to write rules for. So detection never suppresses anywhere in this engine, and the real difference is that the CLI runs a post-pass while this package leaves it to the caller. The note now says that — the old wording made a deliberate architectural shape read as an omission peculiar to `pkg/scan`.

That distinction is the reason this stays documentation-only rather than becoming a removal or a feature: the blank *value* is by design, and only the field's *description* was wrong.

## Test

`TestSuppressedByIsAlwaysEmpty` pins the claim across `ScanText` and `ScanFile`, and fails if suppression is ever wired in — the correct prompt to undeprecate the field, populate it from `detector.SuppressedMatch`, and rewrite both notes. The failure message says so, because the alternative is someone relaxing the test and putting the docs back where they started.

## Verification

`go test ./...` (65 packages), `go vet ./...`, `gofmt`, `make build` — all clean on current `main`. Committed with Code Defender's hooks running.
