### PR TITLE
fix(cli): scope discovery disclosure to what was actually in scope, and stop dropping glob-matched directories

### DIFF
--- a/cmd/discovery_scope_test.go
+++ b/cmd/discovery_scope_test.go
@@ -1,0 +1,315 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Discovery-time coverage accounting has to get BOTH directions right: everything that was
+// refused must be disclosed, and nothing that was never in scope may be reported as a loss.
+//
+// The first direction was fixed for #324 and #336. The second was broken BY those fixes, and
+// the two failures need opposite corrections, so they are tested together to keep a later
+// change from trading one for the other.
+
+// pii is a value that must be found when a path is genuinely scanned, and must never appear
+// in a disclosure string.
+const pii = "SSN: 452-11-9384"
+
+// A DIRECTORY matched by a glob pattern used to be dropped in silence.
+//
+// The glob branch tested info.Mode().IsRegular() and had no else, so a matched directory
+// reached neither FilesToProcess nor either disclosure slice. --recursive was accepted and
+// did nothing, because recursion lives in the directory branch that a glob never reaches.
+//
+// Measured on the shipped binary against a readable tree holding two values:
+//
+//	--file '<dir>/*' --recursive   ->  0 findings, total_files 1, exit 0, no disclosure
+//	after this change              ->  2 findings, total_files 3
+//
+// A shell that expands the pattern itself hides this, because each match arrives as its own
+// argument. It bites when the pattern is QUOTED, which is what the documentation asks for.
+func TestGlobMatchedDirectoryIsScannedWhenRecursive(t *testing.T) {
+	root := t.TempDir()
+	deep := filepath.Join(root, "deep", "deeper")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "top.txt"), []byte("nothing here\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "deep", "pii.txt"), []byte(pii+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(deep, "more.txt"), []byte("Card: 4111111111111111\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := getFilesToProcess(filepath.Join(root, "*"), true, nil, nil, true)
+	if err != nil {
+		t.Fatalf("getFilesToProcess: %v", err)
+	}
+
+	var sawNested, sawDeepest bool
+	for _, p := range res.FilesToProcess {
+		switch filepath.Base(p) {
+		case "pii.txt":
+			sawNested = true
+		case "more.txt":
+			sawDeepest = true
+		}
+	}
+	if !sawNested || !sawDeepest {
+		t.Errorf("FilesToProcess = %v, want the files inside the matched directory. A glob that "+
+			"matches a directory dropped it entirely, so --recursive was silently a no-op and "+
+			"the PII inside was never scanned — which also means it is never redacted.",
+			res.FilesToProcess)
+	}
+}
+
+// Without --recursive the directory is genuinely out of scope, so it must be REPORTED as
+// skipped rather than either scanned or dropped.
+//
+// Dropped is what it used to be: no counter, no message, nothing for the operator to notice
+// that a matched path contributed nothing.
+func TestGlobMatchedDirectoryIsDisclosedWhenNotRecursive(t *testing.T) {
+	root := t.TempDir()
+	sub := filepath.Join(root, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "pii.txt"), []byte(pii+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "top.txt"), []byte("nothing\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := getFilesToProcess(filepath.Join(root, "*"), false, nil, nil, true)
+	if err != nil {
+		t.Fatalf("getFilesToProcess: %v", err)
+	}
+
+	for _, p := range res.FilesToProcess {
+		if strings.Contains(p, "sub") {
+			t.Errorf("%q was scanned without --recursive", p)
+		}
+	}
+
+	var found *SkippedFile
+	for i := range res.SkippedFiles {
+		if strings.Contains(res.SkippedFiles[i].Path, "sub") {
+			found = &res.SkippedFiles[i]
+		}
+	}
+	if found == nil {
+		t.Fatalf("the matched directory is in neither FilesToProcess nor SkippedFiles (%v) — a "+
+			"pattern match that contributes nothing and says nothing is indistinguishable from "+
+			"one that was scanned and was clean", pathsOf(res.SkippedFiles))
+	}
+	if found.Silent {
+		t.Error("the skip is Silent, so nothing is printed; the operator asked for this path by " +
+			"pattern and should be told --recursive is needed to descend into it")
+	}
+	if !strings.Contains(strings.ToLower(found.Reason), "recursive") {
+		t.Errorf("reason = %q, want it to name --recursive as the remedy", found.Reason)
+	}
+	if strings.Contains(found.Reason, "452-11-9384") {
+		t.Errorf("reason leaked file content: %q", found.Reason)
+	}
+}
+
+// A subdirectory the user did not ask to descend into is NOT missing coverage.
+//
+// Go's filepath.Walk calls readDirNames before invoking the callback for a directory and
+// passes that error in the SAME call, so an unreadable directory arrives at the error branch
+// and never reaches the !recursive check below it. The result was exit 3 on a non-recursive
+// scan, blaming the run for not reading something it was never asked to read.
+//
+// A flag that fires outside the requested scope is one people stop passing, which costs
+// exactly the disclosures it exists to deliver.
+func TestNonRecursiveScanDoesNotReportOutOfScopeSubdirectory(t *testing.T) {
+	root := t.TempDir()
+	secret := filepath.Join(root, "secret")
+	if err := os.MkdirAll(secret, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(secret, "pii.txt"), []byte(pii+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "top.txt"), []byte("nothing\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(secret, 0o000); err != nil {
+		t.Skipf("cannot chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(secret, 0o755) })
+	requireUnreadablePathsWork(t, secret)
+
+	res, err := getFilesToProcess(root, false, nil, nil, true)
+	if err != nil {
+		t.Fatalf("getFilesToProcess: %v", err)
+	}
+	for _, u := range res.UnexaminedFiles {
+		if strings.Contains(u.Path, "secret") {
+			t.Errorf("a subdirectory was reported as unexamined on a NON-recursive scan: %q (%q). "+
+				"Without --recursive its contents were never in scope, so nothing was lost and "+
+				"--fail-on-incomplete must not exit 3.", u.Path, u.Reason)
+		}
+	}
+
+	// The control: WITH --recursive the same directory IS a loss and must be reported. Without
+	// this the test above would pass if disclosure were removed altogether.
+	res2, err := getFilesToProcess(root, true, nil, nil, true)
+	if err != nil {
+		t.Fatalf("getFilesToProcess recursive: %v", err)
+	}
+	var reported bool
+	for _, u := range res2.UnexaminedFiles {
+		if strings.Contains(u.Path, "secret") {
+			reported = true
+		}
+	}
+	if !reported {
+		t.Errorf("with --recursive the unreadable directory is NOT reported (%v) — scoping the "+
+			"disclosure must not remove it where it belongs", pathsOf(res2.UnexaminedFiles))
+	}
+}
+
+// A directory the user explicitly excluded is not missing coverage either.
+func TestExcludedUnreadableDirectoryIsNotReported(t *testing.T) {
+	root := t.TempDir()
+	secret := filepath.Join(root, "secret")
+	if err := os.MkdirAll(secret, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(secret, "pii.txt"), []byte(pii+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "top.txt"), []byte("nothing\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(secret, 0o000); err != nil {
+		t.Skipf("cannot chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(secret, 0o755) })
+	requireUnreadablePathsWork(t, secret)
+
+	res, err := getFilesToProcess(root, true, []string{"secret"}, nil, true)
+	if err != nil {
+		t.Fatalf("getFilesToProcess: %v", err)
+	}
+	for _, u := range res.UnexaminedFiles {
+		if strings.Contains(u.Path, "secret") {
+			t.Errorf("an --exclude'd directory was reported as unexamined: %q (%q). The user "+
+				"asked for it not to be scanned; reporting lost coverage for it turns their own "+
+				"instruction into a failing exit code.", u.Path, u.Reason)
+		}
+	}
+}
+
+// A path named directly on the command line that EXISTS but cannot be read is a coverage
+// loss, and a path that does not exist is not.
+//
+// The unreadable case measured as one stderr line, "No files to process", total_files 0, no
+// files_not_examined key, and --fail-on-incomplete exiting 0 — a complete scan of nothing,
+// with an unread SSN at the named path.
+//
+// The nonexistent case is deliberately excluded. A typo is a usage error, and making
+// --fail-on-incomplete fire on misspelled arguments is how people learn to stop passing it.
+func TestNamedPathAccessFailureIsClassified(t *testing.T) {
+	root := t.TempDir()
+	locked := filepath.Join(root, "locked")
+	if err := os.MkdirAll(locked, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(locked, "pii.txt")
+	if err := os.WriteFile(target, []byte(pii+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Skipf("cannot chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
+	requireUnreadablePathsWork(t, locked)
+
+	// Both inputs fail, and they must be classified differently. getFilesToProcess returns an
+	// error for each; the classification happens at the call site in main, so this asserts the
+	// discriminator that call site uses rather than reaching into main itself.
+	if _, err := getFilesToProcess(target, false, nil, nil, true); err == nil {
+		t.Fatal("expected an error for a file inside an unreadable directory")
+	}
+	if !isAccessDenied(target) {
+		t.Errorf("a file inside a mode-000 directory was not classified as access-denied, so it " +
+			"reaches no counter and --fail-on-incomplete stays 0 while the value goes unread")
+	}
+
+	missing := filepath.Join(root, "no-such-file.txt")
+	if isAccessDenied(missing) {
+		t.Errorf("a nonexistent path was classified as access-denied; a typo would then be " +
+			"reported as lost coverage and fail the build")
+	}
+}
+
+// #9: a structured format must produce a parseable document even when every input was
+// refused, which is precisely when it has something to disclose.
+//
+// Driven through the real binary because the defect is in an os.Exit path.
+func TestMachineFormatEmitsValidJSONWhenEveryInputIsRefused(t *testing.T) {
+	bin := buildForExitTest(t)
+	dir := t.TempDir()
+
+	// One oversize file, so discovery refuses it and no file reaches the scanner. Written as
+	// real text first: past ~512 bytes the sniffer classifies it as text, and Truncate then
+	// extends it sparsely so the fixture costs no disk.
+	big := filepath.Join(dir, "big.txt")
+	f, err := os.Create(big) // #nosec G304 -- test temp dir
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(strings.Repeat("Quarterly report text content.\n", 40)); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Truncate(105 * 1024 * 1024); err != nil {
+		_ = f.Close()
+		t.Skipf("cannot create a sparse oversize fixture: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	run := runForExit(t, bin, dir, nil, "--format", "json", "--fail-on-incomplete")
+
+	if run.rc != 3 {
+		t.Errorf("rc = %d, want 3: a refused processable file is lost coverage", run.rc)
+	}
+	var doc map[string]interface{}
+	if err := json.Unmarshal([]byte(run.stdout), &doc); err != nil {
+		t.Fatalf("--format json produced an unparseable document: %v\nfirst 120 bytes: %q\n"+
+			"The no-files path printed a plain-text line on stdout, so `--format json > "+
+			"report.json` yielded a file starting with 'N' — and it failed at the exact moment "+
+			"the scan had a refusal to report.", err, truncateForMsg(run.stdout))
+	}
+	stats, ok := doc["stats"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("the document carries no stats object: %q", truncateForMsg(run.stdout))
+	}
+	if got := stats["files_not_examined"]; got == nil {
+		t.Errorf("stats = %v, want a files_not_examined count so the refusal is machine-readable "+
+			"and not only an exit code", stats)
+	}
+}
+
+// truncateForMsg keeps failure output readable.
+func truncateForMsg(s string) string {
+	if len(s) > 120 {
+		return s[:120] + "..."
+	}
+	return s
+}

--- a/cmd/discovery_scope_test.go
+++ b/cmd/discovery_scope_test.go
@@ -6,6 +6,7 @@ package main
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -257,11 +258,123 @@ func TestNamedPathAccessFailureIsClassified(t *testing.T) {
 	}
 }
 
+// runIsolated runs the binary with pre-commit auto-detection defeated, so a test of ordinary
+// CLI behaviour does not silently measure pre-commit behaviour instead.
+//
+// This is necessary because detection is implicit and platform-dependent. On Windows it
+// treats GIT_EXEC_PATH as a pre-commit signal and Git Bash always sets it; it also fires
+// whenever the working directory is a git repository carrying a pre-commit hook, which the
+// test's own package directory is. Pre-commit mode changes the output shape — quiet, and
+// text unless a format is explicitly requested — so a test asserting on stdout measures a
+// different thing per platform. That is exactly how this test first failed: windows-only,
+// for a reason unrelated to what it asserts.
+//
+// The working directory is a temp dir outside any repository, so `git rev-parse --git-dir`
+// fails, and every environment trigger is set to empty.
+func runIsolated(t *testing.T, bin, dir string, extra ...string) exitRun {
+	t.Helper()
+	args := append([]string{
+		"--file", dir, "--recursive", "--config", os.DevNull,
+		"--checks", "SSN", "--limit", "0", "--enable-preprocessors",
+	}, extra...)
+
+	cmd := exec.Command(bin, args...)
+	cmd.Dir = t.TempDir()
+	cmd.Env = append(os.Environ(),
+		"PRE_COMMIT=", "_PRE_COMMIT_RUNNING=", "PRE_COMMIT_HOME=",
+		"PRE_COMMIT_HOOK=", "GIT_HOOK_TYPE=", "GIT_EXEC_PATH=", "GITHUB_DESKTOP=",
+	)
+	var so, se strings.Builder
+	cmd.Stdout, cmd.Stderr = &so, &se
+	err := cmd.Run()
+
+	rc := 0
+	if ee, ok := err.(*exec.ExitError); ok {
+		rc = ee.ExitCode()
+	} else if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	return exitRun{rc, so.String(), se.String()}
+}
+
+// An explicitly requested --format must outrank an auto-detected pre-commit default.
+//
+// precommitConfig.Format is a default ("text") and was applied unconditionally, so detection
+// silently discarded --format json. Measured with PRE_COMMIT=1 on a directory holding one SSN:
+//
+//	--format json                  1258 bytes of valid JSON
+//	--format json, mode detected   "pii.txt: 1 high confidence issues found"
+//
+// Worse than an unhonoured flag: the caller asked for a machine artifact and got prose at a
+// success-shaped exit, so the consumer either fails to parse or reads no findings at all. On
+// Windows this needed no opt-in — running from Git Bash was enough.
+func TestExplicitFormatOutranksPrecommitDetection(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds a binary")
+	}
+	bin := buildForExitTest(t)
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "pii.txt"), []byte(pii+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got := runForExit(t, bin, dir, []string{"PRE_COMMIT=1"}, "--format", "json")
+	var doc map[string]interface{}
+	if err := json.Unmarshal([]byte(got.stdout), &doc); err != nil {
+		t.Fatalf("PRE_COMMIT=1 with --format json produced a non-JSON document: %v\nstdout: %q\n"+
+			"An auto-detected default overrode an explicit flag.", err, truncateForMsg(got.stdout))
+	}
+	if _, ok := doc["results"]; !ok {
+		t.Errorf("the JSON document has no results key: %q", truncateForMsg(got.stdout))
+	}
+
+	// The other half of the contract: with NO --format flag, pre-commit must still override a
+	// format coming from CONFIG.
+	//
+	// This guards the BEHAVIOUR, not the line above it. Pre-commit's text default is supplied
+	// by the "precommit" profile in resolveConfiguration, so disabling the override entirely
+	// leaves this passing — verified by mutation. The assertion is kept because the behaviour
+	// is worth pinning wherever it comes from: a pre-commit hook that started emitting a
+	// config's json would flood a commit message with a machine document.
+	//
+	// A config file is needed to observe it at all. A bare PRE_COMMIT=1 run proves nothing,
+	// because the ordinary default is "text" too. Measured: config `defaults.format: json`
+	// yields JSON alone and text under PRE_COMMIT=1.
+	cfg := filepath.Join(t.TempDir(), "cfg.yaml")
+	if err := os.WriteFile(cfg, []byte("defaults:\n  format: json\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	runCfg := func(env []string, extra ...string) string {
+		t.Helper()
+		args := append([]string{"--file", dir, "--recursive", "--config", cfg, "--checks", "SSN"}, extra...)
+		c := exec.Command(bin, args...)
+		c.Env = append(os.Environ(), env...)
+		var so strings.Builder
+		c.Stdout = &so
+		_ = c.Run() // a findings exit code is expected; only stdout matters here
+		return so.String()
+	}
+
+	if out := runCfg(nil); !strings.HasPrefix(strings.TrimSpace(out), "{") {
+		t.Fatalf("fixture is wrong: config defaults.format=json did not produce JSON (%q), so the "+
+			"assertion below cannot distinguish anything", truncateForMsg(out))
+	}
+	if out := runCfg([]string{"PRE_COMMIT=1"}); strings.HasPrefix(strings.TrimSpace(out), "{") {
+		t.Errorf("under PRE_COMMIT=1 with no --format flag, the config's json format won: %q. "+
+			"Pre-commit's own default must still override CONFIG; only an explicit flag outranks "+
+			"it.", truncateForMsg(out))
+	}
+}
+
 // #9: a structured format must produce a parseable document even when every input was
 // refused, which is precisely when it has something to disclose.
 //
 // Driven through the real binary because the defect is in an os.Exit path.
 func TestMachineFormatEmitsValidJSONWhenEveryInputIsRefused(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds a binary")
+	}
 	bin := buildForExitTest(t)
 	dir := t.TempDir()
 
@@ -284,7 +397,9 @@ func TestMachineFormatEmitsValidJSONWhenEveryInputIsRefused(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	run := runForExit(t, bin, dir, nil, "--format", "json", "--fail-on-incomplete")
+	// runIsolated, not runForExit: this asserts ordinary output, and pre-commit detection
+	// would change the shape on Windows only.
+	run := runIsolated(t, bin, dir, "--format", "json", "--fail-on-incomplete")
 
 	if run.rc != 3 {
 		t.Errorf("rc = %d, want 3: a refused processable file is lost coverage", run.rc)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1216,7 +1216,28 @@ func main() {
 		if precommitConfig.NoColor {
 			finalConfig.noColor = true
 		}
-		if precommitConfig.Format != "" {
+		// An explicitly requested format outranks an auto-detected default.
+		//
+		// precommitConfig.Format is a DEFAULT for pre-commit runs ("text"), and it was
+		// applied unconditionally — so detection silently discarded `--format json` and
+		// printed prose. Measured with PRE_COMMIT=1 on a directory holding one SSN:
+		//
+		//	--format json                1258 bytes of valid JSON
+		//	--format json, mode detected "pii.txt: 1 high confidence issues found"
+		//
+		// That is worse than an unhonoured flag: the caller asked for a machine artifact
+		// and got prose at exit 0, so whatever consumes it either fails to parse or
+		// silently reads no findings.
+		//
+		// And it is reached without anyone opting in. Detection has a Windows-only branch
+		// that treats GIT_EXEC_PATH as a pre-commit signal, and Git Bash always sets it, so
+		// every Windows user running from Git Bash — the usual way to use this tool there —
+		// got prose for `--format json`. It surfaced as a windows-only CI failure of a test
+		// asserting that `--format json` is parseable.
+		//
+		// Only the explicitly-set case is guarded: with no --format flag the pre-commit
+		// default still applies, which is the behaviour it exists to provide.
+		if precommitConfig.Format != "" && !isFlagSet("format") {
 			finalConfig.format = precommitConfig.Format
 		}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,9 +4,11 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io"
+	"io/fs"
 	"net"
 	"os"
 	"path/filepath"
@@ -1510,6 +1512,34 @@ func main() {
 			// leaving an unparseable file at exit 0. Same defect class as the
 			// media-error write already moved off stdout.
 			fmt.Fprintf(os.Stderr, "Error processing %s: %v\n", inputPath, err)
+
+			// An input that EXISTS but could not be read is missing coverage, and has to
+			// reach a counter like every other refusal.
+			//
+			// Measured on a file named directly on the command line inside a
+			// permission-denied directory: one stderr line, "No files to process",
+			// total_files 0, no files_not_examined key, and --fail-on-incomplete exited 0.
+			// The file was counted nowhere, so the run described a complete scan of nothing
+			// while an unread SSN sat in the named path.
+			//
+			// A path that does NOT exist is excluded on purpose. A typo is a usage error,
+			// not incomplete coverage, and treating it as a coverage loss would make
+			// --fail-on-incomplete fire on misspelled arguments — which trains people to
+			// stop passing the flag. Permission is the discriminator, not the presence of
+			// an error: os.Lstat reports ErrNotExist for the typo and ErrPermission for the
+			// unreadable path, including when it is the PARENT directory that is
+			// unreadable, which is the case that matters here.
+			if isAccessDenied(cleanPath) {
+				detail := humanizeReason(inputPath, err.Error())
+				if detail == "" {
+					detail = "could not be accessed"
+				}
+				discoveryUnexamined = append(discoveryUnexamined, SkippedFile{
+					Path:   inputPath,
+					Reason: detail,
+					Cause:  causeUnreadable,
+				})
+			}
 			continue
 		}
 
@@ -1548,7 +1578,7 @@ func main() {
 					"Verify path exists and contains supported file types")
 			}
 			os.Exit(2) // Use exit code 2 for no files to process as per design
-		} else {
+		} else if finalConfig.format == "text" {
 			// Disclose discovery-time coverage losses BEFORE exiting.
 			//
 			// This path used to print "No files to process" and exit 0 unconditionally,
@@ -1579,6 +1609,23 @@ func main() {
 			fmt.Println("No files to process")
 			os.Exit(0)
 		}
+		// Every other format falls through to the ordinary output path, deliberately.
+		//
+		// "No files to process" on stdout is not JSON, YAML, SARIF, CSV or JUnit. A caller
+		// running `--format json > report.json` got a document whose first byte is 'N', so
+		// the artifact does not parse — and it fails at exactly the moment the scan has
+		// something to say, because this branch is reached when every input was REFUSED.
+		// Measured: a directory holding one oversize file exited 3 with the literal text
+		// "No files to process" where the JSON was expected, so the disclosure that the
+		// exit code was signalling could not be read by the thing reading the code.
+		//
+		// The pipeline handles zero files already: it emits an empty report whose stats
+		// carry total_files, files_not_examined and the unscanned entries, which is a
+		// strictly better artifact than a plain-text line. Verified against a normal scan,
+		// an empty directory and an all-refused directory.
+		//
+		// The test is "not text" rather than a list of structured formats so that a format
+		// added later is parseable by default rather than by remembering to add it here.
 	}
 
 	// Initialize suppression manager. The path comes from resolveConfiguration so
@@ -2432,6 +2479,24 @@ func isExcluded(filePath string, excludePatterns []string) bool {
 // enablePreprocessors is needed to answer whether a size-refused file's TYPE was one
 // the tool could have processed: without preprocessors a .docx is not processable, so
 // refusing it for size loses nothing the run was going to find anyway.
+// isAccessDenied reports whether a path exists but cannot be examined because of
+// permissions, as opposed to not being there at all.
+//
+// This is the discriminator between two inputs that fail identically at the call site and
+// mean opposite things. A path that cannot be READ is missing coverage: something is there,
+// the scan was asked about it, and it went unexamined. A path that does not EXIST is a usage
+// error — a typo — and reporting it as lost coverage would make --fail-on-incomplete fail
+// builds over misspelled arguments, which is how a flag earns a permanent place in a
+// denylist.
+//
+// Lstat rather than Stat, and on the path itself rather than the error text: the case that
+// matters most is a readable filename inside an UNREADABLE PARENT, where the failure belongs
+// to the directory and Lstat still reports it as a permission error.
+func isAccessDenied(path string) bool {
+	_, err := os.Lstat(path)
+	return err != nil && errors.Is(err, fs.ErrPermission)
+}
+
 func getFilesToProcess(inputPath string, recursive bool, excludePatterns []string, ignoreMatcher *gitignore.Matcher, enablePreprocessors bool) (*ProcessingResult, error) {
 	result := &ProcessingResult{
 		FilesToProcess:  []string{},
@@ -2536,8 +2601,64 @@ func getFilesToProcess(inputPath string, recursive bool, excludePatterns []strin
 			}
 			info, err := os.Stat(cleanMatch)
 			if err != nil {
+				// A match the filesystem will not describe cannot be scanned. Only a
+				// permission failure is a coverage loss; see the identical reasoning at the
+				// named-input call site in main.
+				if errors.Is(err, fs.ErrPermission) {
+					result.UnexaminedFiles = append(result.UnexaminedFiles, SkippedFile{
+						Path:   cleanMatch,
+						Reason: "could not be accessed",
+						Cause:  causeUnreadable,
+					})
+				}
 				continue
 			}
+
+			// A DIRECTORY matched by the pattern used to fall past the IsRegular test with
+			// no else branch: dropped from filesToProcess, from SkippedFiles, from
+			// UnexaminedFiles, and from every counter, with nothing printed.
+			//
+			// Measured on `--file '<dir>/*' --recursive` where one match was a directory
+			// holding an SSN: exit 0, total_files 1, no files_not_examined key, "No matches
+			// found." The --recursive flag was set and silently did nothing, because
+			// recursion is implemented in the directory branch below and a glob never
+			// reaches it. A shell that expands the glob itself hides this — each match
+			// arrives as its own argument — so it only bites when the pattern is quoted,
+			// which is exactly what the documentation asks for.
+			if info.IsDir() {
+				if isExcluded(cleanMatch, excludePatterns) || ignoreMatcher.Match(cleanMatch) {
+					continue
+				}
+				if !recursive {
+					result.SkippedFiles = append(result.SkippedFiles, SkippedFile{
+						Path:   cleanMatch,
+						Reason: "directory matched by pattern; pass --recursive to scan its contents",
+						Silent: false,
+					})
+					continue
+				}
+				// Recurse through this same function rather than reimplementing the walk.
+				// It carries the symlink policy, the exclude and .gitignore checks, the size
+				// refusals and their disclosure — all of which a second implementation would
+				// have to keep in step. cleanMatch is a concrete path from Glob and exists,
+				// so the call takes the literal-path branch and cannot re-enter this one.
+				sub, subErr := getFilesToProcess(cleanMatch, recursive, excludePatterns,
+					ignoreMatcher, enablePreprocessors)
+				if subErr != nil {
+					result.UnexaminedFiles = append(result.UnexaminedFiles, SkippedFile{
+						Path: cleanMatch,
+						Reason: "directory could not be read, so an unknown number of files " +
+							"inside it were not scanned",
+						Cause: causeUnreadable,
+					})
+					continue
+				}
+				filesToProcess = append(filesToProcess, sub.FilesToProcess...)
+				result.SkippedFiles = append(result.SkippedFiles, sub.SkippedFiles...)
+				result.UnexaminedFiles = append(result.UnexaminedFiles, sub.UnexaminedFiles...)
+				continue
+			}
+
 			if info.Mode().IsRegular() {
 				// Check if file is excluded
 				if isExcluded(cleanMatch, excludePatterns) {
@@ -2669,6 +2790,41 @@ func getFilesToProcess(inputPath string, recursive bool, excludePatterns []strin
 			// DIRECTORY hides every descendant, and how many is unknowable. See #336
 			// defect 3.
 			if err != nil {
+				// info is nil when Lstat itself failed, so ask the filesystem directly. If
+				// even Lstat fails the kind is unknowable and it is treated as a file.
+				isDir := info != nil && info.IsDir()
+				if info == nil {
+					if di, statErr := os.Lstat(path); statErr == nil && di.IsDir() {
+						isDir = true
+					}
+				}
+
+				// Decide SCOPE before calling this a coverage loss.
+				//
+				// This branch runs before the !recursive and exclude checks below, and for a
+				// directory it has to: Go's filepath.Walk calls readDirNames FIRST and hands
+				// the callback that error in the same invocation, so a directory it cannot
+				// open arrives here with err set and never reaches those checks at all.
+				//
+				// The consequence was over-disclosure, which is its own failure. A
+				// permission-denied subdirectory made a NON-recursive scan exit 3, and made
+				// `--exclude` on that very directory exit 3, both reporting lost coverage
+				// for something the user never asked to be scanned. A flag that fires on
+				// paths outside the requested scope is one people learn to ignore, which
+				// costs exactly the disclosures it exists to deliver.
+				//
+				// Path-based, so it works with a nil info: both predicates take strings.
+				outOfScope := isDir && !recursive && cleanWalkPath != cleanPath
+				if isExcluded(cleanWalkPath, excludePatterns) || ignoreMatcher.Match(cleanWalkPath) {
+					outOfScope = true
+				}
+				if outOfScope {
+					// Silent on purpose: nothing was lost, so there is nothing to report.
+					// Nothing to descend into either — the read that would have listed this
+					// directory is the read that just failed.
+					return nil
+				}
+
 				fmt.Fprintf(os.Stderr, "Warning: Skipping %s: %v\n", path, err)
 
 				// causeUnreadable is the right cause: unlike a size refusal or a
@@ -2677,9 +2833,7 @@ func getFilesToProcess(inputPath string, recursive bool, excludePatterns []strin
 				if detail == "" {
 					detail = "could not be accessed"
 				}
-				// info is nil on an access error, so ask the filesystem directly. If
-				// even Lstat fails the kind is unknowable and the plain wording stands.
-				if di, statErr := os.Lstat(path); statErr == nil && di.IsDir() {
+				if isDir {
 					detail = "directory could not be read, so an unknown number of files " +
 						"inside it were not scanned: " + detail
 				}


### PR DESCRIPTION
## What

Five defects in discovery-time coverage accounting, in **both** directions. Everything refused must be disclosed, and nothing that was never in scope may be reported as a loss. The second half was broken *by* the fixes for the first (`#324`, `#336`/`#341`), so they are corrected together — they need opposite corrections, and testing them apart is how one gets traded for the other.

## Under-disclosure — a real detection miss

A **directory matched by a glob pattern was dropped in silence.** The glob branch tested `info.Mode().IsRegular()` and had no `else`, so a matched directory reached neither `FilesToProcess` nor either disclosure slice. `--recursive` was accepted and did nothing, because recursion lives in the directory branch a glob never reaches.

Measured against a readable tree holding an SSN and a card number:

| | findings | total_files | exit | disclosure |
|---|---|---|---|---|
| before | **0** | 1 | 0 | none |
| after | **2** | 3 | 0 | — |

A shell that expands the pattern hides this, since each match arrives as its own argument. It bites when the pattern is **quoted**, which is what the documentation asks for.

Directories are now walked when `--recursive` is set — by recursing through `getFilesToProcess` itself, so the symlink policy, exclude/`.gitignore` checks and size refusals cannot drift out of step — and reported as skipped, naming `--recursive` as the remedy, when it is not.

A **path named directly on the command line that exists but cannot be read** reached no counter: one stderr line, `No files to process`, `total_files 0`, no `files_not_examined` key, and `--fail-on-incomplete` exited 0. A complete scan of nothing, with an unread SSN at the named path.

A path that does **not** exist is deliberately still not a coverage loss — a typo is a usage error, and failing builds over misspelled arguments is how a flag ends up permanently disabled. `isAccessDenied` is the discriminator, using `Lstat` on the path so the case that matters most (a readable filename inside an unreadable **parent**) classifies correctly.

## Over-disclosure — introduced by `#341`

A permission-denied subdirectory made a **non-recursive** scan exit 3, and made **`--exclude` on that very directory** exit 3 — both reporting lost coverage for something the user never asked to be scanned.

The cause is `filepath.Walk`: it calls `readDirNames` **first** and hands the callback that error in the *same* invocation, so an unreadable directory arrives at the error branch and never reaches the `!recursive` and exclude checks below it. The branch now decides scope before disclosure.

A flag that fires outside the requested scope is one people stop passing, which costs exactly the disclosures it exists to deliver.

## Malformed artifact

`No files to process` went to stdout regardless of `--format`, so `--format json > report.json` produced a document whose first byte is `N` — failing at the exact moment the scan had something to report, since that path is reached when every input was **refused**.

Structured formats now fall through to the ordinary output path, which already emits an empty report carrying `total_files`, `files_not_examined` and the unscanned entries. The pipeline needed no changes to tolerate zero files. The test is `!= "text"` rather than a list of structured formats, so a format added later is parseable by default rather than by remembering to add it here.

## Verification

- All five **mutation-tested**; each mutation compiles and fails a test.
- 66 packages pass; `-race` and `vet` clean on `./cmd`; golden corpus passes forced; `gofmt` clean repo-wide (the exact CI command).
- Old vs new on the repo source tree: **identical 1725 findings**. Text format, pre-commit mode (`rc` 0/1) and `--preprocess-only` (`rc` 2) unchanged. A nonexistent path still exits 0 under `--fail-on-incomplete`.
- An empty directory with `--format json --output` now writes a valid report where it previously wrote **no file at all**.

No file overlap with open PRs `#347`, `#348` or `#350`.

## Issue references

**Refs #353** — partially addresses it. This PR fixes the *forced text* symptom (an explicit `--format` now outranks auto-detected pre-commit defaults). Measured on binaries from both trees, `PRE_COMMIT=1 --format json` on a directory holding one SSN: `main` → 472 bytes of prose, this PR → 837 bytes starting `{"stats":{...`. The rest of #353 is untouched and stays open: the detection heuristic itself (`GIT_EXEC_PATH`/Git Bash), the git-repo-with-hook condition, the missing opt-out, the empty `--output` file, and the `QuietMode`/`NoColor` analogues.

**Refs #342** — this PR *widens* that gap, and it should be fixed there rather than here. #342's mechanism is that every `result.SkippedFiles` entry breaks `files_processed + files_skipped + files_not_examined == total_files` by +1, because those files never enter `consideredFiles = len(filesToProcess) + len(discoveryUnexamined)`. The new glob-matched-directory disclosure lands in that same exogenous ledger. Measured A/B:

| fixture | main | this PR |
|---|---|---|
| glob, 1 matched dir, no `--recursive` | gap +0 | **gap +1** |
| glob, 3 matched dirs | gap +0 | **gap +3** |
| #342's own repro (oversize unprocessable file) | gap +1 | gap +1 (unchanged) |

So the gap now scales with the number of matched directories: the text summary reads `Files: 1 scanned, 3 skipped | Findings: 1` — four files against a total of one. A second new route does the same, and buys real coverage for it: the `--recursive` glob branch propagates `sub.SkippedFiles`, so an oversize file inside a matched subtree also lands in `files_skipped` without entering `total_files` (findings 1 → 2).

This PR's other new counters are identity-**neutral**: the unreadable named-input path and the permission-denied glob match go to `UnexaminedFiles`, which feeds both `total_files` and `files_not_examined` (measured gap +0 before and after), and the new out-of-scope silent return replaces a neutral `UnexaminedFiles` entry with nothing.

Deliberately not fixed here: #342 requires *picking a ledger* and stating it, which changes what `total_files` means for anyone parsing the output, plus a reconciliation test wired to the real pipeline counters including the documented no-body-text overlap term. That belongs in its own change, not bundled into a disclosure fix. A follow-up PR closes #342 generically, which covers these new routes regardless of merge order.
