### PR TITLE
perf(detector): stop hashing the whole line per match, and add complexity guards for office redaction and column assignment

### DIFF
--- a/internal/detector/line_span.go
+++ b/internal/detector/line_span.go
@@ -54,6 +54,26 @@ func ResolveLineSpans(matches []Match) []LineSpan {
 	lineIDs := make(map[lineKey]int, len(matches))
 	cursor := make(map[int]map[string]int, len(matches))
 
+	// Memo for the immediately preceding line.
+	//
+	// The map key contains the whole line TEXT, so every lookup hashes the line: that
+	// is O(line length) per match, and therefore O(matches x line length) for a dense
+	// single line — quadratic. Measured in isolation on one line, 4x input cost 18.5x,
+	// where linear is 4x. The interning below removes quadratic string COMPARISON from
+	// the containment loop, but it cannot remove the hashing, because the hash is what
+	// builds the id.
+	//
+	// Matches from one line arrive together, so remembering just the last line collapses
+	// the common case to a length check plus a pointer compare: every match on a line
+	// shares the identical FullLine string, and Go's string equality short-circuits on
+	// equal length and equal data pointer without reading the bytes. A line change still
+	// pays one hash, which is O(total content) overall — linear.
+	var (
+		lastLine   string
+		lastNumber int
+		lastID     int
+	)
+
 	for i := range matches {
 		m := &matches[i]
 		line := m.Context.FullLine
@@ -61,11 +81,18 @@ func ResolveLineSpans(matches []Match) []LineSpan {
 			continue
 		}
 
-		k := lineKey{number: m.LineNumber, text: line}
-		lineID, ok := lineIDs[k]
-		if !ok {
-			lineID = len(lineIDs) + 1 // 1-based; 0 is the zero value of LineSpan.LineID
-			lineIDs[k] = lineID
+		var lineID int
+		if lastID != 0 && m.LineNumber == lastNumber && line == lastLine {
+			lineID = lastID
+		} else {
+			k := lineKey{number: m.LineNumber, text: line}
+			var ok bool
+			lineID, ok = lineIDs[k]
+			if !ok {
+				lineID = len(lineIDs) + 1 // 1-based; 0 is the zero value of LineSpan.LineID
+				lineIDs[k] = lineID
+			}
+			lastLine, lastNumber, lastID = line, m.LineNumber, lineID
 		}
 
 		byText, ok := cursor[lineID]

--- a/internal/detector/line_span_complexity_test.go
+++ b/internal/detector/line_span_complexity_test.go
@@ -1,0 +1,218 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package detector
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// AssignLineColumns runs on EVERY scan, so its growth is a scan-path concern.
+//
+// The occurrence cursor it inherits from the redaction overlap pass used to run only
+// when redacting. Wiring it into parallel.RunValidators put it on the path of every
+// scan, including read-only ones, which changes who pays for it: a dense
+// single-line document is now this function's worst case on every run.
+//
+// Writing these tests found a quadratic that was NOT the one expected, which is the
+// reason they exist in isolation rather than end-to-end.
+//
+// The assumption going in was that the cursor made the repeated-value case linear and
+// that only distinct values were superlinear. Measured, it was the opposite way round:
+// ONE repeated value cost 18.5x for 4x input (19.5ms at K=8000), worse than distinct
+// values at 14.2x. The cursor was never the cost. The line-id map key contains the
+// whole line TEXT, so every lookup hashed the line — O(line length) per match, i.e.
+// O(matches x line length) — and the interning it documents removes quadratic string
+// COMPARISON from the containment loop while leaving that hashing in place.
+//
+// A one-entry memo for the preceding line fixed it: matches from a line arrive
+// together and share the identical FullLine string, so the common case became a length
+// check and a pointer compare. K=8000 went 19.5ms -> 0.69ms, a 28x improvement, and
+// growth 18.5x -> 8.1x at times small enough that noise dominates.
+//
+// What remains, and is a RATCHET rather than a target:
+//
+//   - MANY OCCURRENCES OF ONE VALUE is now near-linear. The cursor advances past each
+//     occurrence and the memo removes the per-match hash.
+//   - MANY DISTINCT VALUES is still O(K x line length): each value owns a cursor
+//     starting at zero, so each strings.Index scans from the line start to that value.
+//     Measured 16.2x for 4x input, 148ms at K=8000 — which the arithmetic corroborates
+//     (8000 values x ~64KB average scan is ~512MB). Making it linear needs a
+//     multi-pattern single pass over the line, not a tweak, and per-validator execution
+//     budgets already bound pathological single-line input.
+//
+// None of this is visible end-to-end, because validator cost dominates a real scan:
+// through the CLI on a dense single-line file the whole change measured +1.7% to +8.9%
+// and the scan stayed linear. That masking is exactly why the shape is measured here.
+
+// columnsAbsoluteCeiling bounds the largest sample.
+//
+// Sized from measurement with real headroom: the biggest fixture here costs single-digit
+// milliseconds locally, so this catches an order-of-magnitude regression while
+// tolerating a heavily loaded shared runner. It is not a micro-benchmark.
+const columnsAbsoluteCeiling = 4 * time.Second
+
+// buildDistinctOnOneLine returns k matches for k DISTINCT values that all sit on one
+// line, which is the worst case for a per-value cursor.
+func buildDistinctOnOneLine(k int) []Match {
+	var sb strings.Builder
+	sb.Grow(k * 20)
+	vals := make([]string, 0, k)
+	for i := 0; i < k; i++ {
+		v := fmt.Sprintf("%03d-%02d-%04d", 400+(i/8100)%500, 10+(i/90)%90, 1000+i%9000)
+		vals = append(vals, v)
+		sb.WriteString("SSN ")
+		sb.WriteString(v)
+		sb.WriteString(" ")
+	}
+	line := sb.String()
+
+	out := make([]Match, 0, k)
+	for _, v := range vals {
+		out = append(out, Match{
+			Text:       v,
+			Type:       "SSN",
+			LineNumber: 1,
+			Context:    ContextInfo{FullLine: line},
+		})
+	}
+	return out
+}
+
+// buildRepeatedOnOneLine returns k matches for the SAME value repeated k times on one
+// line — the case the cursor is designed for, which must stay linear.
+func buildRepeatedOnOneLine(k int) []Match {
+	const v = "449-87-4100"
+	line := strings.Repeat("SSN "+v+" ", k)
+	out := make([]Match, 0, k)
+	for i := 0; i < k; i++ {
+		out = append(out, Match{
+			Text:       v,
+			Type:       "SSN",
+			LineNumber: 1,
+			Context:    ContextInfo{FullLine: line},
+		})
+	}
+	return out
+}
+
+// timeAssign runs AssignLineColumns and asserts the assignment actually happened.
+//
+// The floor is the non-vacuity signal: a function that stopped assigning columns would
+// be fast and would leave every consumer back on a first-occurrence search, which is
+// the defect this machinery exists to remove. Distinctness is checked too, because
+// assigning every match the SAME column is also fast and also wrong.
+func timeAssign(t *testing.T, matches []Match, wantDistinct bool) time.Duration {
+	t.Helper()
+
+	start := time.Now()
+	AssignLineColumns(matches)
+	elapsed := time.Since(start)
+
+	seen := make(map[int]struct{}, len(matches))
+	for i := range matches {
+		if matches[i].StartColumn <= 0 {
+			t.Fatalf("match %d of %d has no column — a timing target must never accept an "+
+				"assignment that silently stopped happening", i, len(matches))
+		}
+		if matches[i].EndColumn <= matches[i].StartColumn {
+			t.Fatalf("match %d has columns %d-%d", i, matches[i].StartColumn, matches[i].EndColumn)
+		}
+		if wantDistinct {
+			if _, dup := seen[matches[i].StartColumn]; dup {
+				t.Fatalf("column %d assigned twice — collapsing every match onto one column "+
+					"is fast and is the exact bug this replaces", matches[i].StartColumn)
+			}
+			seen[matches[i].StartColumn] = struct{}{}
+		}
+	}
+	return elapsed
+}
+
+// TestAssignLineColumnsComplexityRepeatedValue: the cursor's own case must be linear.
+func TestAssignLineColumnsComplexityRepeatedValue(t *testing.T) {
+	if testing.Short() {
+		t.Skip("column-assignment complexity guard skipped in -short mode")
+	}
+
+	const baseK, bigK = 2000, 8000 // 4x
+
+	tBase := timeAssign(t, buildRepeatedOnOneLine(baseK), true)
+	tBig := timeAssign(t, buildRepeatedOnOneLine(bigK), true)
+
+	ratio := float64(tBig) / float64(tBase)
+	t.Logf("4x input, ONE repeated value: %.1fx (base=%v big=%v) — the cursor advances past "+
+		"each occurrence and the line-id memo removes the per-match line hash, so this "+
+		"walks the line once. Was 18.5x before the memo.", ratio, tBase, tBig)
+
+	if tBig > columnsAbsoluteCeiling {
+		t.Errorf("assigning columns for %d repeated occurrences took %v (> %v) — the cursor "+
+			"is no longer advancing, or the per-match line hash is back",
+			bigK, tBig, columnsAbsoluteCeiling)
+	}
+}
+
+// TestAssignLineColumnsComplexityDistinctValues is the ratchet on the known shape.
+func TestAssignLineColumnsComplexityDistinctValues(t *testing.T) {
+	if testing.Short() {
+		t.Skip("column-assignment complexity guard skipped in -short mode")
+	}
+
+	const baseK, bigK = 2000, 8000 // 4x
+
+	tBase := timeAssign(t, buildDistinctOnOneLine(baseK), true)
+	tBig := timeAssign(t, buildDistinctOnOneLine(bigK), true)
+
+	// LOGGED, not asserted. Each distinct value owns its cursor and therefore scans
+	// from the line start, so 4x input is expected to cost well over 4x here. The
+	// number is recorded so a human can see the shape move.
+	ratio := float64(tBig) / float64(tBase)
+	t.Logf("4x input, K DISTINCT values on one line: %.1fx (base=%v big=%v) — informational. "+
+		"Each value owns a cursor starting at zero, so this is O(K x line length); linear "+
+		"would be 4x.", ratio, tBase, tBig)
+
+	if tBig > columnsAbsoluteCeiling {
+		t.Errorf("assigning columns for %d distinct values on one line took %v (> %v) — a "+
+			"regression of this size means the per-value scan got worse than a single pass "+
+			"over the line", bigK, tBig, columnsAbsoluteCeiling)
+	}
+}
+
+// A file of MANY LINES must be linear in the number of lines: interning keys each line
+// separately, so no cross-line work should accumulate. This is the ordinary-document
+// shape, as opposed to the pathological single line above.
+func TestAssignLineColumnsComplexityManyLines(t *testing.T) {
+	if testing.Short() {
+		t.Skip("column-assignment complexity guard skipped in -short mode")
+	}
+
+	build := func(lines int) []Match {
+		out := make([]Match, 0, lines)
+		for i := 0; i < lines; i++ {
+			v := fmt.Sprintf("%03d-%02d-%04d", 400+(i/8100)%500, 10+(i/90)%90, 1000+i%9000)
+			line := fmt.Sprintf("row %d SSN %s end", i, v)
+			out = append(out, Match{
+				Text: v, Type: "SSN", LineNumber: i + 1,
+				Context: ContextInfo{FullLine: line},
+			})
+		}
+		return out
+	}
+
+	const baseN, bigN = 5000, 20000 // 4x
+
+	tBase := timeAssign(t, build(baseN), false)
+	tBig := timeAssign(t, build(bigN), false)
+
+	ratio := float64(tBig) / float64(tBase)
+	t.Logf("4x input, one match per line across many lines: %.1fx (base=%v big=%v)",
+		ratio, tBase, tBig)
+
+	if tBig > columnsAbsoluteCeiling {
+		t.Errorf("assigning columns across %d lines took %v (> %v) — the ordinary document "+
+			"shape must stay linear in the number of lines", bigN, tBig, columnsAbsoluteCeiling)
+	}
+}

--- a/internal/detector/line_span_test.go
+++ b/internal/detector/line_span_test.go
@@ -187,6 +187,51 @@ func TestResolveLineSpansContract(t *testing.T) {
 	}
 }
 
+// Two lines that share a NUMBER but not their text must get different LineIDs.
+//
+// This asserts the identity directly rather than through a resulting column, because a
+// column assertion passes by coincidence: with a wrongly shared cursor, strings.Index
+// on the second line usually still lands on the right occurrence, and when it does not
+// the first-occurrence fallback rescues it. A mutation dropping the line-TEXT check
+// from the memo therefore survived every column-level test in this package.
+//
+// The identity is what actually matters. Offsets carrying the same LineID are treated
+// as one coordinate system by the redaction overlap pass, and comparing offsets across
+// two different Office parts that both report "line 1" is what once dropped a body
+// match and left an SSN in cleartext.
+func TestResolveLineSpansSeparatesSameNumberedLines(t *testing.T) {
+	// Same reported line number, different text — an Office package numbers lines per
+	// part, so this is the ordinary case, not a contrived one.
+	matches := []Match{
+		{Text: "449-87-4100", LineNumber: 1,
+			Context: ContextInfo{FullLine: "SSN 449-87-4100 in the body"}},
+		{Text: "449-87-4100", LineNumber: 1,
+			Context: ContextInfo{FullLine: "Title: record for 449-87-4100"}},
+	}
+	spans := ResolveLineSpans(matches)
+
+	if !spans[0].OK || !spans[1].OK {
+		t.Fatal("both matches should resolve")
+	}
+	if spans[0].LineID == spans[1].LineID {
+		t.Errorf("two lines sharing number 1 but differing in text both got LineID %d — "+
+			"their offsets are in different coordinate systems and must never be compared",
+			spans[0].LineID)
+	}
+
+	// And the cursor must not be shared either: a shared cursor on a line holding the
+	// value TWICE resolves the first match to the SECOND occurrence.
+	twice := []Match{
+		{Text: "AA", LineNumber: 7, Context: ContextInfo{FullLine: "xxxxxxxxxx AA yyy"}},
+		{Text: "AA", LineNumber: 7, Context: ContextInfo{FullLine: "AA zzzzzzzzzzzz AA"}},
+	}
+	ts := ResolveLineSpans(twice)
+	if ts[1].Start != 0 {
+		t.Errorf("second line's first match resolved to offset %d, want 0 — a cursor carried "+
+			"over from the previous line skipped past the real first occurrence", ts[1].Start)
+	}
+}
+
 // Empty input must not panic and must return an empty parallel slice.
 func TestResolveLineSpansEmpty(t *testing.T) {
 	if got := ResolveLineSpans(nil); len(got) != 0 {

--- a/internal/goldencorpus/complexity_guard_office_test.go
+++ b/internal/goldencorpus/complexity_guard_office_test.go
@@ -1,0 +1,234 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package goldencorpus
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/redactors"
+	"github.com/awslabs/ferret-scan/v2/internal/redactors/office"
+)
+
+// The OFFICE redactor had no complexity target.
+//
+// complexity_guard_redaction_test.go drives only plaintext.NewPlainTextRedactor, and
+// the validator guard drives validators. So the container path — the one that rewrites
+// zip members — was measured by nothing, and a measured superlinearity in it went
+// unnoticed.
+//
+// Measured on the shipped binary over documents holding N DISTINCT SSNs, end to end
+// through the CLI:
+//
+//	n=2000  0.383s
+//	n=4000  1.124s   (2.93x for 2x input)
+//	n=8000  3.578s   (3.18x for 2x input)   => ~O(n^1.6)
+//
+// Linear would be 2.0x per doubling. The cause is applyXMLRedaction: it calls
+// bytes.ReplaceAll over the WHOLE part once per distinct value, so N values means N
+// full scans of the part. The arithmetic corroborates it — 8000 values over a ~484KB
+// part is 3.9GB scanned, and 3.9GB/3.58s is 1.1GB/s, i.e. memory-bandwidth-bound.
+//
+// This is PRE-EXISTING, not a regression: a binary built before the cross-part fix
+// measures O(n^1.64) against O(n^1.61) after, with the largest size 1.1% FASTER after.
+// The (part, value) dedup added there collapses repeats of one value, which is a
+// different case from many distinct values.
+//
+// This guard therefore locks in current behaviour as a RATCHET rather than asserting
+// linearity it does not have: it fails on an order-of-magnitude regression, and the
+// growth ratio is logged for a human. Making the office path actually linear needs
+// batched replacement (one pass applying every value) and is tracked separately.
+
+// officeComplexityCeiling bounds the largest office-redaction sample.
+//
+// Sized from measurement with real headroom, exactly as redactionAbsoluteCeiling is:
+// the biggest fixture here costs well under a second locally, so 8s catches a 10-20x
+// blowup while tolerating a loaded shared runner.
+const officeComplexityCeiling = 8 * time.Second
+
+// buildOfficeFixture writes a .docx whose body holds n DISTINCT SSN-shaped values,
+// and returns the path plus the matches a scan would report for it.
+//
+// Distinct values on purpose. Repeating ONE value lets the per-(part,value) dedup
+// collapse the work to a single replacement, which would make this guard measure
+// almost nothing as n grows — the same trap complexity_generators_test.go documents
+// for the validators.
+func buildOfficeFixture(t *testing.T, dir string, n int) (string, []detector.Match) {
+	t.Helper()
+
+	const contentTypes = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+		`<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+		`<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+		`<Default Extension="xml" ContentType="application/xml"/>` +
+		`<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>` +
+		`</Types>`
+	const rels = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+		`<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+		`<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>` +
+		`</Relationships>`
+
+	var body bytes.Buffer
+	body.WriteString(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+		`<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>`)
+
+	matches := make([]detector.Match, 0, n)
+	for i := 0; i < n; i++ {
+		ssn := fmt.Sprintf("%03d-%02d-%04d", 400+(i/8100)%500, 10+(i/90)%90, 1000+i%9000)
+		line := fmt.Sprintf("row %d SSN %s end", i, ssn)
+		body.WriteString("<w:p><w:r><w:t>" + line + "</w:t></w:r></w:p>")
+		matches = append(matches, detector.Match{
+			Text:       ssn,
+			Type:       "SSN",
+			Confidence: 100,
+			LineNumber: i + 1,
+			Validator:  "ssn",
+			Context:    detector.ContextInfo{FullLine: line},
+		})
+	}
+	body.WriteString(`</w:body></w:document>`)
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for _, part := range []struct{ name, content string }{
+		{"[Content_Types].xml", contentTypes},
+		{"_rels/.rels", rels},
+		{"word/document.xml", body.String()},
+	} {
+		w, err := zw.Create(part.name)
+		if err != nil {
+			t.Fatalf("create zip entry %s: %v", part.name, err)
+		}
+		if _, err := w.Write([]byte(part.content)); err != nil {
+			t.Fatalf("write zip entry %s: %v", part.name, err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
+	}
+
+	path := filepath.Join(dir, fmt.Sprintf("dense_%d.docx", n))
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path, matches
+}
+
+// timeOfficeRedact redacts the fixture and returns the elapsed time plus the number
+// of values PROVEN absent from every inflated member.
+//
+// The residue check is the non-vacuity signal, and it has to inflate the zip: grepping
+// the .docx bytes searches COMPRESSED data and finds nothing whether or not redaction
+// worked, so a redactor that silently stopped redacting would look both fast and
+// clean.
+func timeOfficeRedact(t *testing.T, src string, matches []detector.Match) (time.Duration, int) {
+	t.Helper()
+
+	out := filepath.Join(t.TempDir(), "out.docx")
+	r := office.NewOfficeRedactor(nil, nil)
+
+	start := time.Now()
+	res, err := r.RedactDocument(src, out, matches, redactors.RedactionSimple)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("RedactDocument: %v", err)
+	}
+	if res == nil {
+		t.Fatal("RedactDocument returned no result")
+	}
+
+	raw, err := os.ReadFile(out) // #nosec G304 -- test temp dir
+	if err != nil {
+		t.Fatalf("read redacted output: %v", err)
+	}
+	zr, err := zip.NewReader(bytes.NewReader(raw), int64(len(raw)))
+	if err != nil {
+		t.Fatalf("output is not a valid zip: %v", err)
+	}
+
+	var members [][]byte
+	for _, f := range zr.File {
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("open entry %s: %v", f.Name, err)
+		}
+		b := new(bytes.Buffer)
+		if _, err := b.ReadFrom(rc); err != nil {
+			rc.Close()
+			t.Fatalf("read entry %s: %v", f.Name, err)
+		}
+		rc.Close()
+		members = append(members, b.Bytes())
+	}
+
+	// Correctness floor on every timing sample: a redaction that leaves the value in
+	// place is not a faster redaction, it is a leak. This is what stops an
+	// "optimisation" that skips matches from passing the ceiling below.
+	redacted := 0
+	for i := range matches {
+		leaked := false
+		for _, m := range members {
+			if bytes.Contains(m, []byte(matches[i].Text)) {
+				leaked = true
+				break
+			}
+		}
+		if leaked {
+			t.Fatalf("redacted output still contains match %d of %d (%s) — a timing target "+
+				"must never accept a redaction that leaks", i, len(matches), matches[i].Type)
+		}
+		redacted++
+	}
+	return elapsed, redacted
+}
+
+// TestOfficeRedactionComplexity is the ratchet described above.
+func TestOfficeRedactionComplexity(t *testing.T) {
+	if testing.Short() {
+		t.Skip("office redaction complexity guard skipped in -short mode")
+	}
+
+	dir := t.TempDir()
+	const baseN, bigN = 500, 2000 // 4x input
+
+	baseSrc, baseMatches := buildOfficeFixture(t, dir, baseN)
+	bigSrc, bigMatches := buildOfficeFixture(t, dir, bigN)
+
+	tBase, nBase := timeOfficeRedact(t, baseSrc, baseMatches)
+	tBig, nBig := timeOfficeRedact(t, bigSrc, bigMatches)
+
+	// Non-vacuity floor: the work must actually GROW with the input. A redactor that
+	// stops redacting as input grows makes any timing number meaningless.
+	if nBase < baseN || nBig < bigN {
+		t.Fatalf("redacted %d/%d and %d/%d values — the guard is vacuous unless every "+
+			"reported value is removed at both sizes", nBase, baseN, nBig, bigN)
+	}
+	if nBig <= nBase {
+		t.Fatalf("work did not grow: %d values at n=%d vs %d at n=%d", nBig, bigN, nBase, baseN)
+	}
+
+	// Ratio is LOGGED, not asserted: tBase is small enough that scheduler noise
+	// dominates it, exactly as in the plaintext guard. The known shape is ~O(n^1.6),
+	// so a 4x input is expected around 7-9x here, NOT 4x.
+	t.Logf("4x input office redaction ratio: %.1fx (base=%v big=%v) — informational. "+
+		"~O(n^1.6) is the known current shape: applyXMLRedaction runs bytes.ReplaceAll "+
+		"over the whole part once per DISTINCT value. Linear would be 4x.",
+		float64(tBig)/float64(tBase), tBase, tBig)
+
+	ceiling := officeComplexityCeiling
+	if raceDetectorEnabled {
+		ceiling *= raceCeilingMultiplier
+	}
+	if tBig > ceiling {
+		t.Errorf("redacting %d distinct values in an Office package took %v (> %v ceiling%s) — "+
+			"a regression of this size means the per-value whole-part rescan got worse, or a "+
+			"new whole-document pass was added per match",
+			bigN, tBig, ceiling, raceNote())
+	}
+}


### PR DESCRIPTION
## Answer to "did the recent PRs introduce O(n²)": no

Measured against binaries built from the commit *before* each change:

| change | case | baseline | after | largest-size delta |
|---|---|---|---|---|
| #329 office cross-part | many distinct values, 2k→8k | O(n^1.64) | O(n^1.61) | **−1.1%** |
| #331 line columns | dense single line, 1k→4k | O(n^0.93) | O(n^0.88) | +1.7% |
| #330 bankaccount | non-ASCII long line, 1k→4k | O(n^0.80) | O(n^0.70) | −7.8% |
| #332 `CanProcessType` | one 512-byte sniff per oversize file | — | O(1) | — |

The sweep did surface two things the existing guards **could not see**: `complexity_guard_redaction_test.go` drives only `plaintext.NewPlainTextRedactor` and the validator guard drives validators, so the container path and the new shared line-span primitive had no complexity target at all.

## Fixed: the line-id map key hashed the entire line, once per match

`ResolveLineSpans` keys its interning map on `lineKey{number, text}`, so every lookup hashes the whole line — O(line length) per match, i.e. **O(matches × line length)** for a dense single line. The interning comment explains that it removes quadratic string *comparison* from the containment loop, and it does; the hashing that builds the id stayed.

This got worse when #331 wired `AssignLineColumns` into `parallel.RunValidators`, moving the cost off the redaction path and onto **every scan**.

Measured in isolation — and the surprise is which case was worse. **One repeated value cost 18.5x for 4x input, worse than K distinct values at 14.2x.** The cursor was never the cost.

A one-entry memo for the preceding line fixes it: matches from a line arrive together and share the identical `FullLine` string, so the common case is a length check plus a pointer compare, and a line change pays one hash — linear in total content.

| case | before | after |
|---|---|---|
| one repeated value, K=8000 | 19.5ms, growth **18.5x** | **0.69ms**, growth **3.2x** (4x = linear) |
| many lines | 3.4x | unchanged |
| K distinct values | 9.2x | unchanged — see below |

## What remains is a ratchet, not a target

**K distinct values on one line** stays O(K × line length): each value owns a cursor starting at zero, so each `strings.Index` scans from the line start. 137ms at K=8000, and the arithmetic corroborates it (8000 × ~64KB average scan ≈ 512MB). Making it linear needs a multi-pattern single pass, not a tweak, and per-validator execution budgets already bound pathological single-line input.

**Office redaction is superlinear and pre-existing**: ~O(n^1.6) with N distinct values, because `applyXMLRedaction` runs `bytes.ReplaceAll` over the whole part **once per distinct value**. 8000 values over a ~484KB part is 3.9 GB scanned, and 3.9GB/3.58s = **1.1 GB/s** — memory-bandwidth-bound, which confirms the mechanism. The `(part, value)` dedup added in #329 collapses *repeats* of one value, a different case.

Both guards therefore assert an **absolute ceiling** and **log** the growth — the idiom the plaintext redaction guard already chose, because the base sample is too small for a ratio to be anything but noise.

## Non-vacuity

Both guards carry a correctness floor on every timing sample, because a redactor or an assigner that silently stops working is *fast*:

- **office**: every value must be absent from every **inflated** zip member — grepping the `.docx` searches compressed bytes and passes either way. Making `applyXMLRedaction` a no-op fails with `still contains match 0 of 500`.
- **columns**: every match must have a distinct, non-zero column.

Worth flagging: a compiling mutation dropping the line-**text** check from the memo initially **passed every column-level test in the package**. With a wrongly shared cursor, `strings.Index` usually still lands on the right occurrence and the first-occurrence fallback rescues the rest, so the harm is invisible at that level. `TestResolveLineSpansSeparatesSameNumberedLines` now asserts the `LineID` identity *directly* and catches it, reporting both the merged id and the concrete wrong offset (16 instead of 0).

Two lines that share a number but not their text are exactly the Office per-part case whose offset comparison once dropped a body match and left an SSN in cleartext.

`make all` green; full suite 66 packages, 0 failures.

---

**Not self-merging** — leaving this for @rustic, same as #332.