### PR TITLE
fix(preprocessors): decide unlisted extensions on the bytes, so text files are not silently skipped

### DIFF
--- a/internal/preprocessors/plaintext_preprocessor.go
+++ b/internal/preprocessors/plaintext_preprocessor.go
@@ -114,7 +114,53 @@ func (ptp *PlainTextPreprocessor) CanProcess(filePath string) bool {
 		return ptp.isTextFile(filePath)
 	}
 
+	// An extension no preprocessor claims by name: decide on the BYTES.
+	//
+	// This is the same argument as the container case above, in its weakest form.
+	// A .swift or .kt file is not mislabelled and needs no attacker — it is simply
+	// a text format nobody enumerated. The allowlist above holds ~45 extensions and
+	// will always lag the set of text formats that exist: .swift, .kt, .kts, .tf,
+	// .tfvars, .properties, .jsx, .tsx, .dart, .m, .mm, .proto, .vue and .gradle
+	// were all absent, so a Terraform variables file or a Java .properties — two of
+	// the likeliest places on disk to find a credential — scanned as zero findings.
+	//
+	// Worse, the router's own gate already decides this by sniffing:
+	// CanProcessFile answers `true, "Text file"` for a .swift file, and then
+	// processFileInternal finds no capable preprocessor and fails the file. The
+	// scan reports "No matches found" and exit 0 over a file it never read. That
+	// gate-versus-preprocessor drift is the bug this closes; deciding here on the
+	// same signal the gate uses is what keeps the two in agreement.
+	//
+	// Deliberately NOT claimed: extensions belonging to the image, video and audio
+	// metadata extractors. Those route to a preprocessor that handles them, so they
+	// are not the failing case, and claiming them would change behavior for every
+	// media file rather than recovering an unscanned one.
+	if !claimedByAnotherPreprocessor(ext) {
+		return ptp.isTextFile(filePath)
+	}
+
 	return false
+}
+
+// mediaExtValidator answers which extensions the media metadata extractors handle.
+// It is the same validator the router's routing gate delegates to, so this
+// preprocessor and the gate cannot drift about who owns an extension.
+var mediaExtValidator = NewFileExtensionValidator()
+
+// claimedByAnotherPreprocessor reports whether ext routes to a preprocessor other
+// than this one on name alone.
+//
+// Office and PDF are excluded from the check because containerExtensions has
+// already handled them above with a sniff: they are claimed by another
+// preprocessor AND claimable here when the bytes turn out to be text. What
+// remains are the media types, which this preprocessor should not claim.
+func claimedByAnotherPreprocessor(ext string) bool {
+	// The Is*File predicates run filepath.Ext internally, which returns "" for a
+	// bare ".heic", so give them a filename to inspect.
+	probe := "f" + ext
+	return mediaExtValidator.IsImageFile(probe) ||
+		mediaExtValidator.IsVideoFile(probe) ||
+		mediaExtValidator.IsAudioFile(probe)
 }
 
 // containerExtensions are the extensions whose files are normally binary

