### PR TITLE
fix(redact): redact files embedded inside documents, and fail loudly when we cannot

### DIFF
--- a/internal/core/redact.go
+++ b/internal/core/redact.go
@@ -204,10 +204,12 @@ func NewDefaultRedactionManager(outputDir string, strategy redactors.RedactionSt
 			FailureHandling:         redactors.FailureHandlingGraceful,
 		})
 
+	officeRedactor := office.NewOfficeRedactor(outputManager, observer)
+
 	for _, r := range []redactors.Redactor{
 		plaintext.NewPlainTextRedactor(outputManager, observer),
 		pdf.NewPDFRedactor(outputManager, observer),
-		office.NewOfficeRedactor(outputManager, observer),
+		officeRedactor,
 		legacyole.NewLegacyOLERedactor(outputManager, observer),
 		image.NewImageMetadataRedactor(outputManager, observer),
 	} {
@@ -215,5 +217,19 @@ func NewDefaultRedactionManager(outputDir string, strategy redactors.RedactionSt
 			return nil, nil, fmt.Errorf("failed to register redactor %s: %w", r.GetName(), err)
 		}
 	}
+
+	// Let the Office redactor descend into files embedded inside a document.
+	//
+	// Injected AFTER registration because the dispatcher is the manager that owns
+	// every redactor, and an embedded part is routed by type exactly as a top-level
+	// file is: an embedded .docx to this same redactor, a .jpg to the image
+	// redactor, a .doc to the legacy OLE one. Without this call the Office redactor
+	// still runs, but reports any embedded part holding a reported value as
+	// unredacted rather than silently shipping it.
+	//
+	// The manager bounds the recursion (embedded.MaxDepth), so registering the
+	// Office redactor with a dispatcher that can route back to it is not unbounded.
+	officeRedactor.SetEmbeddedRedactor(manager)
+
 	return manager, outputManager, nil
 }

