### PR TITLE
fix(preprocessors): send media-processing errors to stderr, so a redirected machine artifact stays parseable

### DIFF
--- a/internal/preprocessors/error_handling.go
+++ b/internal/preprocessors/error_handling.go
@@ -6,6 +6,7 @@ package preprocessors
 import (
 	"context"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 )
@@ -305,8 +306,19 @@ func (el *ErrorLogger) LogError(err *MediaProcessingError) {
 		message += fmt.Sprintf(" context=[%s]", strings.Join(contextParts, " "))
 	}
 
-	// In a real implementation, this would use a proper logging framework
-	fmt.Printf("%s\n", message)
+	// STDERR, not stdout.
+	//
+	// This was fmt.Printf — the only stdout write on the scan path — and it corrupted
+	// every machine artifact. `--format json > report.json` produced a file beginning
+	// "[ERROR] media processing failed for ..." which is not valid JSON, so a consumer
+	// got a parse error instead of a report whenever any media file failed to parse.
+	// Verified: the same run with --output wrote valid JSON, because that path writes
+	// the document to a file and leaves stdout alone.
+	//
+	// Every other [ERROR] line in the tree already uses os.Stderr; this one was
+	// placeholder code (the comment said "in a real implementation, this would use a
+	// proper logging framework") that shipped.
+	fmt.Fprintf(os.Stderr, "%s\n", message)
 }
 
 // getLogLevelForError determines appropriate log level for error type

--- a/internal/preprocessors/error_log_order_test.go
+++ b/internal/preprocessors/error_log_order_test.go
@@ -99,15 +99,23 @@ func captureLogOutput(t *testing.T, fn func()) string {
 	if err != nil {
 		t.Fatalf("os.Pipe: %v", err)
 	}
-	orig := os.Stdout
-	os.Stdout = w
+	// STDERR, not stdout. LogError used to write to stdout, which corrupted every
+	// machine artifact: `--format json > report.json` produced a file starting
+	// "[ERROR] media processing failed for ..." and a consumer got a parse error
+	// instead of a report. These tests captured stdout, so they were the thing
+	// pinning the wrong stream in place.
+	//
+	// What they ASSERT is unchanged — the context= fields are sorted and complete.
+	// Only the stream they listen on moved.
+	orig := os.Stderr
+	os.Stderr = w
 	done := make(chan string, 1)
 	go func() {
 		b, _ := io.ReadAll(r)
 		done <- string(b)
 	}()
 	fn()
-	os.Stdout = orig
+	os.Stderr = orig
 	if err := w.Close(); err != nil {
 		t.Fatalf("close write end: %v", err)
 	}


### PR DESCRIPTION
A media file that fails to parse writes an `[ERROR]` line to **stdout**, corrupting every machine format.

## Reproduction

A directory containing one unparseable `.mp4` alongside scannable files:

```console
$ ferret-scan --file dir --format json > report.json
$ head -c 60 report.json
[ERROR] media processing failed for dir/clip.mp4 ty
```

| | bytes | result |
|---|---|---|
| before | 2773 | **INVALID JSON** — `Expecting value: line 1 column 2` |
| after | 2313 | **VALID JSON** — `{"stats":{"total_files":4,…` |

`--format json --output report.json` was **unaffected**, because that path writes the document to a file and leaves stdout alone. So the break is specific to the **redirect** shape — the common CI idiom, and the one where stderr is discarded and the file is what gets archived and diffed.

## Root cause

`internal/preprocessors/error_handling.go:308`:

```go
// In a real implementation, this would use a proper logging framework
fmt.Printf("%s\n", message)
```

Placeholder code that shipped. Every other `[ERROR]` line in the tree already uses `fmt.Fprintf(os.Stderr, …)` — this was the outlier.

A sweep of `internal/` and `pkg/` found **68 stdout writes, and exactly one on the scan path**. The rest are `internal/help` (help text) and `internal/web` (startup banners), where stdout is correct. So this is a one-line fix, not a class of problem.

## Nothing is lost

The diagnostic still reaches the user on stderr (verified). And the same run already reports that file through the `NOT FULLY EXAMINED` block, so the information is in the artifact too — the operator sees the failure and the consumer gets a parseable document.

## Tests

`TestLogErrorContextIsSorted` and `TestLogErrorContextKeepsEveryField` captured **stdout**, so they were the thing pinning the wrong stream in place. **They failed on this change**, which is how you can tell the fix is load-bearing rather than cosmetic. Their capture helper now listens on stderr; what they assert is untouched — the `context=` fields are sorted and complete, the determinism property they were written for.

| gate | result |
|---|---|
| `go vet` / `gofmt -l` | clean |
| `go test ./... -count=1` | **66 packages, 0 failures** |
| golden corpus | pass |
| yaml / sarif / junit / gitlab-sast / csv on a redirect | first byte clean |

Found while investigating console noise on a real directory scan. The related coverage-accounting gap — a >100MB file is absent from `total_files` and `files_not_examined`, and `--fail-on-incomplete` exits 0 — is separate and tracked as **#324**.