### PR TITLE
perf(redactors): rewrite each Office part in one batched pass, and stop rebuilding the part set per match

### DIFF
--- a/internal/redactors/office/batched_replacement_test.go
+++ b/internal/redactors/office/batched_replacement_test.go
@@ -1,0 +1,278 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package office
+
+import (
+	"archive/zip"
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/redactors"
+)
+
+// writeDocx builds a .docx whose body is the supplied lines, and returns its path.
+func writeDocx(t *testing.T, dir, name string, lines ...string) string {
+	t.Helper()
+	const ct = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+		`<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+		`<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+		`<Default Extension="xml" ContentType="application/xml"/>` +
+		`<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>` +
+		`</Types>`
+	const rels = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+		`<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+		`<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>` +
+		`</Relationships>`
+
+	var body bytes.Buffer
+	body.WriteString(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+		`<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>`)
+	for _, l := range lines {
+		body.WriteString("<w:p><w:r><w:t>" + l + "</w:t></w:r></w:p>")
+	}
+	body.WriteString(`</w:body></w:document>`)
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for _, p := range []struct{ n, c string }{
+		{"[Content_Types].xml", ct}, {"_rels/.rels", rels}, {"word/document.xml", body.String()},
+	} {
+		w, err := zw.Create(p.n)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write([]byte(p.c)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// inflateAll returns every decompressed member of a .docx.
+//
+// Grepping the .docx bytes searches COMPRESSED data and finds nothing whether or not
+// redaction worked, so residue must always be checked on inflated members.
+func inflateAll(t *testing.T, path string) map[string][]byte {
+	t.Helper()
+	raw, err := os.ReadFile(path) // #nosec G304 -- test temp dir
+	if err != nil {
+		t.Fatal(err)
+	}
+	zr, err := zip.NewReader(bytes.NewReader(raw), int64(len(raw)))
+	if err != nil {
+		t.Fatalf("output is not a valid zip: %v", err)
+	}
+	out := make(map[string][]byte, len(zr.File))
+	for _, f := range zr.File {
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatal(err)
+		}
+		b, err := io.ReadAll(rc)
+		rc.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		out[f.Name] = b
+	}
+	return out
+}
+
+// Overlapping values must not leave part of the wider value in cleartext.
+//
+// Replacements are applied in ONE batched pass per part instead of one bytes.ReplaceAll
+// per value. strings.Replacer compares the old strings in argument order at each
+// position and never overlaps a replacement, so argument order decides which of two
+// overlapping values wins. Offering them longest-first makes the wider span win,
+// mirroring how redactors.ResolveOverlaps keeps the widest span — the same principle
+// that stops a CREDIT_CARD's BIN being left exposed when a PHONE match inside it is
+// applied first.
+//
+// Two conditions have to hold at once for the ordering to be observable, and it took
+// three attempts to construct them. Recording them so the fixture is not "simplified"
+// back into a vacuous one:
+//
+//  1. The values must be on DIFFERENT lines. redactors.ResolveOverlaps runs first and
+//     drops a match contained in a wider one ON THE SAME LINE, so a same-line pair
+//     never reaches the replacer at all.
+//  2. The narrow value must be a PREFIX of the wide one. strings.Replacer is
+//     positional: it tries the patterns in argument order at each offset, so argument
+//     order only decides an outcome when two patterns match at the SAME offset. A
+//     narrow value merely nested somewhere inside a wider one is never consulted there,
+//     because the replacer has already consumed those bytes.
+//
+// With shortest-first, the narrow prefix wins at that shared offset, is replaced, and
+// the remainder of the wide value survives in cleartext — while a Contains check for
+// the wide value itself PASSES, because its prefix is gone. Only the fragment
+// assertions below catch it.
+func TestBatchedReplacementPrefersTheWidestValue(t *testing.T) {
+	dir := t.TempDir()
+	const (
+		wide   = "449874100-XY" // narrow is a PREFIX of this
+		narrow = "449874100"
+	)
+	line1 := "Account " + wide + " end"
+	line2 := "SSN " + narrow + " alone"
+	src := writeDocx(t, dir, "overlap.docx", line1, line2)
+
+	matches := []detector.Match{
+		{Text: wide, Type: "ACCOUNT", Confidence: 90, LineNumber: 1,
+			Context: detector.ContextInfo{FullLine: line1}},
+		{Text: narrow, Type: "SSN", Confidence: 100, LineNumber: 2,
+			Context: detector.ContextInfo{FullLine: line2}},
+	}
+
+	out := filepath.Join(dir, "out.docx")
+	r := NewOfficeRedactor(nil, nil)
+	if _, err := r.RedactDocument(src, out, matches, redactors.RedactionSimple); err != nil {
+		t.Fatalf("RedactDocument: %v", err)
+	}
+
+	for name, content := range inflateAll(t, out) {
+		for _, secret := range []string{wide, narrow} {
+			if bytes.Contains(content, []byte(secret)) {
+				t.Errorf("%s still contains %q", name, secret)
+			}
+		}
+		// The tell for a shortest-first ordering: the narrow value is replaced inside
+		// the wide one first, so the wide value's WRAPPER survives — a reported value
+		// left partially in cleartext.
+		for _, fragment := range []string{"-XY"} {
+			if bytes.Contains(content, []byte(fragment)) {
+				t.Errorf("%s still contains %q, part of the reported value %q — a shorter "+
+					"overlapping value was applied first and consumed bytes the wider value "+
+					"needed, stranding the rest of it in cleartext", name, fragment, wide)
+			}
+		}
+	}
+}
+
+// A value contained entirely within a wider one must also leave nothing behind.
+func TestBatchedReplacementHandlesFullyContainedValue(t *testing.T) {
+	dir := t.TempDir()
+	const outer = "ACCT-449874100-XY"
+	const inner = "449874100"
+	line := "Reference " + outer + " end"
+	src := writeDocx(t, dir, "contained.docx", line)
+
+	matches := []detector.Match{
+		{Text: inner, Type: "SSN", Confidence: 100, LineNumber: 1,
+			Context: detector.ContextInfo{FullLine: line}},
+		{Text: outer, Type: "ACCOUNT", Confidence: 90, LineNumber: 1,
+			Context: detector.ContextInfo{FullLine: line}},
+	}
+
+	out := filepath.Join(dir, "out.docx")
+	r := NewOfficeRedactor(nil, nil)
+	if _, err := r.RedactDocument(src, out, matches, redactors.RedactionSimple); err != nil {
+		t.Fatalf("RedactDocument: %v", err)
+	}
+	for name, content := range inflateAll(t, out) {
+		for _, secret := range []string{outer, inner} {
+			if bytes.Contains(content, []byte(secret)) {
+				t.Errorf("%s still contains %q", name, secret)
+			}
+		}
+	}
+}
+
+// The batched pass must be deterministic: the same document and matches must produce
+// byte-identical output, whatever order Go iterates the pending map in.
+func TestBatchedReplacementIsDeterministic(t *testing.T) {
+	dir := t.TempDir()
+	line := "SSN 449-87-4100 card 4111111111111111 phone 206-555-0143"
+	src := writeDocx(t, dir, "det.docx", line, "again SSN 449-87-4100")
+
+	matches := []detector.Match{
+		{Text: "449-87-4100", Type: "SSN", Confidence: 100, LineNumber: 1,
+			Context: detector.ContextInfo{FullLine: line}},
+		{Text: "4111111111111111", Type: "CREDIT_CARD", Confidence: 100, LineNumber: 1,
+			Context: detector.ContextInfo{FullLine: line}},
+		{Text: "206-555-0143", Type: "PHONE", Confidence: 90, LineNumber: 1,
+			Context: detector.ContextInfo{FullLine: line}},
+		{Text: "449-87-4100", Type: "SSN", Confidence: 100, LineNumber: 2,
+			Context: detector.ContextInfo{FullLine: "again SSN 449-87-4100"}},
+	}
+
+	r := NewOfficeRedactor(nil, nil)
+	var want []byte
+	for run := 0; run < 12; run++ {
+		out := filepath.Join(t.TempDir(), "o.docx")
+		if _, err := r.RedactDocument(src, out, matches, redactors.RedactionSimple); err != nil {
+			t.Fatalf("run %d: %v", run, err)
+		}
+		got := inflateAll(t, out)["word/document.xml"]
+		if want == nil {
+			want = got
+			continue
+		}
+		if !bytes.Equal(want, got) {
+			t.Fatalf("run %d produced different body bytes — the batched pass depends on map "+
+				"iteration order somewhere", run)
+		}
+	}
+}
+
+// distinctPartCount is the hoist that made this linear in the number of parts rather
+// than the number of text ELEMENTS, so its contract is pinned directly.
+func TestDistinctPartCount(t *testing.T) {
+	// One part named by many consecutive entries — the real shape, since textPositions
+	// carries one entry per <w:t> run.
+	many := make([]OfficeTextPosition, 0, 500)
+	for i := 0; i < 500; i++ {
+		many = append(many, OfficeTextPosition{FileName: "word/document.xml"})
+	}
+	if got := distinctPartCount(many); got != 1 {
+		t.Errorf("distinctPartCount = %d for 500 entries naming one part, want 1", got)
+	}
+
+	mixed := []OfficeTextPosition{
+		{FileName: "word/document.xml"},
+		{FileName: "word/document.xml"},
+		{FileName: "docProps/core.xml"},
+		{FileName: "docProps/app.xml"},
+		{FileName: "docProps/core.xml"}, // returns to an earlier part: must not double count
+	}
+	if got := distinctPartCount(mixed); got != 3 {
+		t.Errorf("distinctPartCount = %d, want 3", got)
+	}
+
+	if got := distinctPartCount(nil); got != 0 {
+		t.Errorf("distinctPartCount(nil) = %d, want 0", got)
+	}
+}
+
+// partReplacements keeps the FIRST replacement recorded for a value.
+//
+// With a format-preserving or synthetic strategy, two matches carrying the same text
+// can generate different replacements. The previous code applied the first and skipped
+// the rest, so first-write-wins preserves that behaviour rather than silently switching
+// to last-write-wins.
+func TestPartReplacementsFirstWriteWins(t *testing.T) {
+	p := &partReplacements{}
+	p.add("value", "FIRST")
+	p.add("value", "SECOND")
+	p.add("other", "X")
+
+	if len(p.order) != 2 {
+		t.Fatalf("order = %v, want 2 entries", p.order)
+	}
+	if p.order[0] != "value" || p.order[1] != "other" {
+		t.Errorf("order = %v, want first-seen order [value other]", p.order)
+	}
+	if p.repl["value"] != "FIRST" {
+		t.Errorf("replacement = %q, want FIRST", p.repl["value"])
+	}
+}

--- a/internal/redactors/office/redactor.go
+++ b/internal/redactors/office/redactor.go
@@ -697,15 +697,27 @@ func (or *OfficeRedactor) redactOfficeContent(zipContents *OfficeZipContents, ex
 	// tracked for the redaction path.
 	partCache := make(map[string]matchLocation)
 
-	// applyXMLRedaction uses bytes.ReplaceAll, so the FIRST rewrite of a value in a
-	// part removes every occurrence of it there and any repeat is a full-part scan
-	// that changes nothing. Redacting one value reported 4000 times across 2 parts
-	// meant 8000 scans of a 243KB part instead of 2.
-	rewritten := make(map[string]struct{})
+	// Replacements are ACCUMULATED per part and applied once, after every match has
+	// been resolved.
+	//
+	// Rewriting per match meant one bytes.ReplaceAll over the whole part per distinct
+	// value, so N distinct values cost N full scans of the part — quadratic in document
+	// size. Measured end to end, growth converged on 4x per doubling (3.26x at
+	// 4k->8k, 3.68x at 8k->16k), and 8000 values over a 484KB part scanned 3.9GB at
+	// 1.1GB/s, i.e. memory-bandwidth-bound. Extrapolated to maxOfficeEntryBytes, the
+	// tool's own 50MB per-part cap, that is roughly 930k findings and ~11.6 HOURS: a
+	// hang on input the scanner itself accepts, with no redaction-side execution budget
+	// to cut it short.
+	//
+	// One batched pass per part replaces that with O(part + total match bytes).
+	pending := make(map[string]*partReplacements)
+
+	// Computed once: see distinctPartCount for why building it per match was quadratic.
+	partCount := distinctPartCount(textPositions)
 
 	// Process each match
 	for _, match := range matches {
-		mapping, err := or.redactMatch(modifiedContents, extractedText, textPositions, match, strategy, docType, partCache, rewritten)
+		mapping, err := or.redactMatch(modifiedContents, extractedText, textPositions, match, strategy, docType, partCache, pending, partCount)
 		if err != nil {
 			or.logEvent("match_redaction_failed", false, map[string]interface{}{
 				"match_type": match.Type,
@@ -720,7 +732,100 @@ func (or *OfficeRedactor) redactOfficeContent(zipContents *OfficeZipContents, ex
 		}
 	}
 
+	// Flush before returning: the caller inspects modifiedContents for residue in
+	// embedded parts, so an unapplied replacement would read as a leak.
+	if err := or.applyPendingRedactions(modifiedContents, pending); err != nil {
+		return nil, nil, err
+	}
+
 	return redactionMap, modifiedContents, nil
+}
+
+// partReplacements is the set of value -> replacement rewrites pending for one part.
+//
+// order preserves first-seen order so the applied result does not depend on Go's map
+// iteration. The map is written ONCE per value: with a format-preserving or synthetic
+// strategy two matches carrying the same text can generate different replacements, and
+// the previous code applied the first and skipped the rest, so first-write-wins keeps
+// that behaviour.
+type partReplacements struct {
+	order []string
+	repl  map[string]string
+}
+
+// add records a rewrite, keeping the first replacement seen for a value.
+func (p *partReplacements) add(value, replacement string) {
+	if p.repl == nil {
+		p.repl = make(map[string]string)
+	}
+	if _, seen := p.repl[value]; seen {
+		return
+	}
+	p.repl[value] = replacement
+	p.order = append(p.order, value)
+}
+
+// applyPendingRedactions rewrites each part in a single pass.
+//
+// Ordering is load-bearing twice over:
+//
+//   - Parts are applied in sorted name order so the output is byte-identical run to
+//     run, rather than following map iteration.
+//   - Within a part, values are offered LONGEST FIRST. strings.Replacer compares the
+//     old strings in argument order at each position and never overlaps a replacement,
+//     so the longest match wins — mirroring how ResolveOverlaps keeps the widest span.
+//     That is what keeps partially-overlapping values leak-safe: a shorter value nested
+//     in a longer one must not consume bytes the longer one needed and strand its head
+//     in cleartext, which is the failure the overlap pass exists to prevent.
+//     Equal-length values are ordered lexicographically, again for determinism.
+func (or *OfficeRedactor) applyPendingRedactions(zipContents *OfficeZipContents, pending map[string]*partReplacements) error {
+	if len(pending) == 0 {
+		return nil
+	}
+
+	names := make([]string, 0, len(pending))
+	for name := range pending {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		pr := pending[name]
+		if pr == nil || len(pr.order) == 0 {
+			continue
+		}
+
+		xmlContent, exists := zipContents.Files[name]
+		if !exists {
+			return fmt.Errorf("XML file not found: %s", name)
+		}
+
+		values := make([]string, len(pr.order))
+		copy(values, pr.order)
+		sort.SliceStable(values, func(i, j int) bool {
+			if len(values[i]) != len(values[j]) {
+				return len(values[i]) > len(values[j])
+			}
+			return values[i] < values[j]
+		})
+
+		args := make([]string, 0, len(values)*2)
+		for _, v := range values {
+			args = append(args, v, pr.repl[v])
+		}
+
+		modifiedContent := []byte(strings.NewReplacer(args...).Replace(string(xmlContent)))
+		zipContents.addFile(name, modifiedContent)
+
+		or.logEvent("xml_content_modified", true, map[string]interface{}{
+			"file_name":     name,
+			"original_size": len(xmlContent),
+			"modified_size": len(modifiedContent),
+			"values":        len(values),
+		})
+	}
+
+	return nil
 }
 
 // positionForOffset returns the extracted-text position covering off.
@@ -758,7 +863,7 @@ type matchLocation struct {
 // Resolving only the FIRST occurrence is what leaked. A value present in two parts
 // -- say an SSN in both word/document.xml and docProps/core.xml -- produces two
 // matches, and strings.Index gave both the same offset, so both selected the same
-// part. applyXMLRedaction's bytes.ReplaceAll is scoped to the part it is given, so
+// part. The rewrite is scoped to the part it is recorded against, so
 // the other part kept the value in CLEARTEXT while the scan reported success and
 // exited 0. Which part leaked was decided by zip entry order, because extractedText
 // is concatenated in that order: reversing the two entries moved the residue from
@@ -769,23 +874,49 @@ type matchLocation struct {
 // dense in one repeated value would be quadratic in the number of matches -- the
 // shape already tracked for the redaction path, not one to add to.
 func partsHoldingMatch(extractedText string, textPositions []OfficeTextPosition, text string) []OfficeTextPosition {
-	return locateMatch(extractedText, textPositions, text).parts
+	return locateMatch(extractedText, textPositions, text, distinctPartCount(textPositions)).parts
 }
 
 // locateMatch performs the single walk behind partsHoldingMatch, also reporting the
 // first occurrence's offset so the caller does not need a second strings.Index pass.
-func locateMatch(extractedText string, textPositions []OfficeTextPosition, text string) matchLocation {
+// distinctPartCount counts the distinct part names in textPositions.
+//
+// Hoisted out of locateMatch, and that hoist is the difference between quadratic and
+// linear. textPositions carries one entry per TEXT ELEMENT, not per part — 16000 <w:t>
+// runs produce 16000 entries that all name word/document.xml — so building this set
+// inside locateMatch meant 16000 map assignments per call, once per distinct value:
+// 256M map writes for a 16000-finding document. A CPU profile put
+// runtime.mapassign_faststr at 21% of total and locateMatch at 37% cumulative.
+//
+// The set depends only on the document, so it is computed once per redaction.
+func distinctPartCount(textPositions []OfficeTextPosition) int {
+	if len(textPositions) == 0 {
+		return 0
+	}
+	// Almost always 1-5 parts, so a small map with a fast path for the common run of
+	// consecutive entries naming the same part.
+	distinct := make(map[string]struct{}, 4)
+	last := ""
+	for _, p := range textPositions {
+		if p.FileName == last {
+			continue
+		}
+		last = p.FileName
+		distinct[p.FileName] = struct{}{}
+	}
+	return len(distinct)
+}
+
+func locateMatch(extractedText string, textPositions []OfficeTextPosition, text string, partCount int) matchLocation {
 	loc := matchLocation{firstOffset: -1}
 	if text == "" || len(textPositions) == 0 {
 		return loc
 	}
-
-	distinct := make(map[string]struct{}, len(textPositions))
-	for _, p := range textPositions {
-		distinct[p.FileName] = struct{}{}
+	if partCount <= 0 {
+		partCount = distinctPartCount(textPositions)
 	}
 
-	seen := make(map[string]struct{}, len(distinct))
+	seen := make(map[string]struct{}, partCount)
 	for base := 0; base+len(text) <= len(extractedText); {
 		i := strings.Index(extractedText[base:], text)
 		if i < 0 {
@@ -799,7 +930,7 @@ func locateMatch(extractedText string, textPositions []OfficeTextPosition, text 
 			if _, dup := seen[pos.FileName]; !dup {
 				seen[pos.FileName] = struct{}{}
 				loc.parts = append(loc.parts, *pos)
-				if len(seen) == len(distinct) {
+				if len(seen) == partCount {
 					break // every part holds it; nothing further to find
 				}
 			}
@@ -810,12 +941,12 @@ func locateMatch(extractedText string, textPositions []OfficeTextPosition, text 
 }
 
 // redactMatch redacts a single match in the Office document
-func (or *OfficeRedactor) redactMatch(zipContents *OfficeZipContents, extractedText string, textPositions []OfficeTextPosition, match detector.Match, strategy redactors.RedactionStrategy, docType OfficeDocumentType, partCache map[string]matchLocation, rewritten map[string]struct{}) (*redactors.RedactionMapping, error) {
+func (or *OfficeRedactor) redactMatch(zipContents *OfficeZipContents, extractedText string, textPositions []OfficeTextPosition, match detector.Match, strategy redactors.RedactionStrategy, docType OfficeDocumentType, partCache map[string]matchLocation, pending map[string]*partReplacements, partCount int) (*redactors.RedactionMapping, error) {
 	// Every part that holds the value, not just the one holding its first
 	// occurrence -- see partsHoldingMatch. Cached per distinct value.
 	loc, cached := partCache[match.Text]
 	if !cached {
-		loc = locateMatch(extractedText, textPositions, match.Text)
+		loc = locateMatch(extractedText, textPositions, match.Text, partCount)
 		if partCache != nil {
 			partCache[match.Text] = loc
 		}
@@ -837,27 +968,26 @@ func (or *OfficeRedactor) redactMatch(zipContents *OfficeZipContents, extractedT
 		return nil, fmt.Errorf("failed to generate replacement: %w", err)
 	}
 
-	// Apply redaction to XML content in every part that holds the value. A part
-	// whose content no longer contains the text (an earlier match with the same
-	// value already rewrote it) is a no-op, so this stays idempotent.
+	// RECORD the rewrite for every part that holds the value, rather than applying it
+	// here. applyPendingRedactions performs one pass per part once all matches are
+	// resolved; rewriting per match is what made this quadratic in document size.
+	//
+	// The part must exist now, not at flush time, so a missing part is still reported
+	// against the match that needed it.
 	redactedParts := make([]string, 0, len(parts))
 	for i := range parts {
-		redactedParts = append(redactedParts, parts[i].FileName)
+		name := parts[i].FileName
+		if _, exists := zipContents.Files[name]; !exists {
+			return nil, fmt.Errorf("failed to apply XML redaction in %s: XML file not found", name)
+		}
+		redactedParts = append(redactedParts, name)
 
-		// Skip a part whose content no longer holds this value because an earlier
-		// match already rewrote it — bytes.ReplaceAll removed every occurrence.
-		key := parts[i].FileName + "\x00" + match.Text
-		if rewritten != nil {
-			if _, done := rewritten[key]; done {
-				continue
-			}
+		pr := pending[name]
+		if pr == nil {
+			pr = &partReplacements{}
+			pending[name] = pr
 		}
-		if err := or.applyXMLRedaction(zipContents, &parts[i], match.Text, replacement, docType); err != nil {
-			return nil, fmt.Errorf("failed to apply XML redaction in %s: %w", parts[i].FileName, err)
-		}
-		if rewritten != nil {
-			rewritten[key] = struct{}{}
-		}
+		pr.add(match.Text, replacement)
 	}
 
 	// Create redaction mapping
@@ -896,33 +1026,6 @@ func (or *OfficeRedactor) redactMatch(zipContents *OfficeZipContents, extractedT
 	})
 
 	return &mapping, nil
-}
-
-// applyXMLRedaction applies redaction to XML content
-func (or *OfficeRedactor) applyXMLRedaction(zipContents *OfficeZipContents, position *OfficeTextPosition, originalText, replacement string, docType OfficeDocumentType) error {
-	// Get the XML content
-	xmlContent, exists := zipContents.Files[position.FileName]
-	if !exists {
-		return fmt.Errorf("XML file not found: %s", position.FileName)
-	}
-
-	// Replace the text in XML content
-	// This is a simplified approach - in production, you'd want more sophisticated XML manipulation
-	modifiedContent := bytes.ReplaceAll(xmlContent, []byte(originalText), []byte(replacement))
-
-	// Update the ZIP contents. addFile rather than a bare map write so the entry
-	// order stays consistent with Files even though this path only ever replaces
-	// a part that is already present.
-	zipContents.addFile(position.FileName, modifiedContent)
-
-	or.logEvent("xml_content_modified", true, map[string]interface{}{
-		"file_name":     position.FileName,
-		"original_size": len(xmlContent),
-		"modified_size": len(modifiedContent),
-		"replacements":  bytes.Count(xmlContent, []byte(originalText)),
-	})
-
-	return nil
 }
 
 // repackageOfficeDocument repackages the modified ZIP contents into a new Office document


### PR DESCRIPTION
Addresses #334. Makes the Office redaction step **16x faster** at 16k findings and removes **two of the three** causes. The third is identified and measured but not fixed here, so **#334 stays open**.

## Cause 1 — one whole-part rescan per distinct value

`applyXMLRedaction` ran `bytes.ReplaceAll` over the entire part, and `redactMatch` called it once per match, so N distinct values meant N full scans. Replacements are now **accumulated per part** and applied in a single pass once every match is resolved.

Ordering in that pass is load-bearing twice:
- **Parts** apply in sorted name order, so output is byte-identical run to run rather than following map iteration.
- **Within a part**, values are offered **longest first** — `strings.Replacer` compares old strings in argument order at each position and never overlaps a replacement, so the wider span wins, mirroring `ResolveOverlaps`.

## Cause 2 — the part-name set was rebuilt on every `locateMatch` call

This was the dominant cost, and **not** what I first assumed. `textPositions` carries one entry per **text element**, not per part: 16000 `<w:t>` runs produce 16000 entries that all name `word/document.xml`. `locateMatch` rebuilt its distinct-part set from that on every call, once per distinct value — **256M map writes** for a 16000-finding document.

A CPU profile put `runtime.mapassign_faststr` at **21%** of total and `locateMatch` at **37%** cumulative. The set depends only on the document, so `distinctPartCount` now computes it once.

## Measured — redaction step only (total minus scan; scan is linear and unaffected)

| n | before | after | speedup |
|---|---|---|---|
| 4000 | 0.720s | 0.036s | **20.0x** |
| 8000 | 2.862s | 0.177s | **16.2x** |
| 16000 | 11.716s | 0.734s | **16.0x** |

Whole `RedactDocument` on the 16k fixture: **3894ms → 828ms**.

## What is left, and why #334 stays open

Growth is still ~4x per doubling. Re-profiling puts `internal/bytealg.IndexString` at **62.8%** — `locateMatch`'s `strings.Index` walk over the extracted text, once per distinct value, i.e. O(values × text). Removing it needs multi-pattern search (Aho-Corasick-shaped), not a tweak, so it belongs in its own change.

Extrapolated to the 50MB per-part cap: roughly **40 minutes** rather than ~11.6 hours. Much better, still not acceptable.

**Two hypotheses I held were wrong, and the diagnostics that "cleared" them were flawed** — worth knowing if you review the reasoning:
- `locateMatch` bypassed looked flat only because my stand-in returned all 16000 `textPositions` as `parts`, swapping one quadratic for another.
- `ResolveOverlaps` bypassed was genuinely flat (it's 3.8% of profile).

Both were settled by profiling, not reasoning.

## Non-vacuity

Skipping the flush fails 9 tests.

The **longest-first ordering took three attempts to guard**, and the first two versions passed with the ordering deliberately reversed:
1. A same-line pair never reaches the replacer — `ResolveOverlaps` drops the contained match first.
2. A narrow value merely *nested* inside a wider one is never consulted at the wider value's offset — `strings.Replacer` is positional and has already consumed those bytes.

Argument order only decides an outcome when two patterns match at the **same offset**, i.e. when one value is a **prefix** of the other. The fixture is now a prefix pair on two different lines, and the assertion is on the surviving **fragment** (`-XY`) — a `Contains` check for the wide value itself *passes* under the bug, because its prefix is gone. That reasoning is recorded in the test so the fixture isn't simplified back into a vacuous one.

`applyXMLRedaction` is deleted rather than left unused.

`make all` green; full suite 66 packages, 0 failures.

---

**Not self-merging** — for @rustic, alongside #332 and #333.