### PR TITLE
fix(audio): recover a WAV whose odd chunk lacks its pad byte, and disclose the malformed layout

### DIFF
--- a/internal/preprocessors/audio_metadata_preprocessor.go
+++ b/internal/preprocessors/audio_metadata_preprocessor.go
@@ -119,13 +119,26 @@ func (amp *AudioMetadataPreprocessor) processAudioMetadataWithRetry(filePath str
 	text := audioMeta.ToProcessedContent()
 
 	// Build successful content using shared utilities
-	return amp.sharedUtils.ContentBuilder.BuildSuccessContent(
+	content := amp.sharedUtils.ContentBuilder.BuildSuccessContent(
 		filePath,
 		text,
 		"audio_metadata",
 		"audio_metadata",
 		0, // Audio files don't have page count
-	), nil
+	)
+
+	// Carry an extraction caveat forward, so a file whose chunk layout could not be
+	// followed is not reported as clean.
+	//
+	// Deliberately NOT an Error: extraction SUCCEEDED and produced findings, so failing
+	// the file would discard real results. Only ExtractionWarning survives the router's
+	// combine step, which is the same route the corrupt-PDF disclosure uses. Without this
+	// a malformed WAV printed "No matches found." and exited 0 — output identical to a
+	// genuinely clean file. See #312.
+	if content != nil && audioMeta.ExtractionWarning != "" {
+		content.ExtractionWarning = audioMeta.ExtractionWarning
+	}
+	return content, nil
 }
 
 // GetName returns the name of this preprocessor

--- a/internal/preprocessors/meta-extractors/meta-extract-audiolib/audio-metadata.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-audiolib/audio-metadata.go
@@ -50,6 +50,19 @@ type AudioMetadata struct {
 
 	// Additional properties
 	Properties map[string]string
+
+	// ExtractionWarning is a short, payload-free note that extraction completed but
+	// may be INCOMPLETE — for example a RIFF chunk layout that could not be walked to
+	// the end, so metadata beyond that point was never read.
+	//
+	// It exists because the failure is otherwise invisible. A WAV whose chunk walk goes
+	// wrong yields an empty result and no error, so the run prints "No matches found."
+	// and exits 0 — byte-identical output to a genuinely clean file, with nothing for an
+	// operator to distinguish "no metadata" from "could not be read". Same shape as the
+	// corrupt-PDF disclosure. See #312.
+	//
+	// Payload-free by contract: it names the condition and the chunk kind, never a value.
+	ExtractionWarning string
 }
 
 // AudioMetadataExtractor interface for audio metadata extraction

--- a/internal/preprocessors/meta-extractors/meta-extract-audiolib/wav-extractor.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-audiolib/wav-extractor.go
@@ -72,6 +72,11 @@ func (e *WAVExtractor) ExtractMetadata(filePath string) (*AudioMetadata, error) 
 
 // parseChunks parses WAV chunks
 func (e *WAVExtractor) parseChunks(file *os.File, metadata *AudioMetadata) error {
+	// sawMissingPad records that an odd-length chunk was not followed by the pad byte RIFF
+	// requires, so the walk had to realign. Reported after the loop rather than on the spot
+	// because recovery succeeds and the note belongs to the file, not to one chunk.
+	sawMissingPad := false
+
 	for {
 		var header WAVChunkHeader
 		if err := binary.Read(file, binary.LittleEndian, &header); err != nil {
@@ -82,6 +87,18 @@ func (e *WAVExtractor) parseChunks(file *os.File, metadata *AudioMetadata) error
 		}
 
 		chunkID := string(header.ID[:])
+
+		// A RIFF chunk ID is four printable ASCII characters. Anything else means the
+		// reader is no longer on a chunk boundary, and continuing would walk garbage: the
+		// default branch below would "skip" by a nonsense size, land somewhere arbitrary,
+		// and eventually hit EOF — at which point the loop breaks and reports success on a
+		// file it never read. Stop and say so instead.
+		if !isPrintableChunkID(header.ID) {
+			metadata.ExtractionWarning = "audio metadata may be incomplete: the WAV chunk " +
+				"layout could not be followed past an unrecognized chunk header, so any " +
+				"metadata after that point was not read"
+			return nil
+		}
 
 		switch chunkID {
 		case "fmt ":
@@ -102,13 +119,58 @@ func (e *WAVExtractor) parseChunks(file *os.File, metadata *AudioMetadata) error
 			}
 		}
 
-		// Align to even byte boundary
+		// Align to even byte boundary.
+		//
+		// RIFF requires an odd-length chunk to be followed by a pad byte, but a truncated
+		// download or a non-compliant writer can omit it. Seeking past it unconditionally
+		// then lands the reader ONE BYTE PAST the next chunk header, so every subsequent
+		// chunk ID is garbage — which used to be skipped silently, ending the walk at EOF
+		// with a nil error and an empty result. Measured on two fixtures identical but for
+		// this single byte: 1 finding versus 0, the second with no disclosure at all.
+		//
+		// The two cases are unambiguous, so the pad byte is detected rather than assumed:
+		// a pad is always 0x00, and a chunk ID's first byte is printable ASCII.
 		if header.Size%2 == 1 {
-			file.Seek(1, io.SeekCurrent)
+			var pad [1]byte
+			n, err := file.Read(pad[:])
+			switch {
+			case err != nil || n == 0:
+				// EOF right after an odd chunk: nothing follows, so nothing is missed.
+			case pad[0] == 0x00:
+				// A real pad byte, already consumed by the read above.
+			default:
+				// Not a pad byte — it is the first byte of the next chunk ID. Put it back
+				// so the walk stays aligned, and note the file is non-compliant.
+				if _, err := file.Seek(-1, io.SeekCurrent); err != nil {
+					return err
+				}
+				sawMissingPad = true
+			}
 		}
 	}
 
