### PR TITLE
perf(preprocessors): assemble embedded-media text with a Builder instead of re-copying it per part

### DIFF
--- a/internal/preprocessors/base_metadata_preprocessor.go
+++ b/internal/preprocessors/base_metadata_preprocessor.go
@@ -244,7 +244,24 @@ func (bmp *BaseMetadataPreprocessor) ProcessEmbeddedMedia(originalFilePath strin
 		return "", nil, nil
 	}
 
-	var result string
+	// A Builder, not a string accumulator.
+	//
+	// This was `var result string` with `result += block` inside the per-part loop below.
+	// Go's string += reallocates and re-copies the whole accumulated prefix on every
+	// iteration, so assembling the combined text cost O(n²) BYTES copied across n embedded
+	// parts. The quadratic is in bytes, not parts, so a few dozen multi-hundred-KB blocks
+	// (embedded documents and PDFs, or a raster-image-heavy deck where each image
+	// round-trips the router for metadata text) already costs tens of MB of pure transient
+	// copying and GC churn.
+	//
+	// Transient only — it never affected results or any counter — but it is the same shape
+	// internal/router/file_router.go already fixed with a Builder when it assembles
+	// multi-part text. See #338.
+	//
+	// Not pre-sized: the blocks are produced inside the loop, so summing their lengths up
+	// front would mean generating each one twice. Builder's amortized growth is what
+	// removes the quadratic; a Grow hint would only shave a constant.
+	var result strings.Builder
 	var sections []ContentSection
 	// warnings records embedded items we declined to descend into, so the caller can
 	// surface them through ExtractionWarning.
@@ -324,7 +341,7 @@ func (bmp *BaseMetadataPreprocessor) ProcessEmbeddedMedia(originalFilePath strin
 
 			// Format and append embedded media section
 			block := bmp.utilities.RouterHelper.FormatEmbeddedMediaSection(i, media.OriginalName, processed.Text)
-			result += block
+			result.WriteString(block)
 
 			// FormatEmbeddedMediaSection prefixes "\n--- ... ---\n", so the
 			// item's own text starts two lines further on.
@@ -365,7 +382,7 @@ func (bmp *BaseMetadataPreprocessor) ProcessEmbeddedMedia(originalFilePath strin
 		}
 	}
 
-	return result, sections, warnings
+	return result.String(), sections, warnings
 }
 
 // EmbeddedMedia represents embedded media extracted from documents