--- a/internal/preprocessors/text_fallback_test.go
+++ b/internal/preprocessors/text_fallback_test.go
@@ -1,0 +1,140 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package preprocessors
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeFile puts content at dir/name and returns the path.
+func writeFile(t *testing.T, dir, name string, content []byte) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// textWithFinding is a body every scan of it should find something in, so a test
+// that gets zero findings has failed rather than merely matched nothing.
+var textWithFinding = []byte("let ssn = \"796-58-4123\"\nlet key = \"AKIAIOSFODNN7EXAMPLE\"\n")
+
+// binaryBytes is unambiguously not text: nulls, invalid UTF-8, no long printable
+// run for the ASCII-ratio fallback to latch onto.
+var binaryBytes = []byte{0x00, 0x01, 0x02, 0x03, 0xff, 0xfe, 0x00, 0x00, 0xde, 0xad, 0xbe, 0xef, 0x00, 0x7f, 0x80, 0x00}
+
+// TestUnlistedTextExtensionsAreClaimed is the recall hole this fallback closes.
+//
+// The extension allowlist held ~45 entries and every extension below was absent,
+// so the file scanned as zero findings while the CLI printed "No matches found"
+// and exited 0. .tf/.tfvars and .properties are the costly ones — a Terraform
+// variables file and a Java properties file are two of the likeliest places on
+// disk to find a live credential.
+func TestUnlistedTextExtensionsAreClaimed(t *testing.T) {
+	ptp := NewPlainTextPreprocessor()
+	dir := t.TempDir()
+
+	// The three that prompted this (a mobile source tree), plus the wider set of
+	// text formats nobody had enumerated.
+	exts := []string{
+		".swift", ".kt", ".kts", // reported: iOS + Android sources
+		".tf", ".tfvars", ".properties", // credentials live here
+		".m", ".mm", ".dart", ".scala", ".groovy", ".gradle",
+		".jsx", ".tsx", ".vue", ".svelte",
+		".proto", ".graphql", ".lua", ".pl", ".r", ".ex", ".exs", ".erl", ".clj",
+		".cc", ".cxx", ".hh", ".editorconfig", ".gitattributes",
+	}
+	for _, ext := range exts {
+		t.Run(ext, func(t *testing.T) {
+			p := writeFile(t, dir, "sample"+ext, textWithFinding)
+			if !ptp.CanProcess(p) {
+				t.Errorf("text bytes named %q are not claimed, so the file is never read", ext)
+			}
+		})
+	}
+}
+
+// TestBinaryBytesRefusedWhateverTheExtension keeps the fallback honest. Claiming an
+// unlisted extension has to remain a decision about the BYTES; if it degraded into
+// "claim everything", the text extractor would be handed compiled objects, archives
+// and images, and the null-byte gate that keeps binary out of the scanner would be
+// the only thing left standing.
+func TestBinaryBytesRefusedWhateverTheExtension(t *testing.T) {
+	ptp := NewPlainTextPreprocessor()
+	dir := t.TempDir()
+
+	for _, name := range []string{"blob.xyz", "blob.frobnicate", "blob.o", "blob.class", "blob"} {
+		t.Run(name, func(t *testing.T) {
+			p := writeFile(t, dir, name, binaryBytes)
+			if ptp.CanProcess(p) {
+				t.Errorf("binary bytes in %q were claimed as text", name)
+			}
+		})
+	}
+}
+
+// TestMediaExtensionsStayWithTheirExtractor guards the one deliberate exclusion.
+//
+// Image, video and audio files route to a metadata extractor that knows how to read
+// them. They are not the failing case this fallback exists for, and claiming them
+// would change behavior for every media file rather than recovering an unscanned
+// one.
+//
+// The list is derived from FileExtensionValidator rather than hardcoded, so if an
+// extension is added there this test covers it automatically instead of drifting —
+// drift between a hardcoded copy and this validator is the original sin behind the
+// bug being fixed here (see the .heic case in internal/router).
+func TestMediaExtensionsStayWithTheirExtractor(t *testing.T) {
+	ptp := NewPlainTextPreprocessor()
+	v := NewFileExtensionValidator()
+	dir := t.TempDir()
+
+	var media []string
+	media = append(media, v.GetImageExtensions()...)
+	media = append(media, v.GetVideoExtensions()...)
+	media = append(media, v.GetAudioExtensions()...)
+	if len(media) == 0 {
+		t.Fatal("validator reported no media extensions; the assertion would be vacuous")
+	}
+
+	for _, ext := range media {
+		t.Run(ext, func(t *testing.T) {
+			// Text bytes, so only the extension exclusion can prevent the claim.
+			p := writeFile(t, dir, "sample"+ext, textWithFinding)
+			if ptp.CanProcess(p) {
+				t.Errorf("%q was claimed as text; it must route to its metadata extractor", ext)
+			}
+		})
+	}
+}
+
+// TestRealContainerStillDeclined pins that the fallback did not weaken the
+// container sniff. A well-formed Office file is a ZIP, so its bytes are binary and
+// this preprocessor must keep declining it — that is what leaves the Office
+// extractor to win on a real document.
+func TestRealContainerStillDeclined(t *testing.T) {
+	ptp := NewPlainTextPreprocessor()
+	dir := t.TempDir()
+
+	// ZIP local file header ("PK\x03\x04") followed by binary payload: the shape of
+	// every OOXML container.
+	zipish := append([]byte("PK\x03\x04"), binaryBytes...)
+	for _, name := range []string{"real.docx", "real.xlsx", "real.pptx"} {
+		t.Run(name, func(t *testing.T) {
+			p := writeFile(t, dir, name, zipish)
+			if ptp.CanProcess(p) {
+				t.Errorf("%q looks like a real container but was claimed as text", name)
+			}
+		})
+	}
+
+	// And the mislabelled case still works: text bytes under a container name.
+	p := writeFile(t, dir, "mislabelled.docx", textWithFinding)
+	if !ptp.CanProcess(p) {
+		t.Error("text bytes named .docx are not claimed; the container sniff regressed")
+	}
+}

