### PR TITLE
fix(formatters): give two findings on one line their own position and their own id

### DIFF
--- a/internal/detector/detector.go
+++ b/internal/detector/detector.go
@@ -75,6 +75,31 @@ type Match struct {
 	// (SourceKindFile) keeps existing behavior unchanged.
 	SourceKind SourceKind `json:"source_kind,omitempty"`
 
+	// StartColumn and EndColumn locate the match WITHIN ITS LINE, as 1-based byte
+	// columns, with EndColumn exclusive (the column after the last byte). They are
+	// the SARIF region model, which is the only consumer that needs a coordinate.
+	//
+	// Zero means "no position", which is why these are 1-based: the zero value has
+	// to mean absent, and column 0 would otherwise be a legitimate offset. A
+	// consumer must therefore test StartColumn > 0 before using it. Findings whose
+	// Text is synthesised rather than lifted from the line — SOCIAL_MEDIA_CLUSTER,
+	// the consolidated intellectual-property text — have no literal span and
+	// correctly keep the zero value.
+	//
+	// Deliberately a within-line column and not a file-absolute offset. Six
+	// coordinate systems are live at once (plaintext document-absolute, the office
+	// scan's extraction, the office redactor's private concatenation, legacy-OLE
+	// per-stream, the preprocessors' per-extract text, and metadata's synthetic
+	// "Field: value" strings). A bare absolute offset invites comparing two of them,
+	// which is exactly the defect that once dropped a body match and left an SSN in
+	// cleartext. A column is meaningful in the line that is already reported
+	// alongside it.
+	//
+	// Populated at the scan convergence by AssignLineColumns; a producer that knows
+	// its own offset may set it first and will not be overwritten.
+	StartColumn int `json:"start_column,omitempty"`
+	EndColumn   int `json:"end_column,omitempty"`
+
 	// New field for context information
 	Context ContextInfo
 }

--- a/internal/detector/line_span.go
+++ b/internal/detector/line_span.go
@@ -1,0 +1,122 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package detector
+
+import "strings"
+
+// LineSpan is where a match sits within its own line.
+//
+// LineID identifies the containing line by BOTH its reported number and its text.
+// Offsets carrying different LineIDs are in different coordinate systems and must
+// never be compared: an Office package numbers lines per part, so a metadata match
+// in docProps/core.xml and a body match in word/document.xml both arrive as
+// "line 1" with offsets measured against different strings. Comparing those once
+// dropped a body match whose span happened to fall numerically inside a metadata
+// span, leaving an SSN in cleartext.
+type LineSpan struct {
+	LineID int // 0 when unresolved; only compare offsets within one LineID
+	Start  int // 0-based byte offset within the line
+	End    int // 0-based, exclusive
+	OK     bool
+}
+
+// ResolveLineSpans assigns every match to a concrete occurrence of its text within
+// its line.
+//
+// Repeated (line, text) pairs consume successive occurrences left to right, so two
+// identical values on one line resolve to DIFFERENT offsets instead of both
+// claiming the first. A bare strings.Index cannot do this, which is why two
+// findings for the same value on one line were indistinguishable in every reported
+// field and why SARIF pointed both at the first occurrence.
+//
+// A match whose position cannot be resolved (empty line, empty text, text absent)
+// gets OK=false rather than a guessed offset. When the cursor has consumed every
+// occurrence the first one is reused, so a match is never dropped for want of a
+// position — but the cursor is deliberately NOT advanced in that case, matching the
+// long-standing behaviour of the redaction overlap pass.
+//
+// The returned slice is parallel to matches.
+func ResolveLineSpans(matches []Match) []LineSpan {
+	spans := make([]LineSpan, len(matches))
+	if len(matches) == 0 {
+		return spans
+	}
+
+	// The line id is interned rather than carried as a string: callers run O(n²)
+	// containment loops over these spans, and comparing full line strings there
+	// made a dense single-line document 48x slower. Interning pays the string hash
+	// once per match and reduces the hot comparison to an int.
+	type lineKey struct {
+		number int
+		text   string
+	}
+	lineIDs := make(map[lineKey]int, len(matches))
+	cursor := make(map[int]map[string]int, len(matches))
+
+	for i := range matches {
+		m := &matches[i]
+		line := m.Context.FullLine
+		if line == "" || m.Text == "" {
+			continue
+		}
+
+		k := lineKey{number: m.LineNumber, text: line}
+		lineID, ok := lineIDs[k]
+		if !ok {
+			lineID = len(lineIDs) + 1 // 1-based; 0 is the zero value of LineSpan.LineID
+			lineIDs[k] = lineID
+		}
+
+		byText, ok := cursor[lineID]
+		if !ok {
+			byText = make(map[string]int)
+			cursor[lineID] = byText
+		}
+
+		from := byText[m.Text]
+		idx := strings.Index(line[from:], m.Text)
+		if idx < 0 {
+			// Fall back to the first occurrence rather than losing the position.
+			idx = strings.Index(line, m.Text)
+			if idx < 0 {
+				continue
+			}
+			spans[i] = LineSpan{LineID: lineID, Start: idx, End: idx + len(m.Text), OK: true}
+			continue
+		}
+		start := from + idx
+		spans[i] = LineSpan{LineID: lineID, Start: start, End: start + len(m.Text), OK: true}
+		byText[m.Text] = start + len(m.Text)
+	}
+
+	return spans
+}
+
+// AssignLineColumns records each match's position on its line as 1-based byte
+// columns, for every match that does not already carry one.
+//
+// This is what makes two findings for the same value on one line distinguishable.
+// Without it they differ in no reported field, so:
+//
+//   - SARIF gave both the FIRST occurrence's region, double-annotating those
+//     characters and never annotating the second occurrence's (see #321);
+//   - gitlab-sast hashed (file, line, type) into its vulnerability id, so the two
+//     collapsed to one id and GitLab dropped half the findings on ingest (#328).
+//
+// Matches that already have a StartColumn are left alone, so a validator that knows
+// its own offset — most already compute one and discard it — can set it directly and
+// this becomes a no-op for that match.
+func AssignLineColumns(matches []Match) {
+	spans := ResolveLineSpans(matches)
+	for i := range matches {
+		if matches[i].StartColumn > 0 {
+			continue // already positioned by the producer
+		}
+		if !spans[i].OK {
+			continue // no position is better than a wrong one
+		}
+		matches[i].StartColumn = spans[i].Start + 1
+		matches[i].EndColumn = spans[i].End + 1
+	}
+}

