### PR TITLE
fix(detector): scrub the nested matches a consolidated finding carries in Clear()

### DIFF
--- a/internal/detector/clear_nested_test.go
+++ b/internal/detector/clear_nested_test.go
@@ -1,0 +1,128 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package detector
+
+import (
+	"testing"
+)
+
+// Clear() must scrub the matches a consolidated finding carries, not just its own fields.
+//
+// A SOCIAL_MEDIA_CLUSTER finding replaces N real matches with one summary and keeps the
+// originals in Metadata["cluster_members"], each with its own Text and its own
+// Context.FullLine. So the match type holding the MOST cleartext — N values plus N whole
+// source lines — was the one Clear() left untouched, while reporting success for having
+// scrubbed the summary string.
+//
+// It matters most through pkg/redact, where Clear() is the scrubbing contract an embedding
+// caller relies on: the caller cleared its matches and still held the input's cleartext.
+func TestClearScrubsNestedClusterMembers(t *testing.T) {
+	const (
+		handleA  = "jane_doe_1985"
+		handleB  = "j.doe.official"
+		fullLine = "Follow me: instagram.com/jane_doe_1985 and twitter.com/j.doe.official"
+	)
+
+	member := func(text string) Match {
+		return Match{
+			Text: text,
+			Type: "SOCIAL_MEDIA",
+			Context: ContextInfo{
+				FullLine:   fullLine,
+				BeforeText: "Follow me: ",
+				AfterText:  " and more",
+			},
+		}
+	}
+
+	m := Match{
+		Text: "2 social media handles on one line",
+		Type: "SOCIAL_MEDIA_CLUSTER",
+		Context: ContextInfo{
+			FullLine: fullLine,
+		},
+		Metadata: map[string]interface{}{
+			"explanation":     "advisory text",
+			"cluster_members": []Match{member(handleA), member(handleB)},
+		},
+	}
+
+	// Hold a reference to the nested slice so the assertion sees the same backing array the
+	// caller would still be holding. Deleting the map key alone would not scrub these.
+	retained, ok := m.Metadata["cluster_members"].([]Match)
+	if !ok {
+		t.Fatal("fixture is wrong: cluster_members is not []Match, so the test would assert nothing")
+	}
+
+	m.Clear()
+
+	if m.Text != "" || m.Context.FullLine != "" {
+		t.Errorf("the top-level fields were not scrubbed: Text=%q FullLine=%q", m.Text, m.Context.FullLine)
+	}
+	if _, still := m.Metadata["cluster_members"]; still {
+		t.Error("cluster_members is still present in Metadata after Clear()")
+	}
+
+	for i := range retained {
+		if retained[i].Text != "" {
+			t.Errorf("member %d still holds its value %q — Clear() scrubbed the summary and left "+
+				"every value the summary replaced, which is the opposite of what it reports",
+				i, retained[i].Text)
+		}
+		if retained[i].Context.FullLine != "" {
+			t.Errorf("member %d still holds the whole source line %q — each member carries its own "+
+				"Context, so a cluster retained N full lines of the input",
+				i, retained[i].Context.FullLine)
+		}
+		if retained[i].Context.BeforeText != "" || retained[i].Context.AfterText != "" {
+			t.Errorf("member %d still holds surrounding context: before=%q after=%q",
+				i, retained[i].Context.BeforeText, retained[i].Context.AfterText)
+		}
+	}
+}
+
+// A self-referential structure must terminate rather than recurse forever.
+//
+// Deleting the key BEFORE clearing the members is what makes that true: the recursive call
+// finds no key and stops. Reversing the two turns this into unbounded recursion, which
+// overflows the stack and panics — so no explicit timeout is needed here, a hang is not the
+// failure mode.
+func TestClearTerminatesOnSelfReferentialMetadata(t *testing.T) {
+	m := Match{Text: "outer", Metadata: map[string]interface{}{}}
+	inner := Match{Text: "inner", Metadata: m.Metadata} // shares the same map
+	m.Metadata["cluster_members"] = []Match{inner}
+
+	m.Clear()
+
+	if m.Text != "" {
+		t.Errorf("Text = %q, want empty", m.Text)
+	}
+}
+
+// Clear() must stay safe on the ordinary shapes: nil metadata, and a wrong type under the key.
+func TestClearHandlesMissingOrWrongTypedClusterMembers(t *testing.T) {
+	cases := map[string]Match{
+		"nil metadata":   {Text: "x"},
+		"empty metadata": {Text: "x", Metadata: map[string]interface{}{}},
+		"wrong type":     {Text: "x", Metadata: map[string]interface{}{"cluster_members": "not a slice"}},
+		"nil slice":      {Text: "x", Metadata: map[string]interface{}{"cluster_members": []Match(nil)}},
+	}
+	for name, m := range cases {
+		t.Run(name, func(t *testing.T) {
+			m.Clear() // must not panic
+			if m.Text != "" {
+				t.Errorf("Text = %q, want empty", m.Text)
+			}
+		})
+	}
+}
+
+// The literal key must match what the redactors write, or the scrub silently applies to
+// nothing. Asserted against the source rather than an import, which would be a cycle.
+func TestClusterMembersKeyMatchesRedactors(t *testing.T) {
+	if clusterMembersMetadataKey != "cluster_members" {
+		t.Errorf("key = %q; redactors.ClusterMembersKey is \"cluster_members\" and the two must "+
+			"agree or Clear() scrubs nothing", clusterMembersMetadataKey)
+	}
+}

