### PR TITLE
fix(redactors): expand a social-media cluster back into its real spans before redacting

### DIFF
--- a/internal/core/cluster_redaction_sink_test.go
+++ b/internal/core/cluster_redaction_sink_test.go
@@ -1,0 +1,158 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/config"
+)
+
+// A clustered social-media finding must not survive redaction in cleartext.
+//
+// This is the assertion the existing gates could not make. SOCIAL_MEDIA_CLUSTER appears
+// in ZERO golden-corpus and ZERO score-corpus cases, and the only cluster test in the
+// tree asserts partition stability, not redaction — so the leak was outside everything
+// that runs on every change.
+//
+// Clustering replaced the matches it grouped with ONE synthesized match whose Text is a
+// rendered summary ("twitter: janedoe | linkedin: janedoe") occurring nowhere in the
+// document. Every redactor locates a match by searching for its Text, so the cluster
+// masked nothing while the real spans had already been dropped from the returned slice.
+//
+// Measured on the shipped binary with the shipped config, before the fix:
+//
+//	[HIGH] SOCIAL_MEDIA SOCIAL_MEDIA_CLUSTER 95.00% line 1
+//	Files: 1 scanned | Findings: 1 (1 high)
+//	diff input redacted  ->  IDENTICAL
+//
+// for simple, synthetic AND format_preserving. One HIGH finding at 95% and both handles
+// in the clear. See #289.
+//
+// It goes through core.RedactFile — the public path pkg/redact and the CLI both reach —
+// and asserts on the BYTES of the written file, because that is the only assertion that
+// distinguishes "reported" from "removed".
+func TestClusteredSocialMediaDoesNotSurviveRedaction(t *testing.T) {
+	// Platform patterns must be supplied: SOCIAL_MEDIA ships none built-in, so with a
+	// default config the scan reports nothing and there is no leak to observe. These
+	// mirror the shipped examples/ferret.yaml, minus its instagram trailing-slash bug
+	// (#343), which is why instagram is not used here.
+	cfg := config.LoadConfigOrDefault("")
+	if cfg.Validators == nil {
+		cfg.Validators = map[string]map[string]any{}
+	}
+	cfg.Validators["social_media"] = map[string]any{
+		"platform_patterns": map[string]any{
+			"twitter": []any{
+				`(?i)https?://(?:www\.)?(twitter|x)\.com/[a-zA-Z0-9_]+`,
+			},
+			"linkedin": []any{
+				`(?i)https?://(?:www\.)?linkedin\.com/in/[a-zA-Z0-9_-]+`,
+			},
+		},
+		"positive_keywords": []any{"profile", "connect with me"},
+	}
+
+	const (
+		twitterURL  = "https://twitter.com/janedoe"
+		linkedinURL = "https://linkedin.com/in/janedoe"
+	)
+	// Multi-line on purpose: a cluster's own LineNumber/FullLine name only the primary
+	// sub-match's line, so a fix that restored to the full line would mask line 1 and
+	// leave line 3 in the clear.
+	content := "Profile: " + twitterURL + "\n" +
+		"connect with me\n" +
+		"And " + linkedinURL + "\n"
+
+	// NOT under a path containing "tmp": exclude_patterns in the shipped config include
+	// "tmp", and a fixture there is skipped before it is ever scanned. t.TempDir() is
+	// safe here only because this test supplies its own config; the note stands as a
+	// warning for anyone reproducing by hand.
+	dir := t.TempDir()
+	src := filepath.Join(dir, "cluster.txt")
+	if err := os.WriteFile(src, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, strategy := range []string{"simple", "format_preserving", "synthetic"} {
+		t.Run(strategy, func(t *testing.T) {
+			outDir := filepath.Join(dir, "out-"+strategy)
+			res, err := RedactFile(RedactConfig{
+				FilePath:  src,
+				OutputDir: outDir,
+				Strategy:  strategy,
+				Checks:    []string{"SOCIAL_MEDIA"},
+				Config:    cfg,
+			})
+			if err != nil {
+				t.Fatalf("RedactFile: %v", err)
+			}
+			if res == nil {
+				t.Fatal("RedactFile returned no result")
+			}
+
+			// Non-vacuity: the fixture must actually produce a clustered finding. If
+			// clustering stops firing (a config change, a threshold change) this test
+			// would otherwise pass while asserting nothing about clusters at all.
+			var sawCluster bool
+			for _, m := range res.Matches {
+				if m.Type == "SOCIAL_MEDIA_CLUSTER" {
+					sawCluster = true
+				}
+			}
+			if len(res.Matches) == 0 {
+				t.Fatal("no findings at all — the fixture or its platform patterns no longer " +
+					"detect anything, so this test cannot observe the leak")
+			}
+			if !sawCluster {
+				t.Fatalf("no SOCIAL_MEDIA_CLUSTER among %d finding(s) — clustering did not fire, "+
+					"so this test is not exercising the clustered path", len(res.Matches))
+			}
+
+			// Find the written file and read its BYTES.
+			var written string
+			err = filepath.Walk(outDir, func(p string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+				if !info.IsDir() && filepath.Base(p) == "cluster.txt" {
+					written = p
+				}
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("walk output dir: %v", err)
+			}
+			if written == "" {
+				t.Fatalf("no redacted copy was written under %s — a clustered finding must "+
+					"either be redacted or refused, never silently skipped", outDir)
+			}
+			got, err := os.ReadFile(written) // #nosec G304 -- test temp dir
+			if err != nil {
+				t.Fatal(err)
+			}
+			out := string(got)
+
+			if out == content {
+				t.Fatalf("the redacted file is BYTE-IDENTICAL to the input — every clustered "+
+					"handle survived in cleartext.\ninput:    %q\nredacted: %q", content, out)
+			}
+			// Each real span, on its own line, must be gone. Asserting both is what
+			// catches a fix that only covers the cluster's primary line.
+			for _, secret := range []string{twitterURL, linkedinURL} {
+				if strings.Contains(out, secret) {
+					t.Errorf("redacted output still contains %q — it was reported (inside the "+
+						"cluster) and not removed:\n%s", secret, out)
+				}
+			}
+			// The synthesized summary must never be written INTO the document either.
+			if strings.Contains(out, "twitter: janedoe") || strings.Contains(out, "|") {
+				t.Errorf("the consolidated summary leaked into the redacted document:\n%s", out)
+			}
+		})
+	}
+}

--- a/internal/redactors/cluster_expansion_test.go
+++ b/internal/redactors/cluster_expansion_test.go
@@ -1,0 +1,182 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package redactors
+
+import (
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+)
+
+// A consolidated cluster must be expanded back into the real spans it replaced.
+//
+// SOCIAL_MEDIA clustering replaces the matches it groups with ONE synthesized match
+// whose Text is a rendered summary — "twitter: janedoe | linkedin: janedoe" — that occurs
+// nowhere in the document. Every redactor locates a match by searching for its Text, so
+// the cluster masked nothing and the real spans had already been dropped.
+//
+// Measured on the shipped binary with the shipped config, a 3-line fixture holding two
+// clustered handles:
+//
+//	[HIGH] SOCIAL_MEDIA SOCIAL_MEDIA_CLUSTER 95.00% line 1
+//	Files: 1 scanned | Findings: 1
+//	diff input redacted -> IDENTICAL
+//
+// for simple, synthetic AND format_preserving. One HIGH finding at 95%, both handles in
+// the clear. See #289.
+func TestExpandClusterMatchesReplacesClusterWithItsMembers(t *testing.T) {
+	members := []detector.Match{
+		{Text: "https://twitter.com/janedoe", Type: "SOCIAL_MEDIA", LineNumber: 1, Confidence: 90,
+			Context: detector.ContextInfo{FullLine: "Profile: https://twitter.com/janedoe"}},
+		{Text: "https://linkedin.com/in/janedoe", Type: "SOCIAL_MEDIA", LineNumber: 3, Confidence: 90,
+			Context: detector.ContextInfo{FullLine: "And https://linkedin.com/in/janedoe"}},
+	}
+	cluster := detector.Match{
+		// A rendered summary, not a span of the document.
+		Text:       "twitter: janedoe | linkedin: janedoe",
+		Type:       "SOCIAL_MEDIA_CLUSTER",
+		LineNumber: 1,
+		Confidence: 95,
+		Context:    detector.ContextInfo{FullLine: "Profile: https://twitter.com/janedoe"},
+		Metadata:   map[string]interface{}{ClusterMembersKey: members},
+	}
+
+	in := []detector.Match{
+		{Text: "unrelated@example.com", Type: "EMAIL", LineNumber: 5},
+		cluster,
+	}
+	out := ExpandClusterMatches(in)
+
+	if len(out) != 3 {
+		t.Fatalf("got %d matches, want 3 (the email plus both cluster members) — %+v", len(out), out)
+	}
+	// Order preserved: matches before the cluster keep their position.
+	if out[0].Text != "unrelated@example.com" {
+		t.Errorf("out[0] = %q, want the untouched earlier match", out[0].Text)
+	}
+	for i, want := range []string{"https://twitter.com/janedoe", "https://linkedin.com/in/janedoe"} {
+		if out[i+1].Text != want {
+			t.Errorf("out[%d].Text = %q, want %q", i+1, out[i+1].Text, want)
+		}
+	}
+	// The synthesized text must be gone: it matches nothing, so leaving it in would
+	// preserve exactly the finding that redacts nothing.
+	for _, m := range out {
+		if m.Type == "SOCIAL_MEDIA_CLUSTER" {
+			t.Error("the cluster survived expansion; its Text occurs nowhere in the document, " +
+				"so it would redact nothing while the real spans stayed dropped")
+		}
+	}
+	// Members must carry the per-line context redaction needs to position them: a cluster
+	// spans SEVERAL lines while its own LineNumber/FullLine name only the primary
+	// sub-match's, which is why a full-line restore (RestoreBoundedMatchText) is not
+	// enough here.
+	if out[2].LineNumber != 3 || out[2].Context.FullLine == out[1].Context.FullLine {
+		t.Errorf("member 2 has line %d and FullLine %q — each member must keep its OWN line, "+
+			"or every line but the primary stays in cleartext",
+			out[2].LineNumber, out[2].Context.FullLine)
+	}
+}
+
+// The input must not be mutated: formatters report the single consolidated finding, and
+// the finding count must not change because redaction expanded it.
+func TestExpandClusterMatchesDoesNotMutateInput(t *testing.T) {
+	members := []detector.Match{{Text: "https://twitter.com/janedoe", LineNumber: 1}}
+	in := []detector.Match{{
+		Text:     "twitter: janedoe",
+		Type:     "SOCIAL_MEDIA_CLUSTER",
+		Metadata: map[string]interface{}{ClusterMembersKey: members},
+	}}
+
+	_ = ExpandClusterMatches(in)
+
+	if len(in) != 1 || in[0].Text != "twitter: janedoe" || in[0].Type != "SOCIAL_MEDIA_CLUSTER" {
+		t.Errorf("input was mutated: %+v — the caller still reports the consolidated finding", in)
+	}
+}
+
+// Fail-safe direction: a cluster that cannot be expanded is passed through unchanged
+// rather than dropped, so expansion can only ever WIDEN what redaction sees.
+func TestExpandClusterMatchesPassesThroughWhatItCannotExpand(t *testing.T) {
+	cases := []struct {
+		name string
+		m    detector.Match
+	}{
+		{"no metadata", detector.Match{Text: "x", Type: "SOCIAL_MEDIA_CLUSTER"}},
+		{"no members key", detector.Match{Text: "x", Type: "SOCIAL_MEDIA_CLUSTER",
+			Metadata: map[string]interface{}{"other": 1}}},
+		{"members wrong type", detector.Match{Text: "x", Type: "SOCIAL_MEDIA_CLUSTER",
+			Metadata: map[string]interface{}{ClusterMembersKey: "not a slice"}}},
+		{"members empty", detector.Match{Text: "x", Type: "SOCIAL_MEDIA_CLUSTER",
+			Metadata: map[string]interface{}{ClusterMembersKey: []detector.Match{}}}},
+		{"members all textless", detector.Match{Text: "x", Type: "SOCIAL_MEDIA_CLUSTER",
+			Metadata: map[string]interface{}{ClusterMembersKey: []detector.Match{{Text: ""}}}}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			out := ExpandClusterMatches([]detector.Match{c.m})
+			if len(out) != 1 || out[0].Text != c.m.Text {
+				t.Errorf("got %+v, want the original passed through — dropping a match it "+
+					"cannot expand would REMOVE it from the redaction input", out)
+			}
+		})
+	}
+
+	// A member with no text is unlocatable and must not be emitted, but its siblings
+	// must survive.
+	mixed := detector.Match{Text: "cluster", Type: "SOCIAL_MEDIA_CLUSTER",
+		Metadata: map[string]interface{}{ClusterMembersKey: []detector.Match{
+			{Text: ""}, {Text: "real@example.com", LineNumber: 2},
+		}}}
+	out := ExpandClusterMatches([]detector.Match{mixed})
+	if len(out) != 1 || out[0].Text != "real@example.com" {
+		t.Errorf("got %+v, want just the locatable member", out)
+	}
+}
+
+// No clusters means no copy and no change — the common path.
+func TestExpandClusterMatchesLeavesOrdinaryMatchesAlone(t *testing.T) {
+	in := []detector.Match{
+		{Text: "a@example.com", LineNumber: 1},
+		{Text: "b@example.com", LineNumber: 2},
+	}
+	out := ExpandClusterMatches(in)
+	if len(out) != len(in) {
+		t.Fatalf("got %d, want %d", len(out), len(in))
+	}
+	for i := range in {
+		if out[i].Text != in[i].Text {
+			t.Errorf("out[%d] = %q, want %q", i, out[i].Text, in[i].Text)
+		}
+	}
+	if ExpandClusterMatches(nil) != nil {
+		t.Error("nil input should return nil")
+	}
+}
+
+// Several clusters in one slice must all expand.
+func TestExpandClusterMatchesHandlesMultipleClusters(t *testing.T) {
+	mk := func(text string, members ...string) detector.Match {
+		ms := make([]detector.Match, 0, len(members))
+		for i, s := range members {
+			ms = append(ms, detector.Match{Text: s, LineNumber: i + 1})
+		}
+		return detector.Match{Text: text, Type: "SOCIAL_MEDIA_CLUSTER",
+			Metadata: map[string]interface{}{ClusterMembersKey: ms}}
+	}
+	out := ExpandClusterMatches([]detector.Match{
+		mk("c1", "one", "two"),
+		{Text: "middle", LineNumber: 9},
+		mk("c2", "three"),
+	})
+	want := []string{"one", "two", "middle", "three"}
+	if len(out) != len(want) {
+		t.Fatalf("got %d matches, want %d — %+v", len(out), len(want), out)
+	}
+	for i := range want {
+		if out[i].Text != want[i] {
+			t.Errorf("out[%d] = %q, want %q", i, out[i].Text, want[i])
+		}
+	}
+}

--- a/internal/redactors/consolidated.go
+++ b/internal/redactors/consolidated.go
@@ -55,6 +55,82 @@ func RestoreBoundedMatchText(matches []detector.Match) []detector.Match {
 	return out
 }
 
+// ClusterMembersKey is the metadata key a validator sets to the constituent matches a
+// consolidated finding replaced, so redaction can still reach the real spans.
+//
+// The SOCIAL_MEDIA validator sets it when clustering collapses several handles into one
+// SOCIAL_MEDIA_CLUSTER finding. Validators write the literal "cluster_members" rather
+// than importing this package (they must not — see the note in
+// socialmedia.leanClusterMembers), so the two must stay in sync.
+const ClusterMembersKey = "cluster_members"
+
+// ExpandClusterMatches returns a copy of matches with every consolidated cluster
+// replaced by the constituent matches it was built from.
+//
+// Why this exists: a cluster's Text is a RENDERED SUMMARY, not a span of the document —
+// "twitter: janedoe | linkedin: janedoe" occurs nowhere in the file. Every redactor
+// locates a match by searching for its Text, so the cluster masks nothing, and the real
+// spans were already dropped when the validator replaced them. Measured on a 3-line
+// fixture with two clustered handles: one HIGH finding at 95% and a "redacted" file
+// BYTE-IDENTICAL to the input, for simple, synthetic AND format_preserving. See #289.
+//
+// Unlike RestoreBoundedMatchText, restoring to Context.FullLine is NOT sufficient here: a
+// cluster spans several lines (twitter on line 1, linkedin on line 3) while LineNumber and
+// FullLine carry only the primary sub-match's line, so a full-line restore would mask one
+// line and leave the rest in the clear.
+//
+// Fail-safe direction, matching its sibling: this can only WIDEN what gets redacted. A
+// cluster whose members are missing or empty is passed through unchanged rather than
+// dropped, so a cluster is never silently removed from the redaction input — it simply
+// keeps today's behaviour of matching nothing. The input slice and its Match structs are
+// not mutated, so formatters still report the single consolidated finding and the finding
+// count does not change.
+func ExpandClusterMatches(matches []detector.Match) []detector.Match {
+	first := -1
+	for i := range matches {
+		if len(clusterMembers(&matches[i])) > 0 {
+			first = i
+			break
+		}
+	}
+	if first == -1 {
+		return matches // common case: no clusters, zero copies
+	}
+
+	out := make([]detector.Match, 0, len(matches)+4)
+	out = append(out, matches[:first]...)
+	for i := first; i < len(matches); i++ {
+		if members := clusterMembers(&matches[i]); len(members) > 0 {
+			out = append(out, members...)
+			continue
+		}
+		out = append(out, matches[i])
+	}
+	return out
+}
+
+// clusterMembers returns the constituent matches recorded on a consolidated finding, or
+// nil when it is not a cluster.
+//
+// Members carrying an empty Text are skipped: they cannot be located, and passing one on
+// would only add a match that silently redacts nothing.
+func clusterMembers(m *detector.Match) []detector.Match {
+	if m.Metadata == nil {
+		return nil
+	}
+	raw, ok := m.Metadata[ClusterMembersKey].([]detector.Match)
+	if !ok {
+		return nil
+	}
+	out := make([]detector.Match, 0, len(raw))
+	for i := range raw {
+		if raw[i].Text != "" {
+			out = append(out, raw[i])
+		}
+	}
+	return out
+}
+
 // isBoundedMatch reports whether the match carries a bounded (truncated)
 // display text that must be restored to its full-line span for redaction.
 func isBoundedMatch(m *detector.Match) bool {

--- a/internal/redactors/legacyole/redactor.go
+++ b/internal/redactors/legacyole/redactor.go
@@ -145,6 +145,12 @@ func (r *LegacyOLERedactor) RedactDocument(originalPath string, outputPath strin
 		logical[i] = s.readLogical(modified)
 	}
 
+	// A consolidated cluster's Text is a rendered summary that occurs in no stream, so
+	// searching for it masks nothing while the real spans it replaced were already
+	// dropped. Expand it first, exactly as the plaintext and office paths do. See
+	// redactors.ExpandClusterMatches and #289.
+	matches = redactors.ExpandClusterMatches(matches)
+
 	for _, m := range matches {
 		if m.Text == "" {
 			continue

--- a/internal/redactors/office/redactor.go
+++ b/internal/redactors/office/redactor.go
@@ -681,6 +681,12 @@ func (or *OfficeRedactor) redactOfficeContent(zipContents *OfficeZipContents, ex
 	// full-line spans first — redaction locates matches by searching for
 	// Match.Text in the extracted content, and a bounded display text does not
 	// occur there. See redactors.RestoreBoundedMatchText.
+	// Expand a consolidated cluster back into the real spans it replaced FIRST: its
+	// Text is a rendered summary that occurs nowhere in the document, so without this
+	// the cluster masks nothing and every handle it grouped survives in cleartext.
+	// See redactors.ExpandClusterMatches and #289.
+	matches = redactors.ExpandClusterMatches(matches)
+
 	matches = redactors.RestoreBoundedMatchText(matches)
 
 	// Collapse overlapping matches to their widest span so a smaller match

--- a/internal/redactors/plaintext/redactor.go
+++ b/internal/redactors/plaintext/redactor.go
@@ -186,6 +186,12 @@ func (ptr *PlainTextRedactor) redactText(originalText string, matches []detector
 	// Match.Text, and a bounded display text does not occur in the document —
 	// without this the whole consolidated line would silently survive
 	// redaction. See redactors.RestoreBoundedMatchText.
+	// Expand a consolidated cluster back into the real spans it replaced FIRST: its
+	// Text is a rendered summary that occurs nowhere in the document, so without this
+	// the cluster masks nothing and every handle it grouped survives in cleartext.
+	// See redactors.ExpandClusterMatches and #289.
+	matches = redactors.ExpandClusterMatches(matches)
+
 	matches = redactors.RestoreBoundedMatchText(matches)
 
 	// Collapse overlapping matches to their widest span first. Otherwise a

--- a/internal/validators/socialmedia/validator.go
+++ b/internal/validators/socialmedia/validator.go
@@ -4462,6 +4462,28 @@ func (v *Validator) reconstructSocialMediaCluster(matches []detector.Match) (det
 		"original_platforms":   originalPlatforms,
 		"primary_match_index":  v.findPrimaryClusterMatchIndex(matches, primaryMatch),
 
+		// The constituent matches this cluster replaced, kept so REDACTION can still
+		// reach the real spans.
+		//
+		// Text below is consolidatedText — a rendered summary like
+		// "twitter: janedoe | linkedin: janedoe" — which does not occur anywhere in the
+		// document. Every redactor locates a match by searching for its Text, so the
+		// cluster masks nothing, and the real spans that were correctly detected have
+		// already been dropped from the returned slice. Measured: a 3-line fixture with
+		// two clustered handles produced one HIGH finding at 95% and a "redacted" file
+		// BYTE-IDENTICAL to the input, for all three strategies. See #289.
+		//
+		// The key is a literal rather than redactors.ClusterMembersKey because
+		// validators must not import internal/redactors — the same reason the
+		// intellectualproperty validator writes "match_text_truncated" as a literal. It
+		// must stay in sync with that constant.
+		//
+		// Held as lean copies with SecureText dropped: these carry the matched value, so
+		// they are withheld from output by the formatters' deny-by-default metadata
+		// allowlist unless --show-match is set, and a SecureString has no business being
+		// serialized.
+		"cluster_members": leanClusterMembers(matches),
+
 		// Reconstruction metadata
 		"source":                   "social_media_clustering",
 		"reconstruction_algorithm": "profile_clustering_analysis",
@@ -4483,6 +4505,37 @@ func (v *Validator) reconstructSocialMediaCluster(matches []detector.Match) (det
 	}
 
 	return reconstructedMatch, nil
+}
+
+// leanClusterMembers copies the constituent matches, keeping only what redaction needs
+// to locate and mask each real span.
+//
+// SecureText is dropped: it is a pointer to a SecureString whose whole purpose is to
+// keep the value out of ordinary memory, and carrying it into a metadata map that may be
+// serialized would defeat that. Metadata is also dropped — a member's own metadata is
+// not needed to redact it, and nesting it would balloon the cluster's map.
+//
+// What is kept is exactly the redaction contract: Text to locate the span, LineNumber
+// plus Context to position it (redactors.ResolveOverlaps needs FullLine to tell two
+// same-numbered lines apart), and Type/Confidence/Filename/Validator so the replacement
+// is generated and attributed as it would have been without clustering.
+func leanClusterMembers(matches []detector.Match) []detector.Match {
+	out := make([]detector.Match, 0, len(matches))
+	for _, m := range matches {
+		out = append(out, detector.Match{
+			Text:        m.Text,
+			LineNumber:  m.LineNumber,
+			Type:        m.Type,
+			Confidence:  m.Confidence,
+			Filename:    m.Filename,
+			Validator:   m.Validator,
+			SourceKind:  m.SourceKind,
+			StartColumn: m.StartColumn,
+			EndColumn:   m.EndColumn,
+			Context:     m.Context,
+		})
+	}
+	return out
 }
 
 // findPrimaryClusterMatch finds the match with the highest confidence to use as primary


### PR DESCRIPTION
Closes #289.

## The leak

SOCIAL_MEDIA clustering replaced the matches it grouped with **one synthesized match** whose `Text` is a rendered summary — `"twitter: janedoe | linkedin: janedoe"` — occurring nowhere in the document. Every redactor locates a match by searching for its `Text`, so the cluster masked nothing, and the real spans had already been dropped from the returned slice.

Reproduced on main with the shipped config, a 3-line fixture with two clustered handles:

```
[HIGH] SOCIAL_MEDIA SOCIAL_MEDIA_CLUSTER 95.00% line 1
Files: 1 scanned | Findings: 1 (1 high)
diff input redacted -> IDENTICAL
```

for **simple, synthetic and format_preserving**. One HIGH finding at 95%, both handles in the clear, exit 0. Clustering is on by default, so this is the shipped path.

## The fix

Uses the seam this codebase already has — reporting and redaction are separable, which `RestoreBoundedMatchText` already relies on for the same class of problem (a `Match.Text` that doesn't occur in the document):

- the validator records the constituent matches it collapsed, as lean copies;
- `redactors.ExpandClusterMatches`, a sibling of `RestoreBoundedMatchText`, replaces a cluster with those members before masking;
- called at the same two sites, ahead of the bounded-text restore.

**Restoring to `Context.FullLine` — what the bounded case does — is not sufficient here.** A cluster spans several lines (twitter on line 1, linkedin on line 3) while its `LineNumber`/`FullLine` carry only the *primary* sub-match's line, so a full-line restore masks one line and leaves the rest in the clear. That's why the fixture is multi-line and asserts **both** spans.

**Reporting is unchanged.** The input slice isn't mutated, so formatters still emit the single consolidated finding and the count stays at 1 — verified.

**Fail-safe direction**, matching the sibling: expansion can only *widen* what redaction sees. A cluster whose members are absent, wrongly typed or empty passes through unchanged rather than being dropped, so a cluster is never silently *removed* from the redaction input.

Members are lean copies with `SecureText` and `Metadata` dropped — `SecureText` exists to keep a value out of ordinary memory and has no business in a possibly-serialized map. What's kept is exactly the redaction contract: `Text` to locate, `LineNumber` + `Context` to position (`ResolveOverlaps` needs `FullLine` to tell two same-numbered lines apart), and `Type`/`Confidence`/`Filename`/`Validator` so the replacement is generated and attributed as it would have been unclustered. They carry the matched value, so the formatters' deny-by-default metadata allowlist withholds them unless `--show-match` is set — where values are shown anyway.

The key is a literal in the validator because validators must not import `internal/redactors`, the same arrangement `intellectualproperty` uses for `match_text_truncated`.

## Why the gates missed it

`SOCIAL_MEDIA_CLUSTER` appears in **zero** golden-corpus and **zero** score-corpus cases, and the only cluster test in the tree asserts partition stability.

The new end-to-end test goes through `core.RedactFile` — the path `pkg/redact` and the CLI both reach — and asserts on the **bytes of the written file** for all three strategies, which is the only assertion that distinguishes "reported" from "removed". It also fails if clustering stops firing, so it can't silently stop testing clusters.

## Non-vacuity

Each half of the wiring caught independently, both reproducing the original symptom verbatim:

| mutation | failure |
|---|---|
| validator stops recording members | `the redacted file is BYTE-IDENTICAL to the input` |
| redaction stops expanding | `the redacted file is BYTE-IDENTICAL to the input` |

## Found while verifying — filed separately

The shipped config's **instagram** pattern requires a trailing slash, so the canonical `instagram.com/handle` is never detected at all. Filed as **#343**; deliberately not used in this fixture.

## Every text-searching redactor is covered (second commit)

My first pass said only plaintext and office normalize matches and left PDF, image and legacy-OLE as a filed follow-up. **That was over-scoped.** Checked rather than assumed:

| redactor | match loops | expands clusters |
|---|---|---|
| plaintext | — | yes |
| office | 2 | yes |
| **legacyole** | 1 | **yes (2nd commit)** |
| pdf | **0** | n/a — no text replacement at all, it refuses (#315) |
| image | **0** | n/a — same |

PDF and image don't iterate matches; they refuse outright, which is a different problem (#315). So the gap was **one** call site, not three — and legacy-OLE had exactly the defect, searching for `m.Text` in each CFB stream's logical bytes. Closed here rather than filed.

`make all` green; full suite 66 packages, 0 failures; golden corpus unchanged.

---

**Not self-merging** — for @rustic.