--- a/internal/router/gate_routing_agreement_test.go
+++ b/internal/router/gate_routing_agreement_test.go
@@ -1,0 +1,143 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package router
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestGateAndRoutingAgree is the invariant whose violation produced this whole bug
+// class, asserted directly rather than through any one extension.
+//
+// CanProcessFile is a PROMISE: the CLI, pkg/scan and the pre-commit hook all use it
+// to decide whether a file is worth handing to the scanner. When it answers true and
+// the routing then finds no capable preprocessor, the file is reported as scanned-and
+// -clean while its contents were never read — "No matches found", exit 0, over a
+// file holding credentials.
+//
+// It has broken twice in opposite directions. For .heic the gate claimed an
+// extension no preprocessor handled (v2 gap 5.3, fixed by deriving the metadata
+// branch of the gate from FileExtensionValidator). For .swift, .kt, .tf and
+// .properties the gate sniffed the bytes, said "Text file", and the text
+// preprocessor's extension allowlist then declined the file. Both are the same
+// defect: two components answering "can this be processed" with different rules.
+//
+// So this test does not enumerate the extensions that happen to be broken today. It
+// asserts the property.
+func TestGateAndRoutingAgree(t *testing.T) {
+	fr := NewFileRouter(false)
+	RegisterDefaultPreprocessors(fr)
+	fr.InitializePreprocessors(CreateRouterConfig(false))
+
+	textBody := []byte("let ssn = \"796-58-4123\"\nlet key = \"AKIAIOSFODNN7EXAMPLE\"\n")
+	binaryBody := []byte{0x00, 0x01, 0x02, 0x03, 0xff, 0xfe, 0x00, 0x00, 0xde, 0xad, 0xbe, 0xef, 0x00, 0x7f}
+
+	cases := []struct {
+		name string
+		body []byte
+	}{
+		// Listed text, unlisted text, and the mobile sources that surfaced this.
+		{"a.txt", textBody},
+		{"a.swift", textBody},
+		{"a.kt", textBody},
+		{"build.gradle.kts", textBody},
+		{"vars.tf", textBody},
+		{"app.properties", textBody},
+		{"a.dart", textBody},
+		{"Component.tsx", textBody},
+		// No extension, and a name with no dot at all.
+		{"noext", textBody},
+		{"Makefile", textBody},
+		// Extensions nothing claims by name.
+		{"a.frobnicate", textBody},
+		{"a.xyz", textBody},
+		// Binary under assorted names, including a container name and an
+		// extension the metadata validator does not recognize.
+		{"b.xyz", binaryBody},
+		{"b.docx", binaryBody},
+		{"b.heic", binaryBody},
+		{"b", binaryBody},
+		// Text bytes wearing a container extension: the mislabelled-export case.
+		{"mislabelled.docx", textBody},
+	}
+
+	dir := t.TempDir()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(dir, tc.name)
+			if err := os.WriteFile(path, tc.body, 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			admitted, reason := fr.CanProcessFile(path, true)
+			if !admitted {
+				// Declining is always allowed — the gate is permitted to be
+				// conservative. It just has to give a reason.
+				if strings.TrimSpace(reason) == "" {
+					t.Errorf("gate declined %q with an empty reason", tc.name)
+				}
+				return
+			}
+
+			// Admitted: the routing must be able to act on that promise.
+			_, err := fr.ProcessFile(path, nil)
+			if err == nil {
+				return
+			}
+			if strings.Contains(err.Error(), "no preprocessor can handle file") {
+				t.Errorf("gate admitted %q as %q, but routing has no preprocessor for it.\n"+
+					"A caller trusting the gate reports this file as scanned while its "+
+					"contents were never read.\nerror: %v", tc.name, reason, err)
+			}
+			// Other errors are real processing failures (a truncated container, an
+			// unreadable stream). Those are disclosed as incomplete coverage by the
+			// callers and are not this invariant's concern.
+		})
+	}
+}
+
+// TestUnlistedTextExtensionScansLikeItsBytes is the end-to-end statement of the
+// fix: routing a .swift file must produce the same extracted text as the identical
+// bytes named .txt. Equality is the point — "some text came back" would pass while
+// silently truncating.
+func TestUnlistedTextExtensionScansLikeItsBytes(t *testing.T) {
+	fr := NewFileRouter(false)
+	RegisterDefaultPreprocessors(fr)
+	fr.InitializePreprocessors(CreateRouterConfig(false))
+
+	body := []byte("let ssn = \"796-58-4123\"\nlet key = \"AKIAIOSFODNN7EXAMPLE\"\n")
+	dir := t.TempDir()
+
+	ref := filepath.Join(dir, "ref.txt")
+	if err := os.WriteFile(ref, body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	refContent, err := fr.ProcessFile(ref, nil)
+	if err != nil {
+		t.Fatalf("reference .txt failed to process: %v", err)
+	}
+	if !strings.Contains(refContent.Text, "796-58-4123") {
+		t.Fatalf("reference .txt did not yield its own content; fixture is broken: %q", refContent.Text)
+	}
+
+	for _, name := range []string{"Creds.swift", "Creds.kt", "build.gradle.kts", "vars.tf", "app.properties"} {
+		t.Run(name, func(t *testing.T) {
+			p := filepath.Join(dir, name)
+			if err := os.WriteFile(p, body, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			got, err := fr.ProcessFile(p, nil)
+			if err != nil {
+				t.Fatalf("%s: %v", name, err)
+			}
+			if got.Text != refContent.Text {
+				t.Errorf("%s extracted text differs from the identical bytes named .txt\n got: %q\nwant: %q",
+					name, got.Text, refContent.Text)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #309. Base is `main`, no stack.

## The bug

A text file whose extension isn't on `PlainTextPreprocessor`'s ~45-entry allowlist was never read. The CLI printed **"No matches found"** and exited **0** over a file holding credentials:

```
$ printf 'let apiKey = "AKIAIOSFODNN7EXAMPLE"\nlet ssn = "796-58-4123"\n' > Creds.swift
$ ferret-scan --file Creds.swift
No matches found.
$ echo $?
0
```

Identical bytes named `Creds.txt` report both findings.

Reported against a mobile source tree (`.swift`, `.kt`, `.kts`), but **all 36** common text extensions I probed were unclaimed — including `.tf`/`.tfvars`, `.properties`, `.jsx`/`.tsx`, `.m`/`.mm`, `.dart`, `.gradle`, `.proto`, `.vue`. A Terraform variables file and a Java properties file are two of the likeliest places on disk to hold a live credential.

Dotfiles are an affected class too, since `filepath.Ext(".dockerignore")` returns `".dockerignore"`. **This repo's own tree had six unexamined files**: `.dockerignore`, `.gitattributes`, `.go-version`, `.trivyignore`, `go.mod`, `go.sum`.

## Root cause: the gate and the preprocessor disagreed about what "text" is

- **`FileRouter.CanProcessFile`** decides by **sniffing the bytes**. For `.swift` → `true, "Text file"`.
- **`PlainTextPreprocessor.CanProcess`** decides by **extension allowlist**, with sniffs bolted on for extensionless files and `containerExtensions`. Everything else hit `return false`.

The gate admits, `processFileInternal` finds `len(capable) == 0`, the file fails mid-pipeline:

```
Creds.swift   gate=true/"Text file"  -> 0 findings, incomplete=true
Creds.txt     gate=true/"Text file"  -> 1 finding,  incomplete=false
```

**This repo already documents that drift as a bug it fixed once** — for `.heic`, where the gate claimed an extension no preprocessor handled, which is why the gate's metadata branch now derives from `FileExtensionValidator` (v2 gap 5.3). The *text* half was never closed, and an allowlist will always lag the set of text formats that exist.

## The fix

`CanProcess` now decides an unclaimed extension the way the gate does — on the bytes. That's the argument `containerExtensions` already makes ("a text file named `.pdf` is exactly as unscannable as one named `.docx`, and the sniff is what decides"), in its weakest form: a `.swift` file isn't even mislabelled, it's a text format nobody enumerated.

No new machinery — `isTextFile` → `LooksLikeText` already handles UTF-8, UTF-16 (BOM'd and heuristic), and a legacy single-byte fallback behind a null-byte gate, and is what keeps real containers out today.

**Media extensions are deliberately still declined.** They route to a metadata extractor that reads them properly, so they aren't the failing case, and claiming them would change behavior for every media file rather than recover an unscanned one. The exclusion derives from the same `FileExtensionValidator` the router's gate uses, so the two can't drift about who owns an extension — that drift being the defect above.

## Measured on this repository

```
before   22 scanned, 6 NOT examined, 1 skipped | 444 findings
after    28 scanned, 0 NOT examined, 1 skipped | 444 findings
```

Coverage up six files, **finding count unchanged** — the newly-read files were clean, so the recall gap closed without adding noise here. On a tree of `.swift`/`.kt` sources it finds what was always there.

Binary files are unaffected: with an unlisted extension they still fail the sniff and are skipped with a reason. Verified for nulls, random bytes, and real ZIP-shaped containers.

## ⚠️ Operational note

Files that were silently skipped are now scanned, so **an existing scan can report findings it didn't before, and a CI gate on finding count can newly fail.** That's the intent — the findings were always there and the tool reported a clean result over them — but it's a behavior change, so I'd suggest **its own release** so the effect is attributable rather than tangled with anything else.

Suppression rules are unaffected: a finding that never existed has no rule.

## Tests

`TestGateAndRoutingAgree` asserts **the invariant, not an extension list**: for every file the gate admits, routing must not fail with "no preprocessor can handle file". That's the property both this bug and the `.heic` bug violated, in opposite directions, so it closes the class rather than the instance. **Mutation-tested** — reverting the fix fails it for `.swift`, `.kt`, `.kts`, `.tf`, `.properties`.

`TestUnlistedTextExtensionScansLikeItsBytes` asserts extracted text is *equal* to the same bytes named `.txt`, so a partial read can't pass.

Preprocessor tests cover the newly claimed extensions, binary refusal under assorted names, real containers still declining, the mislabelled-container case still working, and media staying with their extractor — that last derived from the validator, so a new media extension is covered automatically instead of drifting.

## Verification

`go test ./...` (65 packages), `go vet ./...`, `gofmt`, `make build` — all clean. Golden corpus needed **no** regeneration: no fixture carries an unlisted extension.

## Follow-ups I did not fold in

1. **A skipped file is silently clean in single-file mode.** A binary file with an unlisted extension prints "No matches found" and exits 0 with no disclosure — I verified this is unchanged before and after this fix, so it's pre-existing, but it's the same "undisclosed missing coverage" shape #284 addressed for directory mode. Worth its own issue.
2. **`.heic` and `.avi` are claimed by no preprocessor at all** — absent from `FileExtensionValidator`'s image/video lists, so a real (binary) one gets neither text nor metadata extraction. This PR makes a *text* file so named scannable; real media files stay unsupported. Separate gap.