--- a/internal/detector/detector.go
+++ b/internal/detector/detector.go
@@ -141,8 +141,42 @@ func (m *Match) Clear() {
 	// it must stay in sync with explain.MetadataKey.
 	if m.Metadata != nil {
 		delete(m.Metadata, "explanation")
+
+		// Scrub the NESTED matches a consolidated finding carries.
+		//
+		// Clearing the fields above scrubs one match's payload. A
+		// SOCIAL_MEDIA_CLUSTER finding stores the matches it replaced under this
+		// key, and each of those carries its own Text AND its own
+		// Context.FullLine — so the match type that holds the MOST cleartext,
+		// N values plus N whole source lines, was the one Clear() left
+		// untouched. It reported success having scrubbed the summary string
+		// while every value it summarised stayed in the map.
+		//
+		// This matters most through pkg/redact, where Clear() is the documented
+		// scrubbing contract an embedding caller relies on: the caller cleared
+		// its matches and still held the input's cleartext.
+		//
+		// The key is a literal for the same reason as "explanation" — importing
+		// internal/redactors here would be a cycle. It must stay in sync with
+		// redactors.ClusterMembersKey.
+		//
+		// Deleted BEFORE the members are cleared, so a structure that somehow
+		// referenced itself terminates instead of recursing forever. In practice
+		// depth is one: the validator builds these with a copy that omits
+		// Metadata.
+		if members, ok := m.Metadata[clusterMembersMetadataKey].([]Match); ok {
+			delete(m.Metadata, clusterMembersMetadataKey)
+			for i := range members {
+				members[i].Clear()
+			}
+		}
 	}
 }
+
+// clusterMembersMetadataKey is where a consolidated finding stores the matches it
+// replaced. Kept next to Clear because scrubbing is the only reason detector needs
+// to know the key; see redactors.ClusterMembersKey for the canonical definition.
+const clusterMembersMetadataKey = "cluster_members"
 
 // ContextExtractor extracts context from a file around a specific match
 type ContextExtractor struct {


### PR DESCRIPTION
## What

`Clear()` scrubbed one match's payload. A `SOCIAL_MEDIA_CLUSTER` finding stores the N matches it replaced under `Metadata["cluster_members"]`, and `leanClusterMembers` copies each member's `Text` **and** its `Context` — including `Context.FullLine`, the whole source line.

So the match type holding the **most** cleartext — N values plus N entire lines of input — was the one `Clear()` left untouched. It scrubbed the rendered summary and reported success while every value that summary stood in for stayed in the map.

## Severity: retention, not an output leak

`cluster_members` is not serialised into any report — I verified this against `--format json`, where the key is absent and the raw handle appears zero times. So this is memory retention rather than a disclosure bug, and I'm not claiming otherwise.

It still matters, because `Clear()` is a stated contract rather than an internal detail. `pkg/redact/engine.go` calls it as *"defense in depth so accidental retention doesn't leak the input bytes"*, which means an embedding caller (the Gateway consumes this package) cleared its matches and still held the input's cleartext.

## Safety at the call sites

Removing `cluster_members` could break the cluster redaction added for `#289` if `Clear()` ran first, so I checked all three call sites — `cmd/main.go`, `cmd/stdin.go`, `pkg/redact/engine.go` — and every one runs it **after** formatting and redaction complete. `internal/core`, all seven redactor packages, `pkg/redact` and the golden corpus pass.

## Details

- The key is deleted **before** the members are cleared, so a structure that somehow referenced itself terminates rather than recursing until the stack overflows. In practice depth is one, because `leanClusterMembers` builds members without `Metadata`.
- The key is a literal for the same reason `"explanation"` already is: importing `internal/redactors` here would be an import cycle. A test pins it against `redactors.ClusterMembersKey`'s value, since a drifted key would make the scrub silently apply to nothing.

## Verification

Three mutations tested, each compiling and failing a test: removing the scrub, deleting the key without clearing the members, and clearing the members without deleting the key. Plus nil/empty/wrong-type metadata cases.

66 packages pass; `-race` and `vet` clean on `internal/detector`; `gofmt` clean repo-wide; the repo source tree gives an identical **1725** findings before and after.

No file overlap with open PRs `#347`, `#348`, `#350` or `#351`.

**Refs #337** — related, not a fix. #337 is about a finding pinning its file's entire extracted buffer (match/context strings are substrings of the full content) and all findings being retained twice until exit. This PR adds one more thing `Clear()` scrubs and does not touch either mechanism: no `strings.Clone` at the match boundary, no change to the full-run retention of `allMatches`. Cross-referenced because both concern retention of match payload, so whoever works #337 should know `Clear()` now reaches nested members.
