### PR TITLE
fix(validators): key date dedup on the byte span, and translate uppercased offsets back before slicing the line

### DIFF
--- a/internal/validators/bankaccount/upper_offset_test.go
+++ b/internal/validators/bankaccount/upper_offset_test.go
@@ -1,0 +1,164 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package bankaccount
+
+import (
+	"strings"
+	"testing"
+)
+
+// Offsets found in an uppercased copy of a line must be translated before they are
+// used to slice the original.
+//
+// scanIBAN, the spaced-IBAN pass and scanSWIFT all matched against
+// strings.ToUpper(line) and then sliced `line` with the resulting offsets.
+// Uppercasing is per-rune and not length-preserving: U+017F LATIN SMALL LETTER LONG
+// S is 2 bytes and uppercases to "S", 1 byte, so every offset after it is shifted
+// by one.
+//
+// Measured on the shipped binary:
+//
+//	input:    Payment ref ſ IBAN GB82WEST12345698765432 end
+//	reported: " GB82WEST1234569876543"   (leading space, final digit missing)
+//	redacted: Payment ref ſ IBAN**********************2 end
+//
+// The last digit of the IBAN stayed in cleartext and the mask consumed the
+// preceding space instead, at rc=0.
+func TestIBANOffsetsSurviveNonLengthPreservingUppercase(t *testing.T) {
+	const iban = "GB82WEST12345698765432"
+	v := NewValidator()
+
+	cases := []struct {
+		name string
+		line string
+	}{
+		// The long s appears BEFORE the IBAN, so it shifts the IBAN's offsets.
+		{"long s earlier in the line", "Payment ref ſ IBAN " + iban + " end"},
+		// Control: identical line with an ASCII 's'. Must behave the same.
+		{"ascii control", "Payment ref s IBAN " + iban + " end"},
+		// Two shifting runes, to catch a fix that only handles a single-byte delta.
+		{"two long s", "ſ ref ſ IBAN " + iban + " end"},
+		// Dotless i is also 2 bytes and uppercases to 1.
+		{"dotless i earlier", "ınvoice IBAN " + iban + " end"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			matches, err := v.ValidateContent(c.line, "test.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			var got []string
+			for _, m := range matches {
+				if m.Type == "IBAN" {
+					got = append(got, m.Text)
+				}
+			}
+			if len(got) != 1 {
+				t.Fatalf("got %d IBAN matches %q, want 1", len(got), got)
+			}
+			if got[0] != iban {
+				t.Errorf("reported text = %q, want %q.\n"+
+					"A shifted offset reports a truncated value, and redaction masks the "+
+					"reported span — so the bytes left over stay in cleartext.", got[0], iban)
+			}
+			// The reported text must actually occur in the line at that text, or
+			// downstream redaction cannot locate it.
+			if !strings.Contains(c.line, got[0]) {
+				t.Errorf("reported text %q does not occur in the line %q", got[0], c.line)
+			}
+		})
+	}
+}
+
+// Uppercasing must not be replaced by a case-insensitive match on the original
+// line: (?i)[A-Z] does not fold U+017F, so an IBAN whose own text contains a long s
+// would stop being detected at all. That is a strictly worse outcome than the
+// mis-slice being fixed — the whole value would pass through in cleartext.
+func TestIBANWithFoldingRuneInsideTheValueStillDetected(t *testing.T) {
+	v := NewValidator()
+	// Swedish IBAN with its leading S written as a long s.
+	line := "IBAN ſE3550000000054910000003 end"
+
+	matches, err := v.ValidateContent(line, "test.txt")
+	if err != nil {
+		t.Fatalf("ValidateContent: %v", err)
+	}
+	var got []string
+	for _, m := range matches {
+		if m.Type == "IBAN" {
+			got = append(got, m.Text)
+		}
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d IBAN matches %q, want 1 — an obfuscating rune inside the value "+
+			"must not make the IBAN invisible", len(got), got)
+	}
+	if !strings.Contains(line, got[0]) {
+		t.Errorf("reported text %q does not occur in the line", got[0])
+	}
+	if !strings.HasPrefix(got[0], "ſ") {
+		t.Errorf("reported text = %q, want it to start at the long s so redaction masks the "+
+			"whole token", got[0])
+	}
+}
+
+// upperWithOffsets is the primitive, so its contract is pinned directly.
+func TestUpperWithOffsets(t *testing.T) {
+	t.Run("ascii returns no table", func(t *testing.T) {
+		up, off := upperWithOffsets("plain ascii 123")
+		if up != "PLAIN ASCII 123" {
+			t.Errorf("upper = %q", up)
+		}
+		if off != nil {
+			t.Errorf("offsets = %v, want nil (identity) so the common path allocates nothing", off)
+		}
+	})
+
+	t.Run("table maps every byte back", func(t *testing.T) {
+		line := "aſb" // 'a', long s (2 bytes), 'b' => "ASB" (3 bytes)
+		up, off := upperWithOffsets(line)
+		if up != "ASB" {
+			t.Fatalf("upper = %q, want %q", up, "ASB")
+		}
+		if len(off) != len(up)+1 {
+			t.Fatalf("offsets has %d entries, want %d (one past the end)", len(off), len(up)+1)
+		}
+		// 'A' at upper[0] came from line[0]; 'S' at upper[1] from line[1] (the long
+		// s); 'B' at upper[2] from line[3]; and one past the end maps to len(line).
+		want := []int{0, 1, 3, len(line)}
+		for i := range want {
+			if off[i] != want[i] {
+				t.Errorf("offsets = %v, want %v", off, want)
+				break
+			}
+		}
+	})
+
+	t.Run("every mapped span slices the original safely", func(t *testing.T) {
+		// Invalid UTF-8 must not panic or produce an out-of-range offset.
+		for _, line := range []string{
+			"", "a", "ſ", "\xff\xfe bad bytes ſ x", "ıſı",
+			"mixed ASCII ſ and ı runes",
+		} {
+			up, off := upperWithOffsets(line)
+			for start := 0; start <= len(up); start++ {
+				for end := start; end <= len(up); end++ {
+					s, e := origSpan(off, start, end)
+					if s < 0 || e < s || e > len(line) {
+						t.Fatalf("origSpan(%q, %d, %d) = (%d,%d), out of range for a %d-byte line",
+							line, start, end, s, e, len(line))
+					}
+					_ = line[s:e] // must not panic
+				}
+			}
+		}
+	})
+
+	t.Run("nil table is the identity", func(t *testing.T) {
+		if s, e := origSpan(nil, 3, 7); s != 3 || e != 7 {
+			t.Errorf("origSpan(nil,3,7) = (%d,%d), want (3,7)", s, e)
+		}
+	})
+}