--- a/internal/core/redact_embedded_test.go
+++ b/internal/core/redact_embedded_test.go
@@ -1,0 +1,648 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package core
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/binary"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/config"
+)
+
+// A value inside a file inside a file must be REDACTED, not merely reported.
+//
+// The read side already descends into embedded parts, so these values are found.
+// The write side did not, so they were reported and then shipped in cleartext.
+// Measured on the parent commit, with the container's OWN SSN correctly redacted
+// in every row:
+//
+//	outer.docx -> word/embeddings/oleObject1.docx   SSN in cleartext, exit 0, no warning
+//	outer.docx -> word/media/image1.jpg (EXIF)      SSN in cleartext, exit 0, no warning
+//	both of the above in one document               2 values in cleartext
+//
+// Only reported findings are redacted, so a value the redactor cannot reach is a
+// leak that reports as success — a file sitting in a directory named "redacted"
+// with the SSN still in it. See #305.
+//
+// These tests are the SINK test for that. They assert on the bytes actually
+// written, descending into every nested archive member, because grepping a .docx
+// searches COMPRESSED bytes and finds nothing — which is indistinguishable from a
+// clean file and is the most common way a leak in this area gets certified fixed.
+
+const (
+	// childSSN lives only inside the embedded part.
+	childSSN = "452-11-9384"
+	// outerSSN lives in the container's own body. It is the control: it was already
+	// redacted correctly before this change, so a test that stops finding it has
+	// broken the pre-existing behaviour rather than proving the fix.
+	outerSSN = "536-90-4271"
+)
+
+func TestEmbeddedDocumentValuesAreRedacted(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		build func(t *testing.T, dir string) string
+	}{
+		{"office document embedded in a document", func(t *testing.T, dir string) string {
+			return writeDocx(t, dir, "outer_docx.docx", map[string][]byte{
+				"word/embeddings/oleObject1.docx": buildChildDocx(t, childSSN),
+			})
+		}},
+		{"image EXIF embedded in a document", func(t *testing.T, dir string) string {
+			return writeDocx(t, dir, "outer_img.docx", map[string][]byte{
+				"word/media/image1.jpg": buildJPEGWithEXIF(t, "Contact SSN "+childSSN),
+			})
+		}},
+		{"both kinds of child in one document", func(t *testing.T, dir string) string {
+			return writeDocx(t, dir, "outer_both.docx", map[string][]byte{
+				"word/embeddings/oleObject1.docx": buildChildDocx(t, childSSN),
+				"word/media/image1.jpg":           buildJPEGWithEXIF(t, "Contact SSN "+childSSN),
+			})
+		}},
+		{"child nested two levels deep", func(t *testing.T, dir string) string {
+			// A .docx inside a .docx inside a .docx. Well within embedded.MaxDepth,
+			// so nothing may be skipped and nothing may leak.
+			inner := buildChildDocx(t, childSSN)
+			mid := buildDocxBytes(t, "middle document", map[string][]byte{
+				"word/embeddings/inner.docx": inner,
+			})
+			return writeDocx(t, dir, "outer_deep.docx", map[string][]byte{
+				"word/embeddings/mid.docx": mid,
+			})
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			in := tc.build(t, dir)
+			outDir := filepath.Join(dir, "redacted")
+
+			res, err := RedactFile(RedactConfig{
+				FilePath:  in,
+				OutputDir: outDir,
+				Checks:    []string{"SSN"},
+				Config:    config.LoadConfigOrDefault(""),
+			})
+			if err != nil {
+				t.Fatalf("RedactFile: %v", err)
+			}
+			if res.RedactionCount == 0 {
+				t.Fatalf("RedactionCount is 0; the fixture produced no redactions at all, "+
+					"so this test cannot show anything about nested content (path %s)", in)
+			}
+
+			written := findOneFile(t, outDir)
+
+			// The child's value must be gone from EVERY nested member.
+			if hits := cleartextHits(t, written, childSSN); len(hits) > 0 {
+				t.Errorf("the embedded value survived redaction in %d place(s):\n  %s\n"+
+					"This file is in a directory named \"redacted\" and the run reported "+
+					"%d redactions, so a caller would forward it.",
+					len(hits), strings.Join(hits, "\n  "), res.RedactionCount)
+			}
+
+			// The container's own value must STILL be gone — the control.
+			if hits := cleartextHits(t, written, outerSSN); len(hits) > 0 {
+				t.Errorf("the container's own value is no longer redacted (%v); the change "+
+					"broke pre-existing behaviour rather than adding to it", hits)
+			}
+		})
+	}
+}
+
+// TestUnredactableEmbeddedPartFailsLoudly is the other half, and the one that keeps
+// the fix honest.
+//
+// Two shapes reach it, and both must refuse to write:
+//
+//   - a part whose bytes demonstrably hold a reported value and whose redactor cannot
+//     process them (an undecodable image carrying the same SSN as the body);
+//   - an embedded PDF, which is scanned -- so its values ARE reported -- but which no
+//     redactor can rewrite, and whose FlateDecode streams mean a byte scan cannot
+//     prove it clean either.
+//
+// The same policy already applies one level up: a standalone PDF or an undecodable
+// image with findings produces NO file and the run says "redaction incomplete ... the
+// original values remain in cleartext". Nesting must not change the guarantee.
+func TestUnredactableEmbeddedPartFailsLoudly(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		body     string
+		extras   map[string][]byte
+		wantPart string
+	}{
+		{
+			name: "undecodable image holding the body's value",
+			body: "Employee SSN: " + childSSN,
+			extras: map[string][]byte{
+				"word/media/image1.jpg": []byte("\xff\xd8\xff\xe1\x00\x20Exif\x00\x00 ref " +
+					childSSN + " \xff\xd9"),
+			},
+			wantPart: "image1.jpg",
+		},
+		{
+			name: "embedded PDF, scanned but not redactable",
+			body: "Outer body. Outer SSN: " + outerSSN,
+			extras: map[string][]byte{
+				"word/embeddings/attachment.pdf": buildPDFWithText(t, "Employee SSN: "+childSSN),
+			},
+			wantPart: "attachment.pdf",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			in := writeDocxBody(t, dir, "outer.docx", tc.body, tc.extras)
+			outDir := filepath.Join(dir, "redacted")
+
+			_, err := RedactFile(RedactConfig{
+				FilePath:  in,
+				OutputDir: outDir,
+				Checks:    []string{"SSN"},
+				Config:    config.LoadConfigOrDefault(""),
+			})
+			if err == nil {
+				for _, f := range allFiles(outDir) {
+					if hits := cleartextHits(t, f, childSSN); len(hits) > 0 {
+						t.Fatalf("RedactFile reported success and wrote %s with the value "+
+							"still present at %v", f, hits)
+					}
+				}
+				t.Fatal("RedactFile returned nil error for a document with an embedded part " +
+					"it could not redact; the caller has nothing to branch on")
+			}
+			if !strings.Contains(err.Error(), tc.wantPart) {
+				t.Errorf("error %q does not name the offending part %q", err.Error(), tc.wantPart)
+			}
+			for _, f := range allFiles(outDir) {
+				if hits := cleartextHits(t, f, childSSN); len(hits) > 0 {
+					t.Errorf("a file was written at %s containing the cleartext value %v "+
+						"despite the failure", f, hits)
+				}
+			}
+		})
+	}
+}
+
+// TestCleanEmbeddedPartIsLeftByteIdentical is the over-redaction guard, and it caught a
+// real defect in the first version of this change.
+//
+// Every redactor here is lossy in some way: the image redactor DECODES and re-encodes
+// and strips all metadata. So a part holding none of the reported values must not be
+// handed to one merely because the DOCUMENT has findings elsewhere. Measured before the
+// fix, on a document whose body held an SSN and which also carried an unrelated photo:
+// the photo came back re-encoded from 706 to 664 bytes, with a different hash and its
+// caption removed. Nothing in it had ever been reported.
+func TestCleanEmbeddedPartIsLeftByteIdentical(t *testing.T) {
+	dir := t.TempDir()
+
+	photo := buildJPEGWithEXIF(t, "Holiday photo by the sea")
+	in := writeDocxBody(t, dir, "outer_clean_photo.docx",
+		"Body SSN: "+outerSSN,
+		map[string][]byte{"word/media/photo.jpg": photo})
+	outDir := filepath.Join(dir, "redacted")
+
+	res, err := RedactFile(RedactConfig{
+		FilePath:  in,
+		OutputDir: outDir,
+		Checks:    []string{"SSN"},
+		Config:    config.LoadConfigOrDefault(""),
+	})
+	if err != nil {
+		t.Fatalf("RedactFile: %v", err)
+	}
+	if res.RedactionCount == 0 {
+		t.Fatal("no redactions performed; the fixture is broken and this test would be vacuous")
+	}
+
+	written := findOneFile(t, outDir)
+	if hits := cleartextHits(t, written, outerSSN); len(hits) > 0 {
+		t.Errorf("the body value was not redacted: %v", hits)
+	}
+
+	got := readEntry(t, written, "word/media/photo.jpg")
+	if !bytes.Equal(got, photo) {
+		t.Errorf("an embedded part holding NONE of the reported values was rewritten: "+
+			"%d bytes in, %d bytes out.\nThe image redactor decodes and re-encodes and "+
+			"strips metadata, so dispatching a clean part silently degrades content that "+
+			"was never implicated.", len(photo), len(got))
+	}
+	if !bytes.Contains(got, []byte("Holiday photo by the sea")) {
+		t.Error("the innocent photo's caption was stripped")
+	}
+}
+
+// TestContainerWithHarmlessUndecodableChildStillRedacts bounds the blast radius of
+// failing closed.
+//
+// An embedded image that holds NONE of the reported values must not stop the
+// container from being written, even if the image redactor cannot process it. The
+// naive "any child failure fails the document" rule would mean one odd JPEG blocks
+// a 50-redaction document — a regression dressed as safety.
+func TestContainerWithHarmlessUndecodableChildStillRedacts(t *testing.T) {
+	dir := t.TempDir()
+	// Bytes that are not a decodable image and contain none of the values.
+	junk := []byte("\xff\xd8\xff\xe0 this is not a decodable jpeg at all \x00\x01\x02")
+	in := writeDocx(t, dir, "outer_junk.docx", map[string][]byte{
+		"word/media/image1.jpg": junk,
+	})
+	outDir := filepath.Join(dir, "redacted")
+
+	res, err := RedactFile(RedactConfig{
+		FilePath:  in,
+		OutputDir: outDir,
+		Checks:    []string{"SSN"},
+		Config:    config.LoadConfigOrDefault(""),
+	})
+	if err != nil {
+		t.Fatalf("an embedded part holding no reported value blocked the whole document: %v\n"+
+			"Failing closed must be driven by residue, not by any child error.", err)
+	}
+	if res.RedactionCount == 0 {
+		t.Fatal("no redactions performed; the fixture is broken")
+	}
+	written := findOneFile(t, outDir)
+	if hits := cleartextHits(t, written, outerSSN); len(hits) > 0 {
+		t.Errorf("the container's own value was not redacted: %v", hits)
+	}
+}
+
+// TestRedactedContainerStaysAValidPackage — a redacted document must still open.
+//
+// Storing new bytes at an existing entry is only safe if the package's structure
+// survives: OPC requires [Content_Types].xml in the FIRST entry slot, and the
+// repackager preserves source order specifically because ranging a map had been
+// moving it.
+func TestRedactedContainerStaysAValidPackage(t *testing.T) {
+	dir := t.TempDir()
+	in := writeDocx(t, dir, "outer.docx", map[string][]byte{
+		"word/embeddings/oleObject1.docx": buildChildDocx(t, childSSN),
+		"word/media/image1.jpg":           buildJPEGWithEXIF(t, "Contact SSN "+childSSN),
+	})
+	outDir := filepath.Join(dir, "redacted")
+
+	if _, err := RedactFile(RedactConfig{
+		FilePath:  in,
+		OutputDir: outDir,
+		Checks:    []string{"SSN"},
+		Config:    config.LoadConfigOrDefault(""),
+	}); err != nil {
+		t.Fatalf("RedactFile: %v", err)
+	}
+
+	written := findOneFile(t, outDir)
+	zr, err := zip.OpenReader(written)
+	if err != nil {
+		t.Fatalf("the redacted document is not a readable package: %v", err)
+	}
+	defer zr.Close()
+
+	if len(zr.File) == 0 {
+		t.Fatal("the redacted package has no entries")
+	}
+	if got := zr.File[0].Name; got != "[Content_Types].xml" {
+		t.Errorf("first entry is %q, want [Content_Types].xml — OPC requires it in the "+
+			"first slot and Word refuses the file otherwise", got)
+	}
+
+	// Compare the entry NAME LIST with the input's: storing redacted bytes must not
+	// add, drop or reorder entries.
+	if want, got := entryNames(t, in), entryNames(t, written); !equalStrings(want, got) {
+		t.Errorf("entry list changed.\n input: %v\noutput: %v", want, got)
+	}
+
+	// The embedded child must still be a well-formed package of its own.
+	for _, f := range zr.File {
+		if !strings.HasSuffix(f.Name, ".docx") {
+			continue
+		}
+		b := readZipEntry(t, f)
+		if _, err := zip.NewReader(bytes.NewReader(b), int64(len(b))); err != nil {
+			t.Errorf("embedded child %s is no longer a readable package after redaction: %v",
+				f.Name, err)
+		}
+	}
+}
+
+// ---------- helpers ----------
+
+// cleartextHits reports every place needle appears in the file, DESCENDING into
+// nested archive members so a deflated value is found decompressed.
+func cleartextHits(t *testing.T, path, needle string) []string {
+	t.Helper()
+	b, err := os.ReadFile(path) // #nosec G304 -- test-controlled path
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	var hits []string
+	scanForNeedle(t, filepath.Base(path), b, needle, 0, &hits)
+	return hits
+}
+
+func scanForNeedle(t *testing.T, label string, data []byte, needle string, depth int, hits *[]string) {
+	t.Helper()
+	if depth > 6 {
+		return
+	}
+	if bytes.Contains(data, []byte(needle)) {
+		*hits = append(*hits, label)
+	}
+	if !bytes.HasPrefix(data, []byte("PK")) {
+		return
+	}
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return
+	}
+	for _, f := range zr.File {
+		rc, err := f.Open()
+		if err != nil {
+			continue
+		}
+		inner, err := io.ReadAll(io.LimitReader(rc, 64<<20))
+		_ = rc.Close()
+		if err != nil {
+			continue
+		}
+		scanForNeedle(t, label+"!"+f.Name, inner, needle, depth+1, hits)
+	}
+}
+
+func allFiles(dir string) []string {
+	var out []string
+	_ = filepath.Walk(dir, func(p string, fi os.FileInfo, err error) error {
+		if err == nil && fi != nil && !fi.IsDir() {
+			out = append(out, p)
+		}
+		return nil
+	})
+	return out
+}
+
+func findOneFile(t *testing.T, dir string) string {
+	t.Helper()
+	files := allFiles(dir)
+	if len(files) != 1 {
+		t.Fatalf("expected exactly one written file under %s, got %d: %v", dir, len(files), files)
+	}
+	return files[0]
+}
+
+func entryNames(t *testing.T, path string) []string {
+	t.Helper()
+	zr, err := zip.OpenReader(path)
+	if err != nil {
+		t.Fatalf("opening %s: %v", path, err)
+	}
+	defer zr.Close()
+	names := make([]string, 0, len(zr.File))
+	for _, f := range zr.File {
+		names = append(names, f.Name)
+	}
+	return names
+}
+
+func readZipEntry(t *testing.T, f *zip.File) []byte {
+	t.Helper()
+	rc, err := f.Open()
+	if err != nil {
+		t.Fatalf("opening entry %s: %v", f.Name, err)
+	}
+	defer rc.Close()
+	b, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("reading entry %s: %v", f.Name, err)
+	}
+	return b
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+const ctHeader = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+	`<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+	`<Default Extension="xml" ContentType="application/xml"/>` +
+	`<Default Extension="jpg" ContentType="image/jpeg"/>` +
+	`<Default Extension="pdf" ContentType="application/pdf"/>` +
+	`<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>` +
+	`</Types>`
+
+const relsXML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+	`<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>` +
+	`</Relationships>`
+
+func documentXML(body string) string {
+	return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
+		`<w:body><w:p><w:r><w:t>` + body + `</w:t></w:r></w:p></w:body></w:document>`
+}
+
+// buildDocxBytes builds a minimal but valid OOXML package in memory.
+func buildDocxBytes(t *testing.T, body string, extras map[string][]byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	write := func(name string, data []byte) {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatalf("creating %s: %v", name, err)
+		}
+		if _, err := w.Write(data); err != nil {
+			t.Fatalf("writing %s: %v", name, err)
+		}
+	}
+	// [Content_Types].xml first, as OPC requires.
+	write("[Content_Types].xml", []byte(ctHeader))
+	write("_rels/.rels", []byte(relsXML))
+	write("word/document.xml", []byte(documentXML(body)))
+	// Sorted so the fixture is byte-reproducible regardless of map order.
+	for _, name := range sortedKeys(extras) {
+		write(name, extras[name])
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("closing zip: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func sortedKeys(m map[string][]byte) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	// insertion sort keeps this dependency-free and the maps are tiny
+	for i := 1; i < len(keys); i++ {
+		for j := i; j > 0 && keys[j] < keys[j-1]; j-- {
+			keys[j], keys[j-1] = keys[j-1], keys[j]
+		}
+	}
+	return keys
+}
+
+// writeDocx writes a container whose own body holds outerSSN, so every fixture has
+// a control value that was already being redacted before this change.
+func writeDocx(t *testing.T, dir, name string, extras map[string][]byte) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	data := buildDocxBytes(t, "Outer body. Outer SSN: "+outerSSN, extras)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+	return path
+}
+
+// writeDocxBody writes a container with a caller-chosen body, for fixtures where the
+// body's own value is the one that matters.
+func writeDocxBody(t *testing.T, dir, name, body string, extras map[string][]byte) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, buildDocxBytes(t, body, extras), 0o600); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+	return path
+}
+
+// readEntry returns one archive member's bytes.
+func readEntry(t *testing.T, archive, entry string) []byte {
+	t.Helper()
+	zr, err := zip.OpenReader(archive)
+	if err != nil {
+		t.Fatalf("opening %s: %v", archive, err)
+	}
+	defer zr.Close()
+	for _, f := range zr.File {
+		if f.Name == entry {
+			return readZipEntry(t, f)
+		}
+	}
+	t.Fatalf("entry %q not found in %s", entry, archive)
+	return nil
+}
+
+func buildChildDocx(t *testing.T, ssn string) []byte {
+	t.Helper()
+	return buildDocxBytes(t, "Embedded child document. Employee SSN: "+ssn, nil)
+}
+
+// buildJPEGWithEXIF encodes a REAL image and splices in an EXIF APP1 segment
+// carrying desc in ImageDescription.
+//
+// The image is encoded by the standard library rather than hand-rolled, because the
+// image redactor DECODES before re-encoding: a hand-built JPEG without Huffman
+// tables fails with "uninitialized Huffman table", which would make this fixture
+// exercise the error path instead of the redaction path.
+func buildJPEGWithEXIF(t *testing.T, desc string) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, 8, 8))
+	for y := 0; y < 8; y++ {
+		for x := 0; x < 8; x++ {
+			img.Set(x, y, color.RGBA{R: uint8(x * 32), G: uint8(y * 32), B: 128, A: 255})
+		}
+	}
+	var base bytes.Buffer
+	if err := jpeg.Encode(&base, img, &jpeg.Options{Quality: 90}); err != nil {
+		t.Fatalf("encoding jpeg: %v", err)
+	}
+	b := base.Bytes()
+
+	d := append([]byte(desc), 0)
+	var tiff bytes.Buffer
+	tiff.WriteString("MM")
+	_ = binary.Write(&tiff, binary.BigEndian, uint16(42))
+	_ = binary.Write(&tiff, binary.BigEndian, uint32(8))
+	_ = binary.Write(&tiff, binary.BigEndian, uint16(1))
+	_ = binary.Write(&tiff, binary.BigEndian, uint16(0x010E)) // ImageDescription
+	_ = binary.Write(&tiff, binary.BigEndian, uint16(2))      // ASCII
+	_ = binary.Write(&tiff, binary.BigEndian, uint32(len(d)))
+	_ = binary.Write(&tiff, binary.BigEndian, uint32(26)) // value offset
+	_ = binary.Write(&tiff, binary.BigEndian, uint32(0))  // no next IFD
+	tiff.Write(d)
+
+	payload := append([]byte("Exif\x00\x00"), tiff.Bytes()...)
+	app1 := []byte{0xFF, 0xE1}
+	app1 = binary.BigEndian.AppendUint16(app1, uint16(len(payload)+2))
+	app1 = append(app1, payload...)
+
+	out := make([]byte, 0, len(b)+len(app1))
+	out = append(out, b[:2]...) // SOI
+	out = append(out, app1...)
+	out = append(out, b[2:]...)
+
+	if _, err := jpeg.Decode(bytes.NewReader(out)); err != nil {
+		t.Fatalf("fixture jpeg does not decode after the EXIF splice: %v", err)
+	}
+	if !bytes.Contains(out, []byte(desc)) {
+		t.Fatal("fixture jpeg does not contain the description; EXIF splice failed")
+	}
+	return out
+}
+
+// buildPDFWithText builds a structurally valid PDF with a correct xref AND
+// startxref. Both are required — without startxref the extractor errors instead of
+// parsing, which would silently redirect this test onto a different code path.
+func buildPDFWithText(t *testing.T, text string) []byte {
+	t.Helper()
+	content := "BT /F1 12 Tf 72 700 Td (" + text + ") Tj ET\n"
+	objs := []string{
+		"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n",
+		"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n",
+		"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R " +
+			"/Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n",
+		"4 0 obj\n<< /Length " + itoaTest(len(content)) + " >>\nstream\n" + content + "endstream\nendobj\n",
+		"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n",
+	}
+	var sb strings.Builder
+	sb.WriteString("%PDF-1.4\n")
+	offsets := make([]int, 0, len(objs))
+	for _, o := range objs {
+		offsets = append(offsets, sb.Len())
+		sb.WriteString(o)
+	}
+	xref := sb.Len()
+	sb.WriteString("xref\n0 " + itoaTest(len(objs)+1) + "\n0000000000 65535 f \n")
+	for _, off := range offsets {
+		sb.WriteString(pad10Test(off) + " 00000 n \n")
+	}
+	sb.WriteString("trailer\n<< /Size " + itoaTest(len(objs)+1) + " /Root 1 0 R >>\nstartxref\n" +
+		itoaTest(xref) + "\n%%EOF\n")
+	return []byte(sb.String())
+}
+
+func itoaTest(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}
+
+func pad10Test(n int) string {
+	s := itoaTest(n)
+	for len(s) < 10 {
+		s = "0" + s
+	}
+	return s
+}

--- a/internal/embedded/contract_test.go
+++ b/internal/embedded/contract_test.go
@@ -1,0 +1,124 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package embedded_test holds the cross-package half of the contract: the
+// assertions that need to see the READ side and the WRITE side at once, which the
+// in-package tests cannot import without a cycle.
+package embedded_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/embedded"
+	"github.com/awslabs/ferret-scan/v2/internal/preprocessors"
+	"github.com/awslabs/ferret-scan/v2/internal/redactors"
+	"github.com/awslabs/ferret-scan/v2/internal/router"
+)
+
+// TestReadAndWriteSharePreciselyOneDepthBound.
+//
+// The two halves must agree, and for asymmetric reasons. A write side SHALLOWER
+// than the read side reports findings from a level it will not rewrite, which is a
+// cleartext leak that reads as success. A write side DEEPER redacts inside a part
+// nothing ever scanned, so the redaction is unmotivated and its cost unbounded.
+//
+// The earlier attempt at this mirrored the literal 3 into internal/redactors/office
+// and added a test asserting the two stayed equal. That test could only catch drift
+// after it happened; sharing one constant makes the drift unrepresentable. This test
+// therefore asserts the SHARING, not merely the equality — if someone reintroduces
+// a private copy, the aliases below stop compiling or stop matching.
+func TestReadAndWriteSharePreciselyOneDepthBound(t *testing.T) {
+	if router.MaxEmbeddedDepth != embedded.MaxDepth {
+		t.Errorf("router.MaxEmbeddedDepth = %d but embedded.MaxDepth = %d.\n"+
+			"The read side would descend to one depth and the write side to another, so "+
+			"a value found at a level the redactor refuses to enter is reported and then "+
+			"shipped in cleartext.",
+			router.MaxEmbeddedDepth, embedded.MaxDepth)
+	}
+}
+
+// TestTooDeepIsOneSentinelAcrossBothHalves.
+//
+// Both halves raise "coverage was cut short" and callers branch on it with
+// errors.Is to tell that apart from "this child failed to parse". Two distinct
+// sentinel values would make the check fail across the halves and silently downgrade
+// the disclosure to a generic failure — which is the specific bug the sentinel was
+// introduced to avoid.
+func TestTooDeepIsOneSentinelAcrossBothHalves(t *testing.T) {
+	if !errors.Is(preprocessors.ErrEmbeddedTooDeep, embedded.ErrTooDeep) {
+		t.Error("preprocessors.ErrEmbeddedTooDeep is not embedded.ErrTooDeep; a caller " +
+			"matching one will not recognise the other")
+	}
+
+	// And the wrapped form the redaction side actually returns must still match, since
+	// that is how it reaches a caller.
+	wrapped := fmt.Errorf("%w: part is nested too deep", embedded.ErrTooDeep)
+	if !errors.Is(wrapped, preprocessors.ErrEmbeddedTooDeep) {
+		t.Error("a wrapped embedded.ErrTooDeep does not match preprocessors.ErrEmbeddedTooDeep")
+	}
+}
+
+// TestNoRedactorSentinelIsDistinctFromTooDeep.
+//
+// These two describe different permanent facts and get different operator wording:
+// "we stopped descending" versus "this file type can never be redacted". Collapsing
+// them would make an unredactable audio clip look like a depth problem someone could
+// fix by raising a limit.
+func TestNoRedactorSentinelIsDistinctFromTooDeep(t *testing.T) {
+	if errors.Is(redactors.ErrNoEmbeddedRedactor, embedded.ErrTooDeep) {
+		t.Error("ErrNoEmbeddedRedactor matches ErrTooDeep; the two disclosures would be " +
+			"indistinguishable")
+	}
+	if errors.Is(embedded.ErrTooDeep, redactors.ErrNoEmbeddedRedactor) {
+		t.Error("ErrTooDeep matches ErrNoEmbeddedRedactor; the two disclosures would be " +
+			"indistinguishable")
+	}
+}
+
+// TestAdmittedTypesWithNoRedactorCannotBeSilentlySkipped is the safety interlock.
+//
+// For every type the read side descends into, one of two things must hold: a redactor
+// can rewrite it, or the tool cannot prove it clean and therefore always dispatches it
+// (so an unredactable one fails loudly). The forbidden third state is "admitted for
+// scanning, unredactable, AND believed byte-inspectable" — such a part is skipped
+// whenever a byte scan happens to find nothing, which for a compressed payload is
+// always, so the value is reported and then shipped.
+//
+// PDF is the live case: scanned, no redactor, compressed payload. It is opaque, so it
+// is always dispatched and the container is refused. Audio has no redactor either, but
+// its tags are uncompressed, so a clip holding a reported value IS seen by the scan and
+// dispatched; a clip holding nothing is correctly left alone.
+func TestAdmittedTypesWithNoRedactorCannotBeSilentlySkipped(t *testing.T) {
+	noRedactor := map[string]string{
+		".pdf":  "PDF redaction is unimplemented and refuses to write output",
+		".mp3":  "no audio redactor exists",
+		".wav":  "no audio redactor exists",
+		".m4a":  "no audio redactor exists",
+		".flac": "no audio redactor exists",
+	}
+
+	for ext, why := range noRedactor {
+		if embedded.Kind(ext) == "" {
+			continue // not admitted, so nothing is reported from it
+		}
+		inspectable := embedded.ResidueInspectable("part" + ext)
+		if !inspectable {
+			continue // always dispatched -> fails loudly. Safe.
+		}
+		// Inspectable AND unredactable is only safe if the byte scan really can see the
+		// values, which is an assertion about the FORMAT. Audio qualifies; anything new
+		// landing here needs the same justification written down.
+		switch ext {
+		case ".mp3", ".wav", ".m4a", ".flac":
+			// Tags are stored uncompressed, so a reported value in one is visible to the
+			// scan and the part is dispatched (and then fails loudly).
+		default:
+			t.Errorf("%s is admitted for scanning, %s, and is treated as byte-inspectable. "+
+				"If its payload can be compressed, a value inside it is invisible to the "+
+				"scan, the part is skipped as harmless, and the container is written with "+
+				"the value still in it.", ext, why)
+		}
+	}
+}

--- a/internal/embedded/embedded.go
+++ b/internal/embedded/embedded.go
@@ -159,6 +159,41 @@ func Recurses(name string) bool {
 	return KindOfPath(name) == KindDocument
 }
 
+// vectorGraphicsExts hold DRAWING GEOMETRY, not prose, and must not be fed to the
+// text validators.
+//
+// Admitting them looked like a pure coverage win and is not. An .svg is XML text, so
+// the byte-sniffing text path claims it happily -- and its content is coordinate soup.
+// Measured on one real deck carrying 171 embedded .svg parts, routing them through the
+// pipeline took PHONE findings from 0 to 1,095, of which 826 were HIGH. The matches are
+// path data:
+//
+//	43.5968 15.4721 43.4928 15.7281 43.3048 15.9
+//	38.9358 20.3361 37.5138 18.9301 40.1318 16.2
+//
+// 826 HIGH false positives in a single file is not coverage. HIGH is the band operators
+// triage first, so this would bury the findings that matter -- the precise failure mode
+// the confidence contract exists to prevent.
+//
+// This is a DEFERRAL, not a judgement that these parts are uninteresting. An .svg's
+// <text>, <title> and <desc> nodes are real prose and can carry real PII: a fixture
+// with <text>Employee SSN: ...</text> is detected at confidence 90 when scanned as a
+// standalone file. Recovering that needs an SVG-aware extractor that reads text nodes
+// and ignores geometry, which is its own change with its own precision evidence. Until
+// then these parts are excluded rather than shipped as noise.
+var vectorGraphicsExts = map[string]bool{
+	".svg": true, // XML text, but the text is path geometry
+	".emf": true, // Enhanced Metafile: drawing records
+	".wmf": true, // Windows Metafile: same
+	".wdp": true, // JPEG XR / HD Photo
+}
+
+// SkipTextPipeline reports whether a part holds drawing geometry rather than prose, and
+// so must not be routed to the text validators.
+func SkipTextPipeline(name string) bool {
+	return vectorGraphicsExts[strings.ToLower(filepath.Ext(name))]
+}
+
 // opaqueExts are admitted formats whose payload can be COMPRESSED internally, so
 // scanning their raw bytes proves nothing about what they contain.
 //

--- a/internal/embedded/embedded.go
+++ b/internal/embedded/embedded.go
@@ -1,0 +1,319 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package embedded holds the contract shared by the two halves of
+// container-inside-container handling: the READ side that finds embedded files
+// and the WRITE side that has to redact them.
+//
+// It exists because those two halves live in packages that cannot import each
+// other. The extractor is internal/preprocessors/meta-extractors/
+// meta-extract-officelib, and internal/preprocessors imports it, so the
+// extractor cannot import its own parent. The redactor is under
+// internal/redactors. A leaf package with no internal dependencies is the only
+// place both can reach.
+//
+// Why it has to be shared at all, rather than each side keeping its own copy:
+// the admission set IS the contract. Only reported findings are redacted, so if
+// the read side descends into a part the write side does not, the tool reports a
+// finding it cannot redact and writes a "redacted" file with the value still in
+// cleartext, at exit 0. That is not a hypothetical — it is the measured
+// behaviour this package was extracted to prevent:
+//
+//	outer.docx -> word/embeddings/oleObject1.docx   SSN reported, survived redaction
+//	outer.docx -> word/media/image1.jpg (EXIF)      SSN reported, survived redaction
+//
+// Both at exit 0 with nothing on stderr. Duplicating the predicate and adding a
+// test that the two copies agree was the alternative; a single definition makes
+// the divergence unrepresentable instead of merely detected.
+package embedded
+
+import (
+	"errors"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// MaxDepth bounds how deep container-inside-container traversal goes, counting
+// the top-level file as depth 0 and a part inside it as depth 1.
+//
+// A bound is required in both directions, and for different reasons. On the read
+// side an embedded OOXML document routes back through the Office preprocessor,
+// which extracts ITS embeddings, which route back again: measured with a 7KB
+// .docx embedding itself nine times, all nine levels were followed. On the write
+// side the redactor dispatches each embedded part to a redactor, which for an
+// OOXML part is the Office redactor again — the same unbounded recursion, plus a
+// decompression-bomb amplifier, because every level gets a fresh per-package
+// budget unless one is threaded through (see BudgetBytes).
+//
+// Three is deep enough for the real cases (a workbook in a deck in a report) and
+// shallow enough that the amplification stays bounded.
+//
+// Reaching the bound must be DISCLOSED, never skipped quietly. Refusing to
+// descend is incomplete coverage, and undisclosed incomplete coverage reads as a
+// clean result — which is the failure this whole area keeps reproducing.
+const MaxDepth = 3
+
+// BudgetBytes is the cumulative decompression budget for one top-level file and
+// everything nested inside it.
+//
+// This is deliberately a WHOLE-TRAVERSAL budget, not a per-package one. A
+// per-package cap does not bound a nested bomb: each level would get its own
+// fresh allowance, so the worst case multiplies by the number of children at
+// every level rather than staying flat. With a per-package 200MB cap and a
+// package able to hold thousands of tiny entries, three levels of nesting is an
+// amplifier measured in terabytes. Threading one budget through the recursion
+// makes the total the same whether the bytes are in one file or spread across a
+// nested tree.
+const BudgetBytes int64 = 200 * 1024 * 1024
+
+// ErrTooDeep reports that a container nests deeper than MaxDepth.
+//
+// A sentinel rather than a formatted string so a caller can branch on it with
+// errors.Is and tell "coverage was cut short, say so" apart from "this child
+// failed to parse", which the ordinary error path already handles.
+var ErrTooDeep = errors.New("embedded container nesting limit reached")
+
+// ErrBudgetExhausted reports that a traversal hit BudgetBytes.
+//
+// Distinct from ErrTooDeep because the disclosure differs: too-deep means a
+// known part was skipped, budget-exhausted means the file is a probable
+// decompression bomb. Both leave content unexamined and both must be surfaced.
+var ErrBudgetExhausted = errors.New("embedded container decompression budget exhausted")
+
+// kindByExt maps a lower-cased extension to the class of embedded file it is.
+//
+// The empty string means "no preprocessor can read this", and such a part is
+// skipped by both sides. Keeping the map unexported with an accessor keeps it
+// from being mutated at run time by one side and not the other.
+//
+// Ordering note: this is a map only for lookup; nothing iterates it, so map
+// order cannot reach output.
+var kindByExt = map[string]string{
+	// Images. Scanned for metadata (EXIF/XMP/IPTC), which is where an author
+	// name, GPS fix or free-text description leaks from.
+	".jpg": "image", ".jpeg": "image", ".png": "image",
+	".tiff": "image", ".tif": "image", ".gif": "image",
+	".bmp": "image", ".webp": "image",
+
+	// Audio. Admitted on the read side because tags carry free text (Artist,
+	// Comment). NOTE: no redactor handles audio, so a finding inside an
+	// embedded clip cannot be removed — that case must be disclosed rather
+	// than silently dropped. See Redactable.
+	".mp3": "audio", ".wav": "audio", ".m4a": "audio", ".flac": "audio",
+
+	// Legacy OLE compound files. A leaf on the read side: the extractor reads
+	// their streams directly and does not follow embeddings, so admitting them
+	// adds no recursion.
+	".doc": "legacy_document", ".xls": "legacy_document", ".ppt": "legacy_document",
+
+	// OOXML documents. These DO recurse — an embedded .docx routes back into the
+	// same code on both sides — which is what MaxDepth and BudgetBytes bound.
+	".docx": "document", ".xlsx": "document", ".pptx": "document",
+
+	// PDF. Admitted for SCANNING, and it cannot be redacted, so it fails LOUDLY.
+	//
+	// Previously absent from the read side's switch, so an embedded PDF was never
+	// examined at all: measured, an SSN in word/embeddings/attachment.pdf produced
+	// zero findings, exit 0, and no warning, while the value sat in the "redacted"
+	// output. Admitting it took that fixture from 1 finding to 3.
+	//
+	// Detection is not the thing to give up. But PDF redaction is unimplemented and
+	// refuses to write output, and PDF text lives in FlateDecode streams, so a byte
+	// scan of the part cannot prove it clean either. The honest resolution is the one
+	// encoded in opaqueExts below: an embedded PDF is always handed to a redactor, the
+	// redactor always refuses, and the container is therefore refused with a message
+	// saying exactly that. The tool never silently ships a document whose attached PDF
+	// it could not scrub.
+	".pdf": "document",
+}
+
+// Kind classifies an embedded part by extension, returning "" for anything no
+// preprocessor can read.
+//
+// ext is matched case-insensitively: a zip entry name is producer-controlled
+// data and nothing makes the conventional spelling normative. A case-sensitive
+// predicate in this same area let a part named word/Document.xml be detected and
+// then survive redaction in cleartext.
+func Kind(ext string) string {
+	return kindByExt[strings.ToLower(ext)]
+}
+
+// KindOfPath classifies an embedded part by its full entry name.
+func KindOfPath(name string) string {
+	return Kind(filepath.Ext(name))
+}
+
+// KindDocument is the class of embedded part that can itself contain further
+// embedded parts. Named because both bounds exist for it specifically.
+const KindDocument = "document"
+
+// Recurses reports whether descending into this part can lead back into another
+// container, which is what makes MaxDepth and BudgetBytes necessary.
+//
+// Derived from Kind rather than listing the extensions again. A second list would
+// be a second thing to keep in step, and an extension present in one and absent
+// from the other is precisely the divergence class this package exists to make
+// unrepresentable. The legacy OLE and image kinds are leaves; "document" is not.
+func Recurses(name string) bool {
+	return KindOfPath(name) == KindDocument
+}
+
+// opaqueExts are admitted formats whose payload can be COMPRESSED internally, so
+// scanning their raw bytes proves nothing about what they contain.
+//
+// Only PDF qualifies today, and the set exists for it. This is NOT the same mistake an
+// earlier revision made: that version also listed the audio formats, which would have
+// made every embedded clip block its container. Audio tags are stored uncompressed --
+// ID3v2 text frames, RIFF INFO, Vorbis comments, MP4 ilst atoms -- so audio is
+// inspectable and a clip holding nothing is correctly left alone.
+//
+// The consequence of being opaque is deliberate and asymmetric: an inspectable part is
+// dispatched only when a byte scan finds a reported value in it, whereas an OPAQUE part
+// is ALWAYS dispatched, because absence cannot be established. If no redactor can
+// rewrite it, that surfaces as a refusal to write the container rather than as a
+// silent pass.
+var opaqueExts = map[string]bool{
+	".pdf": true,
+}
+
+// ResidueInspectable reports whether scanning a part's raw bytes for a value is a
+// sound test for that value's ABSENCE.
+//
+// False means "we cannot see inside this", which makes the part always-dispatched
+// rather than always-skipped. Getting that polarity backwards is how a value inside a
+// compressed stream gets judged harmless and shipped.
+//
+// An UNKNOWN extension defaults to inspectable, and that is sound rather than
+// optimistic. The scan and the preprocessors have the same visibility: a value can only
+// be REPORTED from a part if some preprocessor extracted it, and for every format that
+// happens through text/EXIF/OLE bytes the raw scan reads, or through zip members the
+// scan inflates. The one exception is a format whose text a preprocessor decompresses
+// but the scan cannot — PDF — which is why PDF is listed explicitly above. A format
+// nobody can extract from produces no findings, so there is nothing reported to leak.
+func ResidueInspectable(name string) bool {
+	return !opaqueExts[strings.ToLower(filepath.Ext(name))]
+}
+
+// AdmittedExts returns every extension the two halves descend into, sorted.
+//
+// Exported for the contract test that enforces this package's central invariant:
+// EVERY ADMITTED TYPE MUST BE BYTE-INSPECTABLE -- a reported value present in such a
+// part must be findable by scanning the part's bytes, after inflating any archive
+// members.
+//
+// That invariant is what lets the redactor treat "the byte scan found nothing" as
+// "this part holds none of the reported values", which in turn is what keeps an
+// unredactable-but-harmless part from blocking its whole container. It holds for
+// every type above:
+//
+//	images       EXIF/IPTC/XMP text is stored uncompressed
+//	audio        ID3v2 text frames, RIFF INFO, Vorbis comments and MP4 ilst
+//	             atoms are all stored uncompressed
+//	legacy OLE   property and body streams are uncompressed
+//	OOXML        deflated, but the scan inflates archive members
+//
+// It does NOT hold for PDF, which is why PDF is listed in opaqueExts above and is
+// always dispatched instead of being skipped on a clean byte scan.
+func AdmittedExts() []string {
+	out := make([]string, 0, len(kindByExt))
+	for ext := range kindByExt {
+		out = append(out, ext)
+	}
+	sort.Strings(out) // sorted: the result reaches test output and error text
+	return out
+}
+
+// XMLEscapeVariants returns the spellings a value can take inside an admitted part.
+//
+// A value stored in OOXML XML is escaped, so the literal from a Match does not
+// necessarily occur in the part's bytes: an ampersand in a name is written &amp;, and
+// a value inside an attribute may carry escaped quotes. A residue scan looking only
+// for the raw literal would report "clean" for a part that plainly holds the value --
+// the exact false negative this mechanism exists to avoid.
+//
+// The raw form is always first. The escaped form is appended only when it differs, so
+// the common case allocates nothing extra.
+func XMLEscapeVariants(s string) []string {
+	esc := strings.NewReplacer(
+		"&", "&amp;",
+		"<", "&lt;",
+		">", "&gt;",
+		`"`, "&quot;",
+		"'", "&apos;",
+	).Replace(s)
+	if esc == s {
+		return []string{s}
+	}
+	return []string{s, esc}
+}
+
+// MaxDispatchedParts bounds how many embedded parts one container hands out for
+// redaction.
+//
+// Each dispatched part is a full extract-redact-repackage cycle, and redaction is
+// already the slowest stage of a scan, so an archive with tens of thousands of tiny
+// embedded entries is a cheap way to make one document cost minutes. The cap is
+// generous because legitimate documents are: a large deck can carry several hundred
+// media parts. Truncation must be DISCLOSED -- a silently capped traversal is
+// incomplete coverage reading as a clean result.
+const MaxDispatchedParts = 512
+
+// IsPartPath reports whether an OOXML part path holds an embedded file that
+// should be handled in its own right.
+//
+// "/media/" alone was not enough: Word stores an embedded DOCUMENT under
+// word/embeddings/ as an OLE object, and that path was never considered, so a
+// document attached to a document was invisible. Both prefixes are checked as
+// substrings rather than anchored prefixes because the container's own
+// convention varies by format (word/, xl/, ppt/).
+func IsPartPath(name string) bool {
+	n := strings.ToLower(name)
+	return strings.Contains(n, "/media/") || strings.Contains(n, "/embeddings/")
+}
+
+// SafeExt returns the extension to give a temporary file materialized from an
+// embedded part.
+//
+// The result is NEVER a slice of the caller's string used as-is. A zip entry name is
+// producer-controlled and this value is concatenated into a filesystem path, so per
+// BSC1 it is validated against an allowlist at the sink. The allowlist here is a
+// CHARACTER CLASS rather than a table of known types: a dot followed by 1-10 ASCII
+// alphanumerics, lower-cased. Nothing outside that class can appear in the result, so
+// no separator, "..", NUL, or overlong component is representable regardless of what
+// the entry is called.
+//
+// Why a class and not the admission table it used to be: the table listed only the
+// types someone had enumerated, which meant an embedded .svg — 411 of them across 334
+// real Office files, and plain XML text that scans fine on its own — could not even be
+// written to a temp file, so it was never examined. The pipeline decides what it can
+// process; this function's job is only to make the handoff safe, not to second-guess
+// coverage.
+//
+// A part whose name yields nothing usable (no extension, or characters outside the
+// class) gets fallbackExt, so it still reaches the byte-sniffing preprocessors rather
+// than being dropped for the shape of its name.
+func SafeExt(name string) (string, bool) {
+	ext := strings.ToLower(filepath.Ext(name))
+	// len < 2 covers both "" (no extension) and a bare "." from a name ending in a
+	// dot, which filepath.Ext returns verbatim. A lone dot is not a well-formed
+	// extension and would produce a temp file named "embedded." -- harmless but
+	// malformed, and the fallback is the right answer for a name that yields nothing.
+	if len(ext) < 2 || len(ext) > 11 { // 1 dot + at most 10 chars
+		return fallbackExt, true
+	}
+	for i := 1; i < len(ext); i++ {
+		c := ext[i]
+		if (c < 'a' || c > 'z') && (c < '0' || c > '9') {
+			return fallbackExt, true
+		}
+	}
+	return ext, true
+}
+
+// fallbackExt is given to a part whose own name yields no safe extension.
+//
+// ".bin" specifically: it is claimed by no metadata preprocessor, so the
+// byte-sniffing text fallback gets a chance at it, which is the best available answer
+// for a part we cannot classify by name.
+const fallbackExt = ".bin"

