### PR TITLE
feat(router): bound embedded nesting depth and scan Office documents inside Office documents

### DIFF
--- a/internal/preprocessors/base_metadata_preprocessor.go
+++ b/internal/preprocessors/base_metadata_preprocessor.go
@@ -5,6 +5,7 @@ package preprocessors
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -18,7 +19,30 @@ import (
 // BaseMetadataPreprocessor and the specialized preprocessors that embed it.
 type RouterInterface interface {
 	ProcessFile(filePath string, context interface{}) (*ProcessedContent, error)
+
+	// ProcessEmbedded processes a child file that was extracted OUT OF parentPath,
+	// enforcing a nesting-depth bound.
+	//
+	// Separate from ProcessFile because the router is the only component that can own
+	// the depth: the preprocessor instance is shared across concurrent workers (so it
+	// cannot hold per-call state) and Process takes no context to thread one through.
+	// The preprocessor knows its own path — that is the argument to Process — so
+	// passing it as parentPath is enough for the router to compute depth without any
+	// change to the Preprocessor interface.
+	//
+	// Returns ErrEmbeddedTooDeep when the bound is reached. Callers must DISCLOSE
+	// that rather than skipping quietly: refusing to descend is incomplete coverage,
+	// and an undisclosed gap reads as a clean result.
+	ProcessEmbedded(childPath, parentPath string) (*ProcessedContent, error)
 }
+
+// ErrEmbeddedTooDeep is returned by RouterInterface.ProcessEmbedded when a container
+// nests deeper than the router's bound.
+//
+// A sentinel rather than a formatted string so the caller can branch on it with
+// errors.Is and tell "too deep" (coverage was cut short — say so) apart from "this
+// child failed to parse" (already handled by the ordinary error path).
+var ErrEmbeddedTooDeep = errors.New("embedded container nesting limit reached")
 
 // BaseMetadataPreprocessor provides common functionality for all specialized metadata preprocessors
 type BaseMetadataPreprocessor struct {
@@ -193,13 +217,19 @@ func (bmp *BaseMetadataPreprocessor) processWithRetryInternal(filePath string, p
 // blob would be labelled office_metadata and that field would report nothing.
 // Measured: the AUTHOR_INFO finding for an embedded clip's artist address
 // disappeared until these sections were carried.
-func (bmp *BaseMetadataPreprocessor) ProcessEmbeddedMedia(originalFilePath string, embeddedMedia []EmbeddedMedia) (string, []ContentSection) {
+// ProcessEmbeddedMedia now also returns WARNINGS: notes about embedded items it could
+// not descend into. An item skipped silently is undisclosed missing coverage, which is
+// the failure mode this whole area keeps producing.
+func (bmp *BaseMetadataPreprocessor) ProcessEmbeddedMedia(originalFilePath string, embeddedMedia []EmbeddedMedia) (string, []ContentSection, []string) {
 	if bmp.router == nil || len(embeddedMedia) == 0 {
-		return "", nil
+		return "", nil, nil
 	}
 
 	var result string
 	var sections []ContentSection
+	// warnings records embedded items we declined to descend into, so the caller can
+	// surface them through ExtractionWarning.
+	var warnings []string
 	// Line cursor into `result`, maintained incrementally.
 	line := 0
 
@@ -230,7 +260,28 @@ func (bmp *BaseMetadataPreprocessor) ProcessEmbeddedMedia(originalFilePath strin
 		// embeddings. Admitting .docx/.xlsx/.pptx routes back into this same
 		// function, so it requires a real depth cap first — and a cap must DISCLOSE
 		// when it truncates, or it replaces a silent miss with a different one.
-		if processed, err := bmp.router.ProcessFile(media.TempFilePath, nil); err == nil && processed != nil && processed.Success {
+		processed, perr := bmp.router.ProcessEmbedded(media.TempFilePath, originalFilePath)
+		if errors.Is(perr, ErrEmbeddedTooDeep) {
+			// DISCLOSE rather than skip. Hitting the bound means this item's content
+			// was never examined; saying nothing would reproduce the exact bug the
+			// bound was added alongside.
+			warnings = append(warnings, fmt.Sprintf(
+				"embedded item %q was not examined: %v", filepath.Base(media.OriginalName), perr))
+			continue
+		}
+		if perr == nil && processed != nil && processed.Success {
+			// Carry the CHILD's own warning up.
+			//
+			// Without this the disclosure dies one level below where it is needed. The
+			// nesting bound fires deep in the chain and sets ExtractionWarning on THAT
+			// level's content; every level above then reads only processed.Text, so a
+			// 9-level bomb terminated correctly at the bound and reported nothing at all
+			// -- measured: 0 findings, 0 disclosure lines. Propagating it means the top
+			// level, which is the one the operator sees, says coverage was cut short.
+			if processed.ExtractionWarning != "" {
+				warnings = append(warnings, processed.ExtractionWarning)
+			}
+
 			// Update processed content to show original file relationship
 			processed.OriginalPath = embeddedPath
 			processed.Filename = embeddedPath
@@ -278,7 +329,7 @@ func (bmp *BaseMetadataPreprocessor) ProcessEmbeddedMedia(originalFilePath strin
 		}
 	}
 
-	return result, sections
+	return result, sections, warnings
 }
 
 // EmbeddedMedia represents embedded media extracted from documents

--- a/internal/preprocessors/meta-extractors/meta-extract-officelib/legacy_ole_extractor_test.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-officelib/legacy_ole_extractor_test.go
@@ -115,14 +115,23 @@ func TestEmbeddedMediaTypeScoping(t *testing.T) {
 		}
 	}
 
-	// The load-bearing negative. If this starts returning non-empty, unbounded
-	// recursion is live again and a self-nesting document becomes a
-	// decompression-bomb amplifier.
+	// Embedded OOXML documents are now ADMITTED, because the depth bound this test
+	// used to wait for has landed: FileRouter.ProcessEmbedded tracks nesting keyed on
+	// the path it is handed and refuses past MaxEmbeddedDepth, returning
+	// ErrEmbeddedTooDeep, which the caller discloses rather than skipping.
+	//
+	// Bomb-tested: a 9-level self-nesting .docx now terminates in 0.06s with 0 findings
+	// AND a "nesting limit reached" line at the top level, instead of following all
+	// nine levels. See #297.
+	//
+	// The safety property this negative used to protect is not abandoned, it moved:
+	// TestRouterBoundsEmbeddedDepth in internal/router asserts the refusal, so removing
+	// the bound fails there rather than here.
 	for _, ext := range []string{".docx", ".xlsx", ".pptx"} {
-		if got := embeddedMediaType(ext); got != "" {
-			t.Errorf("embeddedMediaType(%q) = %q, want \"\" — admitting embedded OOXML "+
-				"documents re-enables UNBOUNDED recursion; a depth bound must land first",
-				ext, got)
+		if got := embeddedMediaType(ext); got != "document" {
+			t.Errorf("embeddedMediaType(%q) = %q, want \"document\" — an Office document "+
+				"embedded in an Office document was a cleartext leak (#297): reported clean, "+
+				"exit 0, no redacted file", ext, got)
 		}
 	}
 

--- a/internal/preprocessors/meta-extractors/meta-extract-officelib/office-extractor.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-officelib/office-extractor.go
@@ -725,37 +725,28 @@ func embeddedMediaType(ext string) string {
 		// reads their streams directly and does not itself follow embeddings, so
 		// admitting them adds no recursion and no new bomb surface.
 		return "legacy_document"
+	case ".docx", ".xlsx", ".pptx":
+		// Embedded OOXML documents. Admitted now that the router bounds nesting depth.
+		//
+		// These were excluded because an embedded .docx routes back through the Office
+		// preprocessor, which extracts ITS embeddings, which route back again --
+		// unbounded recursion, and a decompression-bomb amplifier for a tool that runs
+		// on untrusted input. Measured previously with a 7KB .docx embedding itself nine
+		// times: all nine levels were followed.
+		//
+		// The bound now exists: FileRouter.ProcessEmbedded tracks depth keyed on the
+		// path it is handed and refuses past MaxEmbeddedDepth, returning
+		// ErrEmbeddedTooDeep -- which the caller DISCLOSES rather than skipping, so a
+		// truncated traversal is visible instead of silently reading as clean.
+		//
+		// Excluding them was a detection hole with no attacker required: a document
+		// attached to a document is ordinary (an email attachment saved into a report, a
+		// workbook embedded in a deck). Measured before this change, an SSN in
+		// word/embeddings/oleObject1.docx produced 0 findings, exit 0, zero stderr, no
+		// redacted file, and exit 0 even under --fail-on-incomplete. See #297.
+		return "document"
+
 	default:
-		// Embedded OOXML documents (.docx/.xlsx/.pptx) are deliberately NOT
-		// admitted yet, even though they are the other half of the nesting leak.
-		//
-		// An embedded .docx routes back through the Office preprocessor, which
-		// extracts ITS embeddings, which route back again — the recursion is
-		// unbounded. Measured with a 7KB .docx that embeds itself nine times: all
-		// nine levels were followed, with nothing to stop a file that declares
-		// more. Turning that on before a depth bound exists would trade a
-		// detection gap for a decompression-bomb amplifier, which is a worse
-		// trade for a tool that runs on untrusted input.
-		//
-		// A bound is needed FIRST, and note that none exists today: the claim
-		// that the router already tracks depth (formerly in
-		// BaseMetadataPreprocessor.processEmbeddedMedia, citing a
-		// FileRouter.noteEmbeddedChild that was never written) was false. The only
-		// guards are the size caps above, and a deep-nesting bomb is small on disk.
-		//
-		// Depth cannot live on the preprocessor (one instance is shared across
-		// concurrent workers) nor on the router (also one instance), and the
-		// concrete router ProcessingContext type is unreachable from here (router
-		// imports preprocessors, so the reverse is an import cycle). What IS
-		// reachable: RouterInterface has exactly one real implementor, so a
-		// depth-carrying entry point beside ProcessFile is additive rather than a
-		// signature change across every preprocessor.
-		//
-		// Tracked in #297, which carries the measured repro and that design. This
-		// comment is the reason the case is missing, so nobody "fixes" it by adding
-		// the extension: doing that without the cap trades a detection gap for a
-		// decompression-bomb amplifier, which is the worse trade for a tool that
-		// runs on untrusted input.
 		return ""
 	}
 }

--- a/internal/preprocessors/office_metadata_preprocessor.go
+++ b/internal/preprocessors/office_metadata_preprocessor.go
@@ -52,7 +52,7 @@ func (omp *OfficeMetadataPreprocessor) processOfficeMetadata(filePath string) (*
 	text := omp.formatOfficeMetadata(meta)
 
 	// Process embedded media through router if available
-	embeddedText, embeddedSections := omp.processEmbeddedMedia(filePath)
+	embeddedText, embeddedSections, embeddedWarnings := omp.processEmbeddedMedia(filePath)
 
 	// Declare this extractor's own structure out of band. The container's own
 	// property block is one office_metadata section; each embedded item is its own
@@ -84,6 +84,20 @@ func (omp *OfficeMetadataPreprocessor) processOfficeMetadata(filePath string) (*
 	omp.LogSuccessfulProcessing(meta.Filename, meta.FileSize, meta.MimeType)
 
 	content := omp.BuildSuccessContent(filePath, text, "office_metadata", meta.PageCount)
+
+	// Surface embedded items we declined to descend into.
+	//
+	// ExtractionWarning is the channel that survives FileRouter's combine step -- it is
+	// gathered regardless of a preprocessor's error, unlike Error itself. Hitting the
+	// nesting bound means that item's content was never examined, so it has to reach
+	// the operator; a bound that truncates silently just relocates the gap it was added
+	// to close (#297).
+	if len(embeddedWarnings) > 0 {
+		if content.ExtractionWarning != "" {
+			content.ExtractionWarning += "; "
+		}
+		content.ExtractionWarning += strings.Join(embeddedWarnings, "; ")
+	}
 	content.Sections = sections
 	return content, nil
 }
@@ -168,11 +182,11 @@ func (omp *OfficeMetadataPreprocessor) formatOfficeMetadata(meta *meta_extract_o
 
 // processEmbeddedMedia processes embedded media through router integration,
 // returning the text to append and the out-of-band sections describing it.
-func (omp *OfficeMetadataPreprocessor) processEmbeddedMedia(filePath string) (string, []ContentSection) {
+func (omp *OfficeMetadataPreprocessor) processEmbeddedMedia(filePath string) (string, []ContentSection, []string) {
 	// Extract embedded media for processing
 	embeddedMedia, err := meta_extract_officelib.ExtractEmbeddedMediaForProcessing(filePath)
 	if err != nil || len(embeddedMedia) == 0 {
-		return "", nil
+		return "", nil, nil
 	}
 
 	// Ensure cleanup of temporary files

--- a/internal/router/file_router.go
+++ b/internal/router/file_router.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/awslabs/ferret-scan/v2/internal/observability"
@@ -25,7 +26,35 @@ type FileRouter struct {
 	metrics       *RouterMetrics
 	logger        *DebugLogger
 	observer      observability.Observer
+
+	// embeddedDepth records how deep each in-flight file sits inside a container,
+	// keyed by the path handed to ProcessEmbedded. Absent means top level (0).
+	//
+	// This lives on the ROUTER because nothing else can hold it: one preprocessor
+	// instance is shared across concurrent workers, and Preprocessor.Process takes no
+	// context to thread a depth through. A mutex-protected map keyed on path is the
+	// mechanism a stale comment in base_metadata_preprocessor.go used to CLAIM
+	// existed (citing a FileRouter.noteEmbeddedChild that was never written); this is
+	// that mechanism, actually written. See #297.
+	//
+	// Entries are removed when the child finishes, so the map holds only the files
+	// currently being processed rather than growing across a directory scan.
+	embeddedDepthMu sync.Mutex
+	embeddedDepth   map[string]int
 }
+
+// MaxEmbeddedDepth bounds how deep the router follows containers inside containers.
+//
+// Without a bound, admitting embedded OOXML documents is a decompression-bomb
+// amplifier: an embedded .docx routes back through the Office preprocessor, which
+// extracts ITS embeddings, which route back again. Measured previously with a 7KB
+// .docx that embeds itself nine times: all nine levels were followed, with nothing to
+// stop a file declaring more.
+//
+// Three levels covers every legitimate shape observed (a report with an attached
+// workbook that itself has an embedded image) with margin. Reaching the bound is
+// DISCLOSED, not silently skipped -- see ErrEmbeddedTooDeep.
+const MaxEmbeddedDepth = 3
 
 // MaxFileSize is the default maximum file size the router will process (100 MB).
 const MaxFileSize = int64(100 * 1024 * 1024)
@@ -165,6 +194,54 @@ func (fr *FileRouter) ProcessFileWithContext(filePath string, config *Processing
 }
 
 // ProcessFile processes a file through the routing system (interface method)
+// ProcessEmbedded processes a child file extracted OUT OF parentPath, enforcing
+// MaxEmbeddedDepth.
+//
+// The caller (a metadata preprocessor, via RouterInterface) knows its own path -- that
+// is the argument its Process received -- so passing it as parentPath is all the router
+// needs to compute the child's depth. That avoids threading a depth through
+// Preprocessor.Process, which would touch every preprocessor for the benefit of the two
+// that recurse.
+//
+// Returns ErrEmbeddedTooDeep at the bound. The caller must DISCLOSE that: refusing to
+// descend is incomplete coverage, and this whole change exists because undisclosed
+// missing coverage reads as a clean result.
+func (fr *FileRouter) ProcessEmbedded(childPath, parentPath string) (*preprocessors.ProcessedContent, error) {
+	depth := fr.depthOf(parentPath) + 1
+	if depth > MaxEmbeddedDepth {
+		return nil, fmt.Errorf("%w: %s is nested %d levels deep (limit %d)",
+			preprocessors.ErrEmbeddedTooDeep, filepath.Base(childPath), depth, MaxEmbeddedDepth)
+	}
+
+	fr.setDepth(childPath, depth)
+	// Removed when this child finishes, so the map tracks only in-flight files.
+	defer fr.clearDepth(childPath)
+
+	return fr.ProcessFile(childPath, nil)
+}
+
+// depthOf reports how deep a path sits inside containers. Absent = top level.
+func (fr *FileRouter) depthOf(path string) int {
+	fr.embeddedDepthMu.Lock()
+	defer fr.embeddedDepthMu.Unlock()
+	return fr.embeddedDepth[path]
+}
+
+func (fr *FileRouter) setDepth(path string, depth int) {
+	fr.embeddedDepthMu.Lock()
+	defer fr.embeddedDepthMu.Unlock()
+	if fr.embeddedDepth == nil {
+		fr.embeddedDepth = make(map[string]int)
+	}
+	fr.embeddedDepth[path] = depth
+}
+
+func (fr *FileRouter) clearDepth(path string) {
+	fr.embeddedDepthMu.Lock()
+	defer fr.embeddedDepthMu.Unlock()
+	delete(fr.embeddedDepth, path)
+}
+
 func (fr *FileRouter) ProcessFile(filePath string, config interface{}) (*preprocessors.ProcessedContent, error) {
 	if ctx, ok := config.(*ProcessingContext); ok {
 		return fr.processFileInternal(filePath, ctx)


### PR DESCRIPTION
Refs #297.

> ### ⚠️ Read this first: detection is fixed, **redaction is not**
>
> The redacted `.docx` still contains the inner SSN in cleartext, with `rc=0` and no warning. This is **pre-existing** for all embedded content — no redactor rewrites an embedded part (`grep`: **0** files under `internal/redactors/` handle `embeddings`), so an embedded image's EXIF findings were already unredactable. This change adds documents to that class rather than creating it.
>
> The behaviour change worth weighing: before, you had no idea. Now the finding is reported, `--enable-redaction` exits 0, and the output file still holds the value. Tracked as a follow-up; see the bottom of this PR.

## The leak

An Office document embedded in another Office document was never scanned. Measured on main:

```console
$ ferret-scan --config /dev/null --checks SSN --limit 0 --file outer.docx
No matches found.
$ echo $?
0
# stderr: 0 bytes.  --fail-on-incomplete: also 0.  --enable-redaction: no output file at all.
```

The outer document's cover page reads *"Cover page only, nothing sensitive here"*; the SSN sits in `word/embeddings/oleObject1.docx`. Reported clean, no diagnostic, no exit-code signal.

## Why it was excluded, and why that was right

`embeddedMediaType` admitted images, audio and legacy `.doc/.xls/.ppt` (a leaf format — its extractor follows nothing) but excluded OOXML, because an embedded `.docx` routes back through the Office preprocessor, which extracts **its** embeddings, which route back again. Unbounded recursion, and a decompression-bomb amplifier. Measured previously: a 7KB self-nesting `.docx` was followed to all **nine** levels.

That exclusion was correct. What was missing was the bound.

## The bound

`FileRouter` now owns nesting depth in a mutex-protected map keyed on the path handed to a new `ProcessEmbedded(childPath, parentPath)`, refusing past `MaxEmbeddedDepth` (3) with the sentinel `ErrEmbeddedTooDeep`.

The router is the only component that **can** own this: one preprocessor instance is shared across concurrent workers, and `Preprocessor.Process` takes no context to thread a depth through. The preprocessor knows its own path — it's the argument to `Process` — so passing it as `parentPath` suffices, with **no change to the Preprocessor interface**. `RouterInterface` has exactly one real implementor, so the method is additive.

This is the mechanism a comment used to *claim* existed, citing a `FileRouter.noteEmbeddedChild` that was never written (corrected in #298). It is now actually written.

## Disclosure — the half that makes a cap honest

Hitting the bound is **reported**, not skipped. `ProcessEmbeddedMedia` returns warnings; `office_metadata_preprocessor` attaches them to `ExtractionWarning` — the channel that survives `FileRouter`'s combine step, unlike `Error`.

That needed one more link than expected. The bound fires **deep** in the chain and sets the warning on that level's content; every level above read only `processed.Text`, so a 9-level bomb terminated correctly and reported **nothing at all** — measured: 0 findings, 0 disclosure lines. The loop now carries a child's `ExtractionWarning` upward, so the top level (the one the operator sees) says coverage was cut short.

## Measured

**Depth ladder** — SSN hidden at each level:

| SSN depth | found | "nesting limit" disclosed |
|---|---|---|
| 0 (the file itself) | ✅ | — |
| 1 | ✅ | — |
| 2 | ✅ | — |
| 3 | ✅ | — |
| **4** | ❌ | ✅ |
| 5 | ❌ | ✅ |

**Bomb** — 9-level self-nesting `.docx`: terminates in **0.06s**, 0 findings, and prints

```
embedded item "oleObject1.docx" was not examined: embedded container nesting limit
reached: ... is nested 4 levels deep (limit 3)
```

**Mixed types recurse** — `.docx` → `.docx` → legacy `.doc` with the SSN only in a `1Table` stream (which also exercises #302):

```
[HIGH] ssn SSN 100.00% 447-62-9183   mixed.docx
```

**O(n²)** — fan-out 5/10/20/40 embedded children: **1.16×, 1.30×** per doubling, sub-linear. Depth capped at 3, so depth × fan-out stays linear.

## Test-pin inversion

`TestEmbeddedMediaTypeScoping` pinned the exclusion with *"a depth bound must land first"*. It has landed, so the assertion is inverted and now points at the router test guarding the bound — the safety property moved rather than being dropped.

## Test plan

- **1** build / vet / gofmt clean
- **2** full suite `rc=0`, **65 packages**
- **3** golden **0 files moved**; **3b** score corpus unchanged
- **4** fan-out growth above; complexity guard green
- **13** `-race` clean on router, preprocessors, and the office extractor
- **5 FAILS BY DESIGN** — see the banner at the top. Documented rather than hidden.

## Follow-up

The redaction half needs the Office redactor to descend into embedded parts, or — smaller and honest in the meantime — `core/redact.go`'s existing `UnredactedFiles` guard wired to this case, so the tool cannot report success on a file it found something in but could not clean. Filing that separately.