### PR TITLE
fix(metadata): record a custom property once, and stop charging it twice for one classification word

### DIFF
--- a/internal/preprocessors/meta-extractors/meta-extract-officelib/custom_props_single_emit_test.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-officelib/custom_props_single_emit_test.go
@@ -1,0 +1,189 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package metaextractofficelib
+
+import (
+	"archive/zip"
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A custom property must be recorded ONCE.
+//
+// extractOfficeMetadata used to store every custom property in CustomProps AND mirror it
+// into Properties under a "Custom_" prefix, described as "for easy scanning". The office
+// preprocessor renders both maps — the dedicated "--- Custom Properties ---" block from
+// CustomProps, then FormatPropertiesMap over Properties — and both lines carry the
+// custom_ prefix the validator types on, so every custom property was reported TWICE.
+//
+// Measured on a real corpus of 304 .docx files: 506 CUSTOM_PROPERTY findings across 202
+// files, ZERO files with an odd count, every (file, confidence) bucket even. A synthetic
+// one-property fixture produced 2 findings.
+//
+// The existing dedup cannot catch this: per #202 its key is the BYTE SPAN, and the two
+// rendered lines occupy genuinely different spans, so they are correctly treated as two
+// occurrences of duplicated input. The fix belongs at the point the value was written
+// into two maps. See #308.
+
+func TestCustomPropertyIsRecordedOnce(t *testing.T) {
+	path := writeDocxWithCustomProps(t, map[string]string{
+		"ProjectCode": "PROJECT-ALPHA-7",
+	})
+
+	got, err := ExtractMetadata(path)
+	if err != nil {
+		t.Fatalf("extraction failed: %v", err)
+	}
+
+	if len(got.CustomProps) != 1 {
+		t.Errorf("CustomProps has %d entries, want 1: %v", len(got.CustomProps), got.CustomProps)
+	}
+	if got.CustomProps["ProjectCode"] != "PROJECT-ALPHA-7" {
+		t.Errorf("CustomProps[ProjectCode] = %q, want the extracted value",
+			got.CustomProps["ProjectCode"])
+	}
+
+	// The mirror must be gone. Counting Custom_-prefixed keys rather than asserting a
+	// specific one, so a differently-named mirror is caught too.
+	var mirrored []string
+	for k := range got.Properties {
+		if strings.HasPrefix(k, "Custom_") {
+			mirrored = append(mirrored, k)
+		}
+	}
+	if len(mirrored) != 0 {
+		t.Errorf("Properties still mirrors %d custom propert(ies) under a Custom_ prefix: %v\n"+
+			"The office preprocessor renders BOTH maps, so each mirrored entry becomes a "+
+			"second identical finding.", len(mirrored), mirrored)
+	}
+}
+
+// TestManyCustomPropertiesAreEachRecordedOnce — the count is what matters.
+//
+// An existence-only assertion ("a finding was produced") passes just as well when every
+// property is duplicated, which is exactly how this shipped.
+func TestManyCustomPropertiesAreEachRecordedOnce(t *testing.T) {
+	props := map[string]string{
+		"ProjectCode":       "PROJECT-ALPHA-7",
+		"EmployeeSSN":       "452-11-9384",
+		"ContentTypeId":     "0x0101002A3B4C",
+		"ComplianceAssetId": "abc-123",
+		"Classification":    "CONFIDENTIAL",
+	}
+	path := writeDocxWithCustomProps(t, props)
+
+	got, err := ExtractMetadata(path)
+	if err != nil {
+		t.Fatalf("extraction failed: %v", err)
+	}
+
+	if len(got.CustomProps) != len(props) {
+		t.Errorf("CustomProps has %d entries, want %d", len(got.CustomProps), len(props))
+	}
+	for k, want := range props {
+		if got.CustomProps[k] != want {
+			t.Errorf("CustomProps[%q] = %q, want %q", k, got.CustomProps[k], want)
+		}
+	}
+
+	// Total renderable custom entries across BOTH maps must equal the property count.
+	// This is the assertion that actually fails on the duplicated shape: it would be
+	// 2 * len(props).
+	total := len(got.CustomProps)
+	for k := range got.Properties {
+		if strings.HasPrefix(k, "Custom_") {
+			total++
+		}
+	}
+	if total != len(props) {
+		t.Errorf("%d renderable custom entries across CustomProps+Properties, want %d. "+
+			"Each surplus entry becomes a duplicate finding.", total, len(props))
+	}
+}
+
+// writeDocxWithCustomProps builds a minimal OOXML package carrying docProps/custom.xml.
+func writeDocxWithCustomProps(t *testing.T, props map[string]string) string {
+	t.Helper()
+
+	const contentTypes = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+		`<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+		`<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+		`<Default Extension="xml" ContentType="application/xml"/>` +
+		`<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>` +
+		`<Override PartName="/docProps/custom.xml" ContentType="application/vnd.openxmlformats-officedocument.custom-properties+xml"/>` +
+		`</Types>`
+
+	const rels = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+		`<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+		`<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>` +
+		`<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/custom-properties" Target="docProps/custom.xml"/>` +
+		`</Relationships>`
+
+	const doc = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+		`<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
+		`<w:body><w:p><w:r><w:t>Body text.</w:t></w:r></w:p></w:body></w:document>`
+
+	// Sorted keys so the fixture bytes are reproducible regardless of map order.
+	names := make([]string, 0, len(props))
+	for k := range props {
+		names = append(names, k)
+	}
+	for i := 1; i < len(names); i++ {
+		for j := i; j > 0 && names[j] < names[j-1]; j-- {
+			names[j], names[j-1] = names[j-1], names[j]
+		}
+	}
+
+	var custom strings.Builder
+	custom.WriteString(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+		`<Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/custom-properties" ` +
+		`xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes">`)
+	for i, name := range names {
+		custom.WriteString(`<property fmtid="{D5CDD505-2E9C-101B-9397-08002B2CF9AE}" pid="`)
+		custom.WriteString(itoaSmall(i + 2))
+		custom.WriteString(`" name="` + name + `"><vt:lpwstr>` + props[name] + `</vt:lpwstr></property>`)
+	}
+	custom.WriteString(`</Properties>`)
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for _, e := range []struct{ name, body string }{
+		{"[Content_Types].xml", contentTypes},
+		{"_rels/.rels", rels},
+		{"word/document.xml", doc},
+		{"docProps/custom.xml", custom.String()},
+	} {
+		w, err := zw.Create(e.name)
+		if err != nil {
+			t.Fatalf("creating %s: %v", e.name, err)
+		}
+		if _, err := w.Write([]byte(e.body)); err != nil {
+			t.Fatalf("writing %s: %v", e.name, err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(t.TempDir(), "customprops.docx")
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func itoaSmall(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}

--- a/internal/preprocessors/meta-extractors/meta-extract-officelib/office-extractor.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-officelib/office-extractor.go
@@ -367,13 +367,31 @@ func extractOfficeOpenXMLMetadata(filePath string, metadata *Metadata) (*Metadat
 		}
 	}
 
-	// Extract custom properties (HIGH RISK)
+	// Extract custom properties (HIGH RISK).
+	//
+	// CustomProps is the ONLY home. A mirror of every entry used to be written into
+	// Properties under a "Custom_" prefix as well, described as "for easy scanning",
+	// and the office preprocessor renders BOTH maps — the dedicated
+	// "--- Custom Properties ---" block from CustomProps, then FormatPropertiesMap over
+	// Properties. Both lines carry the custom_ prefix the validator types on, so every
+	// custom property was reported TWICE.
+	//
+	// Measured on a real corpus of 304 .docx files: 506 CUSTOM_PROPERTY findings across
+	// 202 files, with ZERO files holding an odd count and every (file, confidence)
+	// bucket even — i.e. ~253 real properties each counted twice. A synthetic
+	// one-property fixture produced 2 findings.
+	//
+	// The existing dedup could not catch it: per #202 the key is the BYTE SPAN, and the
+	// two lines occupy genuinely different spans in the preprocessed text, so they are
+	// correctly treated as two occurrences of duplicated input. The fix belongs here, at
+	// the point the same value was written into two maps.
+	//
+	// Nothing read the mirror by key — verified, the write below was its only reference
+	// anywhere in the tree — so dropping it removes the duplicate rendering without
+	// costing any consumer. The legacy OLE extractor already populates CustomProps
+	// alone, so this also brings the two extractors into line. See #308.
 	if customProps, err := extractCustomPropertiesOptimized(fileIndex); err == nil && len(customProps) > 0 {
 		metadata.CustomProps = customProps
-		// Also store in Properties map with "Custom_" prefix for easy scanning
-		for key, value := range customProps {
-			metadata.Properties["Custom_"+key] = value
-		}
 	}
 
 	// Extract document-specific metadata

--- a/internal/validators/metadata/classification_marking_test.go
+++ b/internal/validators/metadata/classification_marking_test.go
@@ -1,0 +1,175 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package metadata
+
+import "testing"
+
+// A sensitivity MARKING must rank below an actual disclosure.
+//
+// Two scorers were charging a custom property for the same classification word.
+// CalculateConfidence's containsEnhancedCopyright matches a bare substring —
+// "confidential", "proprietary", "trade secret", "(c)" — anywhere in the line, and
+// analyzeCustomPropertyRisk's classification branch then scored the SAME word again.
+// Measured, holding the property NAME constant and varying only the value:
+//
+//	Custom_Notice: Quarterly summary                            ->  60
+//	Custom_Notice: Confidential                                 -> 100
+//	Custom_Notice: Confidential - Project Nightjar acquisition  -> 100
+//
+// The bare marking saturated the score, so a document that merely CARRIES a Purview
+// label ranked identically to one carrying the label AND naming a live acquisition
+// project. That ordering failure is the defect. A label is standard enterprise plumbing
+// on a large fraction of real documents — measured, CUSTOM_PROPERTY was the largest HIGH
+// population of any metadata type on a 304-file corpus — so treating the marking as
+// CRITICAL crowds the band operators triage first.
+//
+// This is deliberately NOT a veto: a marking is still worth reporting, just not at HIGH.
+// See #307.
+
+// TestBareMarkingIsNotHigh is the reported defect.
+func TestBareMarkingIsNotHigh(t *testing.T) {
+	for _, line := range []string{
+		// The Purview/MSIP shape, which is what showed up in the real corpus.
+		`Custom_MSIP_Label_a1b2c3d4-e5f6-7890-abcd-ef1234567890_Name: Confidential`,
+		// The same statement, undressed.
+		`Custom_Notice: Confidential`,
+		`Custom_Sensitivity: Internal Only`,
+		`Custom_Handling: Restricted`,
+	} {
+		got := confidenceFor(t, PreprocessorTypeOfficeMetadata, line, "CUSTOM_PROPERTY")
+		if got < 0 {
+			t.Errorf("%q produced NO finding; a marking should still be reported, just not "+
+				"at HIGH — suppressing it entirely would be a different bug", line)
+			continue
+		}
+		if got >= 90 {
+			t.Errorf("%q scored %.0f (HIGH). A sensitivity marking states the document's "+
+				"handling class; it discloses nothing by itself, and at HIGH it crowds out "+
+				"the findings that do.", line, got)
+		}
+	}
+}
+
+// TestMarkingPlusDisclosureOutranksMarkingAlone is the ordering the fix exists to
+// restore, and the assertion that keeps the fix from becoming a blanket demotion.
+//
+// Asserted as a RELATIONSHIP rather than against fixed numbers, so it survives future
+// re-weighting: what must hold is that adding a project codename to a classification
+// property raises it above the bare label.
+func TestMarkingPlusDisclosureOutranksMarkingAlone(t *testing.T) {
+	marking := confidenceFor(t, PreprocessorTypeOfficeMetadata,
+		`Custom_Notice: Confidential`, "CUSTOM_PROPERTY")
+	disclosure := confidenceFor(t, PreprocessorTypeOfficeMetadata,
+		`Custom_Notice: Confidential - Project Nightjar acquisition`, "CUSTOM_PROPERTY")
+
+	if marking < 0 || disclosure < 0 {
+		t.Fatalf("fixture produced no finding (marking=%.0f disclosure=%.0f)", marking, disclosure)
+	}
+	if disclosure <= marking {
+		t.Errorf("a classification property naming a project scored %.0f, no higher than the "+
+			"bare marking at %.0f. The tool cannot then rank a disclosure above a label, "+
+			"which is the whole point.", disclosure, marking)
+	}
+	if disclosure < 90 {
+		t.Errorf("marking + project codename scored %.0f, want >= 90 (HIGH): the fix must not "+
+			"demote real disclosures along with the labels", disclosure)
+	}
+}
+
+// TestClassificationWithContentStaysHigh pins the pre-existing requirement.
+//
+// value_shape_risk_test.go already demands this one be >= 90. It is restated here
+// because it is the case that ruled OUT the simpler design: making a marking never
+// promote at all dropped this to 70, since the project branch requires a literal
+// "project-" (with hyphen) in the value and "Project Nightjar" does not match it. The
+// simpler rule was measured and rejected on this evidence, not on taste.
+func TestClassificationWithContentStaysHigh(t *testing.T) {
+	got := confidenceFor(t, PreprocessorTypeOfficeMetadata,
+		`Custom_Classification: SECRET - Project Nightjar`, "CUSTOM_PROPERTY")
+	if got < 90 {
+		t.Errorf("Custom_Classification 'SECRET - Project Nightjar' scored %.0f, want >= 90. "+
+			"A classification property that also names a codename IS a disclosure.", got)
+	}
+}
+
+// TestCopyrightHeuristicStillAppliesToOtherMetadataTypes bounds the blast radius.
+//
+// The double-count was withdrawn for CUSTOM_PROPERTY only. For an image's Copyright
+// field the IP heuristic is the RIGHT signal and there is no second scorer doubling it,
+// so removing it there would be a recall loss. This asserts the withdrawal did not leak
+// into other types.
+func TestCopyrightHeuristicStillAppliesToOtherMetadataTypes(t *testing.T) {
+	v := NewValidator()
+
+	// Same field name both times, so only the VALUE differs: the control must contain
+	// no copyright pattern at all. A first attempt compared "Copyright: (c) ..." against
+	// "Copyright: 2026 ...", and both scored identically — because the field NAME itself
+	// contains "copyright" and fires the same check. The control has to be marker-free.
+	withMarker, _ := v.CalculateConfidence("Artist: (c) 2026 Acme Corporation")
+	without, _ := v.CalculateConfidence("Artist: 2026 Acme Corporation")
+
+	if withMarker <= without {
+		t.Errorf("the enhanced-copyright signal no longer raises confidence (%.2f vs %.2f). "+
+			"CalculateConfidence is shared by every metadata type; the CUSTOM_PROPERTY fix "+
+			"must not disarm it globally.", withMarker, without)
+	}
+}
+
+// TestClassificationIsBareMarkingRecognisesRealLabelSpellings.
+//
+// Real labels arrive dressed — bracketed, punctuated, slash-separated — and all of those
+// are the same statement. What must NOT count as bare is a value carrying content
+// alongside the label, because that content is what makes the property a disclosure.
+func TestClassificationIsBareMarkingRecognisesRealLabelSpellings(t *testing.T) {
+	bare := []string{
+		"confidential",
+		"  confidential  ",
+		"[confidential]",
+		"confidential.",
+		"confidential / internal",
+		"highly confidential",
+		"internal use only",
+		"restricted",
+		"",
+	}
+	for _, v := range bare {
+		if !classificationIsBareMarking(v) {
+			t.Errorf("classificationIsBareMarking(%q) = false; this is a label spelling with "+
+				"no content, so it must not be promoted to CRITICAL", v)
+		}
+	}
+
+	notBare := []string{
+		"confidential - project nightjar acquisition",
+		"secret - project nightjar",
+		"confidential: jane.doe@example.com",
+		"restricted to the acme merger team",
+	}
+	for _, v := range notBare {
+		if classificationIsBareMarking(v) {
+			t.Errorf("classificationIsBareMarking(%q) = true; this value carries content "+
+				"beyond the label and must keep the full classification weight", v)
+		}
+	}
+}
+
+// TestIsClassifiedIsUnchangedInSubstance — the predicate was extracted from an inline
+// condition, so it must still recognise exactly what that condition did. A narrower
+// predicate would silently stop treating some properties as classified at all.
+func TestIsClassifiedIsUnchangedInSubstance(t *testing.T) {
+	for _, tc := range []struct{ name, value string }{
+		{"classification", "anything"},
+		{"clearance", "anything"},
+		{"notice", "secret"},
+		{"notice", "confidential"},
+		{"notice", "restricted"},
+	} {
+		if !isClassified(tc.name, tc.value) {
+			t.Errorf("isClassified(%q, %q) = false, want true", tc.name, tc.value)
+		}
+	}
+	if isClassified("documentpurpose", "quarterly summary") {
+		t.Error("isClassified fired on a property with no classification signal")
+	}
+}

--- a/internal/validators/metadata/metadata_validator.go
+++ b/internal/validators/metadata/metadata_validator.go
@@ -394,7 +394,7 @@ func (v *Validator) CalculateConfidence(match string) (float64, map[string]bool)
 
 	// Enhanced copyright detection - apply intellectual property validator patterns to media
 	if v.containsEnhancedCopyright(match) {
-		confidence += 0.4 // Increased confidence for enhanced copyright detection
+		confidence += enhancedCopyrightBoost
 		flags["contains_enhanced_copyright"] = true
 	} else if strings.Contains(matchLower, "copyright:") ||
 		strings.Contains(matchLower, "rights:") ||
@@ -1232,6 +1232,40 @@ func (v *Validator) validateWithPreprocessorRules(content router.MetadataContent
 
 			confidence, checks := v.CalculateConfidence(line)
 
+			// A custom property must not be charged for its classification word TWICE.
+			//
+			// CalculateConfidence is the generic metadata scorer, and its
+			// containsEnhancedCopyright check matches a bare substring — "confidential",
+			// "proprietary", "trade secret", "(c)" — anywhere in the line, worth
+			// +enhancedCopyrightBoost. analyzeCustomPropertyRisk, reached through
+			// applyValueShapeRisk below, then scores the SAME word again in its own
+			// classification branch. One occurrence, two scorers.
+			//
+			// Measured holding the property NAME constant and varying only the value:
+			//
+			//	Notice: Quarterly summary                           ->  60
+			//	Notice: Confidential                                -> 100
+			//	Notice: Confidential - Project Nightjar acquisition -> 100
+			//
+			// The bare marking saturates the score, so a document that merely CARRIES a
+			// sensitivity label ranks identically to one carrying the label AND naming a
+			// live acquisition project. That ranking failure is the defect, not the number:
+			// a Purview label is standard enterprise plumbing on a large fraction of real
+			// documents, so it crowds the HIGH band operators triage first. Measured on a
+			// 304-file corpus, CUSTOM_PROPERTY was the largest HIGH population of any
+			// metadata type.
+			//
+			// The classification signal belongs to analyzeCustomPropertyRisk, which tiers
+			// it deliberately (CRITICAL/HIGH/MEDIUM by name and value). Withdrawing the
+			// generic copyright contribution for this ONE type leaves exactly one scorer
+			// responsible for it. Other metadata types are untouched: for an image's
+			// Copyright field the IP heuristic is the right signal and no second scorer
+			// doubles it. See #307.
+			if matchType == "CUSTOM_PROPERTY" && checks["contains_enhanced_copyright"] {
+				confidence -= enhancedCopyrightBoost
+				delete(checks, "contains_enhanced_copyright")
+			}
+
 			// Create context info for the line
 			contextInfo := detector.ContextInfo{
 				FullLine: line,
@@ -1593,6 +1627,13 @@ func (v *Validator) applyPreprocessorConfidenceBoosts(match *detector.Match, pre
 }
 
 // containsEnhancedCopyright checks for enhanced copyright patterns
+// enhancedCopyrightBoost is the weight containsEnhancedCopyright contributes.
+//
+// Named so the CUSTOM_PROPERTY discount below subtracts exactly what was added. Two
+// copies of 0.4 would drift, and a discount that no longer matches the boost is worse
+// than no discount: it would silently re-inflate or over-penalise.
+const enhancedCopyrightBoost = 0.4
+
 func (v *Validator) containsEnhancedCopyright(match string) bool {
 	matchLower := strings.ToLower(match)
 
@@ -3080,15 +3121,36 @@ func (v *Validator) analyzeCustomPropertyRisk(line string) CustomPropertyRisk {
 			propNameLower := strings.ToLower(propName)
 			propValueLower := strings.ToLower(propValue)
 
-			// Classification properties (CRITICAL)
-			if strings.Contains(propNameLower, "classification") ||
-				strings.Contains(propNameLower, "clearance") ||
-				strings.Contains(propValueLower, "secret") ||
-				strings.Contains(propValueLower, "confidential") ||
-				strings.Contains(propValueLower, "restricted") {
-				risk.RiskFactors = append(risk.RiskFactors, "Contains security classification")
-				risk.ConfidenceBoost += 0.5
-				risk.RiskLevel = "CRITICAL"
+			// Classification properties.
+			//
+			// Split by whether the VALUE carries anything beyond the marking itself. A
+			// document that merely records "this is Confidential" is stating its own
+			// handling class; a document whose classification property also names a
+			// project, a person or a system is disclosing something. Both used to score
+			// +0.5 CRITICAL, which meant the two were indistinguishable:
+			//
+			//	Notice: Confidential                                -> 100
+			//	Notice: Confidential - Project Nightjar acquisition -> 100
+			//
+			// Purview/MSIP writes a bare label into custom properties on a large fraction
+			// of real enterprise documents, so treating the marking as CRITICAL floods the
+			// HIGH band that operators triage first — and the finding that actually
+			// matters sits in the same bucket as thousands of labels. Demoting the marking
+			// rather than vetoing it keeps it reportable (it IS worth knowing a document is
+			// marked) while restoring the ordering.
+			if isClassified(propNameLower, propValueLower) {
+				if classificationIsBareMarking(propValueLower) {
+					risk.RiskFactors = append(risk.RiskFactors,
+						"Carries a sensitivity marking (no additional content)")
+					risk.ConfidenceBoost += 0.1
+					if risk.RiskLevel == "LOW" {
+						risk.RiskLevel = "MEDIUM"
+					}
+				} else {
+					risk.RiskFactors = append(risk.RiskFactors, "Contains security classification")
+					risk.ConfidenceBoost += 0.5
+					risk.RiskLevel = "CRITICAL"
+				}
 			}
 
 			// Project information (HIGH)
@@ -3169,4 +3231,64 @@ func (v *Validator) analyzeCustomPropertyRisk(line string) CustomPropertyRisk {
 	}
 
 	return risk
+}
+
+// isClassified reports whether a custom property looks like a security classification,
+// by name or by value. Unchanged in substance from the inline condition it replaces;
+// extracted so the bare-marking test below reads against the same predicate.
+func isClassified(propNameLower, propValueLower string) bool {
+	return strings.Contains(propNameLower, "classification") ||
+		strings.Contains(propNameLower, "clearance") ||
+		strings.Contains(propValueLower, "secret") ||
+		strings.Contains(propValueLower, "confidential") ||
+		strings.Contains(propValueLower, "restricted")
+}
+
+// classificationMarkings are the values a sensitivity label takes on its own.
+//
+// Deliberately the full label vocabulary rather than a couple of examples: the point is
+// to recognise a value that is ONLY a marking, and a list that misses "highly
+// confidential" would treat that one as a disclosure while treating "confidential" as a
+// marking — an inconsistency worse than either rule alone.
+var classificationMarkings = map[string]bool{
+	"confidential": true, "highly confidential": true, "strictly confidential": true,
+	"secret": true, "top secret": true, "restricted": true, "internal": true,
+	"internal only": true, "internal use only": true, "public": true,
+	"general": true, "private": true, "sensitive": true, "unclassified": true,
+	"non-business": true, "personal": true, "protected": true,
+}
+
+// classificationIsBareMarking reports whether a value is nothing but a sensitivity
+// marking, so it states the document's handling class without disclosing content.
+//
+// Punctuation and label-plumbing decoration are stripped before the comparison because
+// real labels arrive dressed: "Confidential", "[Confidential]", "Confidential."  and
+// "Confidential / Internal" are all the same statement. What must NOT be stripped is a
+// project name, a person or a system — those are the content that makes a classification
+// property a disclosure, and anything left over after decoration is treated as exactly
+// that.
+func classificationIsBareMarking(propValueLower string) bool {
+	v := strings.TrimSpace(propValueLower)
+	if v == "" {
+		return true
+	}
+	// Split on the separators labels use, then require EVERY part to be a known marking.
+	// Requiring all parts (rather than any) is what keeps
+	// "confidential - project nightjar" out: one part is a marking, the other is not.
+	parts := strings.FieldsFunc(v, func(r rune) bool {
+		switch r {
+		case '/', '\\', '|', ',', ';', '-', '\u2013', '\u2014', ':', '(', ')', '[', ']', '.', '_':
+			return true
+		}
+		return false
+	})
+	if len(parts) == 0 {
+		return true
+	}
+	for _, p := range parts {
+		if !classificationMarkings[strings.TrimSpace(p)] {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
Closes #308. Closes #307.

Two defects in the same area, fixed together because the first changes the numbers the second is measured against.

## 1. Every custom property was reported twice (#308)

The extractor stored each property in `CustomProps` **and** mirrored it into `Properties["Custom_"+key]`, and the office preprocessor renders **both** maps. Both rendered lines carry the `custom_` prefix the validator types on.

Measured on 304 real `.docx` files: **506 findings across 202 files, zero files with an odd count, every (file, confidence) bucket even** — ~253 real properties each counted twice.

The existing dedup cannot catch this: per #202 its key is the **byte span**, and the two rendered lines occupy genuinely different spans, so they are correctly treated as two occurrences of duplicated *input*. The fix belongs where the value was written into two maps. Nothing read the mirror by key — that write was its only reference in the tree.

## 2. One classification word, two scorers (#307)

`containsEnhancedCopyright` matches a bare substring (`confidential`, `proprietary`, `(c)`) for +0.4, and `analyzeCustomPropertyRisk` then scored the **same word again**. Holding the property NAME constant and varying only the value:

| value | before | after |
|---|---|---|
| `Quarterly summary` | 60 | 60 |
| `Confidential` | **100** | **80** |
| `Confidential - Project Nightjar acquisition` | 100 | 100 |
| `Classification: SECRET - Project Nightjar` | 100 | 100 |
| MSIP/Purview label | **100** | **80** |
| `Proprietary` | **100** | **60** |

The bare marking saturated the score, so a document that merely *carries* a label ranked identically to one carrying the label **and naming a live acquisition project**. That ordering failure is the defect, not the number.

Both changes are scoped to `CUSTOM_PROPERTY`. Other metadata types are untouched — for an images `Copyright` field the IP heuristic is the right signal and nothing doubles it (asserted by a test).

### A simpler rule was tried and rejected on evidence

Making a marking never promote at all is cleaner and avoids a leaky "extra tokens" proxy. I implemented and measured it: it dropped `Custom_Classification: SECRET - Project Nightjar` to **70**, failing the pre-existing `>= 90` assertion in `value_shape_risk_test.go` — the project branch does not rescue it because it requires a literal `project-` with a hyphen. The proxy stays because that test encodes a real requirement.

## Effect on detection

Real corpus, `--checks all`, against parent `0ad462a`:

| | before | after |
|---|---|---|
| total | 168,244 | 167,841 (**−403**) |
| CUSTOM_PROPERTY | 506 | **253** |
| … HIGH | 292 | 144 |

**Every one of the 403 is a duplicate of a finding that remains:** 253 CUSTOM_PROPERTY + 129 INTELLECTUAL_PROPERTY + 17 BUSINESS + 4 PERSON_NAME = **403 exactly**. The non-metadata types dropped because those validators were *also* matching the duplicated line. Nothing unique was lost.

**Stated plainly:** pure dedup would leave 146 HIGH and the result is 144, so the **scoring change moves only 2 findings** on this corpus. The mechanism is proven by fixtures, but the corpus HIGH population was mostly not bare markings — the MSIP family is mostly `_Enabled`/`_SetDate`/`_SiteId`, whose values are not markings. The precision win here is small; the corpus win is the dedup.

## Performance — faster, increasingly so

Halving the emitted lines halves the work in the loop `CalculateConfidence` dominates. Binaries built outside `/tmp`:

| N props | before | after | speedup |
|---|---|---|---|
| 250 | 0.075s | 0.070s | 1.1x |
| 1000 | 0.173s | 0.098s | 1.8x |
| 2000 | **0.535s** | **0.151s** | **3.5x** |

Sub-linear after (0.94–1.55x per doubling); the baseline was drifting **superlinear at 3.1x** on its last doubling.

## Testing

- **8 new tests.**
- **6 mutations, each compiled and each caught:** restoring the mirror, disabling the copyright discount, disabling the bare-marking demotion, flattening the CRITICAL weight, gutting the markings list, narrowing `isClassified`.
- One of my own fixtures was wrong on the first pass and is recorded in the code: the blast-radius control compared `Copyright: (c) ...` against `Copyright: 2026 ...` and both scored identically, because the field **name** contains "copyright" and fires the same check. The control now uses a marker-free value under the same field name.

| gate | result |
|---|---|
| `go build` / `go vet` / `gofmt -l` | clean |
| `go test ./... -count=1` | **66 packages, 0 failures** |
| golden corpus | pass, **zero goldens moved** |
| `make score` | unchanged (`recall_all=1.0000 whole_leak=0`) |

## Known limitation, filed separately

A marking dressed with harmless decoration — `Confidential - Draft`, `Confidential FY25`, `Confidential (Rev 3)` — still reaches 100, because the decoration reads as content. Extending the marking word list is the trap that produced this bug, so it is tracked rather than papered over.

Corpus figures are aggregate counts only; every value shown is from a synthetic fixture.