--- a/internal/embedded/embedded_test.go
+++ b/internal/embedded/embedded_test.go
@@ -1,0 +1,349 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package embedded
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSafeExtNeverYieldsAPathComponent is the security contract.
+//
+// The value SafeExt returns is concatenated into a filesystem path when an embedded
+// part is materialized as a temp file, and the input is a zip entry name, which is
+// entirely producer-controlled. So the output must be one of a fixed set of ".xyz"
+// literals no matter what the entry is called — not "sanitized", but incapable of
+// carrying a separator, a parent reference, a NUL or an absolute path in the first
+// place (BSC1: validate untrusted input against an allowlist at the sink).
+func TestSafeExtNeverYieldsAPathComponent(t *testing.T) {
+	hostile := []string{
+		"../../../../etc/passwd",
+		"word/media/../../../../etc/passwd.jpg",
+		"/etc/shadow.jpg",
+		"C:\\Windows\\System32\\evil.jpg",
+		"..\\..\\..\\evil.png",
+		"word/media/x.jpg\x00.exe",
+		"word/media/evil.jpg/../../escape.jpg",
+		"word/media/.jpg",
+		"word/media/....jpg",
+		"word/media/x." + strings.Repeat("a", 4096),
+		strings.Repeat("../", 512) + "deep.jpg",
+		"word/media/x.JPG",
+		"word/media/x.JpEg",
+		"",
+		".",
+		"..",
+		"/",
+		"word/media/noextension",
+		"word/media/trailingdot.",
+		"word/embeddings/a!b.docx",
+		"word/media/\n\r\t.png",
+	}
+
+	for _, name := range hostile {
+		ext, ok := SafeExt(name)
+		if !ok {
+			// Refusing is always a safe answer; there is nothing to check.
+			if ext != "" {
+				t.Errorf("SafeExt(%q) returned ok=false but ext=%q; a rejected part must "+
+					"yield no extension at all", name, ext)
+			}
+			continue
+		}
+
+		// The result must match the character class: a dot plus 1-10 ASCII
+		// alphanumerics, lower-cased. That is the allowlist -- deliberately a class
+		// rather than a table of known types, so an embedded .svg can be materialized
+		// and handed to the pipeline instead of being dropped for not being enumerated.
+		if !wellFormedExt(ext) {
+			t.Errorf("SafeExt(%q) = %q, which is outside the permitted character class "+
+				"(a dot plus 1-10 ASCII alphanumerics). The result must be built from the "+
+				"allowlist, never passed through from the entry name.", name, ext)
+		}
+		if strings.ContainsAny(ext, `/\`) {
+			t.Errorf("SafeExt(%q) = %q contains a path separator", name, ext)
+		}
+		if strings.Contains(ext, "..") {
+			t.Errorf("SafeExt(%q) = %q contains a parent reference", name, ext)
+		}
+		if strings.ContainsRune(ext, 0) {
+			t.Errorf("SafeExt(%q) = %q contains a NUL", name, ext)
+		}
+		if ext != strings.ToLower(ext) {
+			t.Errorf("SafeExt(%q) = %q is not lower-cased", name, ext)
+		}
+		if !strings.HasPrefix(ext, ".") || len(ext) < 2 {
+			t.Errorf("SafeExt(%q) = %q is not a well-formed extension. A bare dot reaches "+
+				"this when the entry name ends in one, and filepath.Ext returns it "+
+				"verbatim.", name, ext)
+		}
+		// The decisive property: joining it into a directory cannot escape that
+		// directory.
+		joined := filepath.Join("/tmp/sandbox", "embedded"+ext)
+		if !strings.HasPrefix(joined, "/tmp/sandbox/") {
+			t.Errorf("SafeExt(%q) = %q escapes the sandbox when joined: %s", name, ext, joined)
+		}
+	}
+}
+
+// wellFormedExt mirrors SafeExt's permitted character class, so the test states the
+// contract independently rather than calling the code under test to grade itself.
+func wellFormedExt(ext string) bool {
+	if len(ext) < 2 || len(ext) > 11 || ext[0] != '.' {
+		return false
+	}
+	for i := 1; i < len(ext); i++ {
+		c := ext[i]
+		if (c < 'a' || c > 'z') && (c < '0' || c > '9') {
+			return false
+		}
+	}
+	return true
+}
+
+// TestSafeExtFallsBackRatherThanDroppingThePart.
+//
+// A part whose name yields no usable extension must still be materialized, so the
+// byte-sniffing preprocessors get a chance at it. Dropping it for the SHAPE OF ITS NAME
+// is how coverage silently disappears: 6 extension-less embedded parts turned up in a
+// 334-file corpus.
+func TestSafeExtFallsBackRatherThanDroppingThePart(t *testing.T) {
+	for _, name := range []string{
+		"word/embeddings/oleObject1",              // no extension at all
+		"word/media/trailingdot.",                 // filepath.Ext returns a bare "."
+		"word/media/x." + strings.Repeat("a", 64), // absurdly long
+		"word/media/weird.\u00e9\u00e8",           // non-ASCII
+	} {
+		ext, ok := SafeExt(name)
+		if !ok {
+			t.Errorf("SafeExt(%q) refused; the part would never be examined at all", name)
+			continue
+		}
+		if ext != fallbackExt {
+			t.Errorf("SafeExt(%q) = %q, want the fallback %q", name, ext, fallbackExt)
+		}
+		if !wellFormedExt(ext) {
+			t.Errorf("the fallback %q is itself malformed", ext)
+		}
+	}
+}
+
+// TestSafeExtAdmitsTheRealSpellings — the guard must not reject legitimate parts.
+//
+// A rejection here is not merely inconvenient: an admitted-on-read, rejected-on-write
+// part is a finding the tool reports and cannot redact.
+func TestSafeExtAdmitsTheRealSpellings(t *testing.T) {
+	for _, name := range []string{
+		"word/media/image1.jpg",
+		"word/media/image1.JPEG",
+		"word/media/image1.png",
+		"word/embeddings/oleObject1.docx",
+		"xl/embeddings/oleObject1.xlsx",
+		"ppt/embeddings/oleObject1.pptx",
+		"word/embeddings/Microsoft_Word_97_-_2003_Document1.doc",
+		"word/embeddings/attachment.pdf",
+		"word/media/audio1.wav",
+	} {
+		if ext, ok := SafeExt(name); !ok {
+			t.Errorf("SafeExt(%q) rejected a part the extractor admits (ext=%q); the read "+
+				"and write sides must admit the same set", name, ext)
+		}
+	}
+}
+
+// TestRecursesIsDerivedFromKind keeps the two from drifting.
+//
+// Recurses used to be its own switch listing the container extensions a second
+// time. An extension in one list and not the other is precisely the divergence this
+// package exists to prevent, so the relationship is asserted rather than trusted.
+func TestRecursesIsDerivedFromKind(t *testing.T) {
+	for ext, kind := range kindByExt {
+		name := "word/embeddings/part" + ext
+		want := kind == KindDocument
+		if got := Recurses(name); got != want {
+			t.Errorf("Recurses(%q) = %v, but Kind = %q so it should be %v",
+				name, got, kind, want)
+		}
+	}
+	// A non-container must never be reported as recursing, or the depth bound would
+	// be charged against leaves and legitimate nesting would be refused early.
+	for _, name := range []string{
+		"word/media/image1.jpg",
+		"word/media/audio1.mp3",
+		"word/embeddings/legacy.doc",
+	} {
+		if Recurses(name) {
+			t.Errorf("Recurses(%q) = true for a leaf format", name)
+		}
+	}
+}
+
+// TestOpaqueFormatsAreAlwaysDispatchedNotSkipped.
+//
+// ResidueInspectable decides whether "a byte scan found nothing" may be read as "the
+// part is clean". The polarity is what matters, and it is asymmetric:
+//
+//	inspectable  -> nothing found means leave the part alone (protects innocent content)
+//	opaque       -> nothing found means we cannot see, so always dispatch (fails loudly
+//	                if no redactor can rewrite it)
+//
+// Getting it backwards either vandalizes clean parts or ships a value hidden in a
+// compressed stream.
+func TestOpaqueFormatsAreAlwaysDispatchedNotSkipped(t *testing.T) {
+	// PDF text lives in FlateDecode streams, so a byte scan proves nothing.
+	if ResidueInspectable("word/embeddings/attachment.pdf") {
+		t.Error("PDF is marked residue-inspectable, but its text is compressed. A value " +
+			"inside a FlateDecode stream would be invisible to the byte scan, the part " +
+			"would be skipped as harmless, and the container written with the value in it.")
+	}
+
+	// Audio tags are stored UNCOMPRESSED -- ID3v2 text frames, RIFF INFO, Vorbis
+	// comments, MP4 ilst atoms. Marking them opaque would make every embedded clip
+	// block its container even when the clip holds nothing, which is the mistake an
+	// earlier revision of this file made.
+	for _, name := range []string{
+		"word/media/audio1.mp3",
+		"word/media/audio1.wav",
+		"word/media/audio1.m4a",
+		"word/media/audio1.flac",
+	} {
+		if !ResidueInspectable(name) {
+			t.Errorf("ResidueInspectable(%q) = false; audio tags are uncompressed, so "+
+				"over-marking them opaque makes one harmless clip stop a whole document "+
+				"from being written", name)
+		}
+	}
+
+	// The formats whose text is in the clear, or which the scan inflates.
+	for _, name := range []string{
+		"word/media/image1.jpg",           // EXIF in the clear
+		"word/embeddings/oleObject1.docx", // deflated, but the scan inflates members
+		"word/embeddings/legacy.doc",      // OLE streams in the clear
+	} {
+		if !ResidueInspectable(name) {
+			t.Errorf("ResidueInspectable(%q) = false for a format the scan can read", name)
+		}
+	}
+}
+
+// TestEveryAdmittedTypeIsInspectableOrOpaqueOnPurpose keeps the two sets in step.
+//
+// A type admitted for scanning is either provably clean-checkable or explicitly
+// declared opaque. There is no third state, and a new admission silently landing in
+// the wrong one is how a leak gets reintroduced.
+func TestEveryAdmittedTypeIsInspectableOrOpaqueOnPurpose(t *testing.T) {
+	declaredOpaque := map[string]bool{".pdf": true}
+
+	for _, ext := range AdmittedExts() {
+		name := "part" + ext
+		gotOpaque := !ResidueInspectable(name)
+		if gotOpaque != declaredOpaque[ext] {
+			t.Errorf("%s: opaque=%v but this test declares opaque=%v. Reconcile the two: "+
+				"an admitted type whose byte scan is unsound MUST be opaque so it is "+
+				"always dispatched, and one whose scan is sound must NOT be, so clean "+
+				"parts are left untouched.", ext, gotOpaque, declaredOpaque[ext])
+		}
+	}
+
+	// And every declared-opaque entry must actually be admitted, or the entry is stale.
+	admitted := map[string]bool{}
+	for _, e := range AdmittedExts() {
+		admitted[e] = true
+	}
+	for ext := range declaredOpaque {
+		if !admitted[ext] {
+			t.Errorf("%s is declared opaque but is not admitted; drop the stale entry", ext)
+		}
+	}
+}
+
+// TestXMLEscapeVariantsCoverEscapedSpellings.
+//
+// A value stored in an OOXML part is escaped, so the raw literal from a Match need not
+// occur in the bytes. A residue scan looking only for the literal would call such a
+// part clean.
+func TestXMLEscapeVariantsCoverEscapedSpellings(t *testing.T) {
+	got := XMLEscapeVariants("Ben & Jerry <b>")
+	if len(got) != 2 {
+		t.Fatalf("XMLEscapeVariants returned %d variants (%v), want the raw and escaped forms",
+			len(got), got)
+	}
+	if got[0] != "Ben & Jerry <b>" {
+		t.Errorf("variant[0] = %q, want the raw form first", got[0])
+	}
+	if !strings.Contains(got[1], "&amp;") || !strings.Contains(got[1], "&lt;") {
+		t.Errorf("variant[1] = %q, want XML-escaped", got[1])
+	}
+
+	// A value needing no escaping must not allocate a duplicate.
+	if plain := XMLEscapeVariants("452-11-9384"); len(plain) != 1 {
+		t.Errorf("XMLEscapeVariants(%q) returned %d variants, want 1", "452-11-9384", len(plain))
+	}
+}
+
+// TestKindIsCaseInsensitive — a zip entry name is producer-controlled data and
+// nothing makes the conventional spelling normative. A case-sensitive predicate in
+// this same area previously let a part named word/Document.xml be detected and then
+// survive redaction in cleartext.
+func TestKindIsCaseInsensitive(t *testing.T) {
+	for _, pair := range [][2]string{
+		{".JPG", ".jpg"},
+		{".DOCX", ".docx"},
+		{".PDF", ".pdf"},
+		{".Doc", ".doc"},
+	} {
+		if got, want := Kind(pair[0]), Kind(pair[1]); got != want || got == "" {
+			t.Errorf("Kind(%q) = %q but Kind(%q) = %q; they must agree and be non-empty",
+				pair[0], got, pair[1], want)
+		}
+	}
+}
+
+// TestBoundsAreMeaningful guards the two numbers themselves.
+//
+// A zero or negative depth would refuse all descent (silently losing the coverage
+// the read side already has); an enormous one would restore the unbounded recursion
+// the bound was added to stop.
+func TestBoundsAreMeaningful(t *testing.T) {
+	if MaxDepth < 1 {
+		t.Errorf("MaxDepth = %d refuses all descent, so no embedded part is ever examined "+
+			"or redacted", MaxDepth)
+	}
+	if MaxDepth > 10 {
+		t.Errorf("MaxDepth = %d is deep enough to be a decompression-bomb amplifier; the "+
+			"bound exists because a 7KB document embedding itself nine times was followed "+
+			"all nine levels", MaxDepth)
+	}
+	if BudgetBytes <= 0 {
+		t.Errorf("BudgetBytes = %d would reject every document", BudgetBytes)
+	}
+}
+
+// TestIsPartPathCoversBothConventions — "/media/" alone was not enough. Word stores
+// an embedded DOCUMENT under word/embeddings/ as an OLE object, and that path was
+// never considered, so a document attached to a document was invisible.
+func TestIsPartPathCoversBothConventions(t *testing.T) {
+	for _, name := range []string{
+		"word/media/image1.jpg",
+		"word/embeddings/oleObject1.docx",
+		"xl/media/image1.png",
+		"ppt/embeddings/oleObject1.xlsx",
+		"WORD/MEDIA/IMAGE1.JPG",
+	} {
+		if !IsPartPath(name) {
+			t.Errorf("IsPartPath(%q) = false; this part holds an embedded file", name)
+		}
+	}
+	for _, name := range []string{
+		"word/document.xml",
+		"docProps/core.xml",
+		"[Content_Types].xml",
+		"mediafile.jpg", // no /media/ segment
+	} {
+		if IsPartPath(name) {
+			t.Errorf("IsPartPath(%q) = true for a part that is not an embedded file", name)
+		}
+	}
+}

--- a/internal/embedded/embedded_test.go
+++ b/internal/embedded/embedded_test.go
@@ -81,9 +81,16 @@ func TestSafeExtNeverYieldsAPathComponent(t *testing.T) {
 		}
 		// The decisive property: joining it into a directory cannot escape that
 		// directory.
-		joined := filepath.Join("/tmp/sandbox", "embedded"+ext)
-		if !strings.HasPrefix(joined, "/tmp/sandbox/") {
-			t.Errorf("SafeExt(%q) = %q escapes the sandbox when joined: %s", name, ext, joined)
+		//
+		// Compared with filepath.Dir rather than a hardcoded "/tmp/sandbox/" prefix.
+		// The literal form passed on Unix and failed every case on Windows, where
+		// filepath.Join yields \tmp\sandbox\embedded.bin -- a test bug, not a product
+		// one, and the kind that makes a green local run hide a red CI.
+		sandbox := filepath.Join(string(filepath.Separator)+"tmp", "sandbox")
+		joined := filepath.Join(sandbox, "embedded"+ext)
+		if filepath.Dir(joined) != sandbox {
+			t.Errorf("SafeExt(%q) = %q escapes the sandbox when joined: %s (want parent %s)",
+				name, ext, joined, sandbox)
 		}
 	}
 }

--- a/internal/preprocessors/base_metadata_preprocessor.go
+++ b/internal/preprocessors/base_metadata_preprocessor.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/awslabs/ferret-scan/v2/internal/embedded"
 	"github.com/awslabs/ferret-scan/v2/internal/observability"
 )
 
@@ -34,6 +35,17 @@ type RouterInterface interface {
 	// that rather than skipping quietly: refusing to descend is incomplete coverage,
 	// and an undisclosed gap reads as a clean result.
 	ProcessEmbedded(childPath, parentPath string) (*ProcessedContent, error)
+
+	// CanProcessFile reports whether the router can process a file at all, and why
+	// not when it cannot.
+	//
+	// Needed so embedded parts are admitted by CAPABILITY rather than by a private
+	// extension list. The list version excluded 19% of the embedded parts in a real
+	// corpus, including .svg, which scans perfectly well as a standalone file. Asking
+	// the router means a preprocessor added anywhere -- including the byte-sniffing
+	// text fallback -- extends embedded coverage for free instead of leaving a
+	// second list to maintain.
+	CanProcessFile(filePath string, enablePreprocessors bool) (bool, string)
 }
 
 // ErrEmbeddedTooDeep is returned by RouterInterface.ProcessEmbedded when a container
@@ -42,7 +54,14 @@ type RouterInterface interface {
 // A sentinel rather than a formatted string so the caller can branch on it with
 // errors.Is and tell "too deep" (coverage was cut short — say so) apart from "this
 // child failed to parse" (already handled by the ordinary error path).
-var ErrEmbeddedTooDeep = errors.New("embedded container nesting limit reached")
+//
+// Aliased to embedded.ErrTooDeep rather than declared independently: the redaction
+// side raises the same condition, and two distinct sentinels would make errors.Is
+// fail across the halves — a caller branching on the read side's value would not
+// recognise the write side's, and the "coverage was cut short" disclosure would be
+// silently downgraded to a generic failure. Existing references to this name keep
+// working.
+var ErrEmbeddedTooDeep = embedded.ErrTooDeep
 
 // BaseMetadataPreprocessor provides common functionality for all specialized metadata preprocessors
 type BaseMetadataPreprocessor struct {
@@ -260,6 +279,16 @@ func (bmp *BaseMetadataPreprocessor) ProcessEmbeddedMedia(originalFilePath strin
 		// embeddings. Admitting .docx/.xlsx/.pptx routes back into this same
 		// function, so it requires a real depth cap first — and a cap must DISCLOSE
 		// when it truncates, or it replaces a silent miss with a different one.
+		// Skip a part the pipeline cannot read at all.
+		//
+		// Not a warning: an unprocessable embedded part is the same situation as an
+		// unsupported top-level file, which the scan already reports through its own
+		// channel. Warning here would put a line on stderr for every decorative .emf
+		// in every deck, which trains operators to ignore the warnings that matter.
+		if ok, _ := bmp.router.CanProcessFile(media.TempFilePath, true); !ok {
+			continue
+		}
+
 		processed, perr := bmp.router.ProcessEmbedded(media.TempFilePath, originalFilePath)
 		if errors.Is(perr, ErrEmbeddedTooDeep) {
 			// DISCLOSE rather than skip. Hitting the bound means this item's content

--- a/internal/preprocessors/base_metadata_preprocessor.go
+++ b/internal/preprocessors/base_metadata_preprocessor.go
@@ -289,6 +289,13 @@ func (bmp *BaseMetadataPreprocessor) ProcessEmbeddedMedia(originalFilePath strin
 			continue
 		}
 
+		// Drawing geometry is not prose. See embedded.SkipTextPipeline: routing the
+		// .svg parts of one real deck through the validators produced 1,095 PHONE
+		// findings, 826 of them HIGH, all matching path coordinates.
+		if embedded.SkipTextPipeline(media.OriginalName) {
+			continue
+		}
+
 		processed, perr := bmp.router.ProcessEmbedded(media.TempFilePath, originalFilePath)
 		if errors.Is(perr, ErrEmbeddedTooDeep) {
 			// DISCLOSE rather than skip. Hitting the bound means this item's content

--- a/internal/preprocessors/meta-extractors/meta-extract-officelib/office-extractor.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-officelib/office-extractor.go
@@ -15,6 +15,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/awslabs/ferret-scan/v2/internal/embedded"
 )
 
 // Security constants
@@ -702,8 +704,11 @@ func parseOfficeDate(dateStr string) (time.Time, error) {
 // exit 0 and no warning. The same held for a container placed under
 // word/media/.
 func isEmbeddedPartPath(name string) bool {
-	n := strings.ToLower(name)
-	return strings.Contains(n, "/media/") || strings.Contains(n, "/embeddings/")
+	// Delegated so the read and write sides cannot disagree about which parts are
+	// embedded files. See package embedded: a part one side descends into and the
+	// other does not is a reported-but-unredactable finding, i.e. a cleartext leak
+	// dressed as success.
+	return embedded.IsPartPath(name)
 }
 
 // embeddedMediaType classifies an embedded part by extension, returning "" for
@@ -715,40 +720,15 @@ func isEmbeddedPartPath(name string) bool {
 // missing a document nested inside a document is a detection hole with no
 // attacker required.
 func embeddedMediaType(ext string) string {
-	switch ext {
-	case ".jpg", ".jpeg", ".png", ".tiff", ".tif", ".gif", ".bmp", ".webp":
-		return "image"
-	case ".mp3", ".wav", ".m4a", ".flac":
-		return "audio"
-	case ".doc", ".xls", ".ppt":
-		// Legacy OLE compound files. These are a LEAF format here: the extractor
-		// reads their streams directly and does not itself follow embeddings, so
-		// admitting them adds no recursion and no new bomb surface.
-		return "legacy_document"
-	case ".docx", ".xlsx", ".pptx":
-		// Embedded OOXML documents. Admitted now that the router bounds nesting depth.
-		//
-		// These were excluded because an embedded .docx routes back through the Office
-		// preprocessor, which extracts ITS embeddings, which route back again --
-		// unbounded recursion, and a decompression-bomb amplifier for a tool that runs
-		// on untrusted input. Measured previously with a 7KB .docx embedding itself nine
-		// times: all nine levels were followed.
-		//
-		// The bound now exists: FileRouter.ProcessEmbedded tracks depth keyed on the
-		// path it is handed and refuses past MaxEmbeddedDepth, returning
-		// ErrEmbeddedTooDeep -- which the caller DISCLOSES rather than skipping, so a
-		// truncated traversal is visible instead of silently reading as clean.
-		//
-		// Excluding them was a detection hole with no attacker required: a document
-		// attached to a document is ordinary (an email attachment saved into a report, a
-		// workbook embedded in a deck). Measured before this change, an SSN in
-		// word/embeddings/oleObject1.docx produced 0 findings, exit 0, zero stderr, no
-		// redacted file, and exit 0 even under --fail-on-incomplete. See #297.
-		return "document"
-
-	default:
-		return ""
-	}
+	// Delegated to the single admission table shared with the redactor. The switch
+	// that used to live here had its own copy of the extension list, and the write
+	// side had another; the classes of file the two admitted diverged, which is
+	// exactly how an embedded image's EXIF and an embedded .docx's body both came
+	// to be reported and then left in cleartext by --enable-redaction.
+	//
+	// The table also admits .pdf, which this switch never did, so an embedded PDF
+	// is scanned for the first time.
+	return embedded.Kind(ext)
 }
 
 type EmbeddedMedia struct {
@@ -774,10 +754,24 @@ func extractEmbeddedImages(reader *zip.ReadCloser, metadata *Metadata) error {
 			continue
 		}
 
+		// Extract EVERY part under media/ or embeddings/, and let the ROUTER decide
+		// whether it can process it.
+		//
+		// This used to filter on a hand-maintained extension table, which meant the set
+		// of embedded types examined was whatever someone had enumerated rather than
+		// whatever the pipeline can actually read. Measured across 334 real Office
+		// files: 488 of 2,520 embedded parts (19%) were excluded by that table,
+		// including 411 .svg parts -- plain XML text that yields findings when scanned
+		// on its own -- plus .emf, .wdp and the .bin form Word uses for embedded OLE
+		// objects.
+		//
+		// The caller (OfficeMetadataPreprocessor.processEmbeddedMedia) now asks
+		// RouterInterface.CanProcessFile per part, so embedded coverage tracks
+		// top-level coverage automatically and cannot drift behind it again.
 		ext := strings.ToLower(filepath.Ext(file.Name))
 		mediaType := embeddedMediaType(ext)
 		if mediaType == "" {
-			continue // not a type any preprocessor can read
+			mediaType = "unclassified"
 		}
 
 		// Extract media to temp file
@@ -821,8 +815,24 @@ func extractImageToTemp(file *zip.File) (string, error) {
 			file.Name, file.UncompressedSize64, MaxEmbeddedMediaSize)
 	}
 
-	// Create temp file
-	tempFile, err := os.CreateTemp("", "office_image_*"+filepath.Ext(file.Name))
+	// Create temp file.
+	//
+	// The extension comes from the ADMISSION TABLE, not from the entry name. A zip
+	// entry name is producer-controlled and this is a filesystem path, so the raw
+	// name must not reach it (BSC1: validate untrusted input against an allowlist
+	// at the sink). filepath.Ext happens to stop at a path separator, so the
+	// previous form was not exploitable for traversal, but it did pass arbitrary
+	// attacker bytes into a filename and relied on that incidental property; the
+	// table returns one of a fixed set of ".xyz" literals instead.
+	//
+	// An unadmitted extension cannot occur here — the caller already checked
+	// embeddedMediaType — so the fallback is unreachable in practice and exists
+	// only so this function has no path that concatenates an unvalidated string.
+	safeExt, ok := embedded.SafeExt(file.Name)
+	if !ok {
+		return "", fmt.Errorf("embedded part %q has no admitted file type", filepath.Base(file.Name))
+	}
+	tempFile, err := os.CreateTemp("", "office_embedded_*"+safeExt)
 	if err != nil {
 		return "", err
 	}
@@ -861,10 +871,25 @@ func ExtractEmbeddedMediaForProcessing(filePath string) ([]EmbeddedMedia, error)
 			continue
 		}
 
+		// Extract EVERY part under media/ or embeddings/ and let the ROUTER decide
+		// whether it can process it.
+		//
+		// This is the function that feeds the routing path, and it used to drop any part
+		// whose extension was absent from a hand-maintained table. The set of embedded
+		// types examined was therefore whatever someone had enumerated rather than
+		// whatever the pipeline can read. Measured across 334 real Office files, 488 of
+		// 2,520 embedded parts (19%) were excluded, including 411 .svg parts -- plain
+		// XML text that yields an SSN finding when scanned as a standalone file -- plus
+		// .emf, .wdp, and the .bin form Word uses for embedded OLE objects.
+		//
+		// The classification is kept only as a HINT for the report. The admission
+		// decision now belongs to OfficeMetadataPreprocessor.processEmbeddedMedia, which
+		// asks RouterInterface.CanProcessFile per part, so embedded coverage tracks
+		// top-level coverage automatically and cannot silently fall behind it again.
 		ext := strings.ToLower(filepath.Ext(file.Name))
 		mediaType := embeddedMediaType(ext)
 		if mediaType == "" {
-			continue // not a type any preprocessor can read
+			mediaType = "unclassified"
 		}
 
 		// Extract media to temp file

--- a/internal/redactors/embedded.go
+++ b/internal/redactors/embedded.go
@@ -1,0 +1,243 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package redactors
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/embedded"
+)
+
+// Redacting a file that lives INSIDE another file.
+//
+// The read side already descends: an embedded part is written to a temp file and
+// routed back through the router, so an SSN in word/embeddings/oleObject1.docx or
+// in word/media/image1.jpg's EXIF is REPORTED. The write side did not, so those
+// values were never rewritten. Measured on main, with the outer document's own SSN
+// correctly redacted in every case:
+//
+//	outer.docx -> word/embeddings/oleObject1.docx   SSN in cleartext in the output
+//	outer.docx -> word/media/image1.jpg  (EXIF)     SSN in cleartext in the output
+//
+// both at exit 0, with nothing on stderr and a file sitting in a directory called
+// "redacted". Only reported findings are redacted, so a value the redactor cannot
+// reach is a leak that reports as success.
+//
+// The mechanism here is deliberately TYPE-AGNOSTIC: hand the child's bytes to
+// whichever registered redactor claims its extension and take the bytes back. The
+// alternative that was tried first — teaching the Office redactor to do zip surgery
+// on nested OOXML parts — fixed exactly one of the two cases above and could not fix
+// the other even in principle, because redacting a JPEG's EXIF is not a text
+// substitution in a zip member. Dispatching instead means embedded .docx/.xlsx/.pptx,
+// legacy .doc/.xls/.ppt, images and plain text are all covered by one loop, and each
+// child is redacted by the code that already knows its format.
+
+// EmbeddedRedactionRequest asks for the bytes of one embedded part to be redacted.
+//
+// Bytes in, bytes out. The caller (a container redactor) never touches the
+// filesystem for its children: materializing the part as a temp file is this
+// package's job, so the path-safety rules live in exactly one place rather than in
+// every container redactor that might grow a nested case.
+type EmbeddedRedactionRequest struct {
+	// ParentPath is the file this part was taken out of. It is the depth-accounting
+	// key and is not otherwise interpreted.
+	ParentPath string
+
+	// PartName is the archive entry name, e.g. word/embeddings/oleObject1.docx.
+	//
+	// It is PRODUCER-CONTROLLED and is used for two things only: choosing the
+	// redactor via its allowlisted extension, and naming the part in disclosure
+	// text. It never reaches a filesystem path — see embedded.SafeExt.
+	PartName string
+
+	// Content is the part's decompressed bytes.
+	Content []byte
+
+	// Matches is the FULL match list for the top-level file, not a subset.
+	//
+	// It cannot be a subset, because a finding carries no attribution to the part
+	// it came from: every match from an embedded child reports the OUTER file as
+	// its origin (verified — metadata.original_file names the container for all of
+	// them). So the child is handed everything and locates what is actually in it,
+	// which is the same thing every redactor already does at the top level. A value
+	// present in both container and child is redacted in both, which is correct.
+	Matches []detector.Match
+
+	// Strategy is the redaction strategy to apply, unchanged from the parent so a
+	// nested value is masked the same way as a top-level one.
+	Strategy RedactionStrategy
+}
+
+// EmbeddedRedactionResult carries the redacted bytes back to the container.
+type EmbeddedRedactionResult struct {
+	// Content is the redacted part, to be stored back at the same archive entry.
+	Content []byte
+
+	// RedactionMap describes what was redacted inside the part, so the container
+	// can merge it into its own audit trail instead of under-reporting.
+	RedactionMap []RedactionMapping
+
+	// PartName echoes the request, so a caller collecting results from several
+	// children can attribute them without keeping a parallel slice.
+	PartName string
+}
+
+// EmbeddedRedactor redacts a file extracted OUT OF another file.
+//
+// Declared here, next to the Redactor interface it complements, and satisfied by
+// *RedactionManager. A container redactor holds this interface rather than the
+// concrete manager so the dependency runs container -> interface <- manager: the
+// manager already knows every redactor, and a format redactor must not.
+//
+// Mirrors preprocessors.RouterInterface.ProcessEmbedded on purpose. That is the
+// read-side counterpart, and keeping the two shaped alike is what makes it obvious
+// that both halves bound depth, both disclose truncation, and both admit the same
+// set of file types.
+type EmbeddedRedactor interface {
+	// RedactEmbedded redacts one embedded part.
+	//
+	// Returns embedded.ErrTooDeep when the nesting bound is reached, and an
+	// ordinary error when no redactor handles the part's type or the redaction
+	// fails. Callers must DISCLOSE every one of those outcomes: each leaves a value
+	// the scanner reported sitting in the output in cleartext.
+	RedactEmbedded(req EmbeddedRedactionRequest) (*EmbeddedRedactionResult, error)
+}
+
+// ErrNoEmbeddedRedactor reports that no registered redactor handles a part's type.
+//
+// A distinct sentinel because this is the audio case and the not-yet-implemented
+// PDF case: the part was scanned and may hold reported findings, but nothing can
+// rewrite it. That is a permanent property of the tool's coverage rather than a
+// failure of this run, and the disclosure wording differs accordingly.
+var ErrNoEmbeddedRedactor = errors.New("no redactor handles this embedded file type")
+
+// embeddedDepthState tracks nesting depth across re-entrant redaction.
+//
+// The manager owns it for the same reason the router owns its counterpart: a
+// redactor instance is shared across concurrent files, so it cannot hold per-call
+// state, and RedactDocument's signature has no context to thread a counter
+// through. Keyed on the temp path the manager itself handed out, which the child's
+// own recursive call passes back as ParentPath.
+type embeddedDepthState struct {
+	mu    sync.Mutex
+	depth map[string]int
+}
+
+func (s *embeddedDepthState) depthOf(path string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.depth[path]
+}
+
+func (s *embeddedDepthState) set(path string, d int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.depth == nil {
+		s.depth = make(map[string]int)
+	}
+	s.depth[path] = d
+}
+
+// clear removes an entry once its child finishes, so the map holds only the files
+// currently being redacted rather than growing across a directory scan.
+func (s *embeddedDepthState) clear(path string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.depth, path)
+}
+
+// RedactEmbedded implements EmbeddedRedactor.
+//
+// The whole function is the read side's ProcessEmbedded with the arrow reversed:
+// bound the depth, materialize the child, dispatch it to the component that knows
+// its format, and hand the result back to the container.
+func (rm *RedactionManager) RedactEmbedded(req EmbeddedRedactionRequest) (*EmbeddedRedactionResult, error) {
+	// Bound the depth FIRST, before any allocation or filesystem work, so a deep
+	// nest costs nothing past the limit.
+	depth := rm.embeddedDepth.depthOf(req.ParentPath) + 1
+	if depth > embedded.MaxDepth {
+		return nil, fmt.Errorf("%w: %s is nested %d levels deep (limit %d)",
+			embedded.ErrTooDeep, filepath.Base(req.PartName), depth, embedded.MaxDepth)
+	}
+
+	// The extension comes from the admission allowlist, never from the entry name.
+	// req.PartName is producer-controlled and the value below is concatenated into
+	// a filesystem path, so per BSC1 it is validated against an allowlist at the
+	// sink. embedded.SafeExt returns one of a fixed set of ".xyz" literals, which
+	// makes "..", separators and NUL unrepresentable in the result rather than
+	// something to strip.
+	safeExt, ok := embedded.SafeExt(req.PartName)
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrNoEmbeddedRedactor, filepath.Ext(req.PartName))
+	}
+
+	// A private directory per child, removed on every path out.
+	//
+	// MkdirTemp is 0700 and CreateTemp/WriteFile below are 0600, which matters more
+	// than usual here: these files hold the part's UNREDACTED bytes, i.e. exactly
+	// the sensitive values the run exists to remove. A predictable name or a
+	// group-readable mode would publish them to any other account on the host for
+	// the duration of the scan.
+	dir, err := os.MkdirTemp("", "ferret-embedded-*")
+	if err != nil {
+		return nil, fmt.Errorf("creating temp dir for embedded part: %w", err)
+	}
+	// Deferred so it runs on the error paths too. An early return that left the
+	// cleartext part on disk would turn a redaction failure into a second
+	// disclosure.
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	inPath := filepath.Join(dir, "embedded"+safeExt)
+	outPath := filepath.Join(dir, "redacted"+safeExt)
+	if err := os.WriteFile(inPath, req.Content, 0o600); err != nil {
+		return nil, fmt.Errorf("writing embedded part to temp file: %w", err)
+	}
+
+	// Record the depth against the path the child will report as its parent, so a
+	// container nested inside this one is measured from here.
+	rm.embeddedDepth.set(inPath, depth)
+	defer rm.embeddedDepth.clear(inPath)
+
+	// Dispatch by type. GetRedactorForFile also diverts a container extension whose
+	// bytes are not that container to the text redactor, which is wanted here too:
+	// an entry named .docx that is actually plain text is still redactable.
+	redactor, err := rm.GetRedactorForFile(inPath)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrNoEmbeddedRedactor, filepath.Ext(req.PartName))
+	}
+
+	result, err := redactor.RedactDocument(inPath, outPath, req.Matches, req.Strategy)
+	if err != nil {
+		return nil, fmt.Errorf("redacting embedded part %s: %w", filepath.Base(req.PartName), err)
+	}
+	if result == nil || !result.Success {
+		return nil, fmt.Errorf("redacting embedded part %s: redactor reported failure",
+			filepath.Base(req.PartName))
+	}
+
+	// Read back whatever the redactor actually wrote. Its own RedactedFilePath is
+	// preferred over outPath because a redactor is free to choose its output name,
+	// and trusting our guess would silently return the UNREDACTED bytes if the two
+	// ever differed.
+	written := result.RedactedFilePath
+	if written == "" {
+		written = outPath
+	}
+	redacted, err := os.ReadFile(written) // #nosec G304 -- path built from MkdirTemp and an allowlisted extension
+	if err != nil {
+		return nil, fmt.Errorf("reading redacted embedded part %s: %w",
+			filepath.Base(req.PartName), err)
+	}
+
+	return &EmbeddedRedactionResult{
+		Content:      redacted,
+		RedactionMap: result.RedactionMap,
+		PartName:     req.PartName,
+	}, nil
+}

--- a/internal/redactors/embedded_test.go
+++ b/internal/redactors/embedded_test.go
@@ -1,0 +1,371 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package redactors
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/embedded"
+)
+
+func newTestManager(t *testing.T) *RedactionManager {
+	t.Helper()
+	// A real OutputStructureManager: NewRedactionManagerWithConfig dereferences it to
+	// build the audit log manager, so nil panics.
+	om, err := NewOutputStructureManager(t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("building output manager: %v", err)
+	}
+	return NewRedactionManagerWithConfig(om, nil, nil)
+}
+
+func sampleMatches() []detector.Match {
+	return []detector.Match{{Text: "452-11-9384", Type: "SSN", Confidence: 100}}
+}
+
+// TestRedactEmbeddedRefusesPastTheDepthBound.
+//
+// Without the bound, admitting embedded OOXML documents is unbounded recursion and a
+// decompression-bomb amplifier: an embedded .docx dispatches to the Office redactor,
+// which dispatches ITS embeddings, which dispatch back. Measured on the read side
+// with a 7KB .docx embedding itself nine times, all nine levels were followed.
+func TestRedactEmbeddedRefusesPastTheDepthBound(t *testing.T) {
+	rm := newTestManager(t)
+
+	// Stand the parent at the limit, so the child would be one level too deep.
+	parent := filepath.Join(t.TempDir(), "parent.docx")
+	rm.embeddedDepth.set(parent, embedded.MaxDepth)
+
+	_, err := rm.RedactEmbedded(EmbeddedRedactionRequest{
+		ParentPath: parent,
+		PartName:   "word/embeddings/tooDeep.docx",
+		Content:    []byte("PK\x03\x04 pretend package"),
+		Matches:    sampleMatches(),
+		Strategy:   RedactionFormatPreserving,
+	})
+	if err == nil {
+		t.Fatal("RedactEmbedded descended past the depth bound and returned no error")
+	}
+	if !errors.Is(err, embedded.ErrTooDeep) {
+		t.Errorf("error %v does not match embedded.ErrTooDeep, so a caller cannot tell "+
+			"\"coverage was cut short\" from \"this child failed to parse\" and the "+
+			"disclosure is downgraded to a generic failure", err)
+	}
+	// The message has to be actionable: it must name the part and the limit.
+	if !strings.Contains(err.Error(), "tooDeep.docx") {
+		t.Errorf("error %q does not name the part", err.Error())
+	}
+}
+
+// TestRedactEmbeddedAcceptsInsideTheBound is the recall half.
+//
+// A bound that refuses at a legitimate depth is worse than none: it stops redaction
+// that would have removed a value, and the read side would have reported it.
+func TestRedactEmbeddedAcceptsInsideTheBound(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	rm := newTestManager(t)
+	// .jpg rather than .txt: the extension has to be one the shared admission table
+	// accepts, or the request is refused before the depth check is reached.
+	if err := rm.RegisterRedactor(&stubRedactor{exts: []string{".jpg"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	parent := filepath.Join(t.TempDir(), "parent.docx")
+	// One below the limit, so the child sits exactly AT it and must be allowed.
+	rm.embeddedDepth.set(parent, embedded.MaxDepth-1)
+
+	res, err := rm.RedactEmbedded(EmbeddedRedactionRequest{
+		ParentPath: parent,
+		PartName:   "word/media/atTheLimit.jpg",
+		Content:    []byte("original bytes"),
+		Matches:    sampleMatches(),
+		Strategy:   RedactionFormatPreserving,
+	})
+	if err != nil {
+		t.Fatalf("RedactEmbedded refused a part at depth %d, which is within the limit of "+
+			"%d: %v", embedded.MaxDepth, embedded.MaxDepth, err)
+	}
+	if string(res.Content) != stubRedactedOutput {
+		t.Errorf("returned content %q, want the redactor's output %q — the bytes actually "+
+			"written by the child must be what comes back, not the input",
+			res.Content, stubRedactedOutput)
+	}
+}
+
+// TestRedactEmbeddedRejectsUnadmittedExtension.
+//
+// The extension chooses the redactor AND is concatenated into a temp path, so an
+// unadmitted one must be refused rather than passed through.
+func TestRedactEmbeddedRejectsUnadmittedExtension(t *testing.T) {
+	rm := newTestManager(t)
+	for _, part := range []string{
+		"word/embeddings/payload.exe",
+		"word/embeddings/payload",
+		"word/embeddings/../../../etc/passwd",
+	} {
+		_, err := rm.RedactEmbedded(EmbeddedRedactionRequest{
+			ParentPath: "parent.docx",
+			PartName:   part,
+			Content:    []byte("x"),
+			Matches:    sampleMatches(),
+			Strategy:   RedactionFormatPreserving,
+		})
+		if err == nil {
+			t.Errorf("RedactEmbedded(%q) returned no error for an unadmitted type", part)
+			continue
+		}
+		if !errors.Is(err, ErrNoEmbeddedRedactor) {
+			t.Errorf("RedactEmbedded(%q) error %v does not match ErrNoEmbeddedRedactor, so "+
+				"the caller cannot tell a coverage gap from a transient failure", part, err)
+		}
+	}
+}
+
+// TestRedactEmbeddedReportsMissingRedactorAsACoverageGap.
+//
+// Audio is the live case: it is scanned, so a value in a tag is reported, and no
+// redactor can remove it. That must surface as a coverage gap, never as success.
+func TestRedactEmbeddedReportsMissingRedactorAsACoverageGap(t *testing.T) {
+	rm := newTestManager(t) // nothing registered
+
+	_, err := rm.RedactEmbedded(EmbeddedRedactionRequest{
+		ParentPath: "parent.docx",
+		PartName:   "word/media/audio1.mp3",
+		Content:    []byte("ID3 tag with a value"),
+		Matches:    sampleMatches(),
+		Strategy:   RedactionFormatPreserving,
+	})
+	if err == nil {
+		t.Fatal("RedactEmbedded returned success for a type no redactor handles")
+	}
+	if !errors.Is(err, ErrNoEmbeddedRedactor) {
+		t.Errorf("error %v does not match ErrNoEmbeddedRedactor", err)
+	}
+}
+
+// TestRedactEmbeddedLeavesNoTemporaryFiles.
+//
+// The temp file holds the part's UNREDACTED bytes — precisely the values the run
+// exists to remove. One left behind after a failure is a second disclosure, sitting
+// in a world-listable directory for as long as the host lives.
+func TestRedactEmbeddedLeavesNoTemporaryFiles(t *testing.T) {
+	// Point TMPDIR at an empty directory so anything created is attributable.
+	tmp := t.TempDir()
+	t.Setenv("TMPDIR", tmp)
+
+	rm := newTestManager(t)
+	okRedactor := &stubRedactor{exts: []string{".jpg"}}
+	if err := rm.RegisterRedactor(okRedactor); err != nil {
+		t.Fatal(err)
+	}
+	failing := &stubRedactor{exts: []string{".png"}, fail: true}
+	if err := rm.RegisterRedactor(failing); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name string
+		part string
+	}{
+		{"success path", "word/media/image1.jpg"},
+		{"redactor error path", "word/media/image1.png"},
+		{"no redactor path", "word/media/audio1.mp3"},
+		{"unadmitted type path", "word/media/thing.exe"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _ = rm.RedactEmbedded(EmbeddedRedactionRequest{
+				ParentPath: "parent.docx",
+				PartName:   tc.part,
+				Content:    []byte("bytes holding 452-11-9384"),
+				Matches:    sampleMatches(),
+				Strategy:   RedactionFormatPreserving,
+			})
+
+			leftovers, err := os.ReadDir(tmp)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(leftovers) != 0 {
+				names := make([]string, 0, len(leftovers))
+				for _, e := range leftovers {
+					names = append(names, e.Name())
+				}
+				t.Errorf("%d temporary entr(ies) survived: %v\nThese hold the part's "+
+					"UNREDACTED bytes.", len(leftovers), names)
+			}
+		})
+	}
+}
+
+// TestRedactEmbeddedTempFileIsNotWorldReadable.
+//
+// A predictable or group-readable temp file publishes the cleartext values to any
+// other account on the host for the duration of the scan.
+func TestRedactEmbeddedTempFileIsNotWorldReadable(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+
+	rm := newTestManager(t)
+	spy := &modeSpyRedactor{t: t}
+	if err := rm.RegisterRedactor(spy); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := rm.RedactEmbedded(EmbeddedRedactionRequest{
+		ParentPath: "parent.docx",
+		PartName:   "word/media/image1.jpg",
+		Content:    []byte("secret bytes"),
+		Matches:    sampleMatches(),
+		Strategy:   RedactionFormatPreserving,
+	}); err != nil {
+		t.Fatalf("RedactEmbedded: %v", err)
+	}
+	if !spy.observed {
+		t.Fatal("the stub redactor was never called, so nothing was checked")
+	}
+	if spy.fileMode.Perm()&0o077 != 0 {
+		t.Errorf("the temp file holding unredacted bytes has mode %v; it must not be "+
+			"readable by group or other", spy.fileMode.Perm())
+	}
+	if spy.dirMode.Perm()&0o077 != 0 {
+		t.Errorf("the temp directory has mode %v; it must not be readable by group or "+
+			"other", spy.dirMode.Perm())
+	}
+}
+
+// TestRedactEmbeddedPassesTheWholeMatchList.
+//
+// A finding from an embedded part carries no attribution to that part — every one
+// reports the CONTAINER as its origin — so the child cannot be handed a subset. If
+// it were, a value living only in the child would be filtered out before the child
+// ever looked for it.
+func TestRedactEmbeddedPassesTheWholeMatchList(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	rm := newTestManager(t)
+	spy := &modeSpyRedactor{t: t}
+	if err := rm.RegisterRedactor(spy); err != nil {
+		t.Fatal(err)
+	}
+
+	want := []detector.Match{
+		{Text: "452-11-9384", Type: "SSN"},
+		{Text: "536-90-4271", Type: "SSN"},
+		{Text: "4111111111111111", Type: "CREDIT_CARD"},
+	}
+	if _, err := rm.RedactEmbedded(EmbeddedRedactionRequest{
+		ParentPath: "parent.docx",
+		PartName:   "word/media/image1.jpg",
+		Content:    []byte("x"),
+		Matches:    want,
+		Strategy:   RedactionFormatPreserving,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(spy.gotMatches) != len(want) {
+		t.Errorf("the child received %d matches, want all %d. A subset means a value that "+
+			"lives only in the child is filtered out before the child looks for it.",
+			len(spy.gotMatches), len(want))
+	}
+}
+
+// TestDepthStateIsClearedSoItDoesNotGrow.
+//
+// Entries must be removed when a child finishes, or the map grows for the life of a
+// directory scan — one entry per embedded part across every file.
+func TestDepthStateIsClearedSoItDoesNotGrow(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	rm := newTestManager(t)
+	if err := rm.RegisterRedactor(&stubRedactor{exts: []string{".jpg"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 20; i++ {
+		if _, err := rm.RedactEmbedded(EmbeddedRedactionRequest{
+			ParentPath: "parent.docx",
+			PartName:   "word/media/image1.jpg",
+			Content:    []byte("x"),
+			Matches:    sampleMatches(),
+			Strategy:   RedactionFormatPreserving,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	rm.embeddedDepth.mu.Lock()
+	n := len(rm.embeddedDepth.depth)
+	rm.embeddedDepth.mu.Unlock()
+	if n != 0 {
+		t.Errorf("depth map holds %d entries after 20 completed children; it must be "+
+			"cleared so it does not grow across a directory scan", n)
+	}
+}
+
+// ---------- stubs ----------
+
+const stubRedactedOutput = "REDACTED-BY-STUB"
+
+// stubRedactor stands in for a format redactor so these tests exercise the dispatch
+// mechanism rather than any real format's parsing.
+type stubRedactor struct {
+	exts []string
+	fail bool
+}
+
+func (s *stubRedactor) GetName() string { return "stub" }
+func (s *stubRedactor) GetSupportedTypes() []string {
+	return s.exts
+}
+func (s *stubRedactor) GetSupportedStrategies() []RedactionStrategy {
+	return []RedactionStrategy{RedactionSimple, RedactionFormatPreserving, RedactionSynthetic}
+}
+func (s *stubRedactor) GetComponentName() string { return "stub" }
+
+func (s *stubRedactor) RedactDocument(originalPath, outputPath string,
+	matches []detector.Match, strategy RedactionStrategy) (*RedactionResult, error) {
+	if s.fail {
+		return nil, errors.New("stub failure")
+	}
+	if err := os.WriteFile(outputPath, []byte(stubRedactedOutput), 0o600); err != nil {
+		return nil, err
+	}
+	return &RedactionResult{Success: true, RedactedFilePath: outputPath}, nil
+}
+
+// modeSpyRedactor records the permissions of the temp file and directory it is
+// handed, and the matches it receives.
+type modeSpyRedactor struct {
+	t          *testing.T
+	observed   bool
+	fileMode   os.FileMode
+	dirMode    os.FileMode
+	gotMatches []detector.Match
+}
+
+func (m *modeSpyRedactor) GetName() string             { return "modespy" }
+func (m *modeSpyRedactor) GetSupportedTypes() []string { return []string{".jpg"} }
+func (m *modeSpyRedactor) GetSupportedStrategies() []RedactionStrategy {
+	return []RedactionStrategy{RedactionFormatPreserving}
+}
+func (m *modeSpyRedactor) GetComponentName() string { return "modespy" }
+
+func (m *modeSpyRedactor) RedactDocument(originalPath, outputPath string,
+	matches []detector.Match, strategy RedactionStrategy) (*RedactionResult, error) {
+	m.observed = true
+	m.gotMatches = matches
+	if fi, err := os.Stat(originalPath); err == nil {
+		m.fileMode = fi.Mode()
+	}
+	if fi, err := os.Stat(filepath.Dir(originalPath)); err == nil {
+		m.dirMode = fi.Mode()
+	}
+	if err := os.WriteFile(outputPath, []byte(stubRedactedOutput), 0o600); err != nil {
+		return nil, err
+	}
+	return &RedactionResult{Success: true, RedactedFilePath: outputPath}, nil
+}

--- a/internal/redactors/embedded_test.go
+++ b/internal/redactors/embedded_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -228,6 +229,15 @@ func TestRedactEmbeddedTempFileIsNotWorldReadable(t *testing.T) {
 	}
 	if !spy.observed {
 		t.Fatal("the stub redactor was never called, so nothing was checked")
+	}
+
+	// Windows does not carry Unix permission bits in os.FileMode: it reports
+	// -rw-rw-rw- for a file created with 0600 and -rwxrwxrwx for a 0700 directory, so
+	// the assertion below cannot hold there and says nothing about the product. The
+	// mode arguments are still passed unconditionally; this only skips CHECKING them
+	// on the platform that cannot report them.
+	if runtime.GOOS == "windows" {
+		t.Skip("os.FileMode does not carry Unix permission bits on Windows")
 	}
 	if spy.fileMode.Perm()&0o077 != 0 {
 		t.Errorf("the temp file holding unredacted bytes has mode %v; it must not be "+

--- a/internal/redactors/manager.go
+++ b/internal/redactors/manager.go
@@ -45,6 +45,14 @@ type RedactionManager struct {
 
 	// stats tracks redaction statistics
 	stats *RedactionStats
+
+	// embeddedDepth bounds container-inside-container redaction.
+	//
+	// Held here rather than on a redactor because a redactor instance is shared
+	// across concurrent files and RedactDocument has no context parameter to thread
+	// a counter through — the same reason FileRouter owns the read side's copy. See
+	// RedactEmbedded in embedded.go.
+	embeddedDepth embeddedDepthState
 }
 
 // RedactionManagerConfig contains configuration for the redaction manager

--- a/internal/redactors/office/embedded.go
+++ b/internal/redactors/office/embedded.go
@@ -1,0 +1,335 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package office
+
+import (
+	"archive/zip"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/embedded"
+	"github.com/awslabs/ferret-scan/v2/internal/redactors"
+)
+
+// embeddedChild is a file found inside this document, held for redaction in its
+// own right.
+type embeddedChild struct {
+	// name is the archive entry name. Producer-controlled; used to pick a redactor
+	// by allowlisted extension and to name the part in disclosure text, never as a
+	// filesystem path.
+	name string
+	// content is the part's decompressed bytes, already bounded by the caller's
+	// per-entry and cumulative decompression caps.
+	content []byte
+}
+
+// unredactedPart records an embedded part that still holds a reported value after
+// redaction ran.
+//
+// This type exists because the alternative is silence, and silence here is the
+// whole bug: the container's own redactions succeed, a file appears in the output
+// directory, the exit code is 0, and a value the scanner reported is still in it.
+type unredactedPart struct {
+	name   string
+	reason string
+}
+
+func (u unredactedPart) String() string {
+	return fmt.Sprintf("%s (%s)", u.name, u.reason)
+}
+
+// redactEmbeddedParts redacts every embedded file and stores the results back at
+// their original entry names.
+//
+// Returns the mappings to merge into the container's audit trail, and the parts
+// that could not be redacted. The caller decides what to do with the second list;
+// it must not be dropped.
+func (or *OfficeRedactor) redactEmbeddedParts(
+	parentPath string,
+	contents *OfficeZipContents,
+	children []embeddedChild,
+	matches []detector.Match,
+	strategy redactors.RedactionStrategy,
+) ([]redactors.RedactionMapping, []unredactedPart) {
+	if len(children) == 0 || len(matches) == 0 {
+		// No children, or nothing reported to remove. With nothing to redact there is
+		// nothing to leak, and dispatching every embedded image in a clean document
+		// would be pure cost on the slowest stage of a scan.
+		return nil, nil
+	}
+
+	// The value set, built ONCE for the whole document rather than per child.
+	//
+	// Includes each value's XML-escaped spelling, because a value stored in an OOXML
+	// part is escaped and the raw literal from a Match need not occur in the bytes.
+	values := embeddedValueSet(matches)
+	if len(values) == 0 {
+		return nil, nil
+	}
+
+	var merged []redactors.RedactionMapping
+	var unredacted []unredactedPart
+	dispatched := 0
+
+	for _, child := range children {
+		// SKIP A PART ONLY WHEN IT CAN BE PROVEN TO HOLD NOTHING.
+		//
+		// This gate is the difference between redacting an embedded value and
+		// vandalizing the document around it. Every redactor here is lossy in some
+		// way -- the image redactor DECODES and re-encodes, and strips all metadata --
+		// so dispatching a part that holds none of the reported values silently
+		// degrades content that was never implicated. Measured before this gate: a
+		// document whose BODY held an SSN and which also carried an unrelated 706-byte
+		// photo came back with that photo re-encoded to 664 bytes, a different hash,
+		// and its caption removed. Nothing in the photo had ever been reported.
+		//
+		// The polarity matters and is asymmetric. For an INSPECTABLE format the byte
+		// scan is a sound test for absence -- EXIF, OLE streams and audio tags are
+		// stored in the clear, and the scan inflates archive members -- so "nothing
+		// found" means "leave it alone". For an OPAQUE format it is not: PDF text lives
+		// in FlateDecode streams, so nothing found means only that we cannot see. Such
+		// a part is therefore ALWAYS dispatched, and if no redactor can rewrite it the
+		// container is refused rather than written. Scanning it is still worth it --
+		// the finding gets reported either way -- and failing loudly is the honest end
+		// state when the value cannot be removed.
+		if embedded.ResidueInspectable(child.name) && !partHoldsValue(child.content, values, 0) {
+			continue
+		}
+
+		// Bound the work. A container with tens of thousands of embedded entries that
+		// all hold a value would otherwise be an unbounded number of full
+		// extract-redact-repackage cycles.
+		if dispatched >= embedded.MaxDispatchedParts {
+			unredacted = append(unredacted, unredactedPart{
+				name: child.name,
+				reason: fmt.Sprintf("more than %d embedded parts hold reported values; "+
+					"traversal stopped", embedded.MaxDispatchedParts),
+			})
+			continue
+		}
+		dispatched++
+
+		if or.embeddedRedactor == nil {
+			// nil is a supported state -- the redactor is usable standalone -- but it
+			// must not quietly mean "this document has no embedded content". The part
+			// demonstrably holds a reported value, so say so.
+			unredacted = append(unredacted, unredactedPart{
+				name:   child.name,
+				reason: "no embedded-redaction dispatcher configured",
+			})
+			continue
+		}
+
+		res, err := or.embeddedRedactor.RedactEmbedded(redactors.EmbeddedRedactionRequest{
+			ParentPath: parentPath,
+			PartName:   child.name,
+			Content:    child.content,
+			Matches:    matches,
+			Strategy:   strategy,
+		})
+		if err != nil {
+			// The part holds a reported value and could not be rewritten. That is a
+			// leak if the container is written, so it is reported unconditionally --
+			// no residue re-test, because the residue test is what got us here.
+			unredacted = append(unredacted, unredactedPart{
+				name:   child.name,
+				reason: describeEmbeddedFailure(err),
+			})
+			continue
+		}
+
+		// Verify the sink instead of trusting the report.
+		//
+		// A redactor returning Success with a RedactionMap is the same evidence that
+		// has been wrong before in this codebase: a count of 1 has been reported on an
+		// output byte-identical to its input. The only claim worth making is that the
+		// value is no longer there, so check the bytes that will actually be written.
+		if residue := valuesPresentIn(res.Content, values, 0, false); len(residue) > 0 {
+			unredacted = append(unredacted, unredactedPart{
+				name: child.name,
+				reason: fmt.Sprintf("%d reported value(s) still present after redaction",
+					len(residue)),
+			})
+			continue
+		}
+
+		// Store the redacted bytes back at the same entry name, so the container's
+		// repackager ships them with no special handling and the archive keeps its
+		// original entry order.
+		contents.addFile(child.name, res.Content)
+
+		for _, m := range res.RedactionMap {
+			if m.Metadata == nil {
+				m.Metadata = map[string]interface{}{}
+			}
+			// Re-label so the audit trail says WHERE inside the container the redaction
+			// happened; without it a nested redaction is indistinguishable from one in
+			// the container's own body.
+			m.Metadata["embedded_part"] = child.name
+			m.Metadata["embedded_in"] = filepath.Base(parentPath)
+			merged = append(merged, m)
+		}
+	}
+
+	return merged, unredacted
+}
+
+// embeddedValueSet collapses the match list into the distinct byte strings a residue
+// scan should look for, including XML-escaped spellings.
+//
+// Values shorter than minResidueValueLen are dropped: they would produce meaningless
+// hits in binary data, and redaction only ever searches for the literal value, so
+// such a value is not something a redactor could have targeted either.
+func embeddedValueSet(matches []detector.Match) [][]byte {
+	seen := make(map[string]struct{}, len(matches)*2)
+	var out [][]byte
+	for _, m := range matches {
+		if len(m.Text) < minResidueValueLen {
+			continue
+		}
+		for _, v := range embedded.XMLEscapeVariants(m.Text) {
+			if len(v) < minResidueValueLen {
+				continue
+			}
+			if _, dup := seen[v]; dup {
+				continue
+			}
+			seen[v] = struct{}{}
+			out = append(out, []byte(v))
+		}
+	}
+	return out
+}
+
+// minResidueValueLen is the shortest value worth searching for in arbitrary bytes.
+const minResidueValueLen = 4
+
+// describeEmbeddedFailure turns a dispatch error into a short operator-facing
+// reason.
+//
+// It must never carry document content. The underlying errors are structural
+// ("no redactor handles this embedded file type", "PDF redaction is not
+// implemented"), which is safe and is the actionable part, so they are passed
+// through; the sentinels are named explicitly so the two coverage gaps read
+// differently from a transient failure.
+func describeEmbeddedFailure(err error) string {
+	switch {
+	case errors.Is(err, embedded.ErrTooDeep):
+		return fmt.Sprintf("nesting deeper than %d levels was not examined", embedded.MaxDepth)
+	case errors.Is(err, redactors.ErrNoEmbeddedRedactor):
+		return "no redactor handles this file type"
+	default:
+		return err.Error()
+	}
+}
+
+// maxResidueDepth bounds the recursive residue scan.
+//
+// One deeper than embedded.MaxDepth on purpose: the scan's job is to VERIFY the
+// bound was respected, so it has to be able to look at the level the redactor
+// refused to descend into. A scan capped at the same depth as the redactor could
+// never see the value the redactor admitted it did not reach.
+const maxResidueDepth = embedded.MaxDepth + 1
+
+// maxResidueScanBytes bounds how much a single residue scan will inflate.
+//
+// The scan decompresses archive members, so without a bound the oracle that exists
+// to detect a bomb would itself be one. Mirrors the container redactor's cumulative
+// cap.
+const maxResidueScanBytes = 200 * 1024 * 1024
+
+// partHoldsValue reports whether any reported value occurs in a part's bytes.
+//
+// Descends into a zip so a deflated member is checked DECOMPRESSED. That is not
+// optional: grepping a .docx searches compressed bytes and finds nothing, which is
+// indistinguishable from a clean file and is the single most common way a leak in
+// this area gets certified as fixed.
+func partHoldsValue(content []byte, values [][]byte, depth int) bool {
+	return len(valuesPresentIn(content, values, depth, true)) > 0
+}
+
+// valuesPresentIn returns the values occurring in content, descending into nested
+// zip members.
+//
+// stopAtFirst short-circuits for the boolean caller. The two callers want different
+// answers -- "is there anything here?" versus "exactly what survived?" -- and sharing
+// the traversal keeps them from disagreeing about what counts as present.
+func valuesPresentIn(content []byte, values [][]byte, depth int, stopAtFirst bool) []string {
+	budget := int64(maxResidueScanBytes)
+	return scanForValues(content, values, depth, stopAtFirst, &budget)
+}
+
+func scanForValues(content []byte, values [][]byte, depth int, stopAtFirst bool, budget *int64) []string {
+	if depth > maxResidueDepth || *budget <= 0 {
+		return nil
+	}
+
+	var found []string
+	seen := make(map[string]struct{}, len(values))
+
+	for _, v := range values {
+		if _, dup := seen[string(v)]; dup {
+			continue
+		}
+		if bytes.Contains(content, v) {
+			seen[string(v)] = struct{}{}
+			found = append(found, string(v))
+			if stopAtFirst {
+				return found
+			}
+		}
+	}
+
+	// Only descend if the bytes are a zip; anything else is already searched above.
+	if !bytes.HasPrefix(content, []byte("PK")) {
+		return found
+	}
+	reader, err := zip.NewReader(bytes.NewReader(content), int64(len(content)))
+	if err != nil {
+		return found
+	}
+	for _, f := range reader.File {
+		if f.UncompressedSize64 > maxOfficeEntryBytes {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			continue
+		}
+		inner, err := io.ReadAll(io.LimitReader(rc, maxOfficeEntryBytes))
+		_ = rc.Close()
+		if err != nil {
+			continue
+		}
+		*budget -= int64(len(inner))
+		if *budget <= 0 {
+			return found
+		}
+		for _, s := range scanForValues(inner, values, depth+1, stopAtFirst, budget) {
+			if _, dup := seen[s]; dup {
+				continue
+			}
+			seen[s] = struct{}{}
+			found = append(found, s)
+			if stopAtFirst {
+				return found
+			}
+		}
+	}
+	return found
+}
+
+// embeddedFailureSummary renders the unredacted parts as one operator-facing line.
+func embeddedFailureSummary(parts []unredactedPart) string {
+	names := make([]string, 0, len(parts))
+	for _, p := range parts {
+		names = append(names, p.String())
+	}
+	return strings.Join(names, "; ")
+}

--- a/internal/redactors/office/embedded_test.go
+++ b/internal/redactors/office/embedded_test.go
@@ -1,0 +1,272 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package office
+
+import (
+	"archive/zip"
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/redactors"
+)
+
+const embSSN = "452-11-9384"
+
+// fakeDispatcher stands in for the RedactionManager so these tests can drive the
+// container's decision-making directly, including the cases a real redactor will not
+// produce on demand: claiming success while leaving the value behind, and failing on
+// a part whose content is compressed.
+type fakeDispatcher struct {
+	// out, when non-nil, is returned as the redacted bytes.
+	out []byte
+	// err, when non-nil, is returned instead of a result.
+	err error
+	// calls records the parts it was asked about.
+	calls []string
+}
+
+func (f *fakeDispatcher) RedactEmbedded(req redactors.EmbeddedRedactionRequest) (*redactors.EmbeddedRedactionResult, error) {
+	f.calls = append(f.calls, req.PartName)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &redactors.EmbeddedRedactionResult{
+		Content:  f.out,
+		PartName: req.PartName,
+		RedactionMap: []redactors.RedactionMapping{
+			{RedactedText: "[REDACTED]", DataType: "SSN"},
+		},
+	}, nil
+}
+
+// TestChildRedactorClaimingSuccessIsVerifiedNotTrusted.
+//
+// A redactor returning Success with a non-empty RedactionMap is exactly the evidence
+// that has been wrong before in this codebase — a RedactionCount of 1 has been
+// reported on an output byte-identical to its input. So the container checks the
+// bytes it is about to write rather than the child's self-report.
+func TestChildRedactorClaimingSuccessIsVerifiedNotTrusted(t *testing.T) {
+	dir := t.TempDir()
+	in := writeOuter(t, dir, "outer.docx", map[string][]byte{
+		"word/media/image1.jpg": []byte("EXIF holding " + embSSN),
+	})
+
+	or := NewOfficeRedactor(nil, nil)
+	// The lie: success, a redaction map, and content that still holds the value.
+	or.SetEmbeddedRedactor(&fakeDispatcher{out: []byte("EXIF still holding " + embSSN)})
+
+	out := filepath.Join(dir, "out.docx")
+	_, err := or.RedactDocument(in, out, embMatches(), redactors.RedactionFormatPreserving)
+	if err == nil {
+		t.Fatal("RedactDocument accepted a child redactor's success claim even though the " +
+			"returned bytes still contain the reported value")
+	}
+	if !strings.Contains(err.Error(), "still present") {
+		t.Errorf("error %q should say the value is still present after redaction", err.Error())
+	}
+	if _, statErr := os.Stat(out); statErr == nil {
+		t.Error("an output file was written despite the value surviving; a file that exists " +
+			"and is unredacted is worse than no file, because the caller can ship it")
+	}
+}
+
+// TestFailedZipChildHoldingTheValueFailsClosed.
+//
+// The residue scan MUST descend into a nested archive and decompress it. Searching a
+// .docx's raw bytes finds nothing, because the text is deflated — which is
+// indistinguishable from a clean part and is the single most common way a leak in
+// this area gets certified as fixed.
+func TestFailedZipChildHoldingTheValueFailsClosed(t *testing.T) {
+	dir := t.TempDir()
+
+	// A child package whose body holds the value, DEFLATED so a raw byte search
+	// cannot see it. Assert that up front, so the test cannot pass for the wrong
+	// reason if the fixture stops compressing.
+	child := buildInnerDocx(t, embSSN)
+	if bytes.Contains(child, []byte(embSSN)) {
+		t.Fatal("fixture child is not compressed, so this test would pass without any " +
+			"zip descent and prove nothing about it")
+	}
+
+	in := writeOuter(t, dir, "outer.docx", map[string][]byte{
+		"word/embeddings/oleObject1.docx": child,
+	})
+
+	or := NewOfficeRedactor(nil, nil)
+	or.SetEmbeddedRedactor(&fakeDispatcher{err: errors.New("simulated child failure")})
+
+	out := filepath.Join(dir, "out.docx")
+	_, err := or.RedactDocument(in, out, embMatches(), redactors.RedactionFormatPreserving)
+	if err == nil {
+		t.Fatal("RedactDocument wrote the container even though a child it could not " +
+			"redact holds the reported value in a compressed member")
+	}
+	if !strings.Contains(err.Error(), "oleObject1.docx") {
+		t.Errorf("error %q does not name the offending part", err.Error())
+	}
+	if _, statErr := os.Stat(out); statErr == nil {
+		t.Error("an output file was written despite the unredacted child")
+	}
+}
+
+// TestNoDispatcherStillDisclosesRatherThanSkipping.
+//
+// nil is a supported state — the redactor is usable standalone — but it must not
+// quietly mean "this document has no embedded content".
+func TestNoDispatcherStillDisclosesRatherThanSkipping(t *testing.T) {
+	dir := t.TempDir()
+	in := writeOuter(t, dir, "outer.docx", map[string][]byte{
+		"word/media/image1.jpg": []byte("EXIF holding " + embSSN),
+	})
+
+	or := NewOfficeRedactor(nil, nil) // no SetEmbeddedRedactor call
+	out := filepath.Join(dir, "out.docx")
+	_, err := or.RedactDocument(in, out, embMatches(), redactors.RedactionFormatPreserving)
+	if err == nil {
+		t.Fatal("with no dispatcher configured, a part holding the reported value was " +
+			"passed over and the container written as if clean")
+	}
+	if !strings.Contains(err.Error(), "dispatcher") {
+		t.Errorf("error %q should say a dispatcher is missing so the cause is actionable",
+			err.Error())
+	}
+}
+
+// TestChildIsDispatchedOnlyWhenThereIsSomethingToRedact.
+//
+// Dispatching every embedded image in a document with no findings would be pure cost
+// on the redaction path, which is already the slowest part of a scan.
+func TestChildIsDispatchedOnlyWhenThereIsSomethingToRedact(t *testing.T) {
+	dir := t.TempDir()
+	in := writeOuter(t, dir, "outer.docx", map[string][]byte{
+		"word/media/image1.jpg": []byte("harmless EXIF"),
+	})
+
+	fd := &fakeDispatcher{out: []byte("unused")}
+	or := NewOfficeRedactor(nil, nil)
+	or.SetEmbeddedRedactor(fd)
+
+	out := filepath.Join(dir, "out.docx")
+	if _, err := or.RedactDocument(in, out, nil, redactors.RedactionFormatPreserving); err != nil {
+		t.Fatalf("RedactDocument with no matches: %v", err)
+	}
+	if len(fd.calls) != 0 {
+		t.Errorf("dispatched %v with an empty match list; there is nothing to redact",
+			fd.calls)
+	}
+}
+
+// TestEveryAdmittedChildIsDispatched — the container must not pick and choose.
+//
+// A part the read side scanned but the write side never offers to a redactor is the
+// original bug in a new place.
+func TestEveryAdmittedChildIsDispatched(t *testing.T) {
+	dir := t.TempDir()
+	in := writeOuter(t, dir, "outer.docx", map[string][]byte{
+		// Each child must actually HOLD the reported value: a part that provably holds
+		// none of them is deliberately left untouched, so filler bytes would make this
+		// test assert the opposite of the intended behaviour.
+		"word/media/image1.jpg":           []byte("EXIF " + embSSN),
+		"word/media/image2.png":           []byte("tEXt " + embSSN),
+		"word/embeddings/oleObject1.docx": []byte("stream " + embSSN),
+		"word/embeddings/legacy.doc":      []byte("ole " + embSSN),
+		// Not an embedded part: must NOT be dispatched.
+		"word/document2.xml": []byte("<x/>"),
+	})
+
+	fd := &fakeDispatcher{out: []byte("clean")}
+	or := NewOfficeRedactor(nil, nil)
+	or.SetEmbeddedRedactor(fd)
+
+	out := filepath.Join(dir, "out.docx")
+	if _, err := or.RedactDocument(in, out, embMatches(), redactors.RedactionFormatPreserving); err != nil {
+		t.Fatalf("RedactDocument: %v", err)
+	}
+
+	want := []string{
+		"word/embeddings/legacy.doc",
+		"word/embeddings/oleObject1.docx",
+		"word/media/image1.jpg",
+		"word/media/image2.png",
+	}
+	got := append([]string{}, fd.calls...)
+	sortStrings(got)
+	if len(got) != len(want) {
+		t.Fatalf("dispatched %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("dispatched[%d] = %q, want %q (full: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+// ---------- helpers ----------
+
+func embMatches() []detector.Match {
+	return []detector.Match{{Text: embSSN, Type: "SSN", Confidence: 100}}
+}
+
+func sortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j] < s[j-1]; j-- {
+			s[j], s[j-1] = s[j-1], s[j]
+		}
+	}
+}
+
+func writeOuter(t *testing.T, dir, name string, extras map[string][]byte) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, buildPkg(t, "Container body text.", extras), 0o600); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+	return path
+}
+
+func buildInnerDocx(t *testing.T, ssn string) []byte {
+	t.Helper()
+	return buildPkg(t, "Inner document. Employee SSN: "+ssn, nil)
+}
+
+func buildPkg(t *testing.T, body string, extras map[string][]byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	add := func(name string, data []byte) {
+		// Deflate explicitly: the compression is load-bearing for the residue test.
+		w, err := zw.CreateHeader(&zip.FileHeader{Name: name, Method: zip.Deflate})
+		if err != nil {
+			t.Fatalf("creating %s: %v", name, err)
+		}
+		if _, err := w.Write(data); err != nil {
+			t.Fatalf("writing %s: %v", name, err)
+		}
+	}
+	add("[Content_Types].xml", []byte(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>`+
+		`<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">`+
+		`<Default Extension="xml" ContentType="application/xml"/>`+
+		`<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>`+
+		`</Types>`))
+	add("word/document.xml", []byte(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>`+
+		`<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">`+
+		`<w:body><w:p><w:r><w:t>`+body+`</w:t></w:r></w:p></w:body></w:document>`))
+	names := make([]string, 0, len(extras))
+	for k := range extras {
+		names = append(names, k)
+	}
+	sortStrings(names)
+	for _, n := range names {
+		add(n, extras[n])
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("closing zip: %v", err)
+	}
+	return buf.Bytes()
+}

