### PR TITLE
fix(cli): disclose a path the walk could not access, instead of counting it nowhere

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2593,7 +2593,6 @@ func getFilesToProcess(inputPath string, recursive bool, excludePatterns []strin
 	}
 
 	var filesToProcess []string
-	var skippedFiles []string
 
 	// If it's a regular file, just process it
 	if fileInfo.Mode().IsRegular() {
@@ -2650,10 +2649,45 @@ func getFilesToProcess(inputPath string, recursive bool, excludePatterns []strin
 				return nil // Skip paths with traversal attempts
 			}
 
-			// Handle errors accessing a path
+			// A path the walk could not access is a COVERAGE LOSS, and must be
+			// disclosed like every other one.
+			//
+			// This used to print one stderr warning and append to a local slice that fed
+			// nothing but a "Skipped N files or directories due to errors" count. The
+			// path reached no counter at all: absent from total_files, files_skipped,
+			// files_not_examined, the NOT FULLY EXAMINED block, and --fail-on-incomplete.
+			//
+			// Measured on a permission-denied directory holding an SSN:
+			//
+			//	Skipped 1 files or directories due to errors     (stderr only)
+			//	No matches found.
+			//	--fail-on-incomplete -> exit 0
+			//	json stats carried no files_not_examined key at all
+			//
+			// So a directory of unread PII produced a clean bill of health. Same defect
+			// class as the oversize refusal fixed for #324, and worse: a refused
+			// DIRECTORY hides every descendant, and how many is unknowable. See #336
+			// defect 3.
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: Skipping %s: %v\n", path, err)
-				skippedFiles = append(skippedFiles, path)
+
+				// causeUnreadable is the right cause: unlike a size refusal or a
+				// declined symlink, this path genuinely could not be read.
+				detail := humanizeReason(path, err.Error())
+				if detail == "" {
+					detail = "could not be accessed"
+				}
+				// info is nil on an access error, so ask the filesystem directly. If
+				// even Lstat fails the kind is unknowable and the plain wording stands.
+				if di, statErr := os.Lstat(path); statErr == nil && di.IsDir() {
+					detail = "directory could not be read, so an unknown number of files " +
+						"inside it were not scanned: " + detail
+				}
+				result.UnexaminedFiles = append(result.UnexaminedFiles, SkippedFile{
+					Path:   cleanWalkPath,
+					Reason: detail,
+					Cause:  causeUnreadable,
+				})
 				return nil // Continue walking despite the error
 			}
 
