### PR TITLE
docs: collapse the two contradictory Status tables, and correct six stale rows

### DIFF
--- a/docs/upstream-asks.md
+++ b/docs/upstream-asks.md
@@ -110,28 +110,17 @@ consume it too.
 
 ## Status
 
-| # | Ask | Status | Notes |
-|---|---|---|---|
-| 1 | BANK_ACCOUNT / IBAN | Not started | |
-| 2 | TWO_FACTOR_CODES | Not started | |
-| 3 | DATE_OF_BIRTH | Not started | |
-| 4 | PHYSICAL_ADDRESS | Not started | |
-| 5 | DRIVERS_LICENSE | Not started | |
-| 6 | MEDICAL_ID / PHI | Not started | |
-| 7 | .pkpass / .vcf / .ics | Not started | |
-| 8 | `pkg/scan` public API | **Done** | Implemented: ScanText, ScanFile, RedactText, RedactFile, CanProcessFile, CheckNames, ConfidenceOf, ParseStrategy. 27 tests. |
-
----
-
-## Status
+Verify against `ferret-scan --checks` rather than trusting this table: the check names
+the CLI accepts are the authoritative list, and this table has already drifted behind
+them once.
 
 | # | Ask | Status | Notes |
 |---|---|---|---|
-| 1 | BANK_ACCOUNT / IBAN | Not started | |
-| 2 | TWO_FACTOR_CODES | Not started | |
-| 3 | DATE_OF_BIRTH | Not started | |
-| 4 | PHYSICAL_ADDRESS | Not started | |
-| 5 | DRIVERS_LICENSE | Not started | |
-| 6 | MEDICAL_ID / PHI | Not started | |
-| 7 | .pkpass / .vcf / .ics | Not started | |
-| 8 | ScanText public API | Not started | Highest architectural impact |
+| 1 | BANK_ACCOUNT / IBAN | **Done** | `--checks BANK_ACCOUNT` |
+| 2 | TWO_FACTOR_CODES | **Done** | `--checks OTP` |
+| 3 | DATE_OF_BIRTH | **Done** | `--checks DATE_OF_BIRTH` |
+| 4 | PHYSICAL_ADDRESS | **Done** | `--checks PHYSICAL_ADDRESS` |
+| 5 | DRIVERS_LICENSE | **Done** | `--checks DRIVERS_LICENSE` |
+| 6 | MEDICAL_ID / PHI | **Done** | `--checks MEDICAL_ID` |
+| 7 | .pkpass / .vcf / .ics | Not started | No non-test reference to any of the three extensions |
+| 8 | `pkg/scan` public API | **Done** | ScanText, ScanFile, RedactText, RedactFile, CanProcessFile, CheckNames, ConfidenceOf, ParseStrategy |


### PR DESCRIPTION
Closes #291.

`docs/upstream-asks.md` ended with two `## Status` sections listing the same eight asks and disagreeing about #8 — the first recorded the `pkg/scan` public API as **Done**, the second as *"Not started — highest architectural impact"*. The second was a pre-implementation copy never removed.

**Deduping alone would have left the document wrong in a quieter way**, because *both* tables were stale for asks 1–6. Checked against the CLI's own `--checks` list, which is the authoritative set of names it accepts:

```
BANK_ACCOUNT, DATE_OF_BIRTH, DRIVERS_LICENSE, MEDICAL_ID, OTP, PHYSICAL_ADDRESS
```

All six are present and wired, so asks 1–6 are **Done**, not "Not started". Each row now cites the flag value that proves it, so a reader can check the claim in one command instead of reading the tree.

Ask 7 (`.pkpass` / `.vcf` / `.ics`) is genuinely not started — zero non-test references to any of the three extensions.

Added a note above the table pointing readers at `--checks` rather than at the table, since this is the second time it has drifted behind the code.

---

**Not self-merging** — for @rustic, alongside #332, #333, #335.