--- a/internal/validators/bankaccount/validator.go
+++ b/internal/validators/bankaccount/validator.go
@@ -222,12 +222,85 @@ func (v *Validator) scanLine(ctx stdctx.Context, line string, lineNum int, origi
 	return matches
 }
 
+// upperWithOffsets uppercases line and, when that is not a byte-for-byte mapping,
+// returns a table translating each byte offset in the result back to an offset in
+// line.
+//
+// Uppercasing is per-rune and can change a rune's byte length: U+017F LATIN SMALL
+// LETTER LONG S occupies 2 bytes and uppercases to "S", which occupies 1. Every
+// offset after such a rune is therefore shifted, and slicing line with an offset
+// found in the uppercased copy addresses the wrong bytes. Measured, before this
+// existed:
+//
+//	input:    Payment ref ſ IBAN GB82WEST12345698765432 end
+//	reported: " GB82WEST1234569876543"  (leading space, final digit missing)
+//	redacted: Payment ref ſ IBAN**********************2 end
+//
+// The last digit of the IBAN stayed in cleartext and the mask covered the preceding
+// space instead, at rc=0. The same shift makes scanSWIFT's "original must already
+// be uppercase" comparison fail against a mis-sliced string, dropping a real SWIFT
+// code entirely.
+//
+// The uppercased string is built here rather than by strings.ToUpper so the text and
+// its offset table cannot disagree. A nil table means the identity mapping, which
+// holds for any all-ASCII line — the overwhelming majority — so the common path
+// allocates no table.
+func upperWithOffsets(line string) (string, []int) {
+	ascii := true
+	for i := 0; i < len(line); i++ {
+		if line[i] >= 0x80 {
+			ascii = false
+			break
+		}
+	}
+	if ascii {
+		return strings.ToUpper(line), nil
+	}
+
+	var b strings.Builder
+	b.Grow(len(line) + 8)
+	offsets := make([]int, 0, len(line)+8)
+	for i, r := range line {
+		before := b.Len()
+		b.WriteRune(unicode.ToUpper(r))
+		for j := before; j < b.Len(); j++ {
+			offsets = append(offsets, i)
+		}
+	}
+	// One past the end, so a match's exclusive end offset maps too.
+	offsets = append(offsets, len(line))
+	return b.String(), offsets
+}
+
+// origSpan translates a [start,end) span in the uppercased line back to line.
+// A nil table is the identity mapping.
+func origSpan(offsets []int, start, end int) (int, int) {
+	if offsets == nil {
+		return start, end
+	}
+	last := len(offsets) - 1
+	if start < 0 {
+		start = 0
+	}
+	if start > last {
+		start = last
+	}
+	if end < start {
+		end = start
+	}
+	if end > last {
+		end = last
+	}
+	return offsets[start], offsets[end]
+}
+
 // scanIBAN detects and validates IBAN numbers.
 func (v *Validator) scanIBAN(ctx stdctx.Context, line string, lineNum int, originalPath string, lc lineContext) []detector.Match {
 	var matches []detector.Match
 
-	// Try case-insensitive match by checking uppercase version
-	upperLine := strings.ToUpper(line)
+	// Try case-insensitive match by checking uppercase version. upperMap translates
+	// offsets in upperLine back to line — uppercasing is not length-preserving.
+	upperLine, upperMap := upperWithOffsets(line)
 	idxMatches := reIBAN.FindAllStringIndex(upperLine, -1)
 
 	for i, loc := range idxMatches {
@@ -241,8 +314,12 @@ func (v *Validator) scanIBAN(ctx stdctx.Context, line string, lineNum int, origi
 			continue
 		}
 
+		// Back to offsets in the ORIGINAL line before slicing it — see
+		// upperWithOffsets.
+		oStart, oEnd := origSpan(upperMap, loc[0], loc[1])
+
 		// Context adjustment (per-line invariant)
-		contextInfo := v.buildContextInfo(line, loc[0], loc[1]-loc[0])
+		contextInfo := v.buildContextInfo(line, oStart, oEnd-oStart)
 
 		confidence := 85.0 // IBAN with valid checksum is high confidence
 
@@ -268,7 +345,7 @@ func (v *Validator) scanIBAN(ctx stdctx.Context, line string, lineNum int, origi
 		}
 
 		matches = append(matches, detector.Match{
-			Text:       line[loc[0]:loc[1]], // preserve original case
+			Text:       line[oStart:oEnd], // preserve original case
 			LineNumber: lineNum + 1,
 			Type:       "IBAN",
 			Confidence: confidence,
@@ -294,6 +371,9 @@ func (v *Validator) scanIBAN(ctx stdctx.Context, line string, lineNum int, origi
 			continue
 		}
 
+		// Back to offsets in the ORIGINAL line — see upperWithOffsets.
+		oStart, oEnd := origSpan(upperMap, loc[0], loc[1])
+
 		// Value-intrinsic floor (TM-11) — same reasoning as the compact-form pass
 		// above; mod-97 is verified, so context may demote but not erase.
 		confidence := clampConfidence(85.0 + lc.keywordImpact)
@@ -302,13 +382,13 @@ func (v *Validator) scanIBAN(ctx stdctx.Context, line string, lineNum int, origi
 		}
 
 		matches = append(matches, detector.Match{
-			Text:       line[loc[0]:loc[1]], // original case and spacing
+			Text:       line[oStart:oEnd], // original case and spacing
 			LineNumber: lineNum + 1,
 			Type:       "IBAN",
 			Confidence: confidence,
 			Filename:   originalPath,
 			Validator:  "bank_account",
-			Context:    v.buildContextInfo(line, loc[0], loc[1]-loc[0]),
+			Context:    v.buildContextInfo(line, oStart, oEnd-oStart),
 			Metadata: map[string]any{
 				"country":        normalized[:2],
 				"context_impact": lc.keywordImpact,
@@ -324,7 +404,10 @@ func (v *Validator) scanIBAN(ctx stdctx.Context, line string, lineNum int, origi
 func (v *Validator) scanSWIFT(ctx stdctx.Context, line string, lineNum int, originalPath string, lc lineContext) []detector.Match {
 	var matches []detector.Match
 
-	upperLine := strings.ToUpper(line)
+	// upperMap translates offsets in upperLine back to line — see upperWithOffsets.
+	// Without it the originalText comparison below runs against a mis-sliced string
+	// and silently drops a real SWIFT code.
+	upperLine, upperMap := upperWithOffsets(line)
 	idxMatches := reSWIFT.FindAllStringIndex(upperLine, -1)
 
 	for i, loc := range idxMatches {
@@ -332,9 +415,10 @@ func (v *Validator) scanSWIFT(ctx stdctx.Context, line string, lineNum int, orig
 			return matches
 		}
 		candidate := upperLine[loc[0]:loc[1]]
+		oStart, oEnd := origSpan(upperMap, loc[0], loc[1])
 
 		// The original text must be uppercase -- real SWIFT codes are always uppercase.
-		originalText := line[loc[0]:loc[1]]
+		originalText := line[oStart:oEnd]
 		if originalText != candidate {
 			continue
 		}
@@ -345,7 +429,7 @@ func (v *Validator) scanSWIFT(ctx stdctx.Context, line string, lineNum int, orig
 		}
 
 		// SWIFT codes without banking context are often false positives (random 8-char strings)
-		contextInfo := v.buildContextInfo(line, loc[0], loc[1]-loc[0])
+		contextInfo := v.buildContextInfo(line, oStart, oEnd-oStart)
 		hasBankingContext := lc.bankingKeyword
 
 		// All-letter candidates (no digits) are very likely English words unless

--- a/internal/validators/dob/duplicate_span_test.go
+++ b/internal/validators/dob/duplicate_span_test.go
@@ -1,0 +1,121 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dob
+
+import (
+	"strings"
+	"testing"
+)
+
+// The same date twice on one line is two findings, not one.
+//
+// extractDates shares a `seen` map across every pattern loop so that two patterns
+// matching the same bytes collapse to one candidate — which is correct. But the key
+// was the matched TEXT, so a date appearing twice on one line at different offsets
+// also collapsed, and only the first was emitted.
+//
+// Redaction rewrites what was reported, so the second occurrence survived. Measured
+// on the shipped binary:
+//
+//	input:    Date of Birth: 1985-03-14 (DOB 1985-03-14)
+//	findings: 1
+//	redacted: Date of Birth: ********** (DOB 1985-03-14)
+//
+// rc=0, with a date of birth in cleartext in a file the caller believes is redacted.
+// Keying on the byte span fixes it while still collapsing genuine cross-pattern
+// duplicates.
+func TestSameDateTwiceOnOneLineYieldsTwoCandidates(t *testing.T) {
+	v := NewValidator()
+
+	cases := []struct {
+		name string
+		line string
+		date string
+		want int
+	}{
+		{"iso twice", "Date of Birth: 1985-03-14 (DOB 1985-03-14)", "1985-03-14", 2},
+		{"iso three times", "DOB 1985-03-14 / 1985-03-14 / 1985-03-14", "1985-03-14", 3},
+		{"numeric twice", "Date of Birth: 03/14/1985 confirmed 03/14/1985", "03/14/1985", 2},
+		{"month name twice", "Born March 14, 1985 (DOB March 14, 1985)", "March 14, 1985", 2},
+		// A single occurrence must still be a single finding — the fix must not
+		// start double-emitting.
+		{"single occurrence unchanged", "Date of Birth: 1985-03-14", "1985-03-14", 1},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			matches, err := v.ValidateContent(c.line, "test.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			n := 0
+			for _, m := range matches {
+				if strings.EqualFold(m.Text, c.date) {
+					n++
+				}
+			}
+			if n != c.want {
+				t.Errorf("got %d findings for %q, want %d.\n"+
+					"Redaction only rewrites what was reported, so a dropped occurrence stays "+
+					"in cleartext in the redacted file.", n, c.date, c.want)
+			}
+		})
+	}
+}
+
+// Deduplication must still collapse two PATTERNS matching the same bytes. That is
+// what the shared `seen` map is for, and losing it would emit the same span twice
+// and redact the same bytes twice.
+func TestSameSpanFromDifferentPatternsCollapses(t *testing.T) {
+	// Every candidate returned for a line must have a distinct start offset.
+	for _, line := range []string{
+		"Date of Birth: 1985-03-14",
+		"DOB 03/14/1985",
+		"DOB 3/14/85",
+		"Born March 14, 1985",
+		"Born 14 March 1985",
+		"Mixed 1985-03-14 and 03/14/1985 and March 14, 1985",
+	} {
+		v := NewValidator()
+		got := v.extractDates(line)
+		seenStart := make(map[int]int)
+		for _, c := range got {
+			seenStart[c.start]++
+		}
+		for start, n := range seenStart {
+			if n > 1 {
+				t.Errorf("line %q: %d candidates share start offset %d — the same bytes would be "+
+					"redacted more than once", line, n, start)
+			}
+		}
+	}
+}
+
+// The span key must distinguish occurrences by offset, and collapse identical
+// spans. Asserted on extractDates directly so the guarantee does not depend on
+// downstream scoring choosing to emit.
+func TestExtractDatesKeysOnSpanNotText(t *testing.T) {
+	v := NewValidator()
+	line := "DOB 1985-03-14 and again 1985-03-14"
+
+	got := v.extractDates(line)
+	var starts []int
+	for _, c := range got {
+		if c.text == "1985-03-14" {
+			starts = append(starts, c.start)
+		}
+	}
+	if len(starts) != 2 {
+		t.Fatalf("got %d candidates for the repeated date (starts %v), want 2", len(starts), starts)
+	}
+	if starts[0] == starts[1] {
+		t.Errorf("both candidates report start %d; they are different occurrences", starts[0])
+	}
+	// Each start must actually be where that text occurs.
+	for _, s := range starts {
+		if s < 0 || s+len("1985-03-14") > len(line) || line[s:s+len("1985-03-14")] != "1985-03-14" {
+			t.Errorf("start %d does not address the date in %q", s, line)
+		}
+	}
+}

--- a/internal/validators/dob/validator.go
+++ b/internal/validators/dob/validator.go
@@ -268,18 +268,33 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 	return matches, nil
 }
 
+// dateSpan is the byte range a pattern matched, used to deduplicate candidates.
+//
+// The key must be the SPAN, not the matched text. Several patterns can match the
+// same bytes -- that is the duplicate worth collapsing -- but a text key also
+// collapses the same date appearing TWICE on one line at different offsets, which
+// are separate findings. Only one was emitted, so redaction rewrote only one:
+// "Date of Birth: 1985-03-14 (DOB 1985-03-14)" produced one finding and the
+// redacted line read "Date of Birth: ********** (DOB 1985-03-14)", leaving the
+// second date in cleartext at rc=0. Same lesson as the duplicate-span dedup fix:
+// key on bytes, not on rendered text.
+type dateSpan struct {
+	start int
+	end   int
+}
+
 // extractDates finds all date candidates in a line using the pre-compiled patterns.
 func (v *Validator) extractDates(line string) []dateCandidate {
 	var candidates []dateCandidate
-	seen := make(map[string]bool)
+	seen := make(map[dateSpan]bool)
 
 	// ISO dates: YYYY-MM-DD
 	for _, loc := range reISODate.FindAllStringSubmatchIndex(line, -1) {
 		text := line[loc[0]:loc[1]]
-		if seen[text] {
+		if seen[dateSpan{loc[0], loc[1]}] {
 			continue
 		}
-		seen[text] = true
+		seen[dateSpan{loc[0], loc[1]}] = true
 		year, _ := strconv.Atoi(line[loc[2]:loc[3]])
 		month, _ := strconv.Atoi(line[loc[4]:loc[5]])
 		day, _ := strconv.Atoi(line[loc[6]:loc[7]])
@@ -292,10 +307,10 @@ func (v *Validator) extractDates(line string) []dateCandidate {
 	// Numeric dates: MM/DD/YYYY or DD/MM/YYYY
 	for _, loc := range reNumericDate.FindAllStringSubmatchIndex(line, -1) {
 		text := line[loc[0]:loc[1]]
-		if seen[text] {
+		if seen[dateSpan{loc[0], loc[1]}] {
 			continue
 		}
-		seen[text] = true
+		seen[dateSpan{loc[0], loc[1]}] = true
 		part1, _ := strconv.Atoi(line[loc[2]:loc[3]])
 		part2, _ := strconv.Atoi(line[loc[4]:loc[5]])
 		year, _ := strconv.Atoi(line[loc[6]:loc[7]])
@@ -314,7 +329,7 @@ func (v *Validator) extractDates(line string) []dateCandidate {
 	// Numeric dates with two-digit years: MM/DD/YY or DD/MM/YY
 	for _, loc := range reNumericDate2Y.FindAllStringSubmatchIndex(line, -1) {
 		text := line[loc[0]:loc[1]]
-		if seen[text] {
+		if seen[dateSpan{loc[0], loc[1]}] {
 			continue
 		}
 		// Mixed separators ("3/14-87") are not a date; require both to match.
@@ -327,7 +342,7 @@ func (v *Validator) extractDates(line string) []dateCandidate {
 		if sep == "." && reVersionContext.MatchString(line) {
 			continue
 		}
-		seen[text] = true
+		seen[dateSpan{loc[0], loc[1]}] = true
 		part1, _ := strconv.Atoi(line[loc[2]:loc[3]])
 		part2, _ := strconv.Atoi(line[loc[6]:loc[7]])
 		yy, _ := strconv.Atoi(line[loc[10]:loc[11]])
@@ -345,10 +360,10 @@ func (v *Validator) extractDates(line string) []dateCandidate {
 	// Month DD, YYYY
 	for _, loc := range reMonthDDYYYY.FindAllStringSubmatchIndex(line, -1) {
 		text := line[loc[0]:loc[1]]
-		if seen[text] {
+		if seen[dateSpan{loc[0], loc[1]}] {
 			continue
 		}
-		seen[text] = true
+		seen[dateSpan{loc[0], loc[1]}] = true
 		monthStr := strings.ToLower(line[loc[2]:loc[3]])
 		day, _ := strconv.Atoi(line[loc[4]:loc[5]])
 		year, _ := strconv.Atoi(line[loc[6]:loc[7]])
@@ -362,10 +377,10 @@ func (v *Validator) extractDates(line string) []dateCandidate {
 	// DD Month YYYY
 	for _, loc := range reDDMonthYYYY.FindAllStringSubmatchIndex(line, -1) {
 		text := line[loc[0]:loc[1]]
-		if seen[text] {
+		if seen[dateSpan{loc[0], loc[1]}] {
 			continue
 		}
-		seen[text] = true
+		seen[dateSpan{loc[0], loc[1]}] = true
 		day, _ := strconv.Atoi(line[loc[2]:loc[3]])
 		monthStr := strings.ToLower(line[loc[4]:loc[5]])
 		year, _ := strconv.Atoi(line[loc[6]:loc[7]])


### PR DESCRIPTION
Two independent offset defects, each leaving a reported value in cleartext after redaction. Redaction rewrites the span that was reported, so a wrong span is a leak, not a cosmetic error.

## dob — the same date twice on one line was reported once

`extractDates` shares a `seen` map across every pattern loop so two *patterns* matching the same bytes collapse to one candidate. That is correct and is kept. But the key was the matched **text**, so a date occurring twice on one line at different offsets also collapsed and only the first was emitted:

```
input:    Date of Birth: 1985-03-14 (DOB 1985-03-14)
findings: 1
redacted: Date of Birth: ********** (DOB 1985-03-14)     rc=0
```

Now keyed on the byte span. Cross-pattern collapse is still asserted: no two candidates for a line may share a start offset.

## bankaccount — offsets from an uppercased copy were used to slice the original

`scanIBAN`, the spaced-IBAN pass and `scanSWIFT` matched against `strings.ToUpper(line)` then sliced `line` with the resulting offsets. Uppercasing is per-rune and **not length-preserving** — U+017F LATIN SMALL LETTER LONG S is 2 bytes and uppercases to `S`, 1 byte — so every later offset shifts:

```
input:    Payment ref ſ IBAN GB82WEST12345698765432 end
reported: " GB82WEST1234569876543"   (leading space, final digit missing)
redacted: Payment ref ſ IBAN**********************2 end   rc=0
```

The final digit stayed in cleartext and the mask consumed the preceding space instead. The same shift makes `scanSWIFT`'s "the original must already be uppercase" comparison run against a mis-sliced string, dropping a real SWIFT code entirely.

Fixed with `upperWithOffsets`, which builds the uppercased text *and* its offset table in one pass so the two cannot disagree, plus `origSpan` to translate a span back. A nil table means the identity mapping — true for any all-ASCII line — so the common path allocates nothing.

**Deliberately not fixed** by matching case-insensitively on the original line: `(?i)[A-Z]` does not fold U+017F, so an IBAN whose own text contains a long s would stop being detected at all — the whole value in cleartext instead of all but one character. Verified both ways: `ſE3550000000054910000003` is still detected and now fully masked.

## Detection impact

Measured A/B against main over `internal/` with `--limit 0` — the default 200 truncates and hid this entirely on the first pass:

| | findings |
|---|---|
| main | 6130 |
| this branch | 6155 |

**+25 `DATE_OF_BIRTH`, no other type changed, none lost.** All 25 are genuine second occurrences on lines whose first occurrence was already reported — e.g. `formats_test.go:20` holds `3/14/87` twice. `docs/`, `examples/` and `tests/` are byte-identical.

## Non-vacuity

- Reverting the dob key to the text form fails 4 duplicate cases and the direct `extractDates` assertion, while the single-occurrence and cross-pattern-collapse cases keep passing — and it fails **no pre-existing test**, so the previous suite was blind to this.
- Making `origSpan` the identity reports `" GB82WEST1234569876543"` for one shifting rune and `"N GB82WEST123456987654"` for two, while the ASCII control keeps passing.

`make all` green; full suite 66 packages, 0 failures; golden corpus unchanged.