@@ -2741,10 +2775,16 @@ func getFilesToProcess(inputPath string, recursive bool, excludePatterns []strin
 		filesToProcess = append(filesToProcess, follow...)
 		result.UnexaminedFiles = append(result.UnexaminedFiles, disclose...)
 
-		// Print summary of skipped files
-		if len(skippedFiles) > 0 {
-			fmt.Fprintf(os.Stderr, "Skipped %d files or directories due to errors\n", len(skippedFiles))
-		}
+		// The "Skipped N files or directories due to errors" line is gone with the
+		// local slice that fed it. Its only source was the walk-error branch above,
+		// which now records each path in UnexaminedFiles — so the count is stated in
+		// the NOT FULLY EXAMINED block, with the path and the reason, in every output
+		// format, instead of as a bare number on stderr that named nothing and reached
+		// no counter.
+		//
+		// The label was also wrong: size refusals were appended to the same slice, so a
+		// run whose only "errors" were two oversize files reported "Skipped 2 ... due to
+		// errors". See #336 defect 4.
 
 		result.FilesToProcess = filesToProcess
 		return result, nil

--- a/cmd/walk_error_disclosed_test.go
+++ b/cmd/walk_error_disclosed_test.go
@@ -1,0 +1,192 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// A path the directory walk cannot access must be DISCLOSED, not counted nowhere.
+//
+// The walk callback's error branch printed one stderr warning and appended the path to
+// a local slice whose only consumer was a "Skipped N files or directories due to
+// errors" count. The path reached no counter: absent from total_files, files_skipped,
+// files_not_examined, the NOT FULLY EXAMINED block, and --fail-on-incomplete.
+//
+// Measured on the shipped binary, a permission-denied directory holding an SSN:
+//
+//	Skipped 1 files or directories due to errors     (stderr only, named nothing)
+//	No matches found.
+//	--fail-on-incomplete -> exit 0
+//	json stats carried no files_not_examined key at all
+//
+// A directory of unread PII reported a clean bill of health. Same defect class as the
+// oversize refusal fixed for #324, and worse: a refused DIRECTORY hides every
+// descendant, and how many is unknowable. See #336 defect 3.
+
+// requireUnreadablePathsWork skips on platforms/users where chmod cannot deny access.
+//
+// Both guards are necessary. On Windows the Unix permission bits are not enforced, and
+// root bypasses them entirely — in either case the fixture is readable, the walk
+// reports no error, and the test would pass while asserting nothing.
+func requireUnreadablePathsWork(t *testing.T, path string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits are not enforced on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: permission bits are bypassed, so the fixture would be readable")
+	}
+	// Prove the fixture actually denies access before asserting on the consequence.
+	if _, err := os.ReadDir(path); err == nil {
+		if _, err := os.Open(path); err == nil { // #nosec G304 -- test temp dir
+			t.Skipf("%s is still readable despite chmod 000; cannot exercise the error branch", path)
+		}
+	}
+}
+
+func TestUnreadableDirectoryIsDisclosed(t *testing.T) {
+	root := t.TempDir()
+	secret := filepath.Join(root, "secret")
+	if err := os.MkdirAll(secret, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Real PII inside, so a silent skip is a real loss rather than a cosmetic one.
+	if err := os.WriteFile(filepath.Join(secret, "pii.txt"), []byte("SSN: 452-11-9384\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ok := filepath.Join(root, "readable.txt")
+	if err := os.WriteFile(ok, []byte("nothing here\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(secret, 0o000); err != nil {
+		t.Skipf("cannot chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(secret, 0o755) })
+	requireUnreadablePathsWork(t, secret)
+
+	res, err := getFilesToProcess(root, true, nil, nil, true)
+	if err != nil {
+		t.Fatalf("getFilesToProcess: %v", err)
+	}
+
+	// The readable file is still scanned — the fix must not abort the walk.
+	var sawReadable bool
+	for _, p := range res.FilesToProcess {
+		if filepath.Base(p) == "readable.txt" {
+			sawReadable = true
+		}
+	}
+	if !sawReadable {
+		t.Errorf("FilesToProcess = %v, want readable.txt — an access error on one entry must "+
+			"not stop the rest of the walk", res.FilesToProcess)
+	}
+
+	var found *SkippedFile
+	for i := range res.UnexaminedFiles {
+		if strings.Contains(res.UnexaminedFiles[i].Path, "secret") {
+			found = &res.UnexaminedFiles[i]
+		}
+	}
+	if found == nil {
+		t.Fatalf("the unreadable directory is not in UnexaminedFiles %v — it reaches no "+
+			"counter, so a directory of unread PII reports a clean scan at exit 0",
+			pathsOf(res.UnexaminedFiles))
+	}
+	if found.Cause != causeUnreadable {
+		t.Errorf("cause = %v (%q), want causeUnreadable — this path genuinely could not be "+
+			"read, unlike a size refusal or a declined symlink", found.Cause, found.Cause.String())
+	}
+
+	// A refused DIRECTORY must say its contents are unaccounted for. "cannot read" on
+	// one path reads as one lost file; the real loss is every descendant, and the count
+	// is unknowable.
+	low := strings.ToLower(found.Reason)
+	if !strings.Contains(low, "director") {
+		t.Errorf("reason = %q, want it to say a DIRECTORY was refused so the reader knows "+
+			"descendants are unaccounted for", found.Reason)
+	}
+	if !strings.Contains(low, "unknown number") {
+		t.Errorf("reason = %q, want it to state the descendant count is unknown", found.Reason)
+	}
+	// Payload-free: the reason reaches stderr and every machine format.
+	if strings.Contains(found.Reason, "452-11-9384") {
+		t.Errorf("reason %q leaked file content", found.Reason)
+	}
+}
+
+// An unreadable FILE must be disclosed too, and must NOT claim to be a directory.
+func TestUnreadableFileIsDisclosed(t *testing.T) {
+	root := t.TempDir()
+	locked := filepath.Join(root, "locked.txt")
+	if err := os.WriteFile(locked, []byte("SSN: 452-11-9384\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Skipf("cannot chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o600) })
+	requireUnreadablePathsWork(t, locked)
+
+	res, err := getFilesToProcess(root, true, nil, nil, true)
+	if err != nil {
+		t.Fatalf("getFilesToProcess: %v", err)
+	}
+
+	// filepath.Walk can Lstat a mode-000 FILE fine, so it is handed to the scanner and
+	// the read failure surfaces later through the unreadable channel. Either route is a
+	// disclosure; what must never happen is the entry claiming to be a directory.
+	for _, u := range res.UnexaminedFiles {
+		if strings.Contains(u.Path, "locked.txt") {
+			if strings.Contains(strings.ToLower(u.Reason), "director") {
+				t.Errorf("a FILE was described as a directory: %q", u.Reason)
+			}
+			if u.Cause != causeUnreadable {
+				t.Errorf("cause = %v, want causeUnreadable", u.Cause)
+			}
+			return
+		}
+	}
+	// Not in UnexaminedFiles means the walk could stat it and queued it; the scanner
+	// then reports the read failure. Assert it was not silently dropped.
+	var queued bool
+	for _, p := range res.FilesToProcess {
+		if filepath.Base(p) == "locked.txt" {
+			queued = true
+		}
+	}
+	if !queued {
+		t.Error("the unreadable file is in neither UnexaminedFiles nor FilesToProcess — it " +
+			"was dropped with no record anywhere")
+	}
+}
+
+// The misleading aggregate must be gone.
+//
+// "Skipped N files or directories due to errors" was a bare count on stderr that named
+// nothing, reached no counter, and was fed by size refusals as well as real errors — so
+// a run whose only "errors" were two oversize files reported them as errors. See #336
+// defect 4.
+func TestNoStderrOnlyErrorAggregateRemains(t *testing.T) {
+	data, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+	// The phrase may survive in a comment explaining the removal; what must not survive
+	// is a Fprintf that emits it.
+	for _, line := range strings.Split(src, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "//") {
+			continue
+		}
+		if strings.Contains(line, "files or directories due to errors") {
+			t.Errorf("main.go still emits the stderr-only error aggregate: %s", trimmed)
+		}
+	}
+}


### PR DESCRIPTION
Closes #336 — this is the last of its four defects that needed code here.

It covered four defects; defects 1 and 4-for-size-refusals were already fixed on main (verified below), this PR fixes defects 3 and the rest of 4, and defect 2 is split out as #342 so #336 can close cleanly.

## The leak

A path `filepath.Walk` could not access printed one stderr warning and was appended to a local slice whose only consumer was a bare `Skipped N files or directories due to errors` count. It reached **no counter anywhere** — absent from `total_files`, `files_skipped`, `files_not_examined`, the NOT FULLY EXAMINED block, and `--fail-on-incomplete`.

Measured on the shipped binary against a permission-denied directory holding an SSN:

```
Skipped 1 files or directories due to errors     ← stderr only, named nothing
No matches found.
--fail-on-incomplete -> exit 0
json stats carried no files_not_examined key AT ALL
```

A directory of unread PII produced a clean bill of health. Same defect class as the oversize refusal fixed for #324, and **worse** — a refused *directory* hides every descendant.

## After

```
NOT FULLY EXAMINED: 1 of 2 files — findings may be missing
  cannot read (1)
    /tmp/d3/secret  directory could not be read, so an unknown number of files
                    inside it were not scanned: permission denied
--fail-on-incomplete -> exit 3
total_files 2, files_processed 1, files_skipped 0, files_not_examined 1
```

`causeUnreadable` is the right cause: unlike a size refusal or a declined symlink, this path genuinely could not be read.

A refused **directory** says so, and says the descendant count is unknown — plain "cannot read" on one path reads as one lost file, when the real loss is everything inside it. `info` is nil on an access error, so the kind is resolved with a direct `Lstat`; if even that fails the plain wording stands.

The walk continues, so one refused entry doesn't cost the rest of the tree — asserted.

## Defect 4

The `Skipped N files or directories due to errors` line is deleted along with the slice that fed it. Its only source was this branch, and the label was wrong regardless: size refusals were appended to the same slice, so a run whose only "errors" were two oversize files reported them as errors. The count now appears in the NOT FULLY EXAMINED block with the path and reason, in every output format.

## Already fixed on main (verified, not assumed)

Defect 1 and defect 4's size-refusal half. A run with 11 unexamined files across three causes prints `no body text: 9 · symlink not followed: 1 · file too large to scan: 1` — reconciling with the header — and no "due to errors" line appears for size refusals.

**Defect 2 is split out as #342**, not dropped: `files_skipped` counts files `total_files` excludes. It's accounting-only with no coverage loss, and per the issue it needs a reconciliation test wired to the *real* pipeline counters rather than hand-built fixtures — that is its own change, not a rider on a leak fix.

## Non-vacuity

| mutation | failure |
|---|---|
| swallow the `UnexaminedFiles` append | `not in UnexaminedFiles []` |
| drop the directory-specific wording | reason reads `"permission denied"`, losing that descendants are unaccounted for |

The tests skip on Windows (Unix permission bits unenforced) and as root (bypassed), and each **proves the fixture actually denies access** before asserting on the consequence — otherwise the fixture is readable, the walk reports no error, and the test passes while asserting nothing.

`make all` green; full suite 66 packages, 0 failures.

---

**Not self-merging** — for @rustic.
