### PR TITLE
fix(cli): count a file refused for size as unexamined, and decide the warning from capability

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1549,6 +1549,33 @@ func main() {
 			}
 			os.Exit(2) // Use exit code 2 for no files to process as per design
 		} else {
+			// Disclose discovery-time coverage losses BEFORE exiting.
+			//
+			// This path used to print "No files to process" and exit 0 unconditionally,
+			// which is the exact artifact this report exists to prevent. A single
+			// oversize processable file is refused at discovery, so filesToProcess is
+			// empty and every disclosure downstream — collectUnscanned, the stats
+			// denominator, the NOT FULLY EXAMINED block, and both
+			// resolveIncompleteExitCode calls — was skipped. The run reported a clean,
+			// complete result for a file it never opened, and --fail-on-incomplete
+			// returned 0. It also printed strictly LESS than before this branch, because
+			// discovery warnings were deferred to a report that never ran.
+			//
+			// Same shape for a directory or glob whose inputs are ALL refused.
+			if len(discoveryUnexamined) > 0 {
+				entries := make([]unscannedEntry, 0, len(discoveryUnexamined))
+				for _, u := range discoveryUnexamined {
+					entries = append(entries, unscannedEntry{Path: u.Path, Cause: u.Cause, Detail: u.Reason})
+				}
+				var report strings.Builder
+				if writeUnscannedReport(&report, entries, len(entries), *failOnIncomplete, finalConfig.debug) {
+					fmt.Fprint(os.Stderr, report.String())
+				}
+				fmt.Println("No files to process")
+				// Honour the flag: these files were expected to produce results and did
+				// not, which is precisely what code 3 means.
+				os.Exit(resolveIncompleteExitCode(0, finalConfig.failOnIncomplete, len(entries)))
+			}
 			fmt.Println("No files to process")
 			os.Exit(0)
 		}
@@ -2663,7 +2690,6 @@ func getFilesToProcess(inputPath string, recursive bool, excludePatterns []strin
 						Reason: "file too large (max size: 100MB)",
 						Cause:  causeTooLarge,
 					})
-					skippedFiles = append(skippedFiles, cleanWalkPath)
 				} else {
 					// Unprocessable at any size: a genuine skip.
 					result.SkippedFiles = append(result.SkippedFiles, SkippedFile{
@@ -2671,8 +2697,13 @@ func getFilesToProcess(inputPath string, recursive bool, excludePatterns []strin
 						Reason: "file too large (max size: 100MB)",
 						Silent: true,
 					})
-					skippedFiles = append(skippedFiles, cleanWalkPath)
 				}
+				// Deliberately NOT added to the walk's local skippedFiles slice, which
+				// feeds only "Skipped N files or directories due to errors". A size
+				// refusal is not a walk error, and both branches above now record the
+				// file in a real counter — so appending there both mislabelled it and
+				// reported the same file twice, once as an error and once in the
+				// NOT FULLY EXAMINED block.
 			} else if info.Mode()&os.ModeSymlink != 0 {
 				// A symlink. filepath.Walk hands us Lstat info, so a link is never
 				// ModeRegular and used to fall past the branch above with NO else —

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1502,9 +1502,14 @@ func main() {
 			}
 		}
 
-		result, err := getFilesToProcess(cleanPath, finalConfig.recursive, finalConfig.excludePatterns, ignoreMatcher)
+		result, err := getFilesToProcess(cleanPath, finalConfig.recursive, finalConfig.excludePatterns, ignoreMatcher, finalConfig.enablePreprocessors)
 		if err != nil {
-			fmt.Printf("Error processing %s: %v\n", inputPath, err)
+			// stderr, not stdout: this is on the scan path, and a caller redirecting
+			// stdout to a machine artifact (--format json > report.json) would
+			// otherwise get a diagnostic spliced into the middle of the document,
+			// leaving an unparseable file at exit 0. Same defect class as the
+			// media-error write already moved off stdout.
+			fmt.Fprintf(os.Stderr, "Error processing %s: %v\n", inputPath, err)
 			continue
 		}
 
