### PR TITLE
fix(audio): detect the pad byte in the INFO walk too, and bound a field's declared size

### DIFF
--- a/internal/preprocessors/meta-extractors/meta-extract-audiolib/wav-extractor.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-audiolib/wav-extractor.go
@@ -70,6 +70,51 @@ func (e *WAVExtractor) ExtractMetadata(filePath string) (*AudioMetadata, error) 
 	return metadata, nil
 }
 
+// padByteNote is the disclosure for a file that omits RIFF's required pad byte. Shared
+// by both chunk walks so the two cannot describe the same condition differently.
+const padByteNote = "the WAV chunk layout omits a required pad byte after an odd-length " +
+	"chunk; metadata was recovered by realigning, but the file is malformed and may be " +
+	"truncated"
+
+// consumePadByte applies RIFF's even-alignment rule after a chunk of the given size,
+// DETECTING the pad byte rather than assuming it, and reports how many bytes it consumed.
+//
+// RIFF requires an odd-length chunk to be followed by a pad byte, but a truncated download
+// or a non-compliant writer can omit it. Seeking past it unconditionally then lands the
+// reader ONE BYTE PAST the next chunk header, so every subsequent ID is garbage — read
+// silently, ending the walk at EOF with a nil error and a short result. Measured on two
+// fixtures identical but for this single byte: 1 finding versus 0, the second with no
+// disclosure at all.
+//
+// The two cases are unambiguous, so the pad is detected: a pad is always 0x00, and a chunk
+// ID's first byte is printable ASCII.
+//
+// This lives in one function because it is needed in two places and diverged once already:
+// the outer walk detected the pad while parseInfoChunks — the loop that reads the
+// PII-bearing INFO fields — still assumed it, so the fix covered the metadata an operator
+// cares least about and missed the fields that carry names, comments and copyright.
+func consumePadByte(file *os.File, size uint32) (consumed int, missing bool, err error) {
+	if size%2 == 0 {
+		return 0, false, nil
+	}
+	var pad [1]byte
+	n, rerr := file.Read(pad[:])
+	switch {
+	case rerr != nil || n == 0:
+		// EOF right after an odd chunk: nothing follows, so nothing is missed.
+		return 0, false, nil
+	case pad[0] == 0x00:
+		return 1, false, nil
+	default:
+		// Not a pad byte — it is the first byte of the next chunk ID. Put it back so the
+		// walk stays aligned, and report the file as non-compliant.
+		if _, serr := file.Seek(-1, io.SeekCurrent); serr != nil {
+			return 0, false, serr
+		}
+		return 0, true, nil
+	}
+}
+
 // parseChunks parses WAV chunks
 func (e *WAVExtractor) parseChunks(file *os.File, metadata *AudioMetadata) error {
 	// sawMissingPad records that an odd-length chunk was not followed by the pad byte RIFF
@@ -89,9 +134,9 @@ func (e *WAVExtractor) parseChunks(file *os.File, metadata *AudioMetadata) error
 		chunkID := string(header.ID[:])
 
 		// A RIFF chunk ID is four printable ASCII characters. Anything else means the
-		// reader is no longer on a chunk boundary, and continuing would walk garbage: the
-		// default branch below would "skip" by a nonsense size, land somewhere arbitrary,
-		// and eventually hit EOF — at which point the loop breaks and reports success on a
+		// reader is no longer on a chunk boundary, and continuing would walk garbage:
+		// the walk would "skip" by a nonsense size, land somewhere arbitrary, and
+		// eventually hit EOF — at which point the loop breaks and reports success on a
 		// file it never read. Stop and say so instead.
 		if !isPrintableChunkID(header.ID) {
 			metadata.ExtractionWarning = "audio metadata may be incomplete: the WAV chunk " +
@@ -100,52 +145,53 @@ func (e *WAVExtractor) parseChunks(file *os.File, metadata *AudioMetadata) error
 			return nil
 		}
 
+		// Where this chunk's DATA starts, so the walk can reposition AUTHORITATIVELY
+		// after parsing it.
+		//
+		// Every derailment this extractor has produced came from the same assumption:
+		// that each chunk parser consumes exactly header.Size bytes and leaves the
+		// reader on the next boundary. They do not. parseFormatChunk reads a fixed 16
+		// bytes even when the chunk declares fewer, parseListChunk's skip arithmetic
+		// underflows for a size below 4, and its error path used to seek header.Size
+		// FURTHER from a position already inside the chunk. Each of those silently moved
+		// the walk somewhere arbitrary.
+		//
+		// Seeking to a computed absolute offset makes the header the single source of
+		// truth for where the next chunk begins, so a parser that reads too much or too
+		// little can no longer derail anything after it.
+		dataStart, err := file.Seek(0, io.SeekCurrent)
+		if err != nil {
+			return err
+		}
+
 		switch chunkID {
 		case "fmt ":
 			if err := e.parseFormatChunk(file, header.Size, metadata); err != nil {
 				return err
 			}
 		case "LIST":
-			if err := e.parseListChunk(file, header.Size, metadata); err != nil {
-				// Don't fail on LIST chunk errors, just skip
-				if _, err := file.Seek(int64(header.Size), io.SeekCurrent); err != nil {
-					return err
-				}
+			// A malformed LIST costs its own metadata, not the rest of the file: the
+			// absolute reposition below puts the walk back on the next chunk boundary
+			// regardless of where this parse stopped.
+			if err := e.parseListChunk(file, header.Size, metadata); err != nil &&
+				metadata.ExtractionWarning == "" {
+				metadata.ExtractionWarning = "audio metadata may be incomplete: a WAV " +
+					"LIST chunk could not be parsed, so the fields it holds were not read"
 			}
 		default:
-			// Skip unknown chunks
-			if _, err := file.Seek(int64(header.Size), io.SeekCurrent); err != nil {
-				return err
-			}
+			// Unknown chunk. Nothing to read; the reposition below skips it.
 		}
 
-		// Align to even byte boundary.
-		//
-		// RIFF requires an odd-length chunk to be followed by a pad byte, but a truncated
-		// download or a non-compliant writer can omit it. Seeking past it unconditionally
-		// then lands the reader ONE BYTE PAST the next chunk header, so every subsequent
-		// chunk ID is garbage — which used to be skipped silently, ending the walk at EOF
-		// with a nil error and an empty result. Measured on two fixtures identical but for
-		// this single byte: 1 finding versus 0, the second with no disclosure at all.
-		//
-		// The two cases are unambiguous, so the pad byte is detected rather than assumed:
-		// a pad is always 0x00, and a chunk ID's first byte is printable ASCII.
-		if header.Size%2 == 1 {
-			var pad [1]byte
-			n, err := file.Read(pad[:])
-			switch {
-			case err != nil || n == 0:
-				// EOF right after an odd chunk: nothing follows, so nothing is missed.
-			case pad[0] == 0x00:
-				// A real pad byte, already consumed by the read above.
-			default:
-				// Not a pad byte — it is the first byte of the next chunk ID. Put it back
-				// so the walk stays aligned, and note the file is non-compliant.
-				if _, err := file.Seek(-1, io.SeekCurrent); err != nil {
-					return err
-				}
-				sawMissingPad = true
-			}
+		if _, err := file.Seek(dataStart+int64(header.Size), io.SeekStart); err != nil {
+			return err
+		}
+
+		_, missing, err := consumePadByte(file, header.Size)
+		if err != nil {
+			return err
+		}
+		if missing {
+			sawMissingPad = true
 		}
 	}
 
@@ -153,9 +199,7 @@ func (e *WAVExtractor) parseChunks(file *os.File, metadata *AudioMetadata) error
 	// whether their corpus is intact should know the tool had to compensate. Never
 	// overwrite a more specific warning already set above.
 	if sawMissingPad && metadata.ExtractionWarning == "" {
-		metadata.ExtractionWarning = "the WAV chunk layout omits a required pad byte after " +
-			"an odd-length chunk; metadata was recovered by realigning, but the file is " +
-			"malformed and may be truncated"
+		metadata.ExtractionWarning = padByteNote
 	}
 
 	return nil
@@ -173,8 +217,28 @@ func isPrintableChunkID(id [4]byte) bool {
 	return true
 }
 
-// parseFormatChunk parses the WAV format chunk
+// fmtChunkBodySize is the number of bytes WAVFormatChunk occupies on disk. binary.Read
+// consumes exactly this many, so a chunk declaring fewer would be read past its own end
+// and produce format values assembled partly from whatever follows.
+const fmtChunkBodySize = 16
+
+// parseFormatChunk parses the WAV format chunk.
+//
+// The caller repositions to the end of this chunk afterwards, so this function does not
+// skip any trailing bytes itself; it only needs to avoid reading values it cannot trust.
 func (e *WAVExtractor) parseFormatChunk(file *os.File, size uint32, metadata *AudioMetadata) error {
+	if size < fmtChunkBodySize {
+		// A short fmt chunk is malformed. Reading it anyway would report a sample rate and
+		// bitrate partly composed of the next chunk's bytes, which is worse than reporting
+		// nothing: the numbers look plausible and nothing marks them as invented.
+		if metadata.ExtractionWarning == "" {
+			metadata.ExtractionWarning = "audio metadata may be incomplete: the WAV format " +
+				"chunk is shorter than the format record it declares, so the technical " +
+				"properties were not read"
+		}
+		return nil
+	}
+
 	var format WAVFormatChunk
 	if err := binary.Read(file, binary.LittleEndian, &format); err != nil {
 		return err
@@ -189,65 +253,93 @@ func (e *WAVExtractor) parseFormatChunk(file *os.File, size uint32, metadata *Au
 	metadata.Properties["BitsPerSample"] = fmt.Sprintf("%d", format.BitsPerSample)
 	metadata.Properties["BlockAlign"] = fmt.Sprintf("%d", format.BlockAlign)
 
-	// Skip any remaining format chunk data
-	remaining := size - 16 // 16 bytes already read
-	if remaining > 0 {
-		if _, err := file.Seek(int64(remaining), io.SeekCurrent); err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 
-// parseListChunk parses LIST chunks which may contain INFO metadata
+// listTypeSize is the four-byte form type ("INFO") that opens a LIST chunk's data.
+const listTypeSize = 4
+
+// parseListChunk parses LIST chunks which may contain INFO metadata.
 func (e *WAVExtractor) parseListChunk(file *os.File, size uint32, metadata *AudioMetadata) error {
-	// Read LIST type
-	listType := make([]byte, 4)
-	if _, err := file.Read(listType); err != nil {
+	// size is a uint32 straight from the file, so `size - listTypeSize` underflows to
+	// roughly 4GB for any size below 4 and every length derived from it is nonsense.
+	if size < listTypeSize {
+		return fmt.Errorf("LIST chunk size %d is smaller than its form type", size)
+	}
+
+	listType := make([]byte, listTypeSize)
+	if _, err := io.ReadFull(file, listType); err != nil {
 		return err
 	}
 
 	if string(listType) != "INFO" {
-		// Skip non-INFO LIST chunks
-		remaining := size - 4
-		if _, err := file.Seek(int64(remaining), io.SeekCurrent); err != nil {
-			return err
-		}
+		// Not INFO, so there is nothing here to extract. The caller repositions past the
+		// chunk, so no skip is needed.
 		return nil
 	}
 
-	// Parse INFO chunks
-	remaining := size - 4 // 4 bytes for LIST type already read
-	return e.parseInfoChunks(file, remaining, metadata)
+	return e.parseInfoChunks(file, size-listTypeSize, metadata)
 }
 
-// parseInfoChunks parses INFO chunks within a LIST chunk
+// infoHeaderSize is the per-field ID+size header inside a LIST/INFO chunk.
+const infoHeaderSize = 8
+
+// parseInfoChunks parses INFO chunks within a LIST chunk.
+//
+// These are the fields that carry personal data — IART (artist), ICMT (comment), ICOP
+// (copyright), IENG (engineer) — so a walk that derails here loses exactly the metadata
+// the scan exists to find, and loses it silently.
 func (e *WAVExtractor) parseInfoChunks(file *os.File, totalSize uint32, metadata *AudioMetadata) error {
 	bytesRead := uint32(0)
+	sawMissingPad := false
 
-	for bytesRead < totalSize {
+	// A trailing remainder too small to hold a header is malformed, not a field; reading
+	// it would consume bytes belonging to the next chunk.
+	for totalSize-bytesRead >= infoHeaderSize {
 		var header WAVChunkHeader
 		if err := binary.Read(file, binary.LittleEndian, &header); err != nil {
 			return err
 		}
-		bytesRead += 8
+		bytesRead += infoHeaderSize
 
-		// Read chunk data
+		// header.Size is attacker-controlled and reached make() unchecked. A 60-byte
+		// fixture declaring 0xC0000000 drove 6.1GB of peak RSS at exit 0, and the same
+		// allocation is reachable by accident: one missing pad byte misaligns the reader
+		// so a size field is assembled from a field ID and its data, which measured
+		// 1.7GB from a 102-byte file. Bounding it by the bytes actually left in the LIST
+		// makes the allocation proportional to the file and costs nothing on valid input.
+		if header.Size > totalSize-bytesRead {
+			if metadata.ExtractionWarning == "" {
+				metadata.ExtractionWarning = "audio metadata may be incomplete: a WAV INFO " +
+					"field declares more data than its containing chunk holds, so that " +
+					"field and any after it were not read"
+			}
+			return nil
+		}
+
 		chunkData := make([]byte, header.Size)
-		if _, err := file.Read(chunkData); err != nil {
+		// ReadFull, not Read: a short Read returns n<len with a nil error, which used to
+		// leave the walk misaligned by however many bytes were missing while looking like
+		// a clean parse.
+		if _, err := io.ReadFull(file, chunkData); err != nil {
 			return err
 		}
 		bytesRead += header.Size
 
-		// Parse INFO field
 		e.parseInfoField(string(header.ID[:]), chunkData, metadata)
 
-		// Align to even byte boundary
-		if header.Size%2 == 1 {
-			file.Seek(1, io.SeekCurrent)
-			bytesRead++
+		consumed, missing, err := consumePadByte(file, header.Size)
+		if err != nil {
+			return err
 		}
+		bytesRead += uint32(consumed)
+		if missing {
+			sawMissingPad = true
+		}
+	}
+
+	if sawMissingPad && metadata.ExtractionWarning == "" {
+		metadata.ExtractionWarning = padByteNote
 	}
 
 	return nil

--- a/internal/preprocessors/meta-extractors/meta-extract-audiolib/wav_info_alignment_test.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-audiolib/wav_info_alignment_test.go
@@ -1,0 +1,412 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package audiolib
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// The INFO walk inside a LIST chunk had the same pad-byte defect the outer chunk walk had,
+// and it went unfixed when the outer one was corrected.
+//
+// That is the half that matters. The outer walk sees fmt/data/LIST; the INFO walk sees
+// IART, ICMT, ICOP, IENG — artist, comment, copyright, engineer — which is where personal
+// data actually lives in a WAV. Measured on the shipped binary with two fixtures identical
+// but for one byte:
+//
+//	padded    -> 1 SSN finding, 25MB peak RSS
+//	unpadded  -> 0 SSN findings, 1690MB peak RSS, no disclosure at all
+//
+// Both symptoms come from one cause. Dropping the pad leaves the reader one byte early, so
+// the next field's four-byte ID and the first byte of its size are read as the ID, and the
+// size is assembled from the rest of that field plus the first byte of its data — a
+// nonsense length that both allocates gigabytes and swallows the field. The value's first
+// character is consumed as part of the header, so a token at the start of a field is
+// truncated past recognition and the finding disappears.
+
+// infoFieldSpec is one LIST/INFO field. pad controls whether the RIFF-required pad byte
+// follows an odd-length value, and declaredSize overrides the size header when non-zero so
+// a field can claim more data than it holds.
+type infoFieldSpec struct {
+	id           string
+	value        string
+	pad          bool
+	declaredSize uint32
+}
+
+// buildWAVWithInfo assembles a WAV whose LIST/INFO chunk holds the given fields.
+//
+// fmtSize overrides the declared size of the format chunk when non-zero, and listSize
+// overrides the LIST chunk's declared size when non-zero; both exist so a malformed
+// container can be built without hand-assembling the whole file.
+func buildWAVWithInfo(t *testing.T, path string, fields []infoFieldSpec, fmtSize, listSize uint32) string {
+	t.Helper()
+
+	header := func(id string, size uint32) []byte {
+		out := append([]byte(id), make([]byte, 4)...)
+		binary.LittleEndian.PutUint32(out[4:], size)
+		return out
+	}
+
+	fmtPayload := make([]byte, 16)
+	binary.LittleEndian.PutUint16(fmtPayload[0:], 1)    // PCM
+	binary.LittleEndian.PutUint16(fmtPayload[2:], 1)    // mono
+	binary.LittleEndian.PutUint32(fmtPayload[4:], 8000) // sample rate
+	binary.LittleEndian.PutUint32(fmtPayload[8:], 8000) // byte rate
+	binary.LittleEndian.PutUint16(fmtPayload[12:], 1)
+	binary.LittleEndian.PutUint16(fmtPayload[14:], 8)
+
+	declaredFmt := uint32(len(fmtPayload))
+	if fmtSize != 0 {
+		// The payload is truncated to match, because a chunk header is authoritative for
+		// where the next chunk starts. A fixture that declares 10 bytes while holding 16 is
+		// not a short chunk, it is a file whose every later offset is wrong — and the walk
+		// correctly lands mid-payload on it, which tests nothing about the short-chunk guard.
+		declaredFmt = fmtSize
+		if declaredFmt < uint32(len(fmtPayload)) {
+			fmtPayload = fmtPayload[:declaredFmt]
+		}
+	}
+	body := append(header("fmt ", declaredFmt), fmtPayload...)
+
+	infoBody := []byte("INFO")
+	for _, f := range fields {
+		payload := append([]byte(f.value), 0x00)
+		size := uint32(len(payload))
+		if f.declaredSize != 0 {
+			size = f.declaredSize
+		}
+		infoBody = append(infoBody, header(f.id, size)...)
+		infoBody = append(infoBody, payload...)
+		if f.pad && len(payload)%2 == 1 {
+			infoBody = append(infoBody, 0x00)
+		}
+	}
+
+	declaredList := uint32(len(infoBody))
+	if listSize != 0 {
+		declaredList = listSize
+	}
+	body = append(body, header("LIST", declaredList)...)
+	body = append(body, infoBody...)
+
+	payload := append([]byte("WAVE"), body...)
+	riff := append([]byte("RIFF"), make([]byte, 4)...)
+	binary.LittleEndian.PutUint32(riff[4:], uint32(len(payload)))
+	riff = append(riff, payload...)
+
+	if err := os.WriteFile(path, riff, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// oddValue is 16 characters, so value+NUL is 17 bytes and RIFF requires a pad byte after
+// it. Getting this wrong is how a first attempt at this fixture proved nothing: two
+// even-length values need no pad, so "omitting" it changed nothing and both files parsed
+// identically.
+const oddValue = "Q3 Review Master"
+
+// leadingSecret starts with the sensitive token, which is what makes the miss visible. A
+// misaligned read eats the value's first byte; with the token in the middle of the value
+// the remainder still matches and the bug hides.
+const leadingSecret = "452-11-9384 is the SSN on file"
+
+func TestWAVInfoMissingPadRecoversFollowingField(t *testing.T) {
+	dir := t.TempDir()
+	e := &WAVExtractor{}
+
+	fields := func(pad bool) []infoFieldSpec {
+		return []infoFieldSpec{
+			{id: "INAM", value: oddValue, pad: pad},
+			{id: "ICMT", value: leadingSecret, pad: true},
+		}
+	}
+
+	if (len(oddValue)+1)%2 != 1 {
+		t.Fatalf("fixture is wrong: %q plus its NUL is even, so no pad byte is required and "+
+			"omitting one changes nothing", oddValue)
+	}
+
+	good, err := e.ExtractMetadata(buildWAVWithInfo(t,
+		filepath.Join(dir, "good.wav"), fields(true), 0, 0))
+	if err != nil {
+		t.Fatalf("compliant WAV: %v", err)
+	}
+	if !strings.Contains(good.Comment, leadingSecret) {
+		t.Fatalf("fixture is wrong: the compliant WAV did not yield the comment (got %q). "+
+			"Without this the malformed case below proves nothing.", good.Comment)
+	}
+	if good.ExtractionWarning != "" {
+		t.Errorf("compliant WAV was flagged: %q", good.ExtractionWarning)
+	}
+
+	bad, err := e.ExtractMetadata(buildWAVWithInfo(t,
+		filepath.Join(dir, "bad.wav"), fields(false), 0, 0))
+	if err != nil {
+		t.Fatalf("malformed WAV returned an error: %v — extraction should recover the fields it "+
+			"can still read", err)
+	}
+	if !strings.Contains(bad.Comment, leadingSecret) {
+		t.Errorf("the INFO field after an unpadded one was lost (comment = %q). The reader was "+
+			"left a byte early, so the field's own header absorbed the first byte of its value "+
+			"and the token no longer matched — a detection miss, which means the value is never "+
+			"redacted either.", bad.Comment)
+	}
+	if bad.ExtractionWarning == "" {
+		t.Error("malformed WAV carries no ExtractionWarning — a recovered file is still not " +
+			"RIFF-compliant and the operator should know the tool had to compensate")
+	}
+	if !strings.Contains(strings.ToLower(bad.ExtractionWarning), "pad byte") {
+		t.Errorf("warning = %q, want it to name the pad byte", bad.ExtractionWarning)
+	}
+	if strings.Contains(bad.ExtractionWarning, "452-11-9384") {
+		t.Errorf("the warning leaked the matched value: %q", bad.ExtractionWarning)
+	}
+}
+
+// maxExtractAlloc bounds what extracting a fixture of a few hundred bytes may allocate.
+//
+// The sizes being guarded are uint32s read straight out of the file, so when one reaches
+// make() the allocation is measured in gigabytes: 3GB for a crafted declaration and 1.7GB
+// reached by accident through a single missing pad byte. 8MB leaves generous headroom for
+// the extractor's ordinary work while failing by three orders of magnitude if any of those
+// paths regresses.
+const maxExtractAlloc = 8 << 20
+
+// extractMeasuringAlloc extracts path and reports how many bytes were allocated doing it.
+//
+// A ceiling on allocation is the assertion that actually distinguishes these guards.
+// Asserting only that a warning appears is too weak: an unguarded size underflow ALSO
+// produces a warning, because the walk derails and the garbage-chunk-ID disclosure fires.
+// The test then passes while the defect is fully present, which is how two of these guards
+// first mutation-tested as vacuous.
+func extractMeasuringAlloc(t *testing.T, path string) (*AudioMetadata, uint64) {
+	t.Helper()
+
+	if info, err := os.Stat(path); err != nil {
+		t.Fatal(err)
+	} else if info.Size() > 4096 {
+		t.Fatalf("fixture grew to %d bytes; it must stay tiny for an allocation bound to mean "+
+			"anything", info.Size())
+	}
+
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+
+	meta, err := (&WAVExtractor{}).ExtractMetadata(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	runtime.ReadMemStats(&after)
+	return meta, after.TotalAlloc - before.TotalAlloc
+}
+
+// A field's declared size is a uint32 out of the file and it reached make() unchecked, so a
+// tiny file could demand an arbitrary allocation. This asserts the allocation is bounded by
+// the file rather than by the declaration.
+func TestWAVInfoOversizedFieldIsBoundedAndDisclosed(t *testing.T) {
+	dir := t.TempDir()
+	path := buildWAVWithInfo(t, filepath.Join(dir, "huge.wav"), []infoFieldSpec{
+		// Claims 3GB of data while holding four bytes.
+		{id: "IART", value: "abc", pad: true, declaredSize: 0xC0000000},
+	}, 0, 0)
+
+	meta, allocated := extractMeasuringAlloc(t, path)
+
+	if allocated > maxExtractAlloc {
+		t.Errorf("extracting a tiny file allocated %d bytes (> %d) — a size field read straight "+
+			"out of the file is reaching make(); a 60-byte fixture drove 6.1GB of peak RSS this "+
+			"way, at exit 0", allocated, maxExtractAlloc)
+	}
+	if meta.ExtractionWarning == "" {
+		t.Error("a field declaring more data than its chunk holds produced no warning — the " +
+			"field was not read, and undisclosed missing coverage reads as a clean result")
+	}
+}
+
+// A field whose declared size fits its chunk but runs off the END OF THE FILE must fail
+// loudly, not quietly.
+//
+// os.File.Read returns the bytes it has with a NIL error, so a truncated field used to yield
+// a short value and a byte count that no longer matched the file position — the value was
+// wrong and every field after it was read from the wrong offset, all reported as a clean
+// parse. io.ReadFull turns that into ErrUnexpectedEOF.
+func TestWAVTruncatedInfoFieldIsDisclosed(t *testing.T) {
+	dir := t.TempDir()
+	path := buildWAVWithInfo(t, filepath.Join(dir, "trunc.wav"), []infoFieldSpec{
+		{id: "ICMT", value: leadingSecret, pad: true},
+		{id: "IART", value: "Second Field Value", pad: true},
+	}, 0, 0)
+
+	full, err := os.ReadFile(path) // #nosec G304 -- test-local path
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Cut the file in the middle of the FIRST field's value, leaving both the LIST size and
+	// the field size claiming data that is no longer there.
+	cut := len(full) - len("Second Field Value") - 1 - 8 - len(leadingSecret)/2
+	if cut <= 0 || cut >= len(full) {
+		t.Fatalf("fixture arithmetic is wrong: cut=%d of %d bytes", cut, len(full))
+	}
+	if err := os.WriteFile(path, full[:cut], 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	meta, err := (&WAVExtractor{}).ExtractMetadata(path)
+	if err != nil {
+		// Failing the extraction outright is an acceptable disclosure: the caller surfaces it.
+		return
+	}
+
+	// The assertion that separates ReadFull from Read is about the VALUE, not the warning.
+	// Both paths end up warning, because the loop's next header read hits EOF either way.
+	// The difference is what gets REPORTED in between: a plain Read fills the head of the
+	// buffer and leaves the rest as zeros, and the NUL-trimming in parseInfoField makes that
+	// indistinguishable from a genuinely shorter value. So a field that is half present is
+	// published as though it were whole.
+	//
+	// Reporting a value the file does not contain is worse than reporting nothing. It is
+	// wrong in the output, and where the cut lands inside a token it also changes what the
+	// validators see — the same class of silent detection change as the pad-byte miss.
+	if meta.Comment != "" && meta.Comment != leadingSecret {
+		t.Errorf("a truncated INFO field was reported as a complete value: got %q, and the file "+
+			"holds either the whole of %q or not enough of it to report. A short read returns "+
+			"n<len with a nil error, so the missing tail became NUL padding and was trimmed "+
+			"away, leaving a value that looks legitimately short.", meta.Comment, leadingSecret)
+	}
+	if meta.ExtractionWarning == "" {
+		t.Errorf("a WAV truncated inside an INFO field parsed clean: comment=%q, warning empty",
+			meta.Comment)
+	}
+}
+
+// A short fmt chunk must cost only its own values. It used to consume 16 bytes regardless
+// of what it declared, leaving the walk inside the next chunk.
+func TestWAVShortFormatChunkDoesNotDerailLaterFields(t *testing.T) {
+	dir := t.TempDir()
+	path := buildWAVWithInfo(t, filepath.Join(dir, "shortfmt.wav"), []infoFieldSpec{
+		{id: "ICMT", value: leadingSecret, pad: true},
+	}, 10, 0) // declares 10 bytes of format data, holds 16
+
+	e := &WAVExtractor{}
+	meta, err := e.ExtractMetadata(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(meta.Comment, leadingSecret) {
+		t.Errorf("a short fmt chunk cost the LIST/INFO field that follows it (comment = %q) — "+
+			"reading a fixed 16 bytes from a chunk declaring 10 left the walk six bytes into "+
+			"the next chunk", meta.Comment)
+	}
+	if meta.ExtractionWarning == "" {
+		t.Error("a fmt chunk shorter than the record it declares produced no warning")
+	}
+	if meta.SampleRate != 0 {
+		t.Errorf("SampleRate = %d, want 0: the chunk is too short to hold the format record, "+
+			"so any value would be assembled partly from the bytes that follow it and would "+
+			"look plausible while being invented", meta.SampleRate)
+	}
+}
+
+// A LIST chunk declaring a size below its own four-byte form type underflowed the skip
+// arithmetic to roughly 4GB. It must cost only that chunk.
+func TestWAVUndersizedListChunkIsContained(t *testing.T) {
+	dir := t.TempDir()
+	// The field declares 3GB as well, because that is what makes the underflow observable.
+	// With the guard in place the LIST is rejected before any field is looked at. Without it,
+	// `2 - 4` wraps to about 4GB and becomes the budget every field's declared size is
+	// checked against — so the bound that is supposed to cap the allocation is handed a
+	// ceiling that admits this field. An undersized LIST holding only well-formed fields
+	// cannot show this: the fields parse correctly either way.
+	path := buildWAVWithInfo(t, filepath.Join(dir, "shortlist.wav"), []infoFieldSpec{
+		{id: "ICMT", value: leadingSecret, pad: true, declaredSize: 0xC0000000},
+	}, 0, 2) // LIST declares 2 bytes, less than the "INFO" form type
+
+	meta, allocated := extractMeasuringAlloc(t, path)
+
+	// This is the assertion that catches the underflow. `size - listTypeSize` on a size of 2
+	// wraps to about 4GB, and that value becomes the budget parseInfoChunks measures every
+	// field's declared size against — so the bound that protects the allocation is handed a
+	// ceiling large enough to admit anything.
+	if allocated > maxExtractAlloc {
+		t.Errorf("a LIST chunk declaring %d bytes caused %d bytes to be allocated (> %d) — the "+
+			"size is a uint32, so subtracting the four-byte form type wrapped instead of "+
+			"failing", 2, allocated, maxExtractAlloc)
+	}
+	if meta.ExtractionWarning == "" {
+		t.Error("an undersized LIST chunk produced no warning — its fields were not read")
+	}
+	if strings.Contains(meta.ExtractionWarning, "452-11-9384") {
+		t.Errorf("the warning leaked a value: %q", meta.ExtractionWarning)
+	}
+}
+
+// consumePadByte is the shared primitive both walks depend on. It exists precisely because
+// the two had diverged, so its contract is pinned directly.
+func TestConsumePadByte(t *testing.T) {
+	dir := t.TempDir()
+
+	write := func(name string, b []byte) *os.File {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, b, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		f, err := os.Open(p) // #nosec G304 -- test-local path
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = f.Close() })
+		return f
+	}
+
+	t.Run("even size consumes nothing", func(t *testing.T) {
+		f := write("even", []byte{'f', 'm', 't', ' '})
+		consumed, missing, err := consumePadByte(f, 4)
+		if err != nil || consumed != 0 || missing {
+			t.Errorf("got (%d, %v, %v), want (0, false, nil)", consumed, missing, err)
+		}
+	})
+
+	t.Run("present pad is consumed", func(t *testing.T) {
+		f := write("pad", []byte{0x00, 'L', 'I', 'S', 'T'})
+		consumed, missing, err := consumePadByte(f, 3)
+		if err != nil || consumed != 1 || missing {
+			t.Errorf("got (%d, %v, %v), want (1, false, nil)", consumed, missing, err)
+		}
+	})
+
+	t.Run("absent pad is reported and pushed back", func(t *testing.T) {
+		f := write("nopad", []byte{'L', 'I', 'S', 'T'})
+		consumed, missing, err := consumePadByte(f, 3)
+		if err != nil || consumed != 0 || !missing {
+			t.Fatalf("got (%d, %v, %v), want (0, true, nil)", consumed, missing, err)
+		}
+		// The byte must still be available, or the caller is misaligned anyway.
+		var next [4]byte
+		if _, err := f.Read(next[:]); err != nil {
+			t.Fatal(err)
+		}
+		if string(next[:]) != "LIST" {
+			t.Errorf("next read = %q, want %q: the non-pad byte was not pushed back",
+				next[:], "LIST")
+		}
+	})
+
+	t.Run("EOF after an odd chunk is not an error", func(t *testing.T) {
+		f := write("eof", []byte{})
+		consumed, missing, err := consumePadByte(f, 3)
+		if err != nil || consumed != 0 || missing {
+			t.Errorf("got (%d, %v, %v), want (0, false, nil): nothing follows, so nothing "+
+				"is missed", consumed, missing, err)
+		}
+	})
+}


### PR DESCRIPTION
## What

`#312` fixed the pad-byte assumption in the **outer** WAV chunk walk and left the identical defect in `parseInfoChunks` — the half that matters. The outer walk sees `fmt`/`data`/`LIST`; the INFO walk sees `IART`, `ICMT`, `ICOP`, `IENG` (artist, comment, copyright, engineer), which is where personal data actually lives in a WAV.

## Measured

Two fixtures identical but for **one byte**:

| fixture | SSN findings | peak RSS | disclosure |
|---|---|---|---|
| padded (RIFF-compliant) | 1 | 25 MB | — |
| pad byte omitted | **0** | **1690 MB** | **none** |
| after this change | 1 | 25 MB | names the pad byte |

Plus a crafted 60-byte file declaring `0xC0000000` for a field size: **6.1 GB peak RSS, exit 0** → now 25 MB.

Both symptoms are one cause. Dropping the pad leaves the reader a byte early, so the next field's ID plus the first byte of its size are read as the ID, and its size is assembled from the remainder plus the first byte of the data — a nonsense length that both allocates gigabytes and swallows the field. Because the value's first character is eaten by the header, a token at the **start** of a field is truncated past recognition and the finding disappears.

Audio has no redactor (`#306`), so this is a **reporting** miss rather than a redaction leak: the operator is simply never told the value is there.

## Why the change is structural rather than a one-line patch

The bug class rests on an assumption none of the chunk parsers actually honoured — that each consumes exactly `header.Size` bytes and leaves the reader on the next boundary:

- `parseFormatChunk` read a fixed 16 bytes from a chunk declaring fewer
- `parseListChunk`'s skip arithmetic underflowed to ~4 GB for any size below 4
- its error path seeked `header.Size` **further** from a position already inside the chunk

The walk now repositions to a computed absolute offset after each chunk, so the header is the single source of truth for where the next one begins, and a parser that reads too much or too little can no longer derail anything after it.

Pad detection now lives in one shared function, because it had already diverged once — which is exactly how the INFO walk kept the defect after the outer walk was fixed.

Also: `io.ReadFull` instead of `Read`, so a field truncated by a short file fails loudly instead of publishing a NUL-padded partial value as a complete one; and a `fmt` chunk too short to hold the format record no longer reports a sample rate assembled partly from the bytes that follow it.

## Verification

- All **six** parts mutation-tested; each mutation compiles and fails a test.
- Two assertions were **vacuous on the first pass** — they asserted only that a warning appeared, which an unguarded underflow also produces (the derailed walk trips the garbage-chunk-ID disclosure). They now assert the allocation ceiling and the reported value instead.
- 66 packages pass, 0 failures; `-race` clean on `internal/preprocessors/...`; `vet`/`gofmt` clean.
- Golden corpus passes forced (`-count=1`), and 15 real audio files on a dev machine give byte-identical results.

Prior art: `#312` (outer walk, closed). Related: `#306` (no audio redactor).