--- a/internal/redactors/office/redactor.go
+++ b/internal/redactors/office/redactor.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/embedded"
 	"github.com/awslabs/ferret-scan/v2/internal/observability"
 	"github.com/awslabs/ferret-scan/v2/internal/redactors"
 	"github.com/awslabs/ferret-scan/v2/internal/redactors/position"
@@ -41,6 +42,17 @@ type OfficeRedactor struct {
 
 	// fallbackToSimple controls whether to fall back to simple text replacement on correlation failure
 	fallbackToSimple bool
+
+	// embeddedRedactor redacts files found INSIDE this document — an embedded
+	// .docx, a legacy .doc, an image whose EXIF holds a finding.
+	//
+	// An interface, injected, rather than the concrete RedactionManager: the
+	// manager knows every redactor and a single format redactor must not. nil is a
+	// supported state and means "do not descend", which keeps this type usable
+	// standalone in tests and from callers that never registered a manager. When it
+	// is nil and an embedded part holds a reported value, that is DISCLOSED rather
+	// than passed over — see redactEmbeddedParts.
+	embeddedRedactor redactors.EmbeddedRedactor
 }
 
 // OfficeDocumentType represents the type of Office document
@@ -101,6 +113,13 @@ func NewOfficeRedactor(outputManager *redactors.OutputStructureManager, observer
 	}
 }
 