+	// Recovered, but say so: the file is not RIFF-compliant, and an operator who cares
+	// whether their corpus is intact should know the tool had to compensate. Never
+	// overwrite a more specific warning already set above.
+	if sawMissingPad && metadata.ExtractionWarning == "" {
+		metadata.ExtractionWarning = "the WAV chunk layout omits a required pad byte after " +
+			"an odd-length chunk; metadata was recovered by realigning, but the file is " +
+			"malformed and may be truncated"
+	}
+
 	return nil
+}
+
+// isPrintableChunkID reports whether id is four printable ASCII characters, which every
+// RIFF chunk ID is. It is the cheapest available test for "the reader is still on a chunk
+// boundary".
+func isPrintableChunkID(id [4]byte) bool {
+	for _, b := range id {
+		if b < 0x20 || b > 0x7E {
+			return false
+		}
+	}
+	return true
 }
 
 // parseFormatChunk parses the WAV format chunk

--- a/internal/preprocessors/meta-extractors/meta-extract-audiolib/wav_alignment_test.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-audiolib/wav_alignment_test.go
@@ -1,0 +1,172 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package audiolib
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A WAV whose chunk layout is not RIFF-compliant must not be reported as clean.
+//
+// parseChunks skipped a pad byte whenever a chunk's declared size was odd, ASSUMING the
+// file was compliant. RIFF does require that pad byte, but a truncated download or a
+// sloppy writer can omit it — and then the seek lands ONE BYTE PAST the next chunk header.
+// Every subsequent chunk ID is garbage, which the default branch skipped by a nonsense
+// size, so the walk ended at EOF, returned nil, and produced an empty result.
+//
+// Measured on the shipped binary with two fixtures identical but for that pad byte:
+//
+//	correctly padded  -> 1 finding (SSN, conf 100)
+//	unpadded          -> 0 findings, "No matches found.", exit 0, nothing on stderr
+//
+// An unreadable file was indistinguishable from a clean one. See #312.
+//
+// The pad byte is detectable rather than assumable — a pad is always 0x00 and a chunk ID's
+// first byte is printable ASCII — so this now RECOVERS the metadata instead of only
+// disclosing the failure, which turns a silent miss into a finding.
+
+const wavTestValue = "SSN: 452-11-9384"
+
+// writeWAV builds a minimal WAV carrying wavTestValue in a LIST/INFO ICMT comment.
+//
+// padData controls whether the odd-length data chunk is followed by the pad byte RIFF
+// requires. That single byte is the whole difference between the two fixtures.
+func writeWAV(t *testing.T, path string, padData bool) string {
+	t.Helper()
+
+	chunk := func(id string, payload []byte, pad bool) []byte {
+		out := append([]byte(id), make([]byte, 4)...)
+		binary.LittleEndian.PutUint32(out[4:], uint32(len(payload)))
+		out = append(out, payload...)
+		if pad && len(payload)%2 == 1 {
+			out = append(out, 0x00)
+		}
+		return out
+	}
+
+	fmtPayload := make([]byte, 16)
+	binary.LittleEndian.PutUint16(fmtPayload[0:], 1)    // PCM
+	binary.LittleEndian.PutUint16(fmtPayload[2:], 1)    // mono
+	binary.LittleEndian.PutUint32(fmtPayload[4:], 8000) // sample rate
+	binary.LittleEndian.PutUint32(fmtPayload[8:], 8000) // byte rate
+	binary.LittleEndian.PutUint16(fmtPayload[12:], 1)
+	binary.LittleEndian.PutUint16(fmtPayload[14:], 8)
+
+	icmt := chunk("ICMT", append([]byte(wavTestValue), 0x00), true)
+	info := append([]byte("INFO"), icmt...)
+
+	body := chunk("fmt ", fmtPayload, true)
+	body = append(body, chunk("data", []byte{0x01}, padData)...) // odd length: 1 byte
+	body = append(body, chunk("LIST", info, true)...)
+
+	payload := append([]byte("WAVE"), body...)
+	riff := append([]byte("RIFF"), make([]byte, 4)...)
+	binary.LittleEndian.PutUint32(riff[4:], uint32(len(payload)))
+	riff = append(riff, payload...)
+
+	if err := os.WriteFile(path, riff, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestWAVMissingPadByteIsRecoveredAndDisclosed(t *testing.T) {
+	dir := t.TempDir()
+	e := &WAVExtractor{}
+
+	// Control: RIFF-compliant. Must extract, and must NOT be flagged.
+	good, err := e.ExtractMetadata(writeWAV(t, filepath.Join(dir, "good.wav"), true))
+	if err != nil {
+		t.Fatalf("compliant WAV: %v", err)
+	}
+	if !strings.Contains(good.Comment, wavTestValue) {
+		t.Fatalf("fixture is wrong: the compliant WAV did not yield the comment (got %q). "+
+			"Without this the malformed case below proves nothing.", good.Comment)
+	}
+	if good.ExtractionWarning != "" {
+		t.Errorf("compliant WAV was flagged: %q — a false warning on a well-formed file "+
+			"trains operators to ignore the real ones", good.ExtractionWarning)
+	}
+
+	// The defect: identical file minus the pad byte.
+	bad, err := e.ExtractMetadata(writeWAV(t, filepath.Join(dir, "bad.wav"), false))
+	if err != nil {
+		t.Fatalf("malformed WAV returned an error: %v — extraction should recover, not fail, "+
+			"because failing discards the metadata it can still read", err)
+	}
+	if !strings.Contains(bad.Comment, wavTestValue) {
+		t.Errorf("malformed WAV lost the comment (got %q) — the walk skipped a pad byte that "+
+			"was not there, landing one byte past the next chunk header so every later chunk "+
+			"ID was garbage", bad.Comment)
+	}
+	if bad.ExtractionWarning == "" {
+		t.Error("malformed WAV carries no ExtractionWarning — recovery is not a reason to stay " +
+			"silent about a file that is not RIFF-compliant and may be truncated")
+	}
+	if !strings.Contains(strings.ToLower(bad.ExtractionWarning), "pad byte") {
+		t.Errorf("warning = %q, want it to name the pad byte so the operator knows what is "+
+			"wrong with the file", bad.ExtractionWarning)
+	}
+	// Payload-free: the warning reaches stderr and every machine format.
+	if strings.Contains(bad.ExtractionWarning, "452-11-9384") {
+		t.Errorf("the warning leaked the matched value: %q", bad.ExtractionWarning)
+	}
+}
+
+// A chunk header that is not four printable ASCII bytes means the reader is off a chunk
+// boundary. Walking on would skip by a nonsense size and end at EOF reporting success, so
+// the walk stops and says so.
+func TestWAVUnwalkableChunkHeaderIsDisclosed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "junk.wav")
+
+	body := append([]byte("WAVE"), 0xff, 0xfe, 0x00, 0x01) // garbage where a chunk ID belongs
+	body = append(body, 0x04, 0x00, 0x00, 0x00)            // declared size 4
+	body = append(body, []byte("junk")...)
+	riff := append([]byte("RIFF"), make([]byte, 4)...)
+	binary.LittleEndian.PutUint32(riff[4:], uint32(len(body)))
+	riff = append(riff, body...)
+	if err := os.WriteFile(path, riff, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	e := &WAVExtractor{}
+	meta, err := e.ExtractMetadata(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if meta.ExtractionWarning == "" {
+		t.Error("an unwalkable chunk layout produced no warning — the run would print " +
+			"\"No matches found.\" and exit 0, which is what a clean file prints")
+	}
+	if strings.Contains(strings.ToLower(meta.ExtractionWarning), "pad byte") {
+		t.Errorf("warning = %q, want the unrecognized-header wording rather than the pad-byte "+
+			"one; the two conditions have different remedies", meta.ExtractionWarning)
+	}
+}
+
+// isPrintableChunkID is the boundary test the walk relies on, so its edges are pinned.
+func TestIsPrintableChunkID(t *testing.T) {
+	cases := []struct {
+		id   [4]byte
+		want bool
+	}{
+		{[4]byte{'f', 'm', 't', ' '}, true}, // space is printable (0x20)
+		{[4]byte{'L', 'I', 'S', 'T'}, true},
+		{[4]byte{'d', 'a', 't', 'a'}, true},
+		{[4]byte{0x00, 'a', 'b', 'c'}, false}, // NUL: a consumed pad byte shifted us
+		{[4]byte{'a', 'b', 'c', 0x1f}, false}, // just below printable
+		{[4]byte{'a', 'b', 'c', 0x7f}, false}, // DEL, just above printable
+		{[4]byte{0xff, 0xfe, 0x00, 0x01}, false},
+	}
+	for _, c := range cases {
+		if got := isPrintableChunkID(c.id); got != c.want {
+			t.Errorf("isPrintableChunkID(%q) = %v, want %v", c.id, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #312.

## The defect

`parseChunks` skipped a pad byte whenever a chunk's declared size was odd, **assuming** the file was RIFF-compliant. RIFF does require that byte, but a truncated download or a non-compliant writer can omit it — and then the seek lands **one byte past** the next chunk header. Every subsequent chunk ID is garbage, which the `default` branch skipped by a nonsense size, so the walk ended at EOF, returned `nil`, and produced an empty result.

Measured on the shipped binary with two fixtures identical but for that single byte:

| fixture | findings | stderr |
|---|---|---|
| correctly padded | **1** (SSN, conf 100) | — |
| unpadded | **0** | nothing; stdout says `No matches found.` |

An unreadable file was indistinguishable from a clean one.

## Better than the proposed fix

The issue proposed disclosure. This **recovers** the metadata instead, because the two cases are unambiguous: a pad byte is always `0x00`, and a chunk ID's first byte is printable ASCII. So the byte is *peeked* rather than assumed, and put back when it isn't a pad.

The unpadded fixture now yields the finding it always should have — **a silent miss becomes a detection**, rather than a documented gap.

## Disclosure is still recorded

Recovery is not a reason to stay quiet about a file that is malformed and may be truncated:

```
NOT FULLY EXAMINED: 1 of 1 file — findings may be missing
  bad.wav  audio_metadata: the WAV chunk layout omits a required pad byte after an
           odd-length chunk; metadata was recovered by realigning, but the file is
           malformed and may be truncated
```

A chunk ID that isn't four printable ASCII characters means the reader is off a boundary entirely — that stops the walk with its own distinct wording, since the remedy differs.

## Plumbing

`AudioMetadata` gains `ExtractionWarning`; the audio preprocessor copies it onto `ProcessedContent`. Deliberately **not** an `Error` — extraction succeeded and produced findings, so failing the file would discard real results, and only `ExtractionWarning` survives the router's combine step. Same route the corrupt-PDF disclosure uses.

## Tests

- the compliant fixture is asserted to carry **no** warning — a false warning on a well-formed file trains operators to ignore the real ones;
- the compliant fixture must yield the comment first, so the malformed case can't pass vacuously;
- warnings are asserted payload-free;
- `isPrintableChunkID` boundaries pinned (`0x1f`/`0x20`/`0x7e`/`0x7f`, and NUL — the shifted-pad case).

**Non-vacuity:** restoring the unconditional pad-byte seek fails with `malformed WAV lost the comment`, which is the original defect exactly.

`make all` green; full suite 66 packages, 0 failures.

---

**Not self-merging** — for @rustic.