### PR TITLE
fix(config): drop the mandatory trailing slash from social profile patterns, so the canonical URL is detected

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -367,9 +367,9 @@ validators:
 
       # Instagram - Photo/video sharing platform
       instagram:
-        - "(?i)https?://(?:www\\.)?instagram\\.com/[a-zA-Z0-9_.]+/" # Profile URLs
-        - "(?i)https?://(?:www\\.)?instagr\\.am/[a-zA-Z0-9_.]+/" # Short domain
-        - "(?i)instagram\\.com/[a-zA-Z0-9_.]+/" # Without protocol
+        - "(?i)https?://(?:www\\.)?instagram\\.com/[a-zA-Z0-9_.]+" # Profile URLs
+        - "(?i)https?://(?:www\\.)?instagr\\.am/[a-zA-Z0-9_.]+" # Short domain
+        - "(?i)instagram\\.com/[a-zA-Z0-9_.]+" # Without protocol
 
       # YouTube - Video sharing platform
       youtube:
@@ -380,9 +380,9 @@ validators:
 
       # TikTok - Short video platform
       tiktok:
-        - "(?i)https?://(?:www\\.)?tiktok\\.com/@[a-zA-Z0-9_.]+/" # Profile URLs
+        - "(?i)https?://(?:www\\.)?tiktok\\.com/@[a-zA-Z0-9_.]+" # Profile URLs
         - "(?i)https?://(?:www\\.)?tiktok\\.com/t/[a-zA-Z0-9]+" # Short URLs
-        - "(?i)tiktok\\.com/@[a-zA-Z0-9_.]+/" # Without protocol
+        - "(?i)tiktok\\.com/@[a-zA-Z0-9_.]+" # Without protocol
 
       # Discord - Gaming/community chat platform
       discord:
@@ -398,13 +398,13 @@ validators:
 
       # Snapchat - Multimedia messaging platform
       snapchat:
-        - "(?i)https?://(?:www\\.)?snapchat\\.com/add/[a-zA-Z0-9_.]+/" # Add friend URLs
-        - "(?i)snapchat\\.com/add/[a-zA-Z0-9_.]+/" # Without protocol
+        - "(?i)https?://(?:www\\.)?snapchat\\.com/add/[a-zA-Z0-9_.]+" # Add friend URLs
+        - "(?i)snapchat\\.com/add/[a-zA-Z0-9_.]+" # Without protocol
 
       # Pinterest - Visual discovery platform
       pinterest:
-        - "(?i)https?://(?:www\\.)?pinterest\\.com/[a-zA-Z0-9_]+/" # Profile URLs
-        - "(?i)pinterest\\.com/[a-zA-Z0-9_]+/" # Without protocol
+        - "(?i)https?://(?:www\\.)?pinterest\\.com/[a-zA-Z0-9_]+" # Profile URLs
+        - "(?i)pinterest\\.com/[a-zA-Z0-9_]+" # Without protocol
 
       # Twitch - Live streaming platform
       twitch:

--- a/examples/ferret-windows.yaml
+++ b/examples/ferret-windows.yaml
@@ -171,7 +171,7 @@ validators:
       facebook:
         - "(?i)https?://(?:www\\.)?(facebook|fb)\\.com/[a-zA-Z0-9._-]+"
       instagram:
-        - "(?i)https?://(?:www\\.)?instagram\\.com/[a-zA-Z0-9_.]+/"
+        - "(?i)https?://(?:www\\.)?instagram\\.com/[a-zA-Z0-9_.]+"
       youtube:
         - "(?i)https?://(?:www\\.)?youtube\\.com/(?:user|c|channel)/[a-zA-Z0-9_-]+"
         - "(?i)https?://(?:www\\.)?youtube\\.com/@[a-zA-Z0-9_-]+"

--- a/examples/ferret.yaml
+++ b/examples/ferret.yaml
@@ -178,7 +178,7 @@ validators:
       facebook:
         - "(?i)https?://(?:www\\.)?(facebook|fb)\\.com/[a-zA-Z0-9._-]+"
       instagram:
-        - "(?i)https?://(?:www\\.)?instagram\\.com/[a-zA-Z0-9_.]+/"
+        - "(?i)https?://(?:www\\.)?instagram\\.com/[a-zA-Z0-9_.]+"
       youtube:
         - "(?i)https?://(?:www\\.)?youtube\\.com/(?:user|c|channel)/[a-zA-Z0-9_-]+"
         - "(?i)https?://(?:www\\.)?youtube\\.com/@[a-zA-Z0-9_-]+"