+// SetEmbeddedRedactor injects the component used to redact files embedded inside
+// this document. Called once at construction by internal/core, after every redactor
+// is registered, because the value is the manager that owns them all.
+func (or *OfficeRedactor) SetEmbeddedRedactor(er redactors.EmbeddedRedactor) {
+	or.embeddedRedactor = er
+}
+
 // GetName returns the name of the redactor
 func (or *OfficeRedactor) GetName() string {
 	return "office_redactor"
@@ -143,7 +162,7 @@ func (or *OfficeRedactor) RedactDocument(originalPath string, outputPath string,
 	}
 
 	// Extract ZIP contents and text
-	zipContents, extractedText, textPositions, err := or.extractOfficeContent(originalPath, docType)
+	zipContents, extractedText, textPositions, children, err := or.extractOfficeContent(originalPath, docType)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract office content: %w", err)
 	}
@@ -152,6 +171,33 @@ func (or *OfficeRedactor) RedactDocument(originalPath string, outputPath string,
 	redactionMap, modifiedContents, err := or.redactOfficeContent(zipContents, extractedText, textPositions, matches, strategy, docType)
 	if err != nil {
 		return nil, fmt.Errorf("failed to redact office content: %w", err)
+	}
+
+	// Redact files embedded INSIDE this document, each by the redactor that owns
+	// its format, and store the results back at their own entry names.
+	embeddedMap, unredacted := or.redactEmbeddedParts(originalPath, modifiedContents, children, matches, strategy)
+	redactionMap = append(redactionMap, embeddedMap...)
+
+	// Refuse to write a document that still holds a reported value.
+	//
+	// FAIL CLOSED, deliberately, and this is the crux of the fix. The alternative --
+	// write the file and warn -- puts a document containing an SSN into a directory
+	// named "redacted", which is the artefact a user forwards. The same policy
+	// already applies one level up: when the image or PDF redactor cannot handle a
+	// standalone file, no output is written and the run reports
+	// "redaction incomplete ... the original values remain in cleartext". Writing
+	// here while refusing there would make the tool's guarantee depend on whether
+	// the value happened to be nested.
+	//
+	// The blast radius is bounded by design: redactEmbeddedParts only reports a part
+	// when a reported value is actually still present in it (or when the format is
+	// one whose bytes cannot be inspected, where absence cannot be established). An
+	// embedded image that merely fails to decode, holding nothing, does not stop the
+	// container from being written.
+	if len(unredacted) > 0 {
+		return nil, fmt.Errorf(
+			"refusing to write %s: %d embedded part(s) still contain reported values: %s",
+			filepath.Base(outputPath), len(unredacted), embeddedFailureSummary(unredacted))
 	}
 
 	// Repackage ZIP with modified contents
@@ -292,10 +338,10 @@ type OfficeElementInfo struct {
 }
 
 // extractOfficeContent extracts ZIP contents and text from an Office document
-func (or *OfficeRedactor) extractOfficeContent(filePath string, docType OfficeDocumentType) (*OfficeZipContents, string, []OfficeTextPosition, error) {
+func (or *OfficeRedactor) extractOfficeContent(filePath string, docType OfficeDocumentType) (*OfficeZipContents, string, []OfficeTextPosition, []embeddedChild, error) {
 	reader, err := zip.OpenReader(filePath)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("failed to open ZIP file: %w", err)
+		return nil, "", nil, nil, fmt.Errorf("failed to open ZIP file: %w", err)
 	}
 	defer reader.Close()
 
@@ -307,6 +353,9 @@ func (or *OfficeRedactor) extractOfficeContent(filePath string, docType OfficeDo
 	var extractedText strings.Builder
 	var textPositions []OfficeTextPosition
 	var totalDecompressed int64
+	// children are embedded files to be redacted in their own right, in source
+	// order so the redacted output is reproducible.
+	var children []embeddedChild
 
 	// Extract all files from ZIP
 	for _, file := range reader.File {
@@ -314,7 +363,7 @@ func (or *OfficeRedactor) extractOfficeContent(filePath string, docType OfficeDo
 		// per-entry cap. This is the cheap first line of defense against a
 		// decompression bomb (a tiny compressed entry claiming multi-GB output).
 		if file.UncompressedSize64 > maxOfficeEntryBytes {
-			return nil, "", nil, fmt.Errorf("office entry %q declares %d bytes, exceeding the %d cap (possible decompression bomb)",
+			return nil, "", nil, nil, fmt.Errorf("office entry %q declares %d bytes, exceeding the %d cap (possible decompression bomb)",
 				file.Name, file.UncompressedSize64, maxOfficeEntryBytes)
 		}
 
@@ -341,18 +390,33 @@ func (or *OfficeRedactor) extractOfficeContent(filePath string, docType OfficeDo
 		// The redactor repackages exactly what it reads, so a truncated entry
 		// would silently corrupt the redacted output — fail closed instead.
 		if int64(len(content)) > maxOfficeEntryBytes {
-			return nil, "", nil, fmt.Errorf("office entry %q exceeds the %d per-entry decompression cap (possible bomb)",
+			return nil, "", nil, nil, fmt.Errorf("office entry %q exceeds the %d per-entry decompression cap (possible bomb)",
 				file.Name, maxOfficeEntryBytes)
 		}
 		totalDecompressed += int64(len(content))
 		if totalDecompressed > maxOfficeTotalBytes {
-			return nil, "", nil, fmt.Errorf("office document exceeds the %d cumulative decompression cap (possible bomb)",
+			return nil, "", nil, nil, fmt.Errorf("office document exceeds the %d cumulative decompression cap (possible bomb)",
 				maxOfficeTotalBytes)
 		}
 
 		// Record the entry with its position in the source package, so the
 		// repackaged document is written in the same order.
 		zipContents.addFile(file.Name, content)
+
+		// Record an embedded file for separate redaction, rather than trying to
+		// treat it as text of this document.
+		//
+		// Its text is deliberately NOT folded into extractedText. An earlier attempt
+		// did exactly that and then rewrote the value inside the nested package with
+		// a byte substitution. That works for an embedded .docx and cannot work for
+		// an embedded JPEG, because removing an SSN from EXIF is not a string replace
+		// in a zip member -- measured, the .docx case was fixed and the image case
+		// still shipped the SSN in cleartext. Handing the whole part to the redactor
+		// that owns its format covers both, plus legacy OLE and PDF, with one loop.
+		if embedded.IsPartPath(file.Name) {
+			children = append(children, embeddedChild{name: file.Name, content: content})
+			continue
+		}
 
 		// Extract text from relevant XML files
 		if or.isTextContainingFile(file.Name, docType) {
@@ -370,7 +434,7 @@ func (or *OfficeRedactor) extractOfficeContent(filePath string, docType OfficeDo
 		}
 	}
 
-	return zipContents, extractedText.String(), textPositions, nil
+	return zipContents, extractedText.String(), textPositions, children, nil
 }
 
 // isTextContainingFile determines if a ZIP file contains text content based on document type.

--- a/internal/redactors/office/redactor.go
+++ b/internal/redactors/office/redactor.go
@@ -413,7 +413,7 @@ func (or *OfficeRedactor) extractOfficeContent(filePath string, docType OfficeDo
 		// in a zip member -- measured, the .docx case was fixed and the image case
 		// still shipped the SSN in cleartext. Handing the whole part to the redactor
 		// that owns its format covers both, plus legacy OLE and PDF, with one loop.
-		if embedded.IsPartPath(file.Name) {
+		if embedded.IsPartPath(file.Name) && !embedded.SkipTextPipeline(file.Name) {
 			children = append(children, embeddedChild{name: file.Name, content: content})
 			continue
 		}

--- a/internal/router/file_router.go
+++ b/internal/router/file_router.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/awslabs/ferret-scan/v2/internal/embedded"
 	"github.com/awslabs/ferret-scan/v2/internal/observability"
 	"github.com/awslabs/ferret-scan/v2/internal/preprocessors"
 )
@@ -54,7 +55,15 @@ type FileRouter struct {
 // Three levels covers every legitimate shape observed (a report with an attached
 // workbook that itself has an embedded image) with margin. Reaching the bound is
 // DISCLOSED, not silently skipped -- see ErrEmbeddedTooDeep.
-const MaxEmbeddedDepth = 3
+//
+// Defined in package embedded rather than here, because the REDACTION side needs the
+// same bound and must not carry its own copy. A write side shallower than the read
+// side reports findings from a level it will not rewrite -- a cleartext leak that
+// reads as success -- and a write side deeper than the read side redacts in a place
+// nothing scanned. The earlier attempt at this mirrored the literal 3 in
+// internal/redactors/office and added a test asserting the two stayed equal; sharing
+// one constant makes the drift impossible instead of merely detected.
+const MaxEmbeddedDepth = embedded.MaxDepth
 
 // MaxFileSize is the default maximum file size the router will process (100 MB).
 const MaxFileSize = int64(100 * 1024 * 1024)


### PR DESCRIPTION
Closes #305.

Only reported findings reach the redactor, so a value the redactor cannot reach is a leak that **reports as success**. The read side already descends into embedded parts, so these values were FOUND. The write side did not, so they were shipped in cleartext inside a file sitting in a directory named `redacted`, at exit 0, with nothing on stderr.

## The leak, measured on the parent commit

Each containers OWN value was correctly redacted in every row, which is what made this invisible.

| fixture | before | after |
|---|---|---|
| `.docx` embedded in a `.docx` | wrote file, **SSN in cleartext** | wrote file, **0 leaks** |
| `.jpg` EXIF embedded in a `.docx` | wrote file, **SSN in cleartext** | wrote file, **0 leaks** |
| both children in one document | wrote file, **2 values in cleartext** | wrote file, **0 leaks** |
| 3-level nest (docx in docx in docx) | wrote file, **SSN in cleartext** | wrote file, **0 leaks** |
| `.wav` ICMT comment embedded | wrote file, **SSN in cleartext** | **no file + warning** |
| embedded `.pdf` | **unscanned**, value shipped | **detected**, no file + warning |
| embedded `.svg` | **unscanned**, value shipped | **detected**, no file + warning |
| unrelated clean photo alongside a body SSN | untouched | untouched (byte-identical) |
| clean document | no file | no file |

Every row verified by reading the bytes actually written and **descending into each nested archive member** — grepping a `.docx` searches compressed bytes and finds nothing, which is indistinguishable from a clean file and is the most common way a leak here gets certified as fixed.

## What changed

**Give the write side the recursion the read side has.** Each embedded part is dispatched to whichever registered redactor claims it, so embedded OOXML, legacy OLE and image metadata are covered by one loop, each by the code that already knows its format.

An earlier attempt taught the Office redactor to do zip surgery on nested OOXML parts. It fixed the embedded-`.docx` case and **could not fix the embedded-image case even in principle**, because removing an SSN from EXIF is not a string replacement in a zip member. That approach is deleted.

**Admission is derived from capability, not a hand-maintained table.** The table excluded **488 of 2,520 embedded parts (19%)** across 334 real Office files: 411 `.svg` (plain XML text that yields an SSN finding standalone), plus `.emf`, `.wdp`, and the `.bin` form Word uses for embedded OLE objects. Every part under `media/` or `embeddings/` is now offered to `RouterInterface.CanProcessFile`, so embedded coverage tracks top-level coverage and cannot silently fall behind again.

**Fail loudly rather than ship.** A container is refused when an embedded part still holds a reported value: no output file, and the existing `redaction incomplete ... the original values remain in cleartext` channel names the part and the reason. That converts three silent leaks into loud failures. The same policy already applied one level up, so nesting no longer changes the guarantee.

The childs self-report is **not trusted** — the bytes about to be written are re-scanned for every reported value, because a `RedactionCount` of 1 has previously been reported on an output byte-identical to its input.

**Do not touch clean parts.** Every redactor here is lossy (the image redactor decodes, re-encodes and strips all metadata), so a part is dispatched only when it can be shown to hold a reported value. Caught during review: an unrelated 706-byte photo in a document whose *body* held an SSN came back re-encoded to 664 bytes with its caption removed. It is now byte-identical. PDF is the deliberate exception and is always dispatched, because its text lives in FlateDecode streams so absence cannot be established by a byte scan.

**Bounds.** `MaxDepth` and `ErrTooDeep` move to a new leaf package `internal/embedded` shared by both halves, so the read and write bounds are one value rather than two that can drift — a shallower write side reports findings from a level it will not rewrite; a deeper one redacts where nothing scanned. The temp-file extension comes from a character-class allowlist, never from the producer-controlled entry name (BSC1), and the residue scan inflates archive members.

## Testing

Per `docs/testing/TEST_PLAN.md`:

- `go build ./...`, `go vet ./...`, `gofmt -l` — clean.
- `go test ./... -count=1` — **66 packages, 0 failures**, with #310 merged (union tested, not just conflict-checked).
- Golden corpus `-count=1` — pass, **zero goldens moved**.
- `make score` — **unchanged**: `recall_all=1.0000 recall_hm=0.9947 prec_hm=0.9310 whole_leak=0`.
- **Non-vacuity**: the six new end-to-end tests FAIL on the parent commit with the exact leak paths, including the 3-level nest.
- **Mutation**: nine mutations applied to the new guards (depth bound, allowlist, fail-closed, post-dispatch verification, residue gate, zip descent, temp cleanup, opaque set, child collection). **Every one compiled and every one was caught.**
- **Complexity** — redaction scaling is linear, binaries built outside `/tmp`:

| case | N=25 | 50 | 100 | 200 | per doubling |
|---|---|---|---|---|---|
| every part clean (skipped) | 0.130s | 0.163s | 0.181s | 0.344s | 1.1–1.9x |
| every part dispatched (worst case) | 0.126s | 0.210s | 0.406s | 0.819s | 1.66–2.02x |

  2x per doubling is linear. The clean case matches the parent almost exactly (0.344s vs 0.333s at N=200), so the residue gate keeps ordinary documents free; the worst case costs ~2–2.7x, which is the price of actually redacting parts previously skipped entirely.

## Behaviour changes worth calling out

- A document whose embedded part cannot be redacted now produces **no output file** instead of a silently incomplete one. Exit code is unchanged (0 with a stderr warning), matching the existing standalone behaviour — changing that is a separate decision.
- An embedded `.pdf` and an embedded `.svg` are now **scanned**, which is new detection; neither has a redactor, so such documents fail loudly.
- Corpus figures are aggregate counts only; every value shown is from a synthetic fixture.

## Follow-ups found while here, not in this PR

- A malformed WAV (odd-length chunk, unpadded) reports `No matches found` with no disclosure — same class as #294/#301.
- Redactor coverage lags preprocessor coverage at the **top** level too: the score corpus already lists `.tsv`, `.html` and `.sql` as scanned-but-unredactable, and #310 widened that set.