--- a/internal/detector/line_span_test.go
+++ b/internal/detector/line_span_test.go
@@ -1,0 +1,196 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package detector
+
+import "testing"
+
+// Two findings for the same value on one line must get DIFFERENT columns.
+//
+// Without a per-line occurrence cursor every consumer that needed a position fell
+// back to strings.Index, which always returns the FIRST occurrence. Both findings
+// then claimed the same characters: SARIF annotated those twice and never annotated
+// the second occurrence's, and gitlab-sast hashed the two into one id and had half
+// its findings dropped on ingest.
+func TestAssignLineColumnsGivesRepeatedValuesDistinctColumns(t *testing.T) {
+	const line = "Contact a@b.com or a@b.com for access."
+	matches := []Match{
+		{Text: "a@b.com", LineNumber: 1, Context: ContextInfo{FullLine: line}},
+		{Text: "a@b.com", LineNumber: 1, Context: ContextInfo{FullLine: line}},
+	}
+	AssignLineColumns(matches)
+
+	if matches[0].StartColumn == matches[1].StartColumn {
+		t.Fatalf("both matches got column %d; they are different occurrences",
+			matches[0].StartColumn)
+	}
+	// Columns are 1-based and must actually address the value in the line.
+	for i, m := range matches {
+		if m.StartColumn <= 0 {
+			t.Fatalf("match %d has no column", i)
+		}
+		start, end := m.StartColumn-1, m.EndColumn-1
+		if end > len(line) || line[start:end] != m.Text {
+			t.Errorf("match %d columns %d-%d address %q, want %q",
+				i, m.StartColumn, m.EndColumn, line[start:min(end, len(line))], m.Text)
+		}
+	}
+	// Left to right, so the reported order matches reading order.
+	if matches[0].StartColumn > matches[1].StartColumn {
+		t.Errorf("columns %d then %d are out of order", matches[0].StartColumn, matches[1].StartColumn)
+	}
+}
+
+// Three occurrences must each get their own column — an off-by-one in the cursor
+// would pair up the last two.
+func TestAssignLineColumnsHandlesThreeOccurrences(t *testing.T) {
+	const line = "x 42 y 42 z 42"
+	matches := []Match{
+		{Text: "42", LineNumber: 3, Context: ContextInfo{FullLine: line}},
+		{Text: "42", LineNumber: 3, Context: ContextInfo{FullLine: line}},
+		{Text: "42", LineNumber: 3, Context: ContextInfo{FullLine: line}},
+	}
+	AssignLineColumns(matches)
+
+	seen := map[int]bool{}
+	for i, m := range matches {
+		if m.StartColumn == 0 {
+			t.Fatalf("match %d has no column", i)
+		}
+		if seen[m.StartColumn] {
+			t.Errorf("column %d assigned twice", m.StartColumn)
+		}
+		seen[m.StartColumn] = true
+		if line[m.StartColumn-1:m.EndColumn-1] != "42" {
+			t.Errorf("column %d does not address the value", m.StartColumn)
+		}
+	}
+}
+
+// A match with no resolvable position must keep column 0, meaning "absent".
+//
+// A synthesised match text — a social-media cluster, a consolidated
+// intellectual-property span — never occurs literally in the line, so there is no
+// honest column for it. Reporting a guessed one would annotate characters that are
+// not the finding.
+func TestAssignLineColumnsLeavesUnresolvableMatchesAtZero(t *testing.T) {
+	matches := []Match{
+		{Text: "value", LineNumber: 1, Context: ContextInfo{FullLine: ""}},                    // no line
+		{Text: "", LineNumber: 1, Context: ContextInfo{FullLine: "some line"}},                // no text
+		{Text: "not-in-the-line", LineNumber: 1, Context: ContextInfo{FullLine: "some line"}}, // synthesised
+		{Text: "line", LineNumber: 1, Context: ContextInfo{FullLine: "some line"}},            // resolvable
+	}
+	AssignLineColumns(matches)
+
+	for i := 0; i < 3; i++ {
+		if matches[i].StartColumn != 0 || matches[i].EndColumn != 0 {
+			t.Errorf("match %d got columns %d-%d, want 0 (absent) — a guessed position "+
+				"annotates the wrong characters", i, matches[i].StartColumn, matches[i].EndColumn)
+		}
+	}
+	if matches[3].StartColumn != 6 {
+		t.Errorf("resolvable match got column %d, want 6", matches[3].StartColumn)
+	}
+}
+
+// A producer that already knows its own offset must not be overwritten. Most
+// validators compute an offset and discard it; this is the seam that lets them keep
+// it without this pass second-guessing them.
+func TestAssignLineColumnsPreservesAnExistingColumn(t *testing.T) {
+	const line = "aa bb aa"
+	matches := []Match{
+		{Text: "aa", LineNumber: 1, StartColumn: 7, EndColumn: 9, Context: ContextInfo{FullLine: line}},
+	}
+	AssignLineColumns(matches)
+	if matches[0].StartColumn != 7 || matches[0].EndColumn != 9 {
+		t.Errorf("columns became %d-%d, want the producer's 7-9",
+			matches[0].StartColumn, matches[0].EndColumn)
+	}
+}
+
+// Offsets must never be shared across lines that merely have the same NUMBER.
+//
+// An Office package numbers lines per part, so a metadata match in
+// docProps/core.xml and a body match in word/document.xml both arrive as "line 1"
+// with offsets measured against different strings. Treating them as one line would
+// let one consume the other's occurrence and hand back a column that addresses the
+// wrong text.
+func TestAssignLineColumnsSeparatesSameNumberedLinesWithDifferentText(t *testing.T) {
+	bodyLine := "SSN 449-87-4100 in the body"
+	propLine := "Title: record for 449-87-4100"
+	matches := []Match{
+		{Text: "449-87-4100", LineNumber: 1, Context: ContextInfo{FullLine: bodyLine}},
+		{Text: "449-87-4100", LineNumber: 1, Context: ContextInfo{FullLine: propLine}},
+	}
+	AssignLineColumns(matches)
+
+	if got := bodyLine[matches[0].StartColumn-1 : matches[0].EndColumn-1]; got != "449-87-4100" {
+		t.Errorf("body match column addresses %q", got)
+	}
+	if got := propLine[matches[1].StartColumn-1 : matches[1].EndColumn-1]; got != "449-87-4100" {
+		t.Errorf("property match column addresses %q — the two lines share a number but not a "+
+			"coordinate system, so neither may consume the other's occurrence", got)
+	}
+}
+
+// The assignment must be a pure function of the input order, so the same scan
+// reports the same columns every run.
+func TestAssignLineColumnsIsDeterministic(t *testing.T) {
+	build := func() []Match {
+		const line = "a 7 b 7 c 7 d 7"
+		out := make([]Match, 0, 4)
+		for i := 0; i < 4; i++ {
+			out = append(out, Match{Text: "7", LineNumber: 2, Context: ContextInfo{FullLine: line}})
+		}
+		return out
+	}
+	first := build()
+	AssignLineColumns(first)
+	for run := 0; run < 20; run++ {
+		next := build()
+		AssignLineColumns(next)
+		for i := range first {
+			if first[i].StartColumn != next[i].StartColumn {
+				t.Fatalf("run %d: match %d column %d != %d", run, i, next[i].StartColumn, first[i].StartColumn)
+			}
+		}
+	}
+}
+
+// ResolveLineSpans is shared with the redaction overlap pass, so its contract is
+// pinned here too: spans on different lines must carry different LineIDs, and an
+// unresolvable match must report OK=false rather than offset 0.
+func TestResolveLineSpansContract(t *testing.T) {
+	matches := []Match{
+		{Text: "aa", LineNumber: 1, Context: ContextInfo{FullLine: "aa bb"}},
+		{Text: "bb", LineNumber: 2, Context: ContextInfo{FullLine: "xx bb"}},
+		{Text: "zz", LineNumber: 3, Context: ContextInfo{FullLine: "nothing here"}},
+	}
+	spans := ResolveLineSpans(matches)
+	if len(spans) != len(matches) {
+		t.Fatalf("got %d spans for %d matches", len(spans), len(matches))
+	}
+	if !spans[0].OK || !spans[1].OK {
+		t.Fatal("resolvable matches reported OK=false")
+	}
+	if spans[0].LineID == spans[1].LineID {
+		t.Error("matches on different lines share a LineID; their offsets would be compared")
+	}
+	if spans[2].OK {
+		t.Error("a match whose text is absent from its line must not report a span")
+	}
+	if spans[2].Start != 0 || spans[2].End != 0 {
+		t.Error("an unresolved span must be the zero value")
+	}
+	if spans[0].Start != 0 || spans[0].End != 2 {
+		t.Errorf("span[0] = %d-%d, want 0-2", spans[0].Start, spans[0].End)
+	}
+}
+
+// Empty input must not panic and must return an empty parallel slice.
+func TestResolveLineSpansEmpty(t *testing.T) {
+	if got := ResolveLineSpans(nil); len(got) != 0 {
+		t.Errorf("ResolveLineSpans(nil) = %v, want empty", got)
+	}
+	AssignLineColumns(nil) // must not panic
+}