--- a/internal/config/shipped_social_patterns_test.go
+++ b/internal/config/shipped_social_patterns_test.go
@@ -1,0 +1,170 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The shipped configs' social-media patterns must actually match the profile URLs people
+// paste.
+//
+// Nothing in the test suite loaded a shipped config and exercised its regexes, so a
+// pattern bug was invisible to every gate. The instagram entry required a TRAILING SLASH:
+//
+//	"(?i)https?://(?:www\\.)?instagram\\.com/[a-zA-Z0-9_.]+/"
+//
+// while every other platform omitted it. Measured on the shipped binary:
+//
+//	https://instagram.com/janedoe/   -> 1 finding
+//	https://instagram.com/janedoe    -> 0 findings, "No matches found."
+//
+// The unslashed form is what a browser address bar shows and what people paste, so the
+// common case was the undetected one — and by the sink rule an undetected value is an
+// unredacted one: it passes through --enable-redaction in cleartext with no disclosure.
+// See #343, found while fixing #289.
+//
+// The inconsistency with its siblings was the tell, which is what this test encodes:
+// a platform pattern that only matches one of the two forms is almost certainly an
+// anchoring mistake rather than a deliberate choice.
+
+// shippedConfigs are the files a user actually gets. config.yaml is the repo's tracked
+// config; examples/ferret.yaml is what `make install-config` installs.
+var shippedConfigs = []string{
+	filepath.Join("..", "..", "config.yaml"),
+	filepath.Join("..", "..", "examples", "ferret.yaml"),
+	filepath.Join("..", "..", "examples", "ferret-windows.yaml"),
+}
+
+// profileURLs are canonical profile links per platform, in BOTH the slashed and unslashed
+// form. A platform must match both: the character class stops at "/", so a pattern with no
+// trailing slash matches either, while one that requires the slash matches only the first.
+var profileURLs = map[string][]string{
+	"instagram": {"https://instagram.com/janedoe", "https://instagram.com/janedoe/"},
+	"twitter":   {"https://twitter.com/janedoe", "https://twitter.com/janedoe/"},
+	"linkedin":  {"https://linkedin.com/in/janedoe", "https://linkedin.com/in/janedoe/"},
+	"facebook":  {"https://facebook.com/janedoe", "https://facebook.com/janedoe/"},
+}
+
+func TestShippedSocialMediaPatternsMatchCanonicalProfileURLs(t *testing.T) {
+	for _, path := range shippedConfigs {
+		t.Run(filepath.Base(filepath.Dir(path))+"/"+filepath.Base(path), func(t *testing.T) {
+			cfg, err := LoadConfig(path)
+			if err != nil {
+				t.Fatalf("LoadConfig(%s): %v", path, err)
+			}
+			sm, ok := cfg.Validators["social_media"]
+			if !ok {
+				t.Skipf("%s defines no social_media validator config", path)
+			}
+			raw, ok := sm["platform_patterns"].(map[string]any)
+			if !ok || len(raw) == 0 {
+				t.Skipf("%s defines no platform_patterns", path)
+			}
+
+			// Non-vacuity: the platforms we assert on must actually be present, or this
+			// test would silently assert nothing after a config rename.
+			var checked int
+			for platform, urls := range profileURLs {
+				patterns, present := raw[platform]
+				if !present {
+					continue
+				}
+				list, ok := patterns.([]any)
+				if !ok || len(list) == 0 {
+					t.Errorf("%s: platform %q has no patterns", path, platform)
+					continue
+				}
+				checked++
+
+				for _, url := range urls {
+					var matched bool
+					for _, p := range list {
+						expr, ok := p.(string)
+						if !ok {
+							t.Errorf("%s: platform %q has a non-string pattern %v", path, platform, p)
+							continue
+						}
+						re, err := regexp.Compile(expr)
+						if err != nil {
+							// A pattern Go's RE2 cannot compile is silently dropped at
+							// runtime, so the platform stops detecting with no warning.
+							t.Errorf("%s: platform %q pattern %q does not compile: %v",
+								path, platform, expr, err)
+							continue
+						}
+						if re.MatchString(url) {
+							matched = true
+							break
+						}
+					}
+					if !matched {
+						t.Errorf("%s: platform %q matches none of its patterns against %q.\n"+
+							"Both the slashed and unslashed profile form must match — the "+
+							"unslashed one is what a browser shows and what people paste, and "+
+							"an undetected value is also an unredacted one.",
+							path, platform, url)
+					}
+				}
+			}
+			if checked == 0 {
+				t.Errorf("%s: none of the expected platforms (%v) were found in "+
+					"platform_patterns — this test asserted nothing",
+					path, keysOf(profileURLs))
+			}
+		})
+	}
+}
+
+// No shipped platform pattern may require a trailing slash.
+//
+// Asserted separately from the match test because it names the specific mistake, so a
+// reviewer seeing this fail knows immediately what to look for rather than deducing it
+// from a failed URL match.
+func TestNoShippedSocialPatternRequiresATrailingSlash(t *testing.T) {
+	for _, path := range shippedConfigs {
+		cfg, err := LoadConfig(path)
+		if err != nil {
+			t.Fatalf("LoadConfig(%s): %v", path, err)
+		}
+		sm, ok := cfg.Validators["social_media"]
+		if !ok {
+			continue
+		}
+		raw, ok := sm["platform_patterns"].(map[string]any)
+		if !ok {
+			continue
+		}
+		for platform, patterns := range raw {
+			list, ok := patterns.([]any)
+			if !ok {
+				continue
+			}
+			for _, p := range list {
+				expr, ok := p.(string)
+				if !ok {
+					continue
+				}
+				// A character class immediately followed by "/" at the END of the pattern
+				// makes the slash mandatory, which excludes the canonical form.
+				if strings.HasSuffix(expr, "]+/") || strings.HasSuffix(expr, "]*/") {
+					t.Errorf("%s: platform %q pattern %q ends with a mandatory trailing "+
+						"slash, so the canonical profile URL without one never matches",
+						path, platform, expr)
+				}
+			}
+		}
+	}
+}
+
+func keysOf(m map[string][]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
Closes #343. Found while fixing #289.

## The bug

Several shipped social-media profile patterns required a **trailing slash**:

```yaml
instagram:
  - "(?i)https?://(?:www\\.)?instagram\\.com/[a-zA-Z0-9_.]+/"
```

so the form a browser address bar shows — and the form people paste — never matched:

```
https://instagram.com/janedoe/   -> 1 finding
https://instagram.com/janedoe    -> 0 findings, "No matches found."
```

By the sink rule an undetected value is also an **unredacted** one: it passed straight through `--enable-redaction` in cleartext with no disclosure. This is why the #289 fixture still showed `Also https://instagram.com/janedoe` after that leak was fixed — instagram was never detected, so there was nothing to redact.

## Scope — bigger than I first thought

I found instagram by hand and assumed it was the only one. **Writing the general test found three more platforms with the identical mistake:**

| platform | patterns affected |
|---|---|
| instagram | 3 (profile, `instagr.am` short domain, without protocol) |
| tiktok | 2 |
| snapchat | 2 |
| pinterest | 2 |
| `examples/ferret.yaml`, `examples/ferret-windows.yaml` | 1 each |

**11 patterns across three shipped files.** No other platform required a trailing slash, which is what made it a typo rather than a deliberate choice.

Dropping the slash matches both forms, because the character class stops at `/`. It adds no false-positive class — a post URL like `instagram.com/p/ABC123` matched the slashed pattern too (as `p/`), so that's unchanged.

## Why no gate caught it

Nothing in the test suite loaded a shipped config and exercised its regexes — the patterns live in YAML and the Go tests never read them. Two tests close that:

- each shipped config's platform patterns must match **both** the slashed and unslashed profile URL, and must **compile** (an RE2-invalid pattern is silently dropped at runtime, so a platform stops detecting with no warning);
- no shipped pattern may end with a character class followed by `/`, which names the specific mistake so a future failure is self-explanatory.

The first also fails if none of the expected platforms are present, so a config rename can't leave it asserting nothing.

Verified on the binary: instagram, tiktok, snapchat and pinterest all now detect the canonical profile URL, and redaction removes it.

## Pre-existing, not addressed here

A single URL reports **twice**, because the with-protocol and without-protocol patterns both match (nested spans). `ResolveOverlaps` collapses those on the redaction path but not on the reporting path, so the finding count is inflated while redaction is correct. Same family as #321; out of scope for a config fix.

`make all` green; full suite 66 packages, 0 failures.

---

**Not self-merging** — for @rustic.