### PR TITLE
fix(redactors): normalize matches before EVERY consumer, not just the first

### DIFF
--- a/internal/core/cluster_redaction_sink_test.go
+++ b/internal/core/cluster_redaction_sink_test.go
@@ -4,6 +4,9 @@
 package core
 
 import (
+	"archive/zip"
+	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -155,4 +158,212 @@ func TestClusteredSocialMediaDoesNotSurviveRedaction(t *testing.T) {
 			}
 		})
 	}
+}
+
+// A clustered value inside an EMBEDDED part must be redacted, not merely refused.
+//
+// The office redactor has TWO consumers of Match.Text: redactOfficeContent and
+// redactEmbeddedParts. The cluster expansion lived inside the former, which takes `matches`
+// as a parameter, so reassigning it there normalized only that local slice — and the
+// ORIGINAL slice was handed to the embedded path. That path builds the residue value set
+// used by both the dispatch gate and the post-redaction verification, so a cluster's
+// rendered summary made every part look clean: the part holding the real handles was never
+// dispatched, and the fail-closed refusal never fired.
+//
+// Measured on a binary built from fefc0ee: 2 HIGH findings, rc=0, body cleaned, embedded
+// inner.docx still holding BOTH handles verbatim.
+//
+// This goes through core.RedactFile because only the real wiring injects an embedded
+// dispatcher — a bare OfficeRedactor has none and correctly refuses instead, which proves
+// "no leaking output" but not that the part is actually redacted.
+func TestClusteredValueInsideEmbeddedPartIsRedactedEndToEnd(t *testing.T) {
+	cfg := config.LoadConfigOrDefault("")
+	if cfg.Validators == nil {
+		cfg.Validators = map[string]map[string]any{}
+	}
+	cfg.Validators["social_media"] = map[string]any{
+		"platform_patterns": map[string]any{
+			"twitter":  []any{`(?i)https?://(?:www\.)?(twitter|x)\.com/[a-zA-Z0-9_]+`},
+			"linkedin": []any{`(?i)https?://(?:www\.)?linkedin\.com/in/[a-zA-Z0-9_-]+`},
+		},
+		"positive_keywords": []any{"profile", "connect with me"},
+	}
+
+	const (
+		twitterURL  = "https://twitter.com/janedoe"
+		linkedinURL = "https://linkedin.com/in/janedoe"
+	)
+	body := `<w:p><w:r><w:t>Profile: ` + twitterURL + `</w:t></w:r></w:p>` +
+		`<w:p><w:r><w:t>connect with me</w:t></w:r></w:p>` +
+		`<w:p><w:r><w:t>And ` + linkedinURL + `</w:t></w:r></w:p>`
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "outer.docx")
+	writeEmbeddedDocx(t, src, body, buildInnerDocx(t, body))
+
+	outDir := filepath.Join(dir, "out")
+	res, err := RedactFile(RedactConfig{
+		FilePath:  src,
+		OutputDir: outDir,
+		Strategy:  "simple",
+		Checks:    []string{"SOCIAL_MEDIA"},
+		Config:    cfg,
+	})
+	if err != nil {
+		// A refusal is safe, but then nothing may have been written.
+		if written := findWritten(t, outDir, "outer.docx"); written != "" {
+			t.Fatalf("RedactFile errored (%v) but still wrote %s", err, written)
+		}
+		return
+	}
+
+	// Non-vacuity: the fixture must actually produce a cluster.
+	var sawCluster bool
+	for _, m := range res.Matches {
+		if m.Type == "SOCIAL_MEDIA_CLUSTER" {
+			sawCluster = true
+		}
+	}
+	if !sawCluster {
+		t.Fatalf("no SOCIAL_MEDIA_CLUSTER among %d finding(s) — clustering did not fire, so this "+
+			"test is not exercising the clustered embedded path", len(res.Matches))
+	}
+
+	written := findWritten(t, outDir, "outer.docx")
+	if written == "" {
+		return // refused to write: safe
+	}
+	for _, secret := range []string{twitterURL, linkedinURL} {
+		if embeddedPartContains(t, written, secret) {
+			t.Errorf("the EMBEDDED part of the written container still contains %q — it was "+
+				"reported inside a cluster and the container was written anyway", secret)
+		}
+	}
+}
+
+// writeEmbeddedDocx builds a .docx whose body holds bodyText and which embeds inner at
+// word/embeddings/inner.docx.
+func writeEmbeddedDocx(t *testing.T, path, bodyText string, inner []byte) {
+	t.Helper()
+
+	const ct = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+		`<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+		`<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+		`<Default Extension="xml" ContentType="application/xml"/>` +
+		`<Default Extension="docx" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document"/>` +
+		`<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>` +
+		`</Types>`
+	const rels = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+		`<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+		`<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>` +
+		`</Relationships>`
+	doc := `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+		`<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>` +
+		bodyText + `</w:body></w:document>`
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for _, p := range []struct{ name, body string }{
+		{"[Content_Types].xml", ct}, {"_rels/.rels", rels}, {"word/document.xml", doc},
+	} {
+		w, err := zw.Create(p.name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write([]byte(p.body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if inner != nil {
+		w, err := zw.Create("word/embeddings/inner.docx")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write(inner); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// buildInnerDocx returns the bytes of a standalone .docx holding bodyText.
+func buildInnerDocx(t *testing.T, bodyText string) []byte {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "inner.docx")
+	writeEmbeddedDocx(t, p, bodyText, nil)
+	b, err := os.ReadFile(p) // #nosec G304 -- test temp dir
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+// findWritten locates a written file by base name beneath dir, or "" if none.
+func findWritten(t *testing.T, dir, base string) string {
+	t.Helper()
+	var found string
+	_ = filepath.Walk(dir, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil // the dir may not exist when the write was refused
+		}
+		if !info.IsDir() && filepath.Base(p) == base {
+			found = p
+		}
+		return nil
+	})
+	return found
+}
+
+// embeddedPartContains reports whether value survives inside an embedded .docx of path.
+//
+// It inflates the NESTED package: grepping its compressed bytes finds nothing whether or not
+// redaction worked, which is how this defect stayed invisible.
+func embeddedPartContains(t *testing.T, path, value string) bool {
+	t.Helper()
+	raw, err := os.ReadFile(path) // #nosec G304 -- test temp dir
+	if err != nil {
+		t.Fatal(err)
+	}
+	zr, err := zip.NewReader(bytes.NewReader(raw), int64(len(raw)))
+	if err != nil {
+		t.Fatalf("output is not a valid zip: %v", err)
+	}
+	for _, f := range zr.File {
+		if filepath.Ext(f.Name) != ".docx" {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatal(err)
+		}
+		nested, err := io.ReadAll(rc)
+		rc.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		nz, err := zip.NewReader(bytes.NewReader(nested), int64(len(nested)))
+		if err != nil {
+			continue
+		}
+		for _, nf := range nz.File {
+			nrc, err := nf.Open()
+			if err != nil {
+				t.Fatal(err)
+			}
+			body, err := io.ReadAll(nrc)
+			nrc.Close()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if bytes.Contains(body, []byte(value)) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/internal/redactors/legacyole/redactor.go
+++ b/internal/redactors/legacyole/redactor.go
@@ -145,11 +145,22 @@ func (r *LegacyOLERedactor) RedactDocument(originalPath string, outputPath strin
 		logical[i] = s.readLogical(modified)
 	}
 
-	// A consolidated cluster's Text is a rendered summary that occurs in no stream, so
-	// searching for it masks nothing while the real spans it replaced were already
-	// dropped. Expand it first, exactly as the plaintext and office paths do. See
-	// redactors.ExpandClusterMatches and #289.
+	// Normalize the match set before searching the streams for it. BOTH of these rewrite
+	// matches whose Text does not occur in the document, and this redactor locates a value
+	// by searching for m.Text in each CFB stream's logical bytes — so an un-normalized
+	// match silently masks nothing.
+	//
+	// A consolidated cluster's Text is a rendered summary present in no stream
+	// (ExpandClusterMatches, #289). A bounded consolidated text — the
+	// INTELLECTUAL_PROPERTY "... [+N more matches on line]" display form — is likewise
+	// absent, and RestoreBoundedMatchText was NEVER called here at all: this redactor got
+	// the cluster expansion without its sibling, so a bounded legal-notice consolidation in
+	// a legacy .doc was located by nothing and the whole line survived.
+	//
+	// Order matters and matches the other paths: expand first, then restore, then let the
+	// caller's overlap resolution run over the result.
 	matches = redactors.ExpandClusterMatches(matches)
+	matches = redactors.RestoreBoundedMatchText(matches)
 
 	for _, m := range matches {
 		if m.Text == "" {

--- a/internal/redactors/office/embedded_cluster_residue_test.go
+++ b/internal/redactors/office/embedded_cluster_residue_test.go
@@ -1,0 +1,290 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package office
+
+import (
+	"archive/zip"
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/redactors"
+)
+
+// A value inside an EMBEDDED part must be redacted even when the finding that reported it
+// is a consolidated cluster.
+//
+// RedactDocument has TWO consumers of Match.Text: redactOfficeContent, and
+// redactEmbeddedParts. The cluster expansion and the bounded-text restore used to live
+// INSIDE redactOfficeContent, which takes `matches` as a parameter — so reassigning it
+// there normalized only that function's local slice, and RedactDocument then handed the
+// ORIGINAL slice to redactEmbeddedParts.
+//
+// That second consumer builds the residue value set used by both the dispatch gate
+// (embedded.go: `ResidueInspectable(child.name) && !partHoldsValue(child.content, values, 0)`)
+// and the post-redaction verification. Fed a cluster, the set contains the cluster's
+// RENDERED SUMMARY — a string present in no part's bytes — so partHoldsValue proved
+// "absence" for every part, the part holding the real values was never dispatched, and the
+// fail-closed unredacted-part refusal never fired because its own residue check was looking
+// for the same absent string.
+//
+// Measured on the shipped binary, a .docx with two clustered handles in its body AND in an
+// embedded inner.docx:
+//
+//	2 HIGH findings reported, rc=0, one file written
+//	body:  handles removed
+//	inner: BOTH handles still present verbatim
+//
+// A non-clustered SSN in the same fixture was correctly removed from the embedded copy,
+// which is what isolates clustering as the cause. Found by an adversarial post-merge sweep;
+// the #344 completeness table counted redactor ENTRY POINTS rather than consumers of
+// Match.Text, and this is the fourth consumer.
+
+// embeddedDocx builds a .docx whose body holds bodyText and which embeds inner at
+// word/embeddings/inner.docx.
+func embeddedDocx(t *testing.T, path string, bodyText string, inner []byte) {
+	t.Helper()
+
+	const ct = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+		`<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+		`<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+		`<Default Extension="xml" ContentType="application/xml"/>` +
+		`<Default Extension="docx" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document"/>` +
+		`<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>` +
+		`</Types>`
+	const rels = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+		`<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+		`<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>` +
+		`</Relationships>`
+	doc := `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+		`<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>` +
+		bodyText + `</w:body></w:document>`
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	write := func(name, body string) {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+		if _, err := w.Write([]byte(body)); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	write("[Content_Types].xml", ct)
+	write("_rels/.rels", rels)
+	write("word/document.xml", doc)
+	if inner != nil {
+		w, err := zw.Create("word/embeddings/inner.docx")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write(inner); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// innerDocx returns the bytes of a standalone .docx holding bodyText.
+func innerDocx(t *testing.T, bodyText string) []byte {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "inner.docx")
+	embeddedDocx(t, p, bodyText, nil)
+	b, err := os.ReadFile(p) // #nosec G304 -- test temp dir
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+// residueInEmbedded reports whether any value survives inside the embedded .docx of path.
+func residueInEmbedded(t *testing.T, path string, values ...string) map[string]bool {
+	t.Helper()
+	raw, err := os.ReadFile(path) // #nosec G304 -- test temp dir
+	if err != nil {
+		t.Fatal(err)
+	}
+	zr, err := zip.NewReader(bytes.NewReader(raw), int64(len(raw)))
+	if err != nil {
+		t.Fatalf("output is not a valid zip: %v", err)
+	}
+	out := map[string]bool{}
+	for _, f := range zr.File {
+		if filepath.Ext(f.Name) != ".docx" {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatal(err)
+		}
+		nested, err := io.ReadAll(rc)
+		rc.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Inflate the NESTED package too: grepping its compressed bytes finds nothing
+		// whether or not redaction worked, which is how this stayed invisible.
+		nz, err := zip.NewReader(bytes.NewReader(nested), int64(len(nested)))
+		if err != nil {
+			t.Fatalf("embedded part is not a valid zip: %v", err)
+		}
+		for _, nf := range nz.File {
+			nrc, err := nf.Open()
+			if err != nil {
+				t.Fatal(err)
+			}
+			body, err := io.ReadAll(nrc)
+			nrc.Close()
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, v := range values {
+				if bytes.Contains(body, []byte(v)) {
+					out[v] = true
+				}
+			}
+		}
+	}
+	return out
+}
+
+func TestClusteredValueInEmbeddedPartIsRedacted(t *testing.T) {
+	const (
+		twitter  = "https://twitter.com/janedoe"
+		linkedin = "https://linkedin.com/in/janedoe"
+	)
+	body := `<w:p><w:r><w:t>Profile: ` + twitter + `</w:t></w:r></w:p>` +
+		`<w:p><w:r><w:t>connect with me</w:t></w:r></w:p>` +
+		`<w:p><w:r><w:t>And ` + linkedin + `</w:t></w:r></w:p>`
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "outer.docx")
+	embeddedDocx(t, src, body, innerDocx(t, body))
+
+	// The finding as clustering reports it: ONE synthesized match whose Text occurs
+	// nowhere, carrying its constituent matches for the expansion to recover.
+	members := []detector.Match{
+		{Text: twitter, Type: "SOCIAL_MEDIA", LineNumber: 1, Confidence: 90,
+			Context: detector.ContextInfo{FullLine: "Profile: " + twitter}},
+		{Text: linkedin, Type: "SOCIAL_MEDIA", LineNumber: 3, Confidence: 90,
+			Context: detector.ContextInfo{FullLine: "And " + linkedin}},
+	}
+	matches := []detector.Match{{
+		Text:       "twitter: janedoe | linkedin: janedoe", // a rendered summary
+		Type:       "SOCIAL_MEDIA_CLUSTER",
+		LineNumber: 1,
+		Confidence: 95,
+		Context:    detector.ContextInfo{FullLine: "Profile: " + twitter},
+		Metadata:   map[string]interface{}{redactors.ClusterMembersKey: members},
+	}}
+
+	out := filepath.Join(dir, "out.docx")
+	r := NewOfficeRedactor(nil, nil)
+	if _, err := r.RedactDocument(src, out, matches, redactors.RedactionSimple); err != nil {
+		// A fail-closed refusal is an acceptable outcome; silently writing a leaking file
+		// is not. Either way there must be no readable output holding the values.
+		if _, statErr := os.Stat(out); statErr == nil {
+			t.Fatalf("RedactDocument errored (%v) but still wrote %s", err, out)
+		}
+		return
+	}
+	if _, err := os.Stat(out); err != nil {
+		return // refused to write: also safe
+	}
+
+	got := residueInEmbedded(t, out, twitter, linkedin)
+	for _, v := range []string{twitter, linkedin} {
+		if got[v] {
+			t.Errorf("the EMBEDDED part still contains %q — the cluster was reported, so "+
+				"redaction was asked to remove it, and the container was written at exit 0 "+
+				"with the value in cleartext", v)
+		}
+	}
+}
+
+// The control: an ordinary, non-clustered match in the same shape must keep working. This is
+// what isolates clustering as the cause rather than the embedded path being broken outright.
+func TestNonClusteredValueInEmbeddedPartStillRedacted(t *testing.T) {
+	const ssn = "452-11-8903"
+	body := `<w:p><w:r><w:t>Employee SSN ` + ssn + ` on file.</w:t></w:r></w:p>`
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "outer.docx")
+	embeddedDocx(t, src, body, innerDocx(t, body))
+
+	matches := []detector.Match{{
+		Text: ssn, Type: "SSN", LineNumber: 1, Confidence: 100,
+		Context: detector.ContextInfo{FullLine: "Employee SSN " + ssn + " on file."},
+	}}
+
+	out := filepath.Join(dir, "out.docx")
+	r := NewOfficeRedactor(nil, nil)
+	_, err := r.RedactDocument(src, out, matches, redactors.RedactionSimple)
+
+	// With no embedded-redaction dispatcher injected, refusing to write is the CORRECT
+	// outcome and the one this redactor documents: nil means "do not descend", and a part
+	// holding a reported value is then disclosed rather than passed over. The point of this
+	// control is that the ORDINARY path reaches that decision — which is exactly what the
+	// cluster case did not, because its residue check was looking for a string present in no
+	// part and therefore concluded every part was clean.
+	if err != nil {
+		if _, statErr := os.Stat(out); statErr == nil {
+			t.Fatalf("errored (%v) but still wrote %s", err, out)
+		}
+		return
+	}
+	if _, statErr := os.Stat(out); statErr != nil {
+		return
+	}
+	if got := residueInEmbedded(t, out, ssn); got[ssn] {
+		t.Errorf("a file was written and its embedded part still contains the SSN")
+	}
+}
+
+// A bounded consolidated text has the same shape as a cluster: its Text does not occur in
+// the document either, so the embedded gate must see the RESTORED full line.
+func TestBoundedConsolidatedValueInEmbeddedPartIsRedacted(t *testing.T) {
+	const secret = "Amazon Confidential and Trademark 452-11-8903"
+	body := `<w:p><w:r><w:t>` + secret + `</w:t></w:r></w:p>`
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "outer.docx")
+	embeddedDocx(t, src, body, innerDocx(t, body))
+
+	matches := []detector.Match{{
+		// The display form: truncated, so it occurs nowhere in the document.
+		Text:       "Amazon Confidential [+218 more matches on line]",
+		Type:       "INTELLECTUAL_PROPERTY",
+		LineNumber: 1,
+		Confidence: 90,
+		Context:    detector.ContextInfo{FullLine: secret},
+		Metadata:   map[string]interface{}{redactors.MatchTextTruncatedKey: true},
+	}}
+
+	out := filepath.Join(dir, "out.docx")
+	r := NewOfficeRedactor(nil, nil)
+	if _, err := r.RedactDocument(src, out, matches, redactors.RedactionSimple); err != nil {
+		if _, statErr := os.Stat(out); statErr == nil {
+			t.Fatalf("RedactDocument errored (%v) but still wrote %s", err, out)
+		}
+		return
+	}
+	if _, err := os.Stat(out); err != nil {
+		return
+	}
+	if got := residueInEmbedded(t, out, secret); got[secret] {
+		t.Errorf("the embedded part still contains the consolidated line — a bounded display "+
+			"text reaches the embedded gate un-restored, same defect as the cluster case")
+	}
+}

--- a/internal/redactors/office/embedded_cluster_residue_test.go
+++ b/internal/redactors/office/embedded_cluster_residue_test.go
@@ -284,7 +284,7 @@ func TestBoundedConsolidatedValueInEmbeddedPartIsRedacted(t *testing.T) {
 		return
 	}
 	if got := residueInEmbedded(t, out, secret); got[secret] {
-		t.Errorf("the embedded part still contains the consolidated line — a bounded display "+
+		t.Errorf("the embedded part still contains the consolidated line — a bounded display " +
 			"text reaches the embedded gate un-restored, same defect as the cluster case")
 	}
 }

--- a/internal/redactors/office/redactor.go
+++ b/internal/redactors/office/redactor.go
@@ -167,6 +167,38 @@ func (or *OfficeRedactor) RedactDocument(originalPath string, outputPath string,
 		return nil, fmt.Errorf("failed to extract office content: %w", err)
 	}
 
+	// Normalize the match set ONCE, here, before every consumer of Match.Text.
+	//
+	// Both of these rewrite matches whose Text does not occur in the document:
+	// ExpandClusterMatches replaces a SOCIAL_MEDIA_CLUSTER with the real spans it
+	// collapsed, and RestoreBoundedMatchText restores a display-truncated consolidated
+	// text to its full line.
+	//
+	// They used to live inside redactOfficeContent, which took `matches` as a PARAMETER —
+	// so reassigning it there normalized only that function's local slice. This function
+	// then handed the ORIGINAL, un-normalized slice to redactEmbeddedParts below, and that
+	// is a second consumer of Match.Text: it builds the residue value set the embedded
+	// dispatch gate and the post-redaction verification both use.
+	//
+	// The consequence was a leak, measured on a .docx holding two clustered handles in its
+	// body AND in an embedded inner.docx:
+	//
+	//	2 HIGH findings reported, rc=0, one file written
+	//	body:  handles removed
+	//	inner: BOTH handles still present verbatim
+	//
+	// embeddedValueSet was built from the cluster's rendered summary — a string in no
+	// part's bytes — so partHoldsValue proved "absence" for every part, the part holding
+	// the real handles was never dispatched, and the fail-closed unredacted-part refusal
+	// that exists to prevent exactly this never fired because its residue check was
+	// looking for the same absent string. A non-clustered SSN in the same fixture is
+	// correctly removed from the embedded copy, which is what isolates the cause.
+	//
+	// Normalizing before both consumers is the fix. redactOfficeContent has exactly one
+	// caller (immediately below), so nothing else depended on it doing this itself.
+	matches = redactors.ExpandClusterMatches(matches)
+	matches = redactors.RestoreBoundedMatchText(matches)
+
 	// Perform redaction
 	redactionMap, modifiedContents, err := or.redactOfficeContent(zipContents, extractedText, textPositions, matches, strategy, docType)
 	if err != nil {
@@ -678,16 +710,9 @@ func (or *OfficeRedactor) redactOfficeContent(zipContents *OfficeZipContents, ex
 	}
 
 	// Restore bounded (display-truncated) consolidated match texts to their
-	// full-line spans first — redaction locates matches by searching for
-	// Match.Text in the extracted content, and a bounded display text does not
-	// occur there. See redactors.RestoreBoundedMatchText.
-	// Expand a consolidated cluster back into the real spans it replaced FIRST: its
-	// Text is a rendered summary that occurs nowhere in the document, so without this
-	// the cluster masks nothing and every handle it grouped survives in cleartext.
-	// See redactors.ExpandClusterMatches and #289.
-	matches = redactors.ExpandClusterMatches(matches)
-
-	matches = redactors.RestoreBoundedMatchText(matches)
+	// Match texts are already normalized by RedactDocument, before BOTH consumers —
+	// see the comment there. Doing it here reached only this function's local slice,
+	// which is what let a cluster through to the embedded-part gate.
 
 	// Collapse overlapping matches to their widest span so a smaller match
 	// contained in a larger one doesn't get redacted first and hide the larger


### PR DESCRIPTION
**A clustered value inside an embedded Office part shipped in cleartext inside a written "redacted" container, at exit 0, with no refusal.** Found by an adversarial post-merge sweep. It is a gap in #344 — mine.

## Mechanism

`RedactDocument` has **two** consumers of `Match.Text`:

```
:171  redactOfficeContent   rewrites the parts
:178  redactEmbeddedParts   dispatches embedded files, and builds the residue value set
```

`ExpandClusterMatches` and `RestoreBoundedMatchText` both lived **inside** `redactOfficeContent`, which takes `matches` as a **parameter** — so reassigning it there normalized only that function's local slice. `RedactDocument` then handed the **original** slice to `redactEmbeddedParts`.

That second consumer feeds `embeddedValueSet`, which both the dispatch gate (`embedded.go:101` — `ResidueInspectable(child.name) && !partHoldsValue(child.content, values, 0)`) and the post-redaction verification rely on. Given a cluster, the set holds the cluster's **rendered summary** — a string present in no part's bytes — so:

- `partHoldsValue` proved "absence" for **every** part, and the part holding the real values was never dispatched;
- the post-redaction check passed **vacuously** against the same absent string;
- the fail-closed unredacted-part refusal, which exists precisely to stop a container holding a reported value from being written, **never fired**.

## Reproduced independently on a `fefc0ee` binary

`.docx` with two clustered handles in its body **and** in an embedded `inner.docx`:

```
2 HIGH SOCIAL_MEDIA_CLUSTER findings, rc=0, one file written
body:  TW=False LI=False   (cleaned)
inner: TW=True  LI=True    (BOTH handles verbatim)
```

**Control** — same fixture, non-clustered SSN: inner `True → False`. So the embedded mechanism works and clustering is the sole cause. After the fix: inner `False False`, control still clean.

## Fix

Normalize **once** in `RedactDocument`, above both consumers; delete the inner copies. `redactOfficeContent` has exactly one caller, so nothing depended on it doing this itself.

Two further holes closed by the same reasoning:

- **Bounded consolidated text** (`INTELLECTUAL_PROPERTY`'s `… [+N more matches on line]`) reached the embedded gate un-restored for the same reason. This half is **pre-existing** — `RestoreBoundedMatchText` was already inside `redactOfficeContent` before #344 — and the same hoist fixes it.
- **legacy-OLE had `ExpandClusterMatches` but zero `RestoreBoundedMatchText` calls.** #344 gave it the expansion without its sibling, so a bounded consolidation in a legacy `.doc` was located by nothing and the whole line survived. Both now applied, same order as the other paths.

## What I got wrong

#344's commit table read *"plaintext expands / office expands / legacyole expands"*. That counted redactor **entry points**. What matters is **consumers of `Match.Text`**, and the embedded dispatch is a fourth one. Coverage of a normalization has to be enumerated over consumers, not over files.

## Tests, and a harness limitation worth recording

A bare `OfficeRedactor` has no embedded dispatcher injected, so it correctly **refuses** to write rather than redacting the part. The unit tests therefore assert *"no leaking output"* (a refusal is safe; a written file with residue is not), and a separate **end-to-end test through `core.RedactFile`** — the only path that injects a real dispatcher — asserts the embedded part is actually redacted.

Both **inflate the nested package**: grepping an embedded `.docx`'s compressed bytes finds nothing whether or not redaction worked, which is how this stayed invisible.

**Non-vacuity:** putting the normalization back inside `redactOfficeContent` fails the cluster test *and* the bounded-text test, each naming the surviving value.

`make all` green; full suite 66 packages, 0 failures.

---

**Not self-merging** — for @rustic. This one is a leak, so it may warrant priority over #347.