--- a/internal/preprocessors/embedded_media_complexity_test.go
+++ b/internal/preprocessors/embedded_media_complexity_test.go
@@ -103,9 +103,44 @@ func timeAssemble(t *testing.T, n, blockSize int) (time.Duration, int, int) {
 
 // TestProcessEmbeddedMediaAssemblyIsNotQuadratic is the guard.
 //
-// The ratio is LOGGED rather than asserted and an absolute ceiling is asserted instead —
-// the same idiom the redaction guard in internal/goldencorpus settled on, because the base
-// sample is small enough that scheduler noise dominates a ratio.
+// It asserts the GROWTH RATIO (see maxGrowth below), with an absolute ceiling kept only as a
+// backstop. An earlier revision of this comment claimed the opposite — that the ratio was
+// merely logged, in the idiom the redaction guard in internal/goldencorpus uses — which was
+// a leftover from a first attempt that was itself vacuous.
+//
+// # Why this drives ProcessEmbeddedMedia directly instead of scanning a real document
+//
+// #338 asks for the growth curve to be pinned "the same way the detector/redaction hot paths
+// are", i.e. over a real fixture. That target was built and measured, twice, and neither
+// version can gate on the defect.
+//
+// A real .docx carrying n embedded JPEGs (each with 4KB of EXIF ImageDescription), scanned
+// end-to-end through core.ScanFile, times IDENTICALLY with and without the fix:
+//
+//	parts    string +=    strings.Builder
+//	   40      0.26s          0.25s
+//	  160      0.72s          0.71s
+//	  320      1.38s          1.31s
+//	  640      2.56s          2.49s
+//
+// The copying is swamped by the linear costs around it — zip inflate, per-part extraction,
+// and validating the combined text. Since #338 describes the defect as "O(n^2) BYTES
+// COPIED", allocation was tried next, measuring runtime.MemStats.TotalAlloc across the same
+// real scan. The quadratic is visible there, but only barely:
+//
+//	per-part text    with fix    reverted
+//	      4KB        3.9x        4.4x   (299MB -> 347MB at 160 parts)
+//	     32KB        4.0x        5.0x   (1081MB -> 1450MB at 160 parts)
+//
+// Separating 4.0x from 5.0x needs a threshold with roughly 12% headroom, on a figure that
+// moves with GOMAXPROCS and GC timing across the three CI runners, at a cost of ~1.4GB of
+// churn per run. A gate that flaky is worse than no gate.
+//
+// Driving the assembly loop in isolation gives a 3.6x margin instead — the accumulator
+// measures ~9.5-11.5x against the Builder's ~2.9-3.2x — which is what makes an assertion
+// possible at all. The cost is honest and worth stating: a stub router means only the append
+// loop is pinned here, so a quadratic introduced in part enumeration, in ProcessEmbedded, or
+// in container-side stitching would need its own target.
 func TestProcessEmbeddedMediaAssemblyIsNotQuadratic(t *testing.T) {
 	if testing.Short() {
 		t.Skip("embedded-media assembly complexity guard skipped in -short mode")

--- a/internal/preprocessors/embedded_media_complexity_test.go
+++ b/internal/preprocessors/embedded_media_complexity_test.go
@@ -1,0 +1,212 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package preprocessors
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ProcessEmbeddedMedia assembles the combined embedded-media text, and that assembly must
+// not be quadratic in bytes.
+//
+// It used a string accumulator — `var result string` with `result += block` inside the
+// per-part loop. Go's string += reallocates and re-copies the whole accumulated prefix on
+// every iteration, so building the combined text cost O(n²) BYTES across n embedded parts.
+// The quadratic is in bytes rather than parts, so a few dozen multi-hundred-KB blocks
+// (embedded documents and PDFs, or a raster-heavy deck where each image round-trips the
+// router for metadata text) already cost tens of MB of transient copying.
+//
+// Transient only — it never affected results or any counter — which is exactly why no
+// existing gate could see it: the complexity guards in internal/goldencorpus cover the
+// validators and the redaction paths, and nothing covered EXTRACTION. See #338.
+
+// embeddedComplexityCeiling bounds the largest sample.
+//
+// Generous on purpose: this is an algorithmic-class check, not a benchmark. Sized so a
+// loaded shared runner passes comfortably while a return to O(n²) copying does not.
+const embeddedComplexityCeiling = 20 * time.Second
+
+// builderProbeRouter is a RouterInterface that returns a fixed-size text block per part,
+// so the measured cost is the ASSEMBLY, not the extraction.
+type builderProbeRouter struct {
+	blockSize int
+	calls     int
+}
+
+func (r *builderProbeRouter) ProcessFile(filePath string, _ interface{}) (*ProcessedContent, error) {
+	r.calls++
+	return &ProcessedContent{
+		OriginalPath:  filePath,
+		Filename:      filePath,
+		Text:          strings.Repeat("embedded metadata line\n", r.blockSize/23),
+		Format:        "image_metadata",
+		ProcessorType: "image_metadata",
+		Success:       true,
+	}, nil
+}
+
+func (r *builderProbeRouter) ProcessEmbedded(childPath, _ string) (*ProcessedContent, error) {
+	return r.ProcessFile(childPath, nil)
+}
+
+func (r *builderProbeRouter) CanProcessFile(string, bool) (bool, string) { return true, "" }
+
+// buildEmbeddedParts creates n real temp files and the EmbeddedMedia entries naming them.
+//
+// Real files because the pipeline stats and routes each part; a fabricated path would be
+// refused before the assembly under test is ever reached.
+func buildEmbeddedParts(t *testing.T, n int) []EmbeddedMedia {
+	t.Helper()
+	dir := t.TempDir()
+	out := make([]EmbeddedMedia, 0, n)
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("image%03d.jpeg", i)
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte("\xff\xd8\xff\xe0 jpeg-ish bytes"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		out = append(out, EmbeddedMedia{
+			OriginalName: "word/media/" + name,
+			TempFilePath: p,
+			MediaType:    "image",
+		})
+	}
+	return out
+}
+
+// timeAssemble runs the assembly and returns the elapsed time plus the combined length.
+//
+// The length is the non-vacuity signal. An assembly that stopped appending would be fast
+// and would produce nothing, so a timing-only assertion would happily pass on a function
+// that had been turned into a no-op.
+func timeAssemble(t *testing.T, n, blockSize int) (time.Duration, int, int) {
+	t.Helper()
+
+	bmp := NewBaseMetadataPreprocessor("probe", "image_metadata")
+	router := &builderProbeRouter{blockSize: blockSize}
+	bmp.SetRouter(router)
+
+	parts := buildEmbeddedParts(t, n)
+
+	start := time.Now()
+	text, _, _ := bmp.ProcessEmbeddedMedia("container.docx", parts)
+	elapsed := time.Since(start)
+
+	return elapsed, len(text), router.calls
+}
+
+// TestProcessEmbeddedMediaAssemblyIsNotQuadratic is the guard.
+//
+// The ratio is LOGGED rather than asserted and an absolute ceiling is asserted instead —
+// the same idiom the redaction guard in internal/goldencorpus settled on, because the base
+// sample is small enough that scheduler noise dominates a ratio.
+func TestProcessEmbeddedMediaAssemblyIsNotQuadratic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("embedded-media assembly complexity guard skipped in -short mode")
+	}
+
+	const (
+		blockSize   = 64 << 10 // 64KB of text per part, i.e. an embedded document, not a thumbnail
+		baseN, bigN = 60, 240  // 4x
+	)
+
+	tBase, lenBase, callsBase := timeAssemble(t, baseN, blockSize)
+	tBig, lenBig, callsBig := timeAssemble(t, bigN, blockSize)
+
+	// Non-vacuity floors, both directions.
+	//
+	// Every part must have been routed (otherwise the loop exited early and the timing
+	// describes nothing), and the combined text must GROW roughly with the input
+	// (otherwise appends are being dropped and a faster run is a broken one).
+	if callsBase != baseN || callsBig != bigN {
+		t.Fatalf("router saw %d/%d and %d/%d parts — the loop did not process every part, so "+
+			"the timings below describe an incomplete assembly", callsBase, baseN, callsBig, bigN)
+	}
+	if lenBase == 0 || lenBig == 0 {
+		t.Fatalf("combined text is empty (%d, %d bytes) — an assembly that appends nothing is "+
+			"fast and wrong", lenBase, lenBig)
+	}
+	if ratio := float64(lenBig) / float64(lenBase); ratio < 3.5 {
+		t.Fatalf("combined text grew only %.2fx for 4x the parts (%d -> %d bytes) — blocks are "+
+			"being dropped, so this measures the wrong thing", ratio, lenBase, lenBig)
+	}
+
+	ratio := float64(tBig) / float64(tBase)
+	t.Logf("4x parts at %dKB each: %.1fx time (base=%v big=%v, %d -> %d bytes). "+
+		"A Builder is linear in total bytes, so ~4x is expected; the string accumulator this "+
+		"replaced copied the whole prefix per part, i.e. ~16x.",
+		blockSize>>10, ratio, tBase, tBig, lenBase, lenBig)
+
+	// The RATIO is asserted, not just a ceiling.
+	//
+	// A ceiling alone made this guard VACUOUS: restoring the string accumulator measured
+	// 9.5x here against the Builder's 2.9x — unmistakably quadratic — and still passed,
+	// because 70ms is nowhere near any sane wall-clock ceiling. The defect this test exists
+	// for was invisible to it.
+	//
+	// A ratio is usable here precisely because the base sample is MILLISECONDS, not
+	// microseconds: at 3-7ms scheduler noise does not dominate, unlike the redaction guard
+	// whose base is small enough that only a ceiling is meaningful.
+	//
+	// The threshold sits between the two measurements with room on both sides: linear is
+	// 4.0, the Builder measures ~2.9, the accumulator ~9.5, true quadratic is 16.0.
+	const maxGrowth = 6.0
+	if ratio > maxGrowth {
+		t.Errorf("4x the parts cost %.1fx the time (> %.1f) — assembly is scaling with "+
+			"(parts x accumulated bytes) again, i.e. the combined text is being re-copied per "+
+			"part instead of appended", ratio, maxGrowth)
+	}
+
+	// Ceiling kept as a backstop for the case a ratio cannot catch: both samples slow
+	// together, which a proportional regression would produce.
+	if tBig > embeddedComplexityCeiling {
+		t.Errorf("assembling %d embedded parts of %dKB took %v (> %v)",
+			bigN, blockSize>>10, tBig, embeddedComplexityCeiling)
+	}
+}
+
+// The assembled text must be byte-identical to a plain concatenation of the blocks, so
+// switching to a Builder cannot have changed the output. Asserted separately from timing
+// because a fast, wrong assembly is the failure mode a ceiling cannot catch.
+func TestProcessEmbeddedMediaAssemblyPreservesContent(t *testing.T) {
+	bmp := NewBaseMetadataPreprocessor("probe", "image_metadata")
+	router := &builderProbeRouter{blockSize: 512}
+	bmp.SetRouter(router)
+
+	parts := buildEmbeddedParts(t, 5)
+	text, sections, _ := bmp.ProcessEmbeddedMedia("container.docx", parts)
+
+	// Every part's name must appear, in order, and the per-part section boundaries must
+	// still line up with the text the cursor was computed against.
+	last := -1
+	for i := range parts {
+		name := filepath.Base(parts[i].OriginalName)
+		at := strings.Index(text, name)
+		if at < 0 {
+			t.Fatalf("part %d (%s) is absent from the combined text", i, name)
+		}
+		if at <= last {
+			t.Errorf("part %d (%s) appears out of order", i, name)
+		}
+		last = at
+	}
+	if len(sections) == 0 {
+		t.Error("no content sections were produced; section anchoring depends on the same " +
+			"per-block line cursor as the assembly")
+	}
+	// The line cursor is maintained independently of the accumulator, so a Builder must
+	// not have shifted it: each section's start line must fall inside the text.
+	totalLines := strings.Count(text, "\n") + 1
+	for i, s := range sections {
+		if s.LineOffset < 0 || s.LineOffset > totalLines {
+			t.Errorf("section %d starts at line %d, outside the %d-line combined text",
+				i, s.LineOffset, totalLines)
+		}
+	}
+}


### PR DESCRIPTION
Closes #338.

`ProcessEmbeddedMedia` accumulated the combined embedded-media text with `var result string` and `result += block` inside the per-part loop. Go's `string +=` reallocates and re-copies the whole accumulated prefix every iteration, so assembly cost **O(n²) bytes** across n embedded parts.

The quadratic is in *bytes*, not parts, so large blocks dominate — embedded documents and PDFs. A vector-heavy deck is unaffected, since `embedded.SkipTextPipeline` excludes SVG/EMF/WMF/WDP up front.

## Memory vs speed — no trade, it wins on all three axes

Both strategies side by side on 64KB blocks (an embedded document, not a thumbnail):

| n | time: accum → builder | allocated: accum → builder | allocs |
|---|---|---|---|
| 60 | 7.0ms → 1.2ms (**5.8x**) | 120MB → 20MB (**5.9x**) | 62 → 16 |
| 240 | 56.9ms → 2.9ms (**19.9x**) | 1895MB → 80MB (**23.8x**) | 243 → 22 |
| 480 | 200.8ms → 7.0ms (**28.7x**) | 7565MB → 156MB (**48.4x**) | 481 → 25 |

Growth per doubling — time: accum 3.5x, builder 2.4x. Bytes: **accum 4.0x (quadratic), builder 2.0x (linear)**.

At n=480 the accumulator allocated **~240x the size of its own 31MB output**; the Builder allocates ~5x.

**Peak memory is roughly unchanged** — both hold an old and a new buffer at the moment they grow, ~2x the final size. What collapses is **churn**, and 7.6 GB of garbage per document is real collector CPU. Worth contrasting with the attempt at #337, which traded churn for peak and delivered nothing measurable, so it was dropped.

## End-to-end — checked because a fixed quadratic can just move

Real binary, `.docx` files carrying 40/80/160 embedded EXIF-bearing JPEGs:

| binary | n=40 | n=80 | n=160 | growth |
|---|---|---|---|---|
| baseline | 0.135s | 0.261s | 0.611s | 1.93x then **2.34x** |
| this | 0.132s | 0.262s | 0.545s | 1.98x then **2.08x** |

Findings **identical** (1200 / 4800) on both, so the comparison isn't vacuous. The whole scan stays linear and is 11% faster at the largest size — **it did not relocate**. The delta is modest here because an EXIF caption block is ~1.3KB, where the quadratic term is small; the 28.7x case is the large-block one the issue names.

## The guard was vacuous on my first attempt

Asserting only an absolute wall-clock ceiling let the restored accumulator **pass** at 9.5x growth — 70ms is nowhere near any sane ceiling, so the exact defect the test exists for was invisible to it.

It now asserts the **ratio** (threshold 6.0, sitting between the Builder's ~2.9 and the accumulator's ~9.5, with linear at 4.0 and quadratic at 16.0), keeping the ceiling only as a backstop for a proportional regression a ratio cannot see. A ratio is sound here because the base sample is *milliseconds* — unlike the redaction guard, whose base is small enough that only a ceiling is meaningful.

Non-vacuity floors on the guard itself: every part must have been routed, the combined text must be non-empty, and it must grow ≥3.5x for 4x the parts — so an assembly that silently stopped appending fails rather than looking fast.

Correctness is asserted separately from timing, since a fast wrong assembly is what a ceiling cannot catch: every part appears in order, sections are still produced, and each section's `LineOffset` falls inside the combined text. The line cursor is maintained independently of the accumulator (`strings.Count` per block), so a Builder can't shift it — asserted, not assumed.

Not pre-sized: blocks are produced inside the loop, so summing their lengths first would generate each twice. Builder's amortized growth is what removes the quadratic.

`make all` green; full suite 66 packages, 0 failures.

---

**Not self-merging** — for @rustic.