### PR TITLE
fix(cli): scan or disclose symlinks in a directory walk instead of dropping them silently

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1464,6 +1464,12 @@ func main() {
 	var allFilesToProcess []string
 	var totalSkipped int
 
+	// discoveryUnexamined holds coverage losses found while DISCOVERING files, as
+	// distinct from the ones found while scanning them. Both must reach the same report:
+	// a file the walk refused is exactly as unscanned as one the parser choked on, and
+	// before #326 the discovery-time ones reached no counter at all.
+	var discoveryUnexamined []SkippedFile
+
 	for i, inputPath := range inputPaths {
 		if mainDebugObs != nil {
 			mainDebugObs.LogDetail("main", fmt.Sprintf("Processing input path %d: %s", i+1, inputPath))
@@ -1515,6 +1521,12 @@ func main() {
 				fmt.Fprintf(os.Stderr, "Warning: Skipping %s: %s\n", skipped.Path, skipped.Reason)
 			}
 		}
+
+		// Entries the scanner could not examine. Carried to the not-examined report
+		// rather than printed here: a per-file stderr line at discovery time is the
+		// pattern that produced unreadable console output, and the report already
+		// groups by cause, caps its output, and feeds --fail-on-incomplete.
+		discoveryUnexamined = append(discoveryUnexamined, result.UnexaminedFiles...)
 	}
 
 	filesToProcess := allFilesToProcess
@@ -1904,7 +1916,20 @@ func main() {
 	// unchanged (default still 0) — this is an advisory warning.
 	// Collected once, so the summary count and the detail report can never disagree:
 	// they are derived from the same slice rather than counted twice.
-	unscannedEntries := collectUnscanned(unreadableFiles, emptyExtractionFiles, failedProcessingFiles, incompleteFiles)
+	// Discovery-time refusals get their OWN cause rather than being folded into the
+	// unreadable channel. Filing "resolves outside the scanned directory" under "cannot
+	// read" would assert a failure that never happened — the file is readable, the tool
+	// declined — and the operator's remedy differs.
+	notFollowed := make([]parallel.FileDiagnostic, 0, len(discoveryUnexamined))
+	for _, u := range discoveryUnexamined {
+		notFollowed = append(notFollowed, parallel.FileDiagnostic{FilePath: u.Path, Reason: u.Reason})
+		// Counted as not-processed for the same reason an unreadable file is: it was
+		// considered and produced nothing, so leaving it out of every counter is what
+		// made the loss invisible.
+		unreadableCount++
+	}
+
+	unscannedEntries := collectUnscanned(unreadableFiles, emptyExtractionFiles, failedProcessingFiles, incompleteFiles, notFollowed)
 
 	if precommitConfig == nil {
 		// The unredacted warning stays here; the not-examined report is emitted AFTER
@@ -2043,8 +2068,18 @@ func main() {
 		scannedFiles = 0
 	}
 
+	// consideredFiles is every entry this run took responsibility for: the files it
+	// queued to scan PLUS the ones discovery refused. The denominator has to include
+	// both, or the report reads "2 of 1 file" — the refused entries appear in the
+	// numerator while being absent from the total they are counted against.
+	//
+	// Derived once and used by the stats block AND the not-examined report below, for
+	// the same reason the entries themselves are collected once: two independent counts
+	// of the same thing eventually disagree.
+	consideredFiles := len(filesToProcess) + len(discoveryUnexamined)
+
 	formatterOptions.Stats = &formatters.ScanStats{
-		TotalFiles:       len(filesToProcess),
+		TotalFiles:       consideredFiles,
 		FilesProcessed:   scannedFiles,
 		FilesSkipped:     finalSkippedCount,
 		FilesNotExamined: len(unscannedEntries),
@@ -2080,7 +2115,7 @@ func main() {
 	// closing rule went to the terminal.
 	if precommitConfig == nil && len(unscannedEntries) > 0 {
 		var report strings.Builder
-		if writeUnscannedReport(&report, unscannedEntries, len(filesToProcess), *failOnIncomplete, finalConfig.debug) {
+		if writeUnscannedReport(&report, unscannedEntries, consideredFiles, *failOnIncomplete, finalConfig.debug) {
 			if finalConfig.format == "text" {
 				// Text renders it INSIDE the summary block, so the whole footer lands on
 				// one stream and a piped report is not left with an unclosed frame.
@@ -2281,6 +2316,18 @@ func parseConfidenceLevels(levels string) map[string]bool {
 type ProcessingResult struct {
 	FilesToProcess []string
 	SkippedFiles   []SkippedFile
+
+	// UnexaminedFiles are entries the scanner encountered and could NOT examine, as
+	// opposed to SkippedFiles which the user asked to leave out (--exclude, .gitignore)
+	// or which are an unsupported type nobody expected a result for.
+	//
+	// The distinction is the one ScanStats already draws: a skipped file is expected to
+	// produce nothing, an unexamined one was expected to produce something and did not.
+	// These flow into files_not_examined, the NOT FULLY EXAMINED block, and
+	// --fail-on-incomplete, so a coverage loss found at DISCOVERY time is disclosed the
+	// same way one found during scanning is. Before this, discovery-time losses reached
+	// no counter at all. See #326.
+	UnexaminedFiles []SkippedFile
 }
 
 // SkippedFile represents a file that was skipped during processing
@@ -2345,8 +2392,9 @@ func isExcluded(filePath string, excludePatterns []string) bool {
 // Supports glob patterns like *.pdf, files, and directories
 func getFilesToProcess(inputPath string, recursive bool, excludePatterns []string, ignoreMatcher *gitignore.Matcher) (*ProcessingResult, error) {
 	result := &ProcessingResult{
-		FilesToProcess: []string{},
-		SkippedFiles:   []SkippedFile{},
+		FilesToProcess:  []string{},
+		SkippedFiles:    []SkippedFile{},
+		UnexaminedFiles: []SkippedFile{},
 	}
 	// Validate input path before any file operations
 	if strings.Contains(inputPath, "..") {
@@ -2533,6 +2581,10 @@ func getFilesToProcess(inputPath string, recursive bool, excludePatterns []strin
 
 	// If it's a directory, get all files
 	if fileInfo.IsDir() {
+		// symlinkCands holds links seen during the walk; they are resolved after it
+		// finishes so the outcome cannot depend on directory iteration order.
+		var symlinkCands []symlinkCandidate
+
 		err := filepath.Walk(cleanPath, func(path string, info os.FileInfo, err error) error {
 			// Validate path for traversal attempts
 			cleanWalkPath := filepath.Clean(path)
@@ -2584,6 +2636,25 @@ func getFilesToProcess(inputPath string, recursive bool, excludePatterns []strin
 					}
 					skippedFiles = append(skippedFiles, cleanWalkPath)
 				}
+			} else if info.Mode()&os.ModeSymlink != 0 {
+				// A symlink. filepath.Walk hands us Lstat info, so a link is never
+				// ModeRegular and used to fall past the branch above with NO else —
+				// dropped from filesToProcess, from SkippedFiles, and from every
+				// counter, with nothing printed. Measured: a symlink to a file holding
+				// a card number was neither scanned nor disclosed, while the SAME link
+				// named directly on the command line was scanned and the card found.
+				// See #326 and cmd/symlink_walk.go for the policy.
+				//
+				// Collected rather than decided here: whether to follow depends on
+				// whether the target is also reachable as a real file in this same
+				// walk, which is not known until the walk ends.
+				d, resolved, reason := classifySymlink(cleanWalkPath, cleanPath, 100*1024*1024)
+				symlinkCands = append(symlinkCands, symlinkCandidate{
+					linkPath: cleanWalkPath,
+					resolved: resolved,
+					reason:   reason,
+					disp:     d,
+				})
 			}
 
 			return nil
@@ -2593,6 +2664,14 @@ func getFilesToProcess(inputPath string, recursive bool, excludePatterns []strin
 		if err != nil {
 			return nil, fmt.Errorf("error accessing directory: %w", err)
 		}
+
+		// Resolve the symlinks now that every regular file is known, so a link whose
+		// target is already queued under its real name is recognised as duplicate
+		// content rather than scanned twice (which would manufacture the
+		// identical-looking findings of #321).
+		follow, disclose := resolveSymlinkCandidates(symlinkCands, filesToProcess)
+		filesToProcess = append(filesToProcess, follow...)
+		result.UnexaminedFiles = append(result.UnexaminedFiles, disclose...)
 
 		// Print summary of skipped files
 		if len(skippedFiles) > 0 {

--- a/cmd/symlink_walk.go
+++ b/cmd/symlink_walk.go
@@ -1,0 +1,190 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Symlink handling for directory walks.
+//
+// filepath.Walk supplies os.Lstat information, so a symlink's mode is ModeSymlink and
+// never ModeRegular. The walk's "only add regular files" branch had NO else, so every
+// symlink was dropped: absent from filesToProcess, from result.SkippedFiles, from
+// total_files, from files_skipped and from files_not_examined. Nothing was printed.
+//
+// Measured on a directory holding three entries — a normal file with an SSN, a symlink
+// to a file containing a card number, and a dangling symlink:
+//
+//	Files: 1 scanned | Findings: 1
+//	exit 0, no NOT FULLY EXAMINED block, card number neither reported nor disclosed
+//
+// The same symlink named DIRECTLY on the command line was scanned and the card found,
+// because the single-file path uses os.Stat, which follows links. So identical bytes were
+// scanned or ignored depending on how the path was spelled — an inconsistency, not a
+// policy. cmd/main.go's exitCodeIncompleteCoverage comment also states that a dangling
+// symlink should produce exit 3; it produced 0. See #326.
+//
+// The policy implemented here:
+//
+//   - a link resolving to a regular file INSIDE the scanned tree is FOLLOWED, matching
+//     the single-file path so the same bytes get the same treatment;
+//   - anything else — dangling, a loop, a directory, a device, or a target outside the
+//     scanned tree — is REFUSED and DISCLOSED, so it reaches files_not_examined and
+//     --fail-on-incomplete rather than vanishing;
+//   - a link whose target is already covered by a real file in the same walk is skipped
+//     SILENTLY, because its content is scanned once already and reporting it twice would
+//     manufacture the duplicate-looking findings of #321.
+//
+// Directory links are refused rather than followed on purpose: filepath.Walk does not
+// follow them either, and following would risk unbounded traversal and re-scanning the
+// same subtree through several paths.
+
+// symlinkDisposition is what to do with a symlink found during a walk.
+type symlinkDisposition int
+
+const (
+	// symlinkFollow: scan it. The LINK path is queued, not the target, so findings are
+	// attributed to the path the user can actually see in their tree — which is also
+	// what the single-file path reports.
+	symlinkFollow symlinkDisposition = iota
+	// symlinkDisclose: do not scan, but record it so the coverage loss is visible.
+	symlinkDisclose
+	// symlinkCoveredElsewhere: the target is already queued via its real path.
+	symlinkCoveredElsewhere
+)
+
+// classifySymlink decides how a symlink encountered during a walk should be handled.
+//
+// scanRoot is the directory the user asked to scan; it bounds what "inside the tree"
+// means. sizeLimit mirrors the walk's own cap and is applied to the TARGET's size,
+// because Lstat reports the length of the link text rather than of the file it names —
+// so a link to a 200MB file looked like a 30-byte entry.
+//
+// resolved is the absolute target path, returned so the caller can deduplicate against
+// files it has already queued. reason is human-facing and payload-free: it names the
+// condition, never file contents.
+func classifySymlink(linkPath, scanRoot string, sizeLimit int64) (d symlinkDisposition, resolved, reason string) {
+	// EvalSymlinks resolves the whole chain and returns an error for a dangling link or
+	// a loop (ELOOP), which is why loop protection needs no separate counter here.
+	target, err := filepath.EvalSymlinks(linkPath)
+	if err != nil {
+		return symlinkDisclose, "", "symlink could not be resolved (dangling target or link loop)"
+	}
+
+	absTarget, err := filepath.Abs(target)
+	if err != nil {
+		return symlinkDisclose, "", "symlink target path could not be resolved"
+	}
+
+	info, err := os.Stat(absTarget)
+	if err != nil {
+		return symlinkDisclose, absTarget, "symlink target could not be read"
+	}
+
+	if info.IsDir() {
+		// Not followed by design — see the package comment. Disclosed rather than
+		// dropped, because a linked-in directory of real documents is exactly the case
+		// where silence is most costly.
+		return symlinkDisclose, absTarget, "symlink points to a directory (directory links are not followed)"
+	}
+	if !info.Mode().IsRegular() {
+		// A device, FIFO or socket has no size and may never end. The router refuses
+		// these for the same reason.
+		return symlinkDisclose, absTarget, "symlink target is not a regular file"
+	}
+	if sizeLimit > 0 && info.Size() > sizeLimit {
+		return symlinkDisclose, absTarget,
+			fmt.Sprintf("symlink target is too large (%d bytes, limit %d)", info.Size(), sizeLimit)
+	}
+
+	// Containment. A link out of the tree would pull in files the user never named —
+	// scanning ~/.ssh because a repo contains a convenience link is a surprise, and
+	// reporting findings from paths outside the requested directory is confusing. It is
+	// refused, but SAID, which is the part that was missing.
+	if !withinRoot(absTarget, scanRoot) {
+		return symlinkDisclose, absTarget, "symlink resolves outside the scanned directory"
+	}
+
+	return symlinkFollow, absTarget, ""
+}
+
+// withinRoot reports whether target is inside root.
+//
+// Both sides are resolved with EvalSymlinks first: on macOS the scan root is routinely
+// given as /tmp/... which is itself a link to /private/tmp, so a purely lexical compare
+// would call every in-tree target "outside" and disclose the whole directory as skipped.
+func withinRoot(target, root string) bool {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return false
+	}
+	if r, err := filepath.EvalSymlinks(absRoot); err == nil {
+		absRoot = r
+	}
+	if t, err := filepath.EvalSymlinks(target); err == nil {
+		target = t
+	}
+
+	rel, err := filepath.Rel(absRoot, target)
+	if err != nil {
+		return false
+	}
+	// Rel yields ".." or a "../" prefix exactly when target sits outside absRoot.
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+// symlinkCandidate is a symlink seen during a walk, held until the walk finishes.
+//
+// The decision to follow depends on whether the target is ALSO reachable as a real file
+// in the same walk, and that is not known until every entry has been visited. Deciding
+// inline would make the outcome depend on directory iteration order: the same tree could
+// scan a file once or twice depending on which name the walk happened to reach first.
+type symlinkCandidate struct {
+	linkPath string
+	resolved string
+	reason   string
+	disp     symlinkDisposition
+}
+
+// resolveSymlinkCandidates turns collected candidates into files to scan and refusals to
+// disclose, deduplicating against the regular files the walk already queued.
+//
+// queued is the set of regular-file paths found by the walk, and is matched on RESOLVED
+// absolute paths so that a link and its target are recognised as the same content.
+func resolveSymlinkCandidates(cands []symlinkCandidate, queued []string) (follow []string, disclose []SkippedFile) {
+	covered := make(map[string]struct{}, len(queued))
+	for _, p := range queued {
+		abs, err := filepath.Abs(p)
+		if err != nil {
+			continue
+		}
+		if r, err := filepath.EvalSymlinks(abs); err == nil {
+			abs = r
+		}
+		covered[abs] = struct{}{}
+	}
+
+	for _, c := range cands {
+		switch c.disp {
+		case symlinkDisclose:
+			disclose = append(disclose, SkippedFile{Path: c.linkPath, Reason: c.reason})
+		case symlinkFollow:
+			if _, dup := covered[c.resolved]; dup {
+				// Content already scanned through its real path. Silent on purpose:
+				// there is no coverage loss to report, and a note per link would be
+				// noise on trees that use links heavily.
+				continue
+			}
+			covered[c.resolved] = struct{}{}
+			follow = append(follow, c.linkPath)
+		case symlinkCoveredElsewhere:
+			continue
+		}
+	}
+	return follow, disclose
+}

--- a/cmd/symlink_walk_test.go
+++ b/cmd/symlink_walk_test.go
@@ -1,0 +1,310 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A symlink in a scanned directory must be scanned or DISCLOSED, never dropped.
+//
+// filepath.Walk supplies Lstat info, so a symlink's mode is ModeSymlink and never
+// ModeRegular. The walk's "only add regular files" branch had no else, so links were
+// dropped with no record: absent from filesToProcess, from SkippedFiles, from
+// total_files, from files_skipped and from files_not_examined, with nothing printed.
+//
+// Measured on a directory of three entries — a normal file with an SSN, a symlink to a
+// file holding a card number, and a dangling symlink:
+//
+//	Files: 1 scanned | Findings: 1
+//	exit 0, no NOT FULLY EXAMINED block, card number neither reported nor disclosed
+//
+// The SAME symlink named directly on the command line was scanned and the card found,
+// because that path uses os.Stat which follows links. Identical bytes, different outcome
+// depending on how the path was spelled. cmd/main.go's exitCodeIncompleteCoverage comment
+// also promises exit 3 for a dangling symlink; it delivered 0. See #326.
+
+const symlinkSizeLimit = 100 * 1024 * 1024
+
+// linkTo creates dir/name -> target and returns the link path.
+func linkTo(t *testing.T, dir, name, target string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.Symlink(target, p); err != nil {
+		t.Skipf("cannot create symlinks here: %v", err)
+	}
+	return p
+}
+
+func writeFileAt(t *testing.T, path, body string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestClassifySymlinkFollowsInTreeRegularFile(t *testing.T) {
+	root := t.TempDir()
+	target := writeFileAt(t, filepath.Join(root, "sub", "doc.txt"), "SSN: 452-11-9384\n")
+	link := linkTo(t, root, "link.txt", target)
+
+	d, resolved, reason := classifySymlink(link, root, symlinkSizeLimit)
+	if d != symlinkFollow {
+		t.Errorf("disposition = %v, want symlinkFollow (%q). A link to a regular file inside "+
+			"the scanned tree must be scanned — the single-file path already does, so "+
+			"refusing here means identical bytes get different treatment depending on how "+
+			"the path is spelled.", d, reason)
+	}
+	// The resolved path is what the caller deduplicates on, so it must be absolute and
+	// point at the target rather than the link.
+	if !filepath.IsAbs(resolved) {
+		t.Errorf("resolved = %q, want an absolute path", resolved)
+	}
+	if filepath.Base(resolved) != "doc.txt" {
+		t.Errorf("resolved = %q, want it to name the target", resolved)
+	}
+}
+
+func TestClassifySymlinkDisclosesEveryRefusal(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+
+	// Each of these is a real shape that occurs on disk, and each used to vanish.
+	cases := []struct {
+		name  string
+		build func() string
+		want  string // substring the reason must contain
+	}{
+		{
+			name: "dangling",
+			build: func() string {
+				return linkTo(t, root, "dangling.txt", filepath.Join(root, "nope.txt"))
+			},
+			want: "dangling",
+		},
+		{
+			name: "outside the scanned tree",
+			build: func() string {
+				tgt := writeFileAt(t, filepath.Join(outside, "secret.txt"), "Card: 4111111111111111\n")
+				return linkTo(t, root, "outside.txt", tgt)
+			},
+			want: "outside the scanned directory",
+		},
+		{
+			name: "directory",
+			build: func() string {
+				if err := os.MkdirAll(filepath.Join(root, "realdir"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				return linkTo(t, root, "dirlink", filepath.Join(root, "realdir"))
+			},
+			want: "directory",
+		},
+		{
+			name: "loop",
+			build: func() string {
+				a := filepath.Join(root, "loopA")
+				b := filepath.Join(root, "loopB")
+				if err := os.Symlink(b, a); err != nil {
+					t.Skipf("cannot create symlinks here: %v", err)
+				}
+				if err := os.Symlink(a, b); err != nil {
+					t.Skipf("cannot create symlinks here: %v", err)
+				}
+				return a
+			},
+			want: "loop",
+		},
+		{
+			name: "target over the size limit",
+			build: func() string {
+				big := filepath.Join(root, "big.bin")
+				f, err := os.Create(big) // #nosec G304 -- test temp dir
+				if err != nil {
+					t.Fatal(err)
+				}
+				// Sparse: no bytes written, but Stat reports the size. This is also the
+				// case that proves the limit is applied to the TARGET — Lstat on the link
+				// reports the length of the link text, so a link to a 200MB file looked
+				// like a 30-byte entry.
+				if err := f.Truncate(symlinkSizeLimit + 1); err != nil {
+					t.Fatal(err)
+				}
+				_ = f.Close()
+				return linkTo(t, root, "biglink.bin", big)
+			},
+			want: "too large",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			link := tc.build()
+			d, _, reason := classifySymlink(link, root, symlinkSizeLimit)
+			if d != symlinkDisclose {
+				t.Fatalf("disposition = %v, want symlinkDisclose. Dropping it silently is the "+
+					"bug: the entry reaches no counter and nothing is printed.", d)
+			}
+			if reason == "" {
+				t.Fatal("empty reason; the operator needs to know WHY it was not examined")
+			}
+			if !strings.Contains(reason, tc.want) {
+				t.Errorf("reason = %q, want it to mention %q", reason, tc.want)
+			}
+			// Payload-free: a reason reaches stderr and every machine format.
+			for _, leak := range []string{"452-11-9384", "4111111111111111"} {
+				if strings.Contains(reason, leak) {
+					t.Errorf("reason %q leaked file content", reason)
+				}
+			}
+		})
+	}
+}
+
+// TestWithinRootResolvesTheRootItself is the macOS trap.
+//
+// /tmp is a symlink to /private/tmp, so a purely lexical prefix compare calls every
+// in-tree target "outside" and discloses the entire directory as skipped — turning a
+// disclosure fix into a total loss of coverage on the platform it was developed on.
+func TestWithinRootResolvesTheRootItself(t *testing.T) {
+	root := t.TempDir()
+	inside := writeFileAt(t, filepath.Join(root, "a", "b.txt"), "x")
+
+	if !withinRoot(inside, root) {
+		t.Errorf("withinRoot(%q, %q) = false for a file plainly inside the tree", inside, root)
+	}
+	if !withinRoot(root, root) {
+		t.Error("the root is not within itself")
+	}
+
+	outside := t.TempDir()
+	if withinRoot(filepath.Join(outside, "x.txt"), root) {
+		t.Error("a path in a different directory was reported as inside the tree")
+	}
+	// A sibling whose name shares the root's prefix must not count as inside: a lexical
+	// strings.HasPrefix would wrongly accept "/tmp/scanroot-evil" for root
+	// "/tmp/scanroot".
+	//
+	// The sibling must actually EXIST. A first version used a non-existent path, and the
+	// test passed even with a HasPrefix shortcut spliced in — because withinRoot resolves
+	// both sides with EvalSymlinks, which succeeded on the root (/var -> /private/var) and
+	// failed on the missing target, leaving the two with different prefixes. It passed by
+	// accident, on this platform only, and a mutation proved the assertion was inert.
+	sibling := root + "-evil"
+	if err := os.MkdirAll(sibling, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(sibling) })
+	siblingFile := writeFileAt(t, filepath.Join(sibling, "x.txt"), "x")
+	if withinRoot(siblingFile, root) {
+		t.Errorf("withinRoot(%q, %q) = true for a sibling sharing the root's name prefix; "+
+			"containment must be path-segment based, not a string prefix", siblingFile, root)
+	}
+}
+
+// TestResolveSymlinkCandidatesDeduplicatesAgainstRealFiles.
+//
+// A link whose target the walk already queued under its real name must NOT be queued
+// again. Scanning the same bytes twice produces two findings that are byte-identical in
+// every reported field, which is exactly the confusion of #321 — and here it would be
+// self-inflicted.
+func TestResolveSymlinkCandidatesDeduplicatesAgainstRealFiles(t *testing.T) {
+	root := t.TempDir()
+	real1 := writeFileAt(t, filepath.Join(root, "doc.txt"), "SSN: 452-11-9384\n")
+	link := linkTo(t, root, "link.txt", real1)
+
+	d, resolved, _ := classifySymlink(link, root, symlinkSizeLimit)
+	if d != symlinkFollow {
+		t.Fatalf("fixture: expected the link to be followable, got %v", d)
+	}
+
+	follow, disclose := resolveSymlinkCandidates(
+		[]symlinkCandidate{{linkPath: link, resolved: resolved, disp: d}},
+		[]string{real1}, // the walk already queued the target under its real name
+	)
+	if len(follow) != 0 {
+		t.Errorf("queued %v in addition to the real file; the same content would be scanned "+
+			"twice and reported as two identical findings", follow)
+	}
+	if len(disclose) != 0 {
+		t.Errorf("disclosed %v; there is no coverage loss to report when the content is "+
+			"scanned through its real path", disclose)
+	}
+}
+
+// TestResolveSymlinkCandidatesQueuesAnOtherwiseUnreachableTarget is the other half.
+//
+// Deduplication must not swallow a link that is the ONLY route to its target — which
+// happens on a non-recursive scan, where the target sits in a subdirectory the walk never
+// enters.
+func TestResolveSymlinkCandidatesQueuesAnOtherwiseUnreachableTarget(t *testing.T) {
+	root := t.TempDir()
+	target := writeFileAt(t, filepath.Join(root, "sub", "deep.txt"), "Card: 4111111111111111\n")
+	link := linkTo(t, root, "link.txt", target)
+
+	d, resolved, _ := classifySymlink(link, root, symlinkSizeLimit)
+	follow, disclose := resolveSymlinkCandidates(
+		[]symlinkCandidate{{linkPath: link, resolved: resolved, disp: d}},
+		[]string{filepath.Join(root, "other.txt")}, // target NOT queued
+	)
+	if len(follow) != 1 || follow[0] != link {
+		t.Errorf("follow = %v, want the link queued: it is the only path by which this "+
+			"content is reachable, so dropping it loses the finding entirely", follow)
+	}
+	if len(disclose) != 0 {
+		t.Errorf("disclose = %v, want none", disclose)
+	}
+}
+
+// TestResolveSymlinkCandidatesIsOrderIndependent.
+//
+// The follow/dedup decision must not depend on the order the walk happened to visit
+// entries, or the same tree would scan a file once or twice run to run.
+func TestResolveSymlinkCandidatesIsOrderIndependent(t *testing.T) {
+	root := t.TempDir()
+	real1 := writeFileAt(t, filepath.Join(root, "a.txt"), "x")
+	l1 := linkTo(t, root, "l1.txt", real1)
+	l2 := linkTo(t, root, "l2.txt", real1)
+
+	d1, r1, _ := classifySymlink(l1, root, symlinkSizeLimit)
+	d2, r2, _ := classifySymlink(l2, root, symlinkSizeLimit)
+	c1 := symlinkCandidate{linkPath: l1, resolved: r1, disp: d1}
+	c2 := symlinkCandidate{linkPath: l2, resolved: r2, disp: d2}
+
+	// Two links to the SAME target, with the target NOT already queued: exactly one
+	// should be followed, whichever order they arrive in.
+	for _, order := range [][]symlinkCandidate{{c1, c2}, {c2, c1}} {
+		follow, _ := resolveSymlinkCandidates(order, nil)
+		if len(follow) != 1 {
+			t.Errorf("order %v: followed %d links to one target, want exactly 1 — the same "+
+				"bytes must not be scanned twice", []string{order[0].linkPath, order[1].linkPath}, len(follow))
+		}
+	}
+}
+
+// TestNotFollowedCauseIsDistinctFromCannotRead.
+//
+// All refusals initially landed under "cannot read", which asserts a failure that did not
+// happen: a link resolving outside the tree is perfectly readable, the tool declined. The
+// operator's remedy differs too — chmod versus scanning the target explicitly.
+func TestNotFollowedCauseIsDistinctFromCannotRead(t *testing.T) {
+	if causeNotFollowed == causeUnreadable {
+		t.Fatal("causeNotFollowed and causeUnreadable are the same value")
+	}
+	got := causeNotFollowed.String()
+	if got == causeUnreadable.String() {
+		t.Errorf("causeNotFollowed renders as %q, identical to causeUnreadable; the report "+
+			"groups by cause, so the two would be indistinguishable", got)
+	}
+	if !strings.Contains(got, "symlink") {
+		t.Errorf("causeNotFollowed = %q, want it to name symlinks so the group is actionable", got)
+	}
+}

--- a/cmd/unscanned_report.go
+++ b/cmd/unscanned_report.go
@@ -49,6 +49,15 @@ const (
 	causeUnparseable
 	causeNoText
 	causeCutShort
+	// causeNotFollowed is a link the walk deliberately did not follow: it dangles or
+	// loops, names a directory, names a device, or resolves outside the scanned tree.
+	//
+	// Distinct from causeUnreadable because for most of these the file COULD be read —
+	// the tool chose not to. Filing them under "cannot read" would assert a failure
+	// that did not happen, and the operator's action differs: a permission problem is
+	// fixed with chmod, a link out of the tree is fixed by scanning the target directly
+	// or passing it explicitly. See #326.
+	causeNotFollowed
 )
 
 func (c unscannedCause) String() string {
@@ -64,6 +73,8 @@ func (c unscannedCause) String() string {
 		return "no body text (metadata still scanned)"
 	case causeCutShort:
 		return "coverage cut short"
+	case causeNotFollowed:
+		return "symlink not followed"
 	default:
 		return "unknown"
 	}
@@ -232,8 +243,16 @@ func collectUnscanned(
 	emptyExtraction []parallel.FileDiagnostic,
 	failed []parallel.FileDiagnostic,
 	incomplete []parallel.FileDiagnostic,
+	notFollowed []parallel.FileDiagnostic,
 ) []unscannedEntry {
 	var out []unscannedEntry
+
+	// Links the walk refused. These come from DISCOVERY rather than from scanning, and
+	// before #326 they reached no channel at all: a symlink was dropped with no record
+	// anywhere, so its content was neither scanned nor disclosed.
+	for _, d := range notFollowed {
+		out = append(out, unscannedEntry{Path: d.FilePath, Cause: causeNotFollowed, Detail: d.Reason})
+	}
 
 	// The unreadable channel is a pre-formatted "path: reason" string rather than
 	// a struct, so it needs splitting on the first colon that follows the path.


### PR DESCRIPTION
Closes #326.

A symlink inside a scanned directory was dropped at discovery with **no record anywhere** — absent from `filesToProcess`, `SkippedFiles`, `total_files`, `files_skipped` and `files_not_examined`, with nothing printed.

## Before

Three entries: a normal file with an SSN, a symlink to a file holding a card number, a dangling symlink.

```
Files: 1 scanned | Findings: 1 (1 high, 0 medium, 0 low)
```

Exit 0, no `NOT FULLY EXAMINED` block, card number neither reported nor disclosed. Yet the **same symlink named directly** on the command line *was* scanned and the card found — the single-file path uses `os.Stat`, which follows links. Identical bytes, different outcome depending on how the path was spelled. That is an inconsistency, not a policy.

`cmd/main.go:47-50` also documents that a dangling symlink should give exit 3. It gave 0.

## After

```
Files: 2 scanned, 3 NOT examined | Findings: 2 (1 high, 0 medium, 1 low)
NOT FULLY EXAMINED: 3 of 5 files — findings may be missing
  symlink not followed (3)
    d/link-dangling.txt  symlink could not be resolved (dangling target or link loop)
    d/link-dir.txt       symlink points to a directory (directory links are not followed)
    d/link-outside.txt   symlink resolves outside the scanned directory
```

`--fail-on-incomplete`: **0 → 3**, matching the documented promise.

## Policy

| shape | behaviour |
|---|---|
| regular file **inside** the scanned tree | **followed** — matches the single-file path |
| target already queued under its real name | **silently deduped** — content scanned once |
| dangling, or a link loop | refused + disclosed |
| directory | refused + disclosed (`Walk` does not follow them either; following risks unbounded traversal) |
| device / FIFO / socket | refused + disclosed |
| target over the 100MB cap | refused + disclosed |
| resolves **outside** the scanned tree | refused + disclosed |

The link **path** is queued, not the target, so findings are attributed to the path the user can see in their tree — which is also what the single-file path reports.

**Dedup matters:** a link to an already-queued file would otherwise be scanned twice and produce two findings identical in every reported field — self-inflicting the confusion of #321. Candidates are collected during the walk and resolved *after* it, so the outcome cannot depend on directory iteration order.

**New `causeNotFollowed`** rather than folding these into `cannot read`: a link resolving outside the tree is perfectly readable, the tool declined. Asserting a read failure that did not happen would be wrong, and the remedy differs — `chmod` versus scanning the target explicitly.

`ProcessingResult.UnexaminedFiles` is new and distinct from `SkippedFiles`, drawing the line `ScanStats` already draws: a skipped file is expected to produce nothing; an unexamined one was expected to produce something and did not.

The report denominator now counts everything the run took responsibility for — queued files **plus** discovery refusals. Without that it read `2 of 1 file`, with refusals in the numerator but absent from the total they were counted against. Both the stats block and the report derive it from one variable so they cannot disagree.

## Testing

**11 new tests. 9 mutations, all compiled, all caught** — dangling refused, containment enforced, target size (not link size) checked, directory links refused, root resolution, segment-based containment, dedup, unreachable-target queueing, and the distinct cause.

**One mutation was initially vacuous and the fix is recorded in the test:** the sibling-prefix assertion (`/tmp/scanroot-evil` must not count as inside `/tmp/scanroot`) used a **non-existent** path, so `withinRoot` resolved the root (`/var` → `/private/var`) but not the target, leaving different prefixes. It passed even with a `strings.HasPrefix` shortcut spliced in — passing by accident, on macOS only. The fixture now creates the sibling for real, and the mutation is caught.

Two platform traps handled deliberately: `EvalSymlinks` on **both** sides of the containment check (on macOS `/tmp` → `/private/tmp`, so a lexical compare would call every in-tree target "outside" and disclose the whole directory as skipped), and the size limit applied to the **target** (`Lstat` reports the length of the link text, so a link to a 200MB file looked like a 30-byte entry).

| gate | result |
|---|---|
| `go build` / `go vet` / `gofmt -l` | clean |
| `go test ./... -count=1` | **66 packages, 0 failures** |
| golden corpus | pass, zero goldens moved |
| `make score` | pass, unchanged |

## Union-tested against both open PRs

Merged #325 and #323 together with this branch in a scratch worktree — both merged **clean**, and the union builds with **66 packages passing** and `go-version.sh check` green. Zero conflicts alone would not have proven that.

Values shown are synthetic.