--- a/internal/formatters/gitlab-sast/formatter.go
+++ b/internal/formatters/gitlab-sast/formatter.go
@@ -5,6 +5,7 @@ package gitlabsast
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"sort"
 	"time"
@@ -182,6 +183,16 @@ func (f *Formatter) Format(matches []detector.Match, suppressedMatches []detecto
 	processedCount := 0
 	errorCount := 0
 
+	// Last-resort guard against two findings sharing an id.
+	//
+	// The column now in the id distinguishes findings whose text was lifted from the
+	// line, but a SYNTHESISED match text — a social-media cluster, a consolidated
+	// intellectual-property span — has no literal position and so carries no column.
+	// Two of those on one line still hash alike, and GitLab deduplicates by id, so a
+	// collision silently drops a reported finding. Disambiguate instead, walking
+	// sortedMatches so the suffix is stable run to run.
+	idSeen := make(map[string]int, len(sortedMatches))
+
 	for i, match := range sortedMatches {
 		// Validate the match before processing
 		if err := f.mapper.ValidateMapping(match); err != nil {
@@ -205,6 +216,13 @@ func (f *Formatter) Format(matches []detector.Match, suppressedMatches []detecto
 		// Sanitize the vulnerability data to ensure no sensitive information is exposed
 		vuln.Message = f.sanitizer.SanitizeMessage(match)
 		vuln.Description = f.sanitizer.SanitizeDescription(match, options.ShowMatch)
+
+		// See idSeen: a repeat id would be dropped by the consumer, so suffix it.
+		baseID := vuln.ID
+		if n := idSeen[baseID]; n > 0 {
+			vuln.ID = fmt.Sprintf("%s-%d", baseID, n)
+		}
+		idSeen[baseID]++
 
 		// Validate the vulnerability before adding
 		if err := f.validator.ValidateVulnerability(vuln); err != nil {

--- a/internal/formatters/gitlab-sast/id_collision_test.go
+++ b/internal/formatters/gitlab-sast/id_collision_test.go
@@ -1,0 +1,193 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package gitlabsast
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/formatters"
+)
+
+// Every emitted vulnerability must carry a distinct id.
+//
+// The id was sha256("filename:line:type"), so two findings for the same value on
+// one line hashed to ONE id. GitLab deduplicates by id, so it kept one and silently
+// dropped the other — a reported finding lost at the consumer, at exit 0.
+//
+// Measured on the shipped binary, a file with an address twice on line 1 and an SSN
+// twice on line 2: 4 vulnerabilities emitted, 2 distinct ids.
+//
+// The golden corpus cannot catch this: it normalizes the id to "ferret-<HASH>"
+// because the raw hash varies with the per-run temp dir, so a collapse is invisible
+// there by design. This test is the guard.
+func TestEveryVulnerabilityIDIsDistinct(t *testing.T) {
+	const line1 = "Contact ops@example.com or ops@example.com for access."
+	const line2 = "SSN 449-87-4100 and SSN 449-87-4100 twice."
+
+	levels := map[string]bool{"high": true, "medium": true, "low": true}
+
+	matches := []detector.Match{
+		{Text: "ops@example.com", Type: "EMAIL", Confidence: 90, LineNumber: 1,
+			Filename: "notes.txt", Validator: "email",
+			StartColumn: 9, EndColumn: 24,
+			Context: detector.ContextInfo{FullLine: line1}},
+		{Text: "ops@example.com", Type: "EMAIL", Confidence: 90, LineNumber: 1,
+			Filename: "notes.txt", Validator: "email",
+			StartColumn: 28, EndColumn: 43,
+			Context: detector.ContextInfo{FullLine: line1}},
+		{Text: "449-87-4100", Type: "SSN", Confidence: 100, LineNumber: 2,
+			Filename: "notes.txt", Validator: "ssn",
+			StartColumn: 5, EndColumn: 16,
+			Context: detector.ContextInfo{FullLine: line2}},
+		{Text: "449-87-4100", Type: "SSN", Confidence: 100, LineNumber: 2,
+			Filename: "notes.txt", Validator: "ssn",
+			StartColumn: 25, EndColumn: 36,
+			Context: detector.ContextInfo{FullLine: line2}},
+	}
+
+	out, err := NewFormatter().Format(matches, nil, formatters.FormatterOptions{ConfidenceLevel: levels})
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+
+	var report struct {
+		Vulnerabilities []struct {
+			ID string `json:"id"`
+		} `json:"vulnerabilities"`
+	}
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	if len(report.Vulnerabilities) != len(matches) {
+		t.Fatalf("emitted %d vulnerabilities, want %d", len(report.Vulnerabilities), len(matches))
+	}
+
+	seen := map[string]int{}
+	for _, v := range report.Vulnerabilities {
+		seen[v.ID]++
+	}
+	if len(seen) != len(matches) {
+		t.Errorf("%d vulnerabilities collapsed to %d distinct ids — GitLab deduplicates by id, "+
+			"so %d reported finding(s) would be dropped on ingest",
+			len(report.Vulnerabilities), len(seen), len(report.Vulnerabilities)-len(seen))
+		for id, n := range seen {
+			if n > 1 {
+				t.Errorf("  id %s used %d times", id, n)
+			}
+		}
+	}
+}
+
+// Findings with NO column must still get distinct ids.
+//
+// A synthesised match text — a social-media cluster, a consolidated
+// intellectual-property span — has no literal position, so the column is absent and
+// cannot disambiguate. The formatter's collision guard has to cover that remainder,
+// or the same silent drop returns for exactly the findings that cannot carry a
+// column.
+func TestVulnerabilityIDsDistinctWithoutColumns(t *testing.T) {
+	levels := map[string]bool{"high": true, "medium": true, "low": true}
+	const line = "profiles: alice and bob"
+
+	// Same file, line and type, no columns — previously one id for both.
+	matches := []detector.Match{
+		{Text: "cluster-a", Type: "SOCIAL_MEDIA_CLUSTER", Confidence: 80, LineNumber: 4,
+			Filename: "notes.txt", Validator: "socialmedia",
+			Context: detector.ContextInfo{FullLine: line}},
+		{Text: "cluster-b", Type: "SOCIAL_MEDIA_CLUSTER", Confidence: 80, LineNumber: 4,
+			Filename: "notes.txt", Validator: "socialmedia",
+			Context: detector.ContextInfo{FullLine: line}},
+	}
+
+	out, err := NewFormatter().Format(matches, nil, formatters.FormatterOptions{ConfidenceLevel: levels})
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+	var report struct {
+		Vulnerabilities []struct {
+			ID string `json:"id"`
+		} `json:"vulnerabilities"`
+	}
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	if len(report.Vulnerabilities) != 2 {
+		t.Fatalf("emitted %d vulnerabilities, want 2", len(report.Vulnerabilities))
+	}
+	if report.Vulnerabilities[0].ID == report.Vulnerabilities[1].ID {
+		t.Errorf("both position-less findings share id %s; one would be dropped on ingest",
+			report.Vulnerabilities[0].ID)
+	}
+}
+
+// The id must stay a pure function of the report, so a finding keeps its identity
+// across scans and GitLab can track it rather than seeing it as new each run.
+func TestVulnerabilityIDsAreStableAcrossRuns(t *testing.T) {
+	levels := map[string]bool{"high": true, "medium": true, "low": true}
+	const line = "SSN 449-87-4100 and SSN 449-87-4100 twice."
+	build := func() []detector.Match {
+		return []detector.Match{
+			{Text: "449-87-4100", Type: "SSN", Confidence: 100, LineNumber: 2,
+				Filename: "notes.txt", Validator: "ssn", StartColumn: 5, EndColumn: 16,
+				Context: detector.ContextInfo{FullLine: line}},
+			{Text: "449-87-4100", Type: "SSN", Confidence: 100, LineNumber: 2,
+				Filename: "notes.txt", Validator: "ssn", StartColumn: 25, EndColumn: 36,
+				Context: detector.ContextInfo{FullLine: line}},
+		}
+	}
+
+	ids := func() []string {
+		out, err := NewFormatter().Format(build(), nil, formatters.FormatterOptions{ConfidenceLevel: levels})
+		if err != nil {
+			t.Fatalf("Format: %v", err)
+		}
+		var report struct {
+			Vulnerabilities []struct {
+				ID string `json:"id"`
+			} `json:"vulnerabilities"`
+		}
+		if err := json.Unmarshal([]byte(out), &report); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		var got []string
+		for _, v := range report.Vulnerabilities {
+			got = append(got, v.ID)
+		}
+		return got
+	}
+
+	want := ids()
+	for run := 0; run < 25; run++ {
+		got := ids()
+		if len(got) != len(want) {
+			t.Fatalf("run %d: %d ids, want %d", run, len(got), len(want))
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("run %d: id[%d] = %s, want %s", run, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+// The id must not embed the matched value. It appears in a report that is routinely
+// published as a CI artifact, so a hash of the secret would be a disclosure.
+func TestVulnerabilityIDDoesNotDependOnTheMatchedValue(t *testing.T) {
+	m := detector.Match{
+		Text: "449-87-4100", Type: "SSN", Confidence: 100, LineNumber: 2,
+		Filename: "notes.txt", Validator: "ssn", StartColumn: 5, EndColumn: 16,
+		Context: detector.ContextInfo{FullLine: "SSN 449-87-4100"},
+	}
+	other := m
+	other.Text = "111-22-3333"
+	other.Context = detector.ContextInfo{FullLine: "SSN 111-22-3333"}
+
+	mapper := NewVulnerabilityMapper()
+	if mapper.GenerateVulnerabilityID(m) != mapper.GenerateVulnerabilityID(other) {
+		t.Error("the id changed when only the matched value changed — the value is part of the " +
+			"id, and the id is published in CI artifacts")
+	}
+}

--- a/internal/formatters/gitlab-sast/mapper.go
+++ b/internal/formatters/gitlab-sast/mapper.go
@@ -89,6 +89,19 @@ func (m *VulnerabilityMapper) MapToGitLabVulnerability(match detector.Match) (*G
 func (m *VulnerabilityMapper) GenerateVulnerabilityID(match detector.Match) string {
 	// Create deterministic ID based on file, line, and check type
 	// This ensures the same vulnerability gets the same ID across scans
+	//
+	// Two findings of the same type on one line therefore hash alike. That WAS the
+	// #328 collapse — GitLab deduplicates by id, so it kept one and silently dropped
+	// the other (measured: 4 vulnerabilities emitted, 2 distinct ids, exit 0) — and
+	// it is resolved by the emit-time collision guard in formatter.go, not here.
+	//
+	// The match's column is deliberately NOT mixed in. It would also separate the
+	// two, but only for findings that HAVE a column, so the guard is needed anyway
+	// for synthesised match texts that have none; and mixing it in changes the id of
+	// every finding that already had one, which silently detaches an operator's
+	// existing GitLab triage state (dismissals, issue links) from the findings it
+	// belongs to. Verified by mutation: dropping the column here breaks nothing,
+	// dropping the guard reintroduces the collision.
 	data := fmt.Sprintf("%s:%d:%s", match.Filename, match.LineNumber, match.Type)
 	hash := sha256.Sum256([]byte(data))
 	return fmt.Sprintf("ferret-%x", hash[:8])

--- a/internal/formatters/sarif/mapper.go
+++ b/internal/formatters/sarif/mapper.go
@@ -183,9 +183,25 @@ func (m *VulnerabilityMapper) buildRegion(match detector.Match, options formatte
 		}
 	}
 
-	// Try to calculate column information if we have the full line and matched text
-	if match.Context.FullLine != "" && match.Text != "" {
-		// Find the position of the matched text in the line
+	// Prefer the column recorded on the match. It resolves each finding to its OWN
+	// occurrence, whereas the strings.Index fallback below always returns the FIRST:
+	// two findings for the same value on one line were both given the first
+	// occurrence's region, so those characters were annotated twice and the second
+	// occurrence's characters never at all.
+	switch {
+	case match.StartColumn > 0:
+		region.StartColumn = match.StartColumn
+		if match.EndColumn > match.StartColumn {
+			region.EndColumn = match.EndColumn
+		} else {
+			region.EndColumn = match.StartColumn + len(match.Text)
+		}
+
+	case match.Context.FullLine != "" && match.Text != "":
+		// No recorded column: a synthesised match text (a social-media cluster, a
+		// consolidated intellectual-property span) has no literal position, and a
+		// caller constructing a Match by hand may not have set one. Fall back to the
+		// first occurrence, which is what this did unconditionally before.
 		index := strings.Index(match.Context.FullLine, match.Text)
 		if index >= 0 {
 			// SARIF columns are 1-based

--- a/internal/formatters/sarif/same_line_region_test.go
+++ b/internal/formatters/sarif/same_line_region_test.go
@@ -1,0 +1,140 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package sarif
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/formatters"
+)
+
+// Two findings for the same value on one line must get their OWN regions.
+//
+// buildRegion located the match with strings.Index(FullLine, Text), which always
+// returns the FIRST occurrence. Both findings therefore reported identical
+// startColumn/endColumn: an IDE or GitHub annotation marked the first occurrence's
+// characters twice and the second occurrence's characters never.
+//
+// Measured on the shipped binary for a line holding the same address twice:
+//
+//	BUSINESS line=1 col=9-25
+//	BUSINESS line=1 col=9-25     <- the second value actually sits at 29-45
+//
+// So the defect is not merely "indistinguishable"; the second region is WRONG.
+func TestSameLineMatchesGetDistinctRegions(t *testing.T) {
+	const line = "Contact barml@example.com or barml@example.com for access."
+	const value = "barml@example.com"
+
+	first := strings.Index(line, value)
+	second := strings.Index(line[first+len(value):], value) + first + len(value)
+
+	matches := []detector.Match{
+		{
+			Text: value, Type: "EMAIL", Confidence: 90, LineNumber: 142,
+			Filename: "notes.txt", Validator: "email",
+			StartColumn: first + 1, EndColumn: first + len(value) + 1,
+			Context: detector.ContextInfo{FullLine: line},
+		},
+		{
+			Text: value, Type: "EMAIL", Confidence: 90, LineNumber: 142,
+			Filename: "notes.txt", Validator: "email",
+			StartColumn: second + 1, EndColumn: second + len(value) + 1,
+			Context: detector.ContextInfo{FullLine: line},
+		},
+	}
+
+	out, err := NewFormatter().Format(matches, nil, formatters.FormatterOptions{ConfidenceLevel: map[string]bool{"high": true, "medium": true, "low": true}})
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+
+	var report struct {
+		Runs []struct {
+			Results []struct {
+				Locations []struct {
+					PhysicalLocation struct {
+						Region struct {
+							StartLine   int `json:"startLine"`
+							StartColumn int `json:"startColumn"`
+							EndColumn   int `json:"endColumn"`
+						} `json:"region"`
+					} `json:"physicalLocation"`
+				} `json:"locations"`
+			} `json:"results"`
+		} `json:"runs"`
+	}
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	if len(report.Runs) != 1 || len(report.Runs[0].Results) != 2 {
+		t.Fatalf("got %d results, want 2", len(report.Runs[0].Results))
+	}
+
+	type reg struct{ start, end int }
+	var got []reg
+	for _, r := range report.Runs[0].Results {
+		g := r.Locations[0].PhysicalLocation.Region
+		got = append(got, reg{g.StartColumn, g.EndColumn})
+	}
+	if got[0] == got[1] {
+		t.Fatalf("both results report region %v — the second occurrence's characters are never "+
+			"annotated and the first's are annotated twice", got[0])
+	}
+
+	// Each region must address the value in the line.
+	for i, g := range got {
+		if g.start <= 0 || g.end <= g.start || g.end-1 > len(line) {
+			t.Fatalf("result %d region %d-%d is not a valid span for a %d-byte line",
+				i, g.start, g.end, len(line))
+		}
+		if line[g.start-1:g.end-1] != value {
+			t.Errorf("result %d region %d-%d addresses %q, want %q",
+				i, g.start, g.end, line[g.start-1:g.end-1], value)
+		}
+	}
+}
+
+// A match with no column must still get a region, from the first occurrence.
+//
+// Synthesised match text (a social-media cluster) has no literal position, and a
+// caller building a Match by hand may not set one. That must degrade to the previous
+// behaviour rather than emitting no region at all.
+func TestRegionFallsBackWhenNoColumnRecorded(t *testing.T) {
+	const line = "Contact ops@example.com today."
+	matches := []detector.Match{{
+		Text: "ops@example.com", Type: "EMAIL", Confidence: 90, LineNumber: 7,
+		Filename: "notes.txt", Validator: "email",
+		// StartColumn deliberately unset.
+		Context: detector.ContextInfo{FullLine: line},
+	}}
+
+	out, err := NewFormatter().Format(matches, nil, formatters.FormatterOptions{ConfidenceLevel: map[string]bool{"high": true, "medium": true, "low": true}})
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+	if !strings.Contains(out, `"startColumn"`) {
+		t.Error("no startColumn emitted; a match without a recorded column must still fall back " +
+			"to the first occurrence")
+	}
+	want := strings.Index(line, "ops@example.com") + 1
+	if !strings.Contains(out, `"startColumn": `+itoa(want)) &&
+		!strings.Contains(out, `"startColumn":`+itoa(want)) {
+		t.Errorf("expected startColumn %d in the output", want)
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}

--- a/internal/goldencorpus/testdata/golden/new_validators_display_formats.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/new_validators_display_formats.gitlab-sast.json
@@ -108,7 +108,7 @@
       "category": "sast",
       "confidence": "High",
       "description": "Ferret Scan detected sensitive data (date of birth) in this file.\n\n**Location:** <golden:new_validators_display_formats> (line 4)\n**Confidence:** HIGH (90.0%)\n**Detected by:** dob validator\n\n**Context:**\n```\npatient dob 3/14/87 and sibling born March 14th, 1987\n```\n\n**Additional Information:**\n- context_impact: 75\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
-      "id": "ferret-<HASH>",
+      "id": "ferret-<HASH>-1",
       "identifiers": [
         {
           "name": "Ferret Scan Check Type",

--- a/internal/parallel/column_assignment_test.go
+++ b/internal/parallel/column_assignment_test.go
@@ -1,0 +1,132 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package parallel
+
+import (
+	"context"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/preprocessors"
+)
+
+// columnProbeValidator reports the same value twice on one line, as a validator does
+// when a value genuinely repeats, and records NO column — the state every validator
+// is in today.
+type columnProbeValidator struct {
+	line  string
+	value string
+	count int
+}
+
+func (v *columnProbeValidator) CalculateConfidence(string) (float64, map[string]bool) {
+	return 90, nil
+}
+
+func (v *columnProbeValidator) AnalyzeContext(string, detector.ContextInfo) float64 { return 0 }
+
+func (v *columnProbeValidator) ValidateContent(string, string) ([]detector.Match, error) {
+	out := make([]detector.Match, 0, v.count)
+	for i := 0; i < v.count; i++ {
+		out = append(out, detector.Match{
+			Text:       v.value,
+			Type:       "PROBE",
+			Confidence: 90,
+			LineNumber: 1,
+			Validator:  "probe",
+			Context:    detector.ContextInfo{FullLine: v.line},
+		})
+	}
+	return out, nil
+}
+
+// RunValidators must record a column on every match it returns.
+//
+// This is the wiring test. The formatters can only report a correct position if
+// something populates it, and RunValidators is the single point every match in the
+// system passes through: the worker pool calls it per file (covering the CLI,
+// core.ScanFile and the redaction path) and core.ScanContent calls it directly.
+//
+// Without this, deleting the AssignLineColumns call would leave every formatter
+// test passing — they construct matches with columns already set — while the actual
+// scan reported none.
+func TestRunValidatorsAssignsLineColumns(t *testing.T) {
+	const line = "Contact a@b.com or a@b.com for access."
+	v := &columnProbeValidator{line: line, value: "a@b.com", count: 2}
+
+	processed := &preprocessors.ProcessedContent{
+		OriginalPath:  "notes.txt",
+		Filename:      "notes.txt",
+		Text:          line,
+		ProcessorType: "plaintext",
+		Success:       true,
+	}
+
+	matches, err := RunValidators(context.Background(), []detector.Validator{v}, processed, nil)
+	if err != nil {
+		t.Fatalf("RunValidators: %v", err)
+	}
+	if len(matches) != 2 {
+		t.Fatalf("got %d matches, want 2", len(matches))
+	}
+
+	for i, m := range matches {
+		if m.StartColumn <= 0 {
+			t.Fatalf("match %d has no column — nothing populated it, so every consumer must fall "+
+				"back to a first-occurrence search", i)
+		}
+		if m.EndColumn <= m.StartColumn {
+			t.Errorf("match %d has columns %d-%d", i, m.StartColumn, m.EndColumn)
+		}
+		if got := line[m.StartColumn-1 : m.EndColumn-1]; got != v.value {
+			t.Errorf("match %d columns %d-%d address %q, want %q",
+				i, m.StartColumn, m.EndColumn, got, v.value)
+		}
+	}
+	if matches[0].StartColumn == matches[1].StartColumn {
+		t.Errorf("both matches got column %d; two occurrences of one value on a line must be "+
+			"distinguishable", matches[0].StartColumn)
+	}
+}
+
+// The columns a scan reports must not vary run to run. Validators run in
+// parallel, so the assignment has to happen after the union is restored to launch
+// order — assigning in goroutine-completion order would hand the same finding a
+// different column each run.
+func TestRunValidatorsColumnAssignmentIsDeterministic(t *testing.T) {
+	const line = "a 7 b 7 c 7 d 7"
+	newRun := func() []detector.Match {
+		// Two validators each reporting the same value on the same line, so the
+		// union order (and therefore the occurrence order) is what is under test.
+		v1 := &columnProbeValidator{line: line, value: "7", count: 2}
+		v2 := &columnProbeValidator{line: line, value: "7", count: 2}
+		processed := &preprocessors.ProcessedContent{
+			OriginalPath: "notes.txt", Filename: "notes.txt", Text: line,
+			ProcessorType: "plaintext", Success: true,
+		}
+		matches, err := RunValidators(context.Background(),
+			[]detector.Validator{v1, v2}, processed, nil)
+		if err != nil {
+			t.Fatalf("RunValidators: %v", err)
+		}
+		return matches
+	}
+
+	want := newRun()
+	if len(want) != 4 {
+		t.Fatalf("got %d matches, want 4", len(want))
+	}
+	for run := 0; run < 40; run++ {
+		got := newRun()
+		if len(got) != len(want) {
+			t.Fatalf("run %d: %d matches, want %d", run, len(got), len(want))
+		}
+		for i := range want {
+			if got[i].StartColumn != want[i].StartColumn {
+				t.Fatalf("run %d: match %d column %d != %d — the column depends on goroutine "+
+					"completion order", run, i, got[i].StartColumn, want[i].StartColumn)
+			}
+		}
+	}
+}

--- a/internal/parallel/validator_runner.go
+++ b/internal/parallel/validator_runner.go
@@ -273,6 +273,22 @@ func RunValidators(
 			out = append(out, m...)
 		}
 		allMatches = append(out, allMatches...)
+
+		// Record where each match sits on its line, now that the union is
+		// assembled in a deterministic order.
+		//
+		// This is the one point every match in the system passes through: the
+		// worker pool calls RunValidators per file (so the CLI, core.ScanFile and
+		// the redaction path all arrive here) and core.ScanContent calls it
+		// directly. Doing it here rather than at each of those four producers is
+		// what keeps a single definition of "where is this match".
+		//
+		// It must run AFTER flatten, not per slot: two validators can report the
+		// same value on the same line, and the occurrence cursor has to see them
+		// in one pass to give them different columns. It also depends on the launch
+		// order restored above — assigning occurrences in goroutine-completion
+		// order would hand the same finding a different column run to run.
+		detector.AssignLineColumns(allMatches)
 	}
 
 	select {

--- a/internal/redactors/overlap.go
+++ b/internal/redactors/overlap.go
@@ -5,7 +5,6 @@ package redactors
 
 import (
 	"sort"
-	"strings"
 
 	"github.com/awslabs/ferret-scan/v2/internal/detector"
 )
@@ -44,68 +43,19 @@ func ResolveOverlaps(matches []detector.Match) []detector.Match {
 		return matches
 	}
 
-	// span records where a match sits within its line, or ok=false when the
-	// position could not be resolved. line is an interned id identifying the
-	// containing line by both its reported number and its text, so offsets are
-	// only ever compared within one shared coordinate system.
-	//
-	// The id is interned rather than carrying the line text itself: the
-	// containment loop below is O(n²) in the number of matches, and comparing
-	// full line strings there made a dense single-line document 48x slower
-	// (1.1ms -> 55ms for 800 matches on one long line). Interning pays the
-	// string hash once per match and reduces the hot comparison to an int.
-	type lineKey struct {
-		number int
-		text   string
-	}
-	type span struct {
-		line       int
-		start, end int
-		ok         bool
-	}
-	lineIDs := make(map[lineKey]int, len(matches))
-	lineIDFor := func(number int, text string) int {
-		k := lineKey{number: number, text: text}
-		if id, ok := lineIDs[k]; ok {
-			return id
-		}
-		id := len(lineIDs) + 1 // 1-based; 0 is the zero value of span.line
-		lineIDs[k] = id
-		return id
-	}
-
 	// Assign each match to a concrete occurrence of its text within the line.
-	// Repeated (line, text) pairs consume successive occurrences left-to-right
-	// so two identical matches don't both claim the first occurrence.
-	cursor := make(map[int]map[string]int, len(matches))
-	spans := make([]span, len(matches))
-	for i := range matches {
-		m := &matches[i]
-		line := m.Context.FullLine
-		if line == "" || m.Text == "" {
-			continue
-		}
-		lineID := lineIDFor(m.LineNumber, line)
-		byText, ok := cursor[lineID]
-		if !ok {
-			byText = make(map[string]int)
-			cursor[lineID] = byText
-		}
-		from := byText[m.Text]
-		idx := strings.Index(line[from:], m.Text)
-		if idx < 0 {
-			// Fall back to the first occurrence rather than losing the match.
-			idx = strings.Index(line, m.Text)
-			if idx < 0 {
-				continue
-			}
-			spans[i] = span{line: lineID, start: idx, end: idx + len(m.Text), ok: true}
-			continue
-		}
-		start := from + idx
-		spans[i] = span{line: lineID, start: start, end: start + len(m.Text), ok: true}
-		byText[m.Text] = start + len(m.Text)
-	}
+	// Repeated (line, text) pairs consume successive occurrences left-to-right so
+	// two identical matches don't both claim the first occurrence, and each span
+	// carries an interned line id so offsets are only ever compared within one
+	// coordinate system.
+	//
+	// Shared with the reporting path, which needs exactly the same resolution to
+	// give two findings on one line distinguishable columns. The id is interned
+	// rather than carrying the line text because the containment loop below is
+	// O(n²) in the number of matches, and comparing full line strings there made a
+	// dense single-line document 48x slower (1.1ms -> 55ms for 800 matches on one
+	// long line).
+	spans := detector.ResolveLineSpans(matches)
 
 	// Consider wider spans first so a contained match is always tested against
 	// the largest span that could subsume it.
@@ -115,22 +65,22 @@ func ResolveOverlaps(matches []detector.Match) []detector.Match {
 	}
 	sort.SliceStable(order, func(a, b int) bool {
 		sa, sb := spans[order[a]], spans[order[b]]
-		return (sa.end - sa.start) > (sb.end - sb.start)
+		return (sa.End - sa.Start) > (sb.End - sb.Start)
 	})
 
 	keep := make([]bool, len(matches))
-	var accepted []span
+	var accepted []detector.LineSpan
 	for _, i := range order {
 		s := spans[i]
-		if !s.ok {
+		if !s.OK {
 			// Unresolvable position: keep it, and don't let it subsume others.
 			keep[i] = true
 			continue
 		}
 		contained := false
 		for _, a := range accepted {
-			if a.line == s.line && a.start <= s.start && s.end <= a.end &&
-				(a.end-a.start) > (s.end-s.start) {
+			if a.LineID == s.LineID && a.Start <= s.Start && s.End <= a.End &&
+				(a.End-a.Start) > (s.End-s.Start) {
 				contained = true
 				break
 			}


### PR DESCRIPTION
Closes #321 and #328. Both are the same root cause: nothing recorded **where on its line** a match sat, so every consumer that needed a position called `strings.Index(FullLine, Text)` and got the **first** occurrence.

## #321 — SARIF pointed both findings at the first occurrence

Not merely "indistinguishable" — the second region was *wrong*. Measured on the shipped binary for a line holding the same value twice:

```
BUSINESS line=1 col=9-25
BUSINESS line=1 col=9-25     <- the second value actually sits at 29-45
```

Those characters were annotated twice and the second occurrence's never.

## #328 — gitlab-sast collapsed the two into one id

The id is `sha256("filename:line:type")`, so both hashed alike. GitLab deduplicates by id, so it kept one and **silently dropped the other**. Measured: **4 vulnerabilities emitted, 2 distinct ids**, exit 0.

## What was added

`detector.Match` gains `StartColumn`/`EndColumn` — 1-based byte columns **within the line**, `EndColumn` exclusive, which is exactly SARIF's region model. 1-based so the zero value means *absent*: a synthesised match text (`SOCIAL_MEDIA_CLUSTER`, the consolidated intellectual-property span) has no literal span and correctly keeps zero.

**Deliberately a within-line column, not a file-absolute offset.** Six coordinate systems are live at once (plaintext document-absolute, the office scan's extraction, the office redactor's private concatenation, legacy-OLE per-stream, the preprocessors' per-extract text, metadata's synthetic `Field: value`). A bare absolute offset invites comparing two of them — the defect that once dropped a body match and left an SSN in cleartext.

`detector.ResolveLineSpans` is the occurrence cursor, lifted **verbatim** out of `redactors.ResolveOverlaps` and now shared with it, so there is one definition of "where is this match" instead of two. Its interned line id — identifying a line by number *and* text — is preserved exactly; that is what stops offsets being compared across Office parts that both report "line 1".

Populated in `parallel.RunValidators`, the single point every match in the system passes through: the worker pool calls it per file (covering the CLI, `core.ScanFile` and the redaction path) and `core.ScanContent` calls it directly. It runs *after* the union is restored to launch order — assigning occurrences in goroutine-completion order would hand the same finding a different column run to run.

## The gitlab id is deliberately unchanged

The collapse is fixed by an emit-time collision guard, **not** by mixing the column into the hash. Mutation testing showed the column there is unnecessary — the guard alone separates every case, including the position-less findings a column cannot help — while mixing it in changes the id of *every* finding that has one, silently detaching an operator's existing GitLab triage state (dismissals, issue links) from the findings it belongs to.

Verified: the id for a single finding is **byte-identical to main**; duplicates now get `<id>` and `<id>-1`.

## The golden corpus was blind to this

`corpus.go` normalizes the id to `ferret-<HASH>` because the raw hash varies with the per-run temp dir — so nine distinct ids and one repeated id look identical. The corpus **did** contain a collapse (two `DATE_OF_BIRTH` findings on line 4 of `new_validators_display_formats` sharing one id) and it rendered as two identical tokens.

Exactly one golden line moves here, to `ferret-<HASH>-1`. Tightening the normalizer so id identity is visible is worth doing and is left as a follow-up; the unit tests are the guard meanwhile.

## Non-vacuity

Each mutation fails its own test:

| mutation | failure |
|---|---|
| remove the `RunValidators` wiring | `match 0 has no column` |
| SARIF ignores the recorded column | `both results report region {9 26}` |
| drop the collision guard | `4 vulnerabilities collapsed to 2 ids` |

The formatter tests alone would **not** have caught the first — they set columns by hand. That is why the wiring test exists.

`make all` green; full suite 66 packages, 0 failures.