@@ -1920,16 +1925,24 @@ func main() {
 	// unreadable channel. Filing "resolves outside the scanned directory" under "cannot
 	// read" would assert a failure that never happened — the file is readable, the tool
 	// declined — and the operator's remedy differs.
-	notFollowed := make([]parallel.FileDiagnostic, 0, len(discoveryUnexamined))
+	// Each discovery refusal carries the cause its producer assigned, rather than all
+	// of them being labelled the same. Discovery is the only place that knows why it
+	// declined: a symlink out of the tree and a 105MB document are both unexamined,
+	// but the operator's remedy differs and so does the wording.
+	discoveryEntries := make([]unscannedEntry, 0, len(discoveryUnexamined))
 	for _, u := range discoveryUnexamined {
-		notFollowed = append(notFollowed, parallel.FileDiagnostic{FilePath: u.Path, Reason: u.Reason})
+		discoveryEntries = append(discoveryEntries, unscannedEntry{
+			Path:   u.Path,
+			Cause:  u.Cause,
+			Detail: u.Reason,
+		})
 		// Counted as not-processed for the same reason an unreadable file is: it was
 		// considered and produced nothing, so leaving it out of every counter is what
 		// made the loss invisible.
 		unreadableCount++
 	}
 
-	unscannedEntries := collectUnscanned(unreadableFiles, emptyExtractionFiles, failedProcessingFiles, incompleteFiles, notFollowed)
+	unscannedEntries := collectUnscanned(unreadableFiles, emptyExtractionFiles, failedProcessingFiles, incompleteFiles, discoveryEntries)
 
 	if precommitConfig == nil {
 		// The unredacted warning stays here; the not-examined report is emitted AFTER
@@ -2335,16 +2348,15 @@ type SkippedFile struct {
 	Path   string
 	Reason string
 	Silent bool // true = don't show to user, false = show as warning
-}
 
-// isUnsupportedType checks if a file extension is an unsupported type that should be silently skipped
-func isUnsupportedType(ext string) bool {
-	unsupportedTypes := map[string]bool{
-		".mp4": true, ".mov": true, ".avi": true, ".mkv": true,
-		".dmg": true, ".iso": true, ".img": true,
-		".zip": true, ".tar": true, ".gz": true, ".7z": true,
-	}
-	return unsupportedTypes[ext]
+	// Cause classifies an entry carried in ProcessingResult.UnexaminedFiles, so the
+	// report can say WHY discovery declined. It is unused for SkippedFiles, which are
+	// by definition entries nobody expected a result from.
+	//
+	// Every UnexaminedFiles producer must set it. The zero value is causeUnreadable,
+	// which would claim the file could not be opened — a failure that did not happen
+	// for anything discovery declines on purpose.
+	Cause unscannedCause
 }
 
 // isExcluded checks if a file path matches any of the exclusion patterns
@@ -2390,7 +2402,10 @@ func isExcluded(filePath string, excludePatterns []string) bool {
 
 // getFilesToProcess returns a list of files to process based on the input path
 // Supports glob patterns like *.pdf, files, and directories
-func getFilesToProcess(inputPath string, recursive bool, excludePatterns []string, ignoreMatcher *gitignore.Matcher) (*ProcessingResult, error) {
+// enablePreprocessors is needed to answer whether a size-refused file's TYPE was one
+// the tool could have processed: without preprocessors a .docx is not processable, so
+// refusing it for size loses nothing the run was going to find anyway.
+func getFilesToProcess(inputPath string, recursive bool, excludePatterns []string, ignoreMatcher *gitignore.Matcher, enablePreprocessors bool) (*ProcessingResult, error) {
 	result := &ProcessingResult{
 		FilesToProcess:  []string{},
 		SkippedFiles:    []SkippedFile{},
@@ -2440,20 +2455,24 @@ func getFilesToProcess(inputPath string, recursive bool, excludePatterns []strin
 				result.FilesToProcess = append(result.FilesToProcess, inputPath)
 				return result, nil
 			}
-			// Skip large unsupported files silently
+			// A file refused for size. Whether that is a coverage LOSS depends on
+			// whether the tool could have processed its type at all — see
+			// router.CanProcessType. An unprocessable type is a genuine skip; a
+			// processable one was expected to produce a result and did not.
 			limitMB := sizeLimit / (1024 * 1024)
-			if isUnsupportedType(ext) {
-				result.SkippedFiles = append(result.SkippedFiles, SkippedFile{
+			reason := fmt.Sprintf("file too large (max size: %dMB)", limitMB)
+			if router.CanProcessType(inputPath, enablePreprocessors) {
+				result.UnexaminedFiles = append(result.UnexaminedFiles, SkippedFile{
 					Path:   inputPath,
-					Reason: fmt.Sprintf("file too large (max size: %dMB)", limitMB),
-					Silent: true,
+					Reason: reason,
+					Cause:  causeTooLarge,
 				})
 				return result, nil
 			}
 			result.SkippedFiles = append(result.SkippedFiles, SkippedFile{
 				Path:   inputPath,
-				Reason: fmt.Sprintf("file too large (max size: %dMB)", limitMB),
-				Silent: false,
+				Reason: reason,
+				Silent: true,
 			})
 			return result, nil
 		}
@@ -2503,17 +2522,28 @@ func getFilesToProcess(inputPath string, recursive bool, excludePatterns []strin
 
 				if info.Size() <= 100*1024*1024 {
 					filesToProcess = append(filesToProcess, cleanMatch)
+				} else if router.CanProcessType(cleanMatch, enablePreprocessors) {
+					// A processable type refused for size is a coverage LOSS, so it has
+					// to reach a counter. Previously this branch wrote a bare stderr
+					// warning and recorded the file nowhere: absent from total_files,
+					// from files_skipped and from files_not_examined, so the machine
+					// artifact described a complete clean scan and --fail-on-incomplete
+					// exited 0. The warning was the only trace, and it is exactly what
+					// CI discards.
+					result.UnexaminedFiles = append(result.UnexaminedFiles, SkippedFile{
+						Path:   cleanMatch,
+						Reason: "file too large (max size: 100MB)",
+						Cause:  causeTooLarge,
+					})
 				} else {
-					// Skip large unsupported files silently
-					ext := strings.ToLower(filepath.Ext(cleanMatch))
-					unsupportedTypes := map[string]bool{
-						".mp4": true, ".mov": true, ".avi": true, ".mkv": true,
-						".dmg": true, ".iso": true, ".img": true,
-						".zip": true, ".tar": true, ".gz": true, ".7z": true,
-					}
-					if !unsupportedTypes[ext] {
-						fmt.Fprintf(os.Stderr, "Warning: Skipping %s: file too large (> 100MB)\n", cleanMatch)
-					}
+					// Unprocessable at any size: a genuine skip, nobody expected a
+					// finding. Recorded rather than dropped so it stays in the
+					// denominator.
+					result.SkippedFiles = append(result.SkippedFiles, SkippedFile{
+						Path:   cleanMatch,
+						Reason: "file too large (max size: 100MB)",
+						Silent: true,
+					})
 				}
 			}
 		}
@@ -2540,21 +2570,22 @@ func getFilesToProcess(inputPath string, recursive bool, excludePatterns []strin
 
 	// If it's a regular file, just process it
 	if fileInfo.Mode().IsRegular() {
-		// Skip large files silently for unsupported types
+		// A file refused for size — see the identical decision on the glob path above
+		// and router.CanProcessType.
 		if fileInfo.Size() > 100*1024*1024 { // 100MB limit
-			ext := strings.ToLower(filepath.Ext(inputPath))
-			if isUnsupportedType(ext) {
-				result.SkippedFiles = append(result.SkippedFiles, SkippedFile{
+			const reason = "file too large (max size: 100MB)"
+			if router.CanProcessType(inputPath, enablePreprocessors) {
+				result.UnexaminedFiles = append(result.UnexaminedFiles, SkippedFile{
 					Path:   inputPath,
-					Reason: "file too large (max size: 100MB)",
-					Silent: true,
+					Reason: reason,
+					Cause:  causeTooLarge,
 				})
-				return result, nil // Skip silently
+				return result, nil
 			}
 			result.SkippedFiles = append(result.SkippedFiles, SkippedFile{
 				Path:   inputPath,
-				Reason: "file too large (max size: 100MB)",
-				Silent: false,
+				Reason: reason,
+				Silent: true,
 			})
 			return result, nil
 		}
@@ -2623,17 +2654,23 @@ func getFilesToProcess(inputPath string, recursive bool, excludePatterns []strin
 				// Check file size
 				if info.Size() <= 100*1024*1024 { // 100MB limit
 					filesToProcess = append(filesToProcess, cleanWalkPath)
+				} else if router.CanProcessType(cleanWalkPath, enablePreprocessors) {
+					// Processable type refused for size: a coverage loss, so it must reach
+					// files_not_examined and --fail-on-incomplete rather than only a
+					// stderr line that CI discards. See the glob path above.
+					result.UnexaminedFiles = append(result.UnexaminedFiles, SkippedFile{
+						Path:   cleanWalkPath,
+						Reason: "file too large (max size: 100MB)",
+						Cause:  causeTooLarge,
+					})
+					skippedFiles = append(skippedFiles, cleanWalkPath)
 				} else {
-					// Skip large unsupported files silently
-					ext := strings.ToLower(filepath.Ext(cleanWalkPath))
-					unsupportedTypes := map[string]bool{
-						".mp4": true, ".mov": true, ".avi": true, ".mkv": true,
-						".dmg": true, ".iso": true, ".img": true,
-						".zip": true, ".tar": true, ".gz": true, ".7z": true,
-					}
-					if !unsupportedTypes[ext] {
-						fmt.Fprintf(os.Stderr, "Warning: Skipping %s: file too large (> 100MB)\n", cleanWalkPath)
-					}
+					// Unprocessable at any size: a genuine skip.
+					result.SkippedFiles = append(result.SkippedFiles, SkippedFile{
+						Path:   cleanWalkPath,
+						Reason: "file too large (max size: 100MB)",
+						Silent: true,
+					})
 					skippedFiles = append(skippedFiles, cleanWalkPath)
 				}
 			} else if info.Mode()&os.ModeSymlink != 0 {

--- a/cmd/oversize_unexamined_test.go
+++ b/cmd/oversize_unexamined_test.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -268,5 +269,123 @@ func TestSymlinkDisclosureCarriesItsCause(t *testing.T) {
 		t.Errorf("cause = %v (%q), want causeNotFollowed. The zero value claims the link "+
 			"could not be read, which is not what happened — the tool declined to follow it",
 			disclose[0].Cause, disclose[0].Cause.String())
+	}
+}
+
+// The collapsed per-cause breakdown must account for EVERY entry the header counts.
+//
+// Above inlineDetailLimit entries the report prints a per-cause tally instead of paths,
+// and that tally iterated a hardcoded list of the four ORIGINAL causes while the header
+// printed len(entries). Every cause added since was counted in the header and given no
+// bucket line: causeNotFollowed (#326) and causeTooLarge (#324) both vanished.
+//
+// Measured on a ~1,870-file scan, the header read 65 while the buckets summed to 64 —
+// and the entry missing from the breakdown was exactly the oversize file this report
+// exists to disclose. See #336.
+//
+// The assertion is the INVARIANT rather than a list of expected labels: buckets must sum
+// to the header, whatever the cause set becomes. A future cause therefore cannot regress
+// this the way the last two did.
+func TestBreakdownAccountsForEveryCause(t *testing.T) {
+	allCauses := []unscannedCause{
+		causeUnreadable, causeUnparseable, causeNoText, causeCutShort,
+		causeNotFollowed, causeTooLarge,
+	}
+
+	// More than inlineDetailLimit entries, so the collapsed tally path is taken.
+	var entries []unscannedEntry
+	want := map[unscannedCause]int{}
+	for i, c := range allCauses {
+		n := i + 2 // distinct per-cause counts, so a mis-attributed bucket shows up
+		for j := 0; j < n; j++ {
+			entries = append(entries, unscannedEntry{
+				Path:   fmt.Sprintf("/f/%d-%d.txt", i, j),
+				Cause:  c,
+				Detail: "detail",
+			})
+		}
+		want[c] = n
+	}
+	if len(entries) <= inlineDetailLimit {
+		t.Fatalf("fixture has %d entries, need more than %d to exercise the collapsed tally",
+			len(entries), inlineDetailLimit)
+	}
+
+	var buf strings.Builder
+	if !writeUnscannedReport(&buf, entries, len(entries), false, false) {
+		t.Fatal("writeUnscannedReport reported nothing to write")
+	}
+	out := buf.String()
+
+	// Every cause must have a bucket, with the right count.
+	sum := 0
+	for c, n := range want {
+		label := fmt.Sprintf("%s: %d", c, n)
+		if !strings.Contains(out, label) {
+			t.Errorf("breakdown is missing %q.\nA cause counted in the header with no bucket "+
+				"line is invisible to the operator — and the last two causes added were the "+
+				"symlink and oversize disclosures.\n--- report ---\n%s", label, out)
+		}
+		sum += n
+	}
+
+	// The invariant: buckets sum to the header count.
+	if !strings.Contains(out, fmt.Sprintf("NOT FULLY EXAMINED: %d of %d", len(entries), len(entries))) {
+		t.Errorf("header does not report %d entries.\n--- report ---\n%s", len(entries), out)
+	}
+	if sum != len(entries) {
+		t.Fatalf("fixture inconsistent: buckets sum to %d, header counts %d", sum, len(entries))
+	}
+}
+
+// A SOLO oversize processable file is the third discovery route, and the one that was
+// missing from the route table above.
+//
+// Its FilesToProcess is empty, which sent main() down the "No files to process" early
+// exit: it printed one stdout line and exited 0, BEFORE the unscanned report and the
+// --fail-on-incomplete gate. So the one invocation this feature exists for produced a
+// silent, complete-looking, zero-exit result. Both existing route fixtures create a
+// small companion file, so FilesToProcess was never empty in any test. See #339.
+func TestSoloOversizeFileIsUnexaminedWithEmptyQueue(t *testing.T) {
+	dir := t.TempDir()
+	solo := bigTextFile(t, filepath.Join(dir, "big_report.txt"))
+
+	res, err := getFilesToProcess(solo, false, nil, nil, true)
+	if err != nil {
+		t.Fatalf("getFilesToProcess: %v", err)
+	}
+
+	if len(res.FilesToProcess) != 0 {
+		t.Errorf("FilesToProcess = %v, want empty — the file is over the limit", res.FilesToProcess)
+	}
+	if len(res.UnexaminedFiles) != 1 {
+		t.Fatalf("UnexaminedFiles = %v, want exactly the oversize file", pathsOf(res.UnexaminedFiles))
+	}
+	if res.UnexaminedFiles[0].Cause != causeTooLarge {
+		t.Errorf("cause = %q, want causeTooLarge", res.UnexaminedFiles[0].Cause.String())
+	}
+
+	// The report must be produced for this entry: an empty scan queue must not mean an
+	// empty disclosure.
+	entries := []unscannedEntry{{
+		Path:   res.UnexaminedFiles[0].Path,
+		Cause:  res.UnexaminedFiles[0].Cause,
+		Detail: res.UnexaminedFiles[0].Reason,
+	}}
+	var buf strings.Builder
+	if !writeUnscannedReport(&buf, entries, len(entries), true, false) {
+		t.Fatal("no report written for a run whose only input was refused")
+	}
+	if !strings.Contains(buf.String(), "file too large to scan") {
+		t.Errorf("report does not name the cause:\n%s", buf.String())
+	}
+
+	// And it must escalate under --fail-on-incomplete.
+	if got := resolveIncompleteExitCode(0, true, len(entries)); got != 3 {
+		t.Errorf("resolveIncompleteExitCode = %d, want 3 — a refused input is exactly the "+
+			"coverage loss this flag exists to surface", got)
+	}
+	if got := resolveIncompleteExitCode(0, false, len(entries)); got != 0 {
+		t.Errorf("resolveIncompleteExitCode without the flag = %d, want 0", got)
 	}
 }

--- a/cmd/oversize_unexamined_test.go
+++ b/cmd/oversize_unexamined_test.go
@@ -1,0 +1,272 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/formatters"
+)
+
+// A file refused for being over the size limit must be COUNTED, and its treatment
+// must follow from whether the tool could have processed its type.
+//
+// Before this, a size refusal reached no counter anywhere. Measured on a directory
+// holding one 105MB file plus a small file with an SSN:
+//
+//	Files: 1 scanned | Findings: 1
+//	total_files 1, files_skipped 0, files_not_examined absent
+//	--fail-on-incomplete -> exit 0
+//
+// So the artifact described a complete, clean scan of a directory containing a file
+// that was never opened. The only trace was a stderr line, which is exactly what CI
+// discards when it redirects stdout to a report. See #324.
+//
+// The warning decision was also a hardcoded 11-extension list, duplicated at three
+// call sites, so the tool was quiet about a few known-big binary types and noisy about
+// everything else — including files it could never have scanned at any size, and
+// including browser partial downloads whose random suffixes no list can cover.
+
+// bigTextFile writes a sparse file over the limit whose FIRST 512 bytes are real text.
+//
+// The leading text has to fill more than the sniff window: Truncate extends with NULs,
+// so a file with only a line or two of text sniffs as binary and the fixture silently
+// tests the wrong branch.
+func bigTextFile(t *testing.T, path string) string {
+	t.Helper()
+	f, err := os.Create(path) // #nosec G304 -- test temp dir
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 40; i++ {
+		if _, err := f.WriteString("Quarterly report text content.\n"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := f.Truncate(101 * 1024 * 1024); err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+	return path
+}
+
+// bigOpaqueFile writes a sparse over-limit file of binary bytes with a random-suffix
+// name, the browser-partial-download shape no extension list can match.
+func bigOpaqueFile(t *testing.T, path string) string {
+	t.Helper()
+	f, err := os.Create(path) // #nosec G304 -- test temp dir
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write(make([]byte, 600)); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Truncate(101 * 1024 * 1024); err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+	return path
+}
+
+func pathsOf(entries []SkippedFile) []string {
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, filepath.Base(e.Path))
+	}
+	return out
+}
+
+// All three discovery routes must agree: single file, glob, and recursive walk.
+func TestOversizeProcessableFileIsUnexamined(t *testing.T) {
+	routes := []struct {
+		name  string
+		input func(dir string) string
+		rec   bool
+	}{
+		{"directory walk", func(dir string) string { return dir }, true},
+		{"glob", func(dir string) string { return filepath.Join(dir, "*") }, false},
+	}
+
+	for _, route := range routes {
+		t.Run(route.name, func(t *testing.T) {
+			dir := t.TempDir()
+			bigTextFile(t, filepath.Join(dir, "big_report.txt"))
+			bigOpaqueFile(t, filepath.Join(dir, ".com.brave.Browser.ABCdef"))
+			small := filepath.Join(dir, "normal.txt")
+			if err := os.WriteFile(small, []byte("SSN: 452-11-9384\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			res, err := getFilesToProcess(route.input(dir), route.rec, nil, nil, true)
+			if err != nil {
+				t.Fatalf("getFilesToProcess: %v", err)
+			}
+
+			// The small file is scanned.
+			if len(res.FilesToProcess) != 1 || filepath.Base(res.FilesToProcess[0]) != "normal.txt" {
+				t.Errorf("FilesToProcess = %v, want just normal.txt", res.FilesToProcess)
+			}
+
+			// The oversize TEXT file is a coverage loss: unexamined, with its own cause.
+			var found *SkippedFile
+			for i := range res.UnexaminedFiles {
+				if filepath.Base(res.UnexaminedFiles[i].Path) == "big_report.txt" {
+					found = &res.UnexaminedFiles[i]
+				}
+			}
+			if found == nil {
+				t.Fatalf("big_report.txt is not in UnexaminedFiles %v — a processable file "+
+					"refused for size was expected to produce a result and did not, so it must "+
+					"reach files_not_examined and --fail-on-incomplete",
+					pathsOf(res.UnexaminedFiles))
+			}
+			if found.Cause != causeTooLarge {
+				t.Errorf("cause = %v (%q), want causeTooLarge. The zero value is causeUnreadable, "+
+					"which would claim the file could not be opened — a failure that did not happen",
+					found.Cause, found.Cause.String())
+			}
+			if !strings.Contains(found.Reason, "too large") {
+				t.Errorf("reason = %q, want it to say the file was too large", found.Reason)
+			}
+			// Payload-free: the reason reaches stderr and every machine format.
+			if strings.Contains(found.Reason, "452-11-9384") {
+				t.Errorf("reason %q leaked file content", found.Reason)
+			}
+
+			// The opaque binary is a genuine SKIP, and silent: nothing would have read
+			// it at any size, so a warning would be noise about a non-event.
+			var opaque *SkippedFile
+			for i := range res.SkippedFiles {
+				if strings.Contains(res.SkippedFiles[i].Path, "Browser") {
+					opaque = &res.SkippedFiles[i]
+				}
+			}
+			if opaque == nil {
+				t.Fatalf("the opaque binary is not in SkippedFiles %v — it must still be "+
+					"recorded so it stays in the denominator", pathsOf(res.SkippedFiles))
+			}
+			if !opaque.Silent {
+				t.Error("the opaque binary produced a visible warning; no extension list can " +
+					"ever cover random-suffix partial downloads, which is why the predicate " +
+					"must be capability-derived")
+			}
+			for _, u := range res.UnexaminedFiles {
+				if strings.Contains(u.Path, "Browser") {
+					t.Error("the opaque binary was reported as unexamined; nothing would have " +
+						"read it, so no coverage was lost")
+				}
+			}
+		})
+	}
+}
+
+// With preprocessors DISABLED, an oversize binary document is not a coverage loss:
+// nothing would have read it either way.
+func TestOversizeBinaryDocumentWithoutPreprocessorsIsASkip(t *testing.T) {
+	dir := t.TempDir()
+	// A .docx is a binary document: processable only with preprocessors.
+	f, err := os.Create(filepath.Join(dir, "big.docx")) // #nosec G304 -- test temp dir
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte("PK\x03\x04")); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Truncate(101 * 1024 * 1024); err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+
+	withPre, err := getFilesToProcess(dir, true, nil, nil, true)
+	if err != nil {
+		t.Fatalf("getFilesToProcess: %v", err)
+	}
+	if len(withPre.UnexaminedFiles) != 1 {
+		t.Errorf("with preprocessors: UnexaminedFiles = %v, want the .docx — its content "+
+			"would have been extracted and scanned", pathsOf(withPre.UnexaminedFiles))
+	}
+
+	without, err := getFilesToProcess(dir, true, nil, nil, false)
+	if err != nil {
+		t.Fatalf("getFilesToProcess: %v", err)
+	}
+	if len(without.UnexaminedFiles) != 0 {
+		t.Errorf("without preprocessors: UnexaminedFiles = %v, want none — nothing would "+
+			"have read a .docx, so refusing it for size loses nothing",
+			pathsOf(without.UnexaminedFiles))
+	}
+}
+
+// Every cmd-side cause must map to a distinct formatter cause.
+//
+// causeNotFollowed had no case in the mapping switch and fell through to the
+// conservative default, so machine formats said "cannot read" for every refused
+// symlink while the text report said "symlink not followed" — a file the tool
+// deliberately declined, reported as an I/O failure that never happened.
+func TestEveryCauseMapsToItsOwnFormatterCause(t *testing.T) {
+	cases := []struct {
+		cause unscannedCause
+		want  formatters.NotExaminedCause
+	}{
+		{causeUnreadable, formatters.NotExaminedUnreadable},
+		{causeUnparseable, formatters.NotExaminedUnparseable},
+		{causeNoText, formatters.NotExaminedNoText},
+		{causeCutShort, formatters.NotExaminedCutShort},
+		{causeNotFollowed, formatters.NotExaminedNotFollowed},
+		{causeTooLarge, formatters.NotExaminedTooLarge},
+	}
+
+	seen := make(map[formatters.NotExaminedCause]unscannedCause, len(cases))
+	for _, c := range cases {
+		got := toFormatterNotExamined([]unscannedEntry{{Path: "f", Cause: c.cause, Detail: "d"}})
+		if len(got) != 1 {
+			t.Fatalf("cause %v produced %d entries", c.cause, len(got))
+		}
+		if got[0].Cause != c.want {
+			t.Errorf("cause %v (%q) mapped to %q, want %q — an unmapped cause silently "+
+				"becomes 'cannot read', asserting a failure that did not happen",
+				c.cause, c.cause.String(), got[0].Cause.String(), c.want.String())
+		}
+		if prev, dup := seen[c.want]; dup {
+			t.Errorf("formatter cause %q is used by both %v and %v; the two are "+
+				"indistinguishable in every machine format", c.want.String(), prev, c.cause)
+		}
+		seen[c.want] = c.cause
+		// The two sides must also agree on the wording, since an operator compares a
+		// human report against a machine artifact from the same run.
+		if c.cause.String() != c.want.String() {
+			t.Errorf("wording differs: cmd says %q, formatter says %q",
+				c.cause.String(), c.want.String())
+		}
+	}
+}
+
+// A refused symlink must keep its own cause through discovery. The cause now travels
+// on SkippedFile, and the zero value is causeUnreadable, so a producer that forgets to
+// set it silently mislabels the entry.
+func TestSymlinkDisclosureCarriesItsCause(t *testing.T) {
+	root := t.TempDir()
+	link := filepath.Join(root, "dangling.txt")
+	if err := os.Symlink(filepath.Join(root, "nope.txt"), link); err != nil {
+		t.Skipf("cannot create symlinks here: %v", err)
+	}
+
+	d, resolved, reason := classifySymlink(link, root, 100*1024*1024)
+	if d != symlinkDisclose {
+		t.Fatalf("fixture: disposition = %v, want symlinkDisclose", d)
+	}
+	_, disclose := resolveSymlinkCandidates(
+		[]symlinkCandidate{{linkPath: link, resolved: resolved, reason: reason, disp: d}}, nil)
+	if len(disclose) != 1 {
+		t.Fatalf("got %d disclosures, want 1", len(disclose))
+	}
+	if disclose[0].Cause != causeNotFollowed {
+		t.Errorf("cause = %v (%q), want causeNotFollowed. The zero value claims the link "+
+			"could not be read, which is not what happened — the tool declined to follow it",
+			disclose[0].Cause, disclose[0].Cause.String())
+	}
+}

--- a/cmd/symlink_walk.go
+++ b/cmd/symlink_walk.go
@@ -172,7 +172,14 @@ func resolveSymlinkCandidates(cands []symlinkCandidate, queued []string) (follow
 	for _, c := range cands {
 		switch c.disp {
 		case symlinkDisclose:
-			disclose = append(disclose, SkippedFile{Path: c.linkPath, Reason: c.reason})
+			// Cause must be set explicitly. It reaches the not-examined report, and the
+			// zero value is causeUnreadable — which would claim the link could not be
+			// opened, a failure that did not happen for anything refused on purpose.
+			disclose = append(disclose, SkippedFile{
+				Path:   c.linkPath,
+				Reason: c.reason,
+				Cause:  causeNotFollowed,
+			})
 		case symlinkFollow:
 			if _, dup := covered[c.resolved]; dup {
 				// Content already scanned through its real path. Silent on purpose:

--- a/cmd/unscanned_report.go
+++ b/cmd/unscanned_report.go
@@ -394,7 +394,24 @@ func writeUnscannedReport(w io.Writer, entries []unscannedEntry, totalFiles int,
 		// Too many to list. Give the per-cause tally and stop; the paths go to a
 		// file in a follow-up change, and until then --debug still lists them.
 		var parts []string
-		for _, c := range []unscannedCause{causeUnreadable, causeUnparseable, causeNoText, causeCutShort} {
+		// Derived from the causes actually PRESENT, never from a hardcoded list.
+		//
+		// This loop used to name the four original causes explicitly while the header
+		// two lines above printed len(entries), which counts them all. Every cause added
+		// since was therefore counted in the header and given no bucket line:
+		// causeNotFollowed (refused symlinks) and causeTooLarge (oversize files) both
+		// vanished from the breakdown. Measured on a ~1,870-file scan, the header read 65
+		// while the buckets summed to 64 — and the file missing from the breakdown was
+		// exactly the oversize file this report exists to disclose.
+		//
+		// Sorting by the cause's numeric value preserves the deliberate presentation
+		// order, because the enum is declared least-to-most partial coverage.
+		present := make([]unscannedCause, 0, len(count))
+		for c := range count {
+			present = append(present, c)
+		}
+		sort.Slice(present, func(i, j int) bool { return present[i] < present[j] })
+		for _, c := range present {
 			if count[c] > 0 {
 				parts = append(parts, fmt.Sprintf("%s: %d", c, count[c]))
 			}

--- a/cmd/unscanned_report.go
+++ b/cmd/unscanned_report.go
@@ -58,6 +58,20 @@ const (
 	// fixed with chmod, a link out of the tree is fixed by scanning the target directly
 	// or passing it explicitly. See #326.
 	causeNotFollowed
+	// causeTooLarge is a file that exceeds the size limit and was therefore never
+	// opened, whose TYPE the tool would otherwise have processed.
+	//
+	// A size-refused file was previously recorded as "skipped", which is the wrong
+	// half of a distinction ScanStats itself draws: a skipped file is an unsupported
+	// type nobody expected a result for, an unexamined one was expected to produce
+	// something and did not. Worse, a size refusal reached no counter at all — not
+	// total_files, not files_skipped, not files_not_examined — so a directory holding
+	// a 105MB document reported a complete, clean scan and --fail-on-incomplete
+	// exited 0. See #324.
+	//
+	// An UNPROCESSABLE type refused for size gets no entry here at all; it is a
+	// genuine skip, because no finding was ever possible from it.
+	causeTooLarge
 )
 
 func (c unscannedCause) String() string {
@@ -75,6 +89,8 @@ func (c unscannedCause) String() string {
 		return "coverage cut short"
 	case causeNotFollowed:
 		return "symlink not followed"
+	case causeTooLarge:
+		return "file too large to scan"
 	default:
 		return "unknown"
 	}
@@ -119,6 +135,10 @@ func toFormatterNotExamined(entries []unscannedEntry) []formatters.NotExaminedFi
 			cause = formatters.NotExaminedNoText
 		case causeCutShort:
 			cause = formatters.NotExaminedCutShort
+		case causeNotFollowed:
+			cause = formatters.NotExaminedNotFollowed
+		case causeTooLarge:
+			cause = formatters.NotExaminedTooLarge
 		default:
 			cause = formatters.NotExaminedUnreadable
 		}
@@ -243,16 +263,19 @@ func collectUnscanned(
 	emptyExtraction []parallel.FileDiagnostic,
 	failed []parallel.FileDiagnostic,
 	incomplete []parallel.FileDiagnostic,
-	notFollowed []parallel.FileDiagnostic,
+	discovery []unscannedEntry,
 ) []unscannedEntry {
 	var out []unscannedEntry
 
-	// Links the walk refused. These come from DISCOVERY rather than from scanning, and
-	// before #326 they reached no channel at all: a symlink was dropped with no record
-	// anywhere, so its content was neither scanned nor disclosed.
-	for _, d := range notFollowed {
-		out = append(out, unscannedEntry{Path: d.FilePath, Cause: causeNotFollowed, Detail: d.Reason})
-	}
+	// Coverage losses found while DISCOVERING files rather than while scanning them:
+	// a symlink the walk refused (#326), a file refused for size (#324). Before those
+	// they reached no channel at all — dropped with no record anywhere, so the content
+	// was neither scanned nor disclosed.
+	//
+	// These arrive already classified, because discovery is the only place that knows
+	// WHY it declined. Forcing them all to one cause is what made every refused
+	// symlink and every oversize file share a label.
+	out = append(out, discovery...)
 
 	// The unreadable channel is a pre-formatted "path: reason" string rather than
 	// a struct, so it needs splitting on the first colon that follows the path.

--- a/internal/formatters/notexamined.go
+++ b/internal/formatters/notexamined.go
@@ -67,6 +67,28 @@ const (
 	// NotExaminedCutShort — a budget, size cap or timeout fired, so the file is
 	// PARTLY scanned. Findings from it may be present and incomplete.
 	NotExaminedCutShort
+
+	// NotExaminedNotFollowed — a symlink the walk deliberately did not follow: it
+	// dangles or loops, names a directory or a device, or resolves outside the
+	// scanned tree.
+	//
+	// Distinct from NotExaminedUnreadable because for most of these the file COULD
+	// have been read — the tool declined. Reporting them as "cannot read" asserts a
+	// failure that did not happen, and the operator's remedy differs: a permission
+	// problem is fixed with chmod, a link out of the tree by scanning the target
+	// directly.
+	//
+	// The cmd side has had this cause since #326, but it was never mapped here and
+	// fell through to NotExaminedUnreadable, so machine formats said "cannot read"
+	// for every refused symlink while the text report said "symlink not followed" —
+	// the exact mislabelling the cmd-side comment warns a new cause would cause.
+	NotExaminedNotFollowed
+
+	// NotExaminedTooLarge — the file exceeds the size limit, so it was never opened.
+	//
+	// Its type WAS one the tool would have processed; an unprocessable type refused
+	// for size is not reported at all, because nobody expected a finding from it.
+	NotExaminedTooLarge
 )
 
 // String returns the operator-facing cause label.
@@ -88,6 +110,10 @@ func (c NotExaminedCause) String() string {
 		return "no body text (metadata still scanned)"
 	case NotExaminedCutShort:
 		return "coverage cut short"
+	case NotExaminedNotFollowed:
+		return "symlink not followed"
+	case NotExaminedTooLarge:
+		return "file too large to scan"
 	default:
 		return "unknown"
 	}

--- a/internal/router/can_process_type_test.go
+++ b/internal/router/can_process_type_test.go
@@ -1,0 +1,134 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package router
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// CanProcessType must answer "would we process this TYPE" without consulting size.
+//
+// CanProcessFile cannot be used for this: its own size gate returns "File too large"
+// before the type is considered, so asking it about an oversize file is circular —
+// which is why the discovery-time warning decision carried a hardcoded 11-extension
+// list instead, duplicated at three call sites. See #324.
+func TestCanProcessTypeIgnoresSize(t *testing.T) {
+	dir := t.TempDir()
+
+	// A text file well over MaxFileSize. Sparse: Truncate extends the length without
+	// allocating the bytes.
+	//
+	// The leading text must fill more than the 512-byte sniff window. Truncate extends
+	// with NULs, so writing only a line or two leaves the rest of the window zeroed and
+	// the sniff correctly calls the file binary — a fixture bug that reads exactly like
+	// a code bug.
+	big := filepath.Join(dir, "big_report.txt")
+	f, err := os.Create(big) // #nosec G304 -- test temp dir
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 40; i++ { // 40 * 31 bytes = 1240 bytes of real text
+		if _, err := f.WriteString("Quarterly report text content.\n"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := f.Truncate(MaxFileSize + 1); err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+
+	info, err := os.Stat(big)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Size() <= MaxFileSize {
+		t.Fatalf("fixture is %d bytes, expected over the %d limit", info.Size(), MaxFileSize)
+	}
+
+	// The whole point: over the limit, still a processable TYPE.
+	if !CanProcessType(big, true) {
+		t.Error("an oversize TEXT file reported as not processable — the size must not " +
+			"participate, or the caller cannot tell a coverage loss from a non-event")
+	}
+
+	// And CanProcessFile still refuses it, for contrast: that is the circularity this
+	// function exists to break.
+	if ok, reason := CanProcessFile(newRouterForTest(t), big, true); ok {
+		t.Errorf("CanProcessFile accepted an oversize file (reason %q)", reason)
+	}
+}
+
+// newRouterForTest builds a router with the default preprocessors registered.
+func newRouterForTest(t *testing.T) *FileRouter {
+	t.Helper()
+	fr := NewFileRouter(false)
+	RegisterDefaultPreprocessors(fr)
+	fr.InitializePreprocessors(nil)
+	return fr
+}
+
+// CanProcessFile is a method; this shim keeps the contrast assertion above readable.
+func CanProcessFile(fr *FileRouter, path string, enablePreprocessors bool) (bool, string) {
+	return fr.CanProcessFile(path, enablePreprocessors)
+}
+
+// Media types are processable when preprocessors are on, because their METADATA is
+// extracted and scanned. An oversize video that went unscanned is therefore a real
+// coverage loss, not a non-event — the previous hardcoded list called it a non-event.
+func TestCanProcessTypeMediaDependsOnPreprocessors(t *testing.T) {
+	dir := t.TempDir()
+	vid := filepath.Join(dir, "clip.mp4")
+	if err := os.WriteFile(vid, []byte{0x00, 0x00, 0x00, 0x18, 'f', 't', 'y', 'p'}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if !CanProcessType(vid, true) {
+		t.Error("a video is not processable with preprocessors enabled, but its metadata " +
+			"is extracted and scanned")
+	}
+	if CanProcessType(vid, false) {
+		t.Error("a video reported processable with preprocessors DISABLED; nothing would " +
+			"have read it, so refusing it for size loses nothing")
+	}
+}
+
+// A type nothing handles must be reported not-processable at any size, so a size
+// refusal for it stays silent. This is the case the old extension list could never
+// cover: browser partial downloads have random suffixes.
+func TestCanProcessTypeRejectsOpaqueBinary(t *testing.T) {
+	dir := t.TempDir()
+
+	// Random-suffix partial download holding binary bytes.
+	partial := filepath.Join(dir, ".com.brave.Browser.ABCdef")
+	body := make([]byte, 600) // NUL bytes: not text under any encoding sniff
+	if err := os.WriteFile(partial, body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if CanProcessType(partial, true) {
+		t.Error("an opaque binary blob reported processable; a size refusal for it would " +
+			"produce a warning about a file that could never have been scanned")
+	}
+
+	// A missing path is not processable, and must not panic.
+	if CanProcessType(filepath.Join(dir, "nope.txt"), true) {
+		t.Error("a nonexistent path reported processable")
+	}
+}
+
+// A plain text file is processable regardless of the preprocessor setting: text needs
+// no preprocessor.
+func TestCanProcessTypeTextNeedsNoPreprocessors(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "notes.txt")
+	if err := os.WriteFile(p, []byte("plain text content\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, enable := range []bool{true, false} {
+		if !CanProcessType(p, enable) {
+			t.Errorf("text file reported not processable with enablePreprocessors=%v", enable)
+		}
+	}
+}

--- a/internal/router/file_router.go
+++ b/internal/router/file_router.go
@@ -172,6 +172,49 @@ func (fr *FileRouter) CanProcessFile(filePath string, enablePreprocessors bool) 
 	return false, "Unsupported file type"
 }
 
+// CanProcessType reports whether this path's TYPE is one the router would process,
+// ignoring the file's size.
+//
+// CanProcessFile cannot answer this question. Its own size gate returns
+// "File too large" before the type is ever considered, so asking it about an
+// oversize file is circular.
+//
+// The caller that needs it is the discovery-time decision of whether a file refused
+// for size is worth telling the user about. That decision used to be a hardcoded
+// 11-extension list duplicated at two call sites, which made the tool quiet about a
+// few known-big binary types and noisy about everything else — including files it
+// could never have scanned at any size, and including browser partial downloads
+// whose random suffixes no extension list can ever cover. The right question is not
+// "is this one of eleven names" but "would we have processed it at all", which is
+// this. Same correction as deriving embedded-part handling from capability rather
+// than from a hand-maintained list.
+//
+// Note this returns true for video and audio, when preprocessors are enabled: the
+// tool extracts and scans their METADATA, so an oversize video that went unscanned
+// is a genuine coverage loss, not a non-event.
+//
+// Cost is bounded regardless of file size: the text branch sniffs at most the first
+// 512 bytes.
+func CanProcessType(filePath string, enablePreprocessors bool) bool {
+	ext := strings.ToLower(filepath.Ext(filePath))
+
+	// Binary documents (office, pdf, image, video, audio) are processable exactly
+	// when preprocessors are available to handle them.
+	if isBinaryDocument(ext) {
+		return enablePreprocessors
+	}
+
+	// Anything else is processable only if it sniffs as text. An unreadable file is
+	// reported as not-processable here: the caller is deciding whether to mention a
+	// SIZE refusal, and a file that also cannot be opened is a separate diagnostic
+	// raised through the unreadable channel.
+	isText, err := isTextFile(filePath)
+	if err != nil {
+		return false
+	}
+	return isText
+}
+
 // describeFileMode names the non-regular kind a path turned out to be, so the skip
 // reason tells the user what they actually pointed at rather than only that it was
 // rejected. Directories are included because a caller can hand a directory path to a


### PR DESCRIPTION
Closes #324. Implements **defect (a)** and **defect (b) option (a)** — the exit-code change.

A file refused for being over the size limit reached **no counter at all**. Measured on a directory holding one 105MB text file plus a small file with an SSN:

```
Files: 1 scanned | Findings: 1
total_files 1, files_processed 1, files_skipped 0, files_not_examined absent
--fail-on-incomplete -> exit 0
```

The artifact described a complete, clean scan of a directory containing a file that was never opened. The only trace was a stderr line — exactly what CI discards when it redirects stdout to a report.

## Defect (a) — the silencing predicate was a hardcoded list, and backwards

It was an 11-extension list duplicated at **three** call sites, not two: the single-file path, the glob loop, and the directory walk (the latter two carrying it inline). The tool was quiet about a few known-big binary types and noisy about everything else, including files it could never have scanned at any size. Browser partial downloads have random suffixes, so no extension list can ever cover them.

Replaced with `router.CanProcessType`, which asks the only question that matters: *would we have processed this type at all?* `CanProcessFile` cannot answer it — its own size gate returns "File too large" before the type is considered, so asking it about an oversize file is circular. All three copies of the list are gone.

**Deliberate consequence:** oversize **video and audio** become disclosed rather than silent when preprocessors are on, because their metadata *is* extracted and scanned — so an oversize video that went unscanned is a genuine coverage loss. That follows from deriving the predicate from capability instead of from a list.

## Defect (b) — a size-refused processable file is UNEXAMINED, not skipped

`ScanStats` already draws the distinction: a skipped file is an unsupported type nobody expected a result for; an unexamined one was expected to produce something and did not.

```
Files: 1 scanned, 1 NOT examined, 1 skipped | Findings: 1
NOT FULLY EXAMINED: 1 of 2 files — findings may be missing
  file too large to scan (1)
    big_report.txt  file too large (max size: 100MB)

total_files 2, files_processed 1, files_skipped 1, files_not_examined 1
--fail-on-incomplete -> exit 3
```

An **unprocessable** type refused for size stays a silent skip, but is now *recorded* rather than dropped, so it stays in the denominator. Verified on all three routes (single file, glob, recursive walk).

⚠️ **This is an exit-code behaviour change**: `--fail-on-incomplete` now returns 3 where it returned 0. That is the flag doing what its name says, and the capability predicate bounds the blast radius to files the run could actually have scanned.

## Also fixed here, because it is in the switch this change had to touch

`causeNotFollowed` (added for #326) was **never mapped** in `toFormatterNotExamined` and fell through to the conservative default — so every refused symlink was reported as "cannot read" in machine formats while the text report said "symlink not followed", asserting an I/O failure that never happened. That is exactly the mislabelling the cmd-side comment warns a new cause would cause.

Both new causes are mapped, and a test asserts every cmd cause maps to a **distinct** formatter cause with identical wording on both sides.

The cause now travels on `SkippedFile`, whose zero value is `causeUnreadable` — so a producer that forgets to set it silently mislabels its entry. A test covers the symlink producer for exactly that.

One **stdout write on the scan path** moved to stderr (`getFilesToProcess`'s error path). stdout is the machine artifact; a diagnostic spliced into it leaves an unparseable document at exit 0. Same defect class as the media-error write already moved in #325.

## Non-vacuity

| mutation | failure |
|---|---|
| `CanProcessType` always false | `big_report.txt is not in UnexaminedFiles []` |
| oversize routed back to skipped | same, plus the preprocessors-off case |
| drop the `causeNotFollowed` mapping | `mapped to "cannot read"` |
| forget `Cause` on symlink disclosure | `cause = cannot read, want causeNotFollowed` |

A fixture note worth keeping: `Truncate` extends with NULs, so a sparse "text" file whose leading text is shorter than the 512-byte sniff window reads as **binary** and silently tests the wrong branch. Both helpers fill the window — I hit this and the test caught it.

`make all` green; full suite 66 packages, 0 failures; golden corpus unchanged.

---

**Not self-merging** — leaving this for @rustic to review.