### PR TITLE
fix(cli): count discovery-time skips in total_files so the summary reconciles

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2108,15 +2108,57 @@ func main() {
 		scannedFiles = 0
 	}
 
-	// consideredFiles is every entry this run took responsibility for: the files it
-	// queued to scan PLUS the ones discovery refused. The denominator has to include
-	// both, or the report reads "2 of 1 file" — the refused entries appear in the
-	// numerator while being absent from the total they are counted against.
+	// consideredFiles is every entry this run took responsibility for: the files it queued
+	// to scan, PLUS the ones discovery refused as a coverage loss, PLUS the ones discovery
+	// SKIPPED. The denominator has to include all three, or the report reads "2 of 1 file" —
+	// entries appear in the numerator while being absent from the total they are counted
+	// against.
 	//
-	// Derived once and used by the stats block AND the not-examined report below, for
-	// the same reason the entries themselves are collected once: two independent counts
-	// of the same thing eventually disagree.
-	consideredFiles := len(filesToProcess) + len(discoveryUnexamined)
+	// totalSkipped was the missing term (#342). Every result.SkippedFiles entry increments it
+	// and none of them are ever appended to filesToProcess, so a run with one small .txt plus
+	// one oversize unprocessable file printed total_files=1, files_processed=1,
+	// files_skipped=1 — two files accounted against a total of one, off by exactly one per
+	// discovery-time skip. Measured before this change: gap +1 for one such file, +3 for three.
+	//
+	// # The identity, which is asserted rather than assumed
+	//
+	//	files_processed + files_skipped + files_not_examined
+	//	    == total_files + overlapMetaOnly + overlapCutShort
+	//
+	// The two correction terms are DELIBERATE double counts, not defects: one file legitimately
+	// occupies two categories, because it was both examined and incompletely examined.
+	//
+	//   - overlapMetaOnly: a file whose body yielded no text but whose METADATA produced a
+	//     surviving finding. Counted as scanned (it produced findings) and as not-examined (its
+	//     body was not read). See the silentEmpty comment above: only the genuinely silent ones
+	//     are removed from the scanned count.
+	//
+	//   - overlapCutShort: a file whose validator coverage was cut short — a per-validator
+	//     budget, a cancellation, or a match-budget stop. The pool leaves Result.Error nil for
+	//     these, so the file is counted in ProcessedFiles AND listed in IncompleteFiles.
+	//     Measured: one file under --validator-budget all=1ns gives total_files=1,
+	//     files_processed=1, files_not_examined=1.
+	//
+	// This term is NOT mentioned in #342 and was not documented anywhere; it breaks the naive
+	// sum with no discovery-time skip involved at all, which is why the reconciliation test
+	// asserts the identity WITH its overlap terms rather than asserting a plain sum.
+	//
+	// Two things deliberately absent from the identity:
+	//   - unreadable and failed-processing files are in total_files and in files_not_examined
+	//     but in NEITHER files_processed nor files_skipped. They need no correction term; they
+	//     are what makes the sum close. An assertion of the form
+	//     "files_processed + files_skipped == total_files" is therefore wrong.
+	//   - the scannedFiles clamp above cannot fire: silentEmpty counts a subset of
+	//     emptyExtractionFiles, every one of which is already counted in processedFiles.
+	//
+	// The identity is over ENTRIES, not distinct paths. collectUnscanned does not deduplicate,
+	// so a file that is both body-empty and cut short contributes two entries — which is why
+	// both terms are counted independently rather than as a set union.
+	//
+	// Derived once and used by the stats block AND the not-examined report below, for the same
+	// reason the entries themselves are collected once: two independent counts of the same
+	// thing eventually disagree.
+	consideredFiles := len(filesToProcess) + len(discoveryUnexamined) + totalSkipped
 
 	formatterOptions.Stats = &formatters.ScanStats{
 		TotalFiles:       consideredFiles,

--- a/cmd/summary_counts_reconcile_test.go
+++ b/cmd/summary_counts_reconcile_test.go
@@ -87,9 +87,19 @@ func runStats(t *testing.T, bin, dir string, extra ...string) (scanStats, string
 
 	cmd := exec.Command(bin, args...)
 	cmd.Dir = t.TempDir()
+	// MSYSTEM and MINGW_PREFIX are the ones that matter in CI and the ones this list first
+	// missed: Git Bash sets all three of MSYSTEM, MINGW_PREFIX and GIT_EXEC_PATH, and the
+	// windows test step runs under it. With detection live, the json formatter returns an EMPTY
+	// document when there are no findings, so --output received zero bytes and this test failed
+	// on "unexpected end of JSON input" — nothing to do with counting.
+	//
+	// This inline list is deliberately NOT a copy of the shared helper added in #356; defining
+	// precommitFreeEnv in two files in one package would not merge. Once #356 is in, this
+	// becomes cmd.Env = precommitFreeEnv() and the list is covered by that PR's drift guard.
 	cmd.Env = append(os.Environ(),
 		"PRE_COMMIT=", "_PRE_COMMIT_RUNNING=", "PRE_COMMIT_HOME=",
 		"PRE_COMMIT_HOOK=", "GIT_HOOK_TYPE=", "GIT_EXEC_PATH=", "GITHUB_DESKTOP=",
+		"MSYSTEM=", "MINGW_PREFIX=",
 	)
 	var so, se strings.Builder
 	cmd.Stdout, cmd.Stderr = &so, &se

--- a/cmd/summary_counts_reconcile_test.go
+++ b/cmd/summary_counts_reconcile_test.go
@@ -1,0 +1,351 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The four printed summary counters must reconcile against each other.
+//
+// #342: every discovery-time skip incremented files_skipped without entering total_files,
+// because those paths are never appended to filesToProcess. Measured on the shipped binary,
+// a directory holding one small .txt plus one oversize unprocessable file:
+//
+//	total_files=1  files_processed=1  files_skipped=1
+//
+// Two files accounted against a total of one, off by exactly one per skip — three matched
+// directories gave a gap of three. No coverage was lost; the harm is that an operator cannot
+// use the printed numbers to confirm a scan was complete.
+//
+// # Why this test drives the real binary
+//
+// internal/formatters/text.TestSummaryCountsReconcile already asserted reconciliation, and
+// could not catch this. It builds ScanStats BY HAND and asserts
+// processed+notExamined+skipped <= total, failing with "the caller must not hand the formatter
+// overlapping categories". The real caller hands it overlapping categories deliberately, so
+// the fixture was internally consistent while contradicting the pipeline it stands in for.
+// The counters only interact in cmd/main.go, so the assertion has to come from a real scan.
+//
+// # The identity being asserted
+//
+//	files_processed + files_skipped + files_not_examined
+//	    == total_files + overlapMetaOnly + overlapCutShort
+//
+// The overlap terms are deliberate double counts, and each fixture below states how many it
+// contains BY CONSTRUCTION, so the term is asserted rather than assumed. A plain-sum
+// assertion would be wrong in the other direction: unreadable and failed-processing files sit
+// in total_files and files_not_examined but in neither processed nor skipped.
+
+// scanStats mirrors the JSON stats block this test reconciles.
+type scanStats struct {
+	TotalFiles       int `json:"total_files"`
+	FilesProcessed   int `json:"files_processed"`
+	FilesSkipped     int `json:"files_skipped"`
+	FilesNotExamined int `json:"files_not_examined"`
+	TotalFindings    int `json:"total_findings"`
+}
+
+func (s scanStats) gap() int {
+	return s.FilesProcessed + s.FilesSkipped + s.FilesNotExamined - s.TotalFiles
+}
+
+func (s scanStats) String() string {
+	return fmt.Sprintf("total=%d processed=%d skipped=%d notExamined=%d findings=%d",
+		s.TotalFiles, s.FilesProcessed, s.FilesSkipped, s.FilesNotExamined, s.TotalFindings)
+}
+
+// runStats scans dir with the real binary and returns the parsed stats block plus stdout.
+//
+// Pre-commit auto-detection is defeated deliberately, and it is not optional. Detection has a
+// Windows-only branch that treats GIT_EXEC_PATH as a pre-commit signal — Git Bash always sets
+// it, and CI runs the test step under it — and it also fires when the working directory is a
+// git repository carrying a pre-commit hook, which this package's directory is. In that mode
+// the requested format is replaced with pre-commit's text default, so --format json yields
+// prose and the parse below fails on ONE platform for a reason unrelated to counting. A
+// sibling test learned that the expensive way. The working directory is therefore a temp dir
+// outside any repository, so `git rev-parse --git-dir` fails, and every trigger variable is
+// emptied.
+func runStats(t *testing.T, bin, dir string, extra ...string) (scanStats, string) {
+	t.Helper()
+
+	out := filepath.Join(t.TempDir(), "stats.json")
+	args := append([]string{
+		"--file", dir, "--recursive", "--config", os.DevNull,
+		"--checks", "SSN", "--limit", "0", "--enable-preprocessors",
+		"--format", "json", "--output", out,
+	}, extra...)
+
+	cmd := exec.Command(bin, args...)
+	cmd.Dir = t.TempDir()
+	cmd.Env = append(os.Environ(),
+		"PRE_COMMIT=", "_PRE_COMMIT_RUNNING=", "PRE_COMMIT_HOME=",
+		"PRE_COMMIT_HOOK=", "GIT_HOOK_TYPE=", "GIT_EXEC_PATH=", "GITHUB_DESKTOP=",
+	)
+	var so, se strings.Builder
+	cmd.Stdout, cmd.Stderr = &so, &se
+	if err := cmd.Run(); err != nil {
+		if _, ok := err.(*exec.ExitError); !ok {
+			t.Fatalf("run: %v\nstderr: %s", err, se.String())
+		}
+		// A non-zero exit is expected for several of these fixtures (findings, or coverage
+		// cut short). The artifact still has to be written and parseable.
+	}
+
+	raw, err := os.ReadFile(out) // #nosec G304 -- test temp dir
+	if err != nil {
+		t.Fatalf("no output artifact written: %v\nstderr: %s", err, se.String())
+	}
+	var doc struct {
+		Stats scanStats `json:"stats"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("stats artifact is not parseable JSON: %v\nfirst 160 bytes: %q", err, raw[:min(160, len(raw))])
+	}
+	return doc.Stats, se.String()
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// writeTextFile writes a small file carrying one SSN, so it is scanned and yields a finding.
+func writeTextFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("Employee record\nSSN: 452-11-9384\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// writeOversizeUnprocessable writes a file past the 100MB gate whose bytes sniff as BINARY, so
+// discovery refuses it as a SKIP rather than as a coverage loss. This is the only shape that
+// produces #342's missing term.
+//
+// Sparse: NUL/0xFF bytes first so the sniffer classifies it, then Truncate extends it without
+// occupying disk.
+func writeOversizeUnprocessable(t *testing.T, path string) {
+	t.Helper()
+	f, err := os.Create(path) // #nosec G304 -- test temp dir
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write(bytes.Repeat([]byte{0x00, 0xFF}, 64)); err != nil {
+		_ = f.Close()
+		t.Fatal(err)
+	}
+	if err := f.Truncate(101 * 1024 * 1024); err != nil {
+		_ = f.Close()
+		t.Skipf("cannot create a sparse oversize fixture: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// writeMetaOnlyDocx writes a .docx whose BODY is empty but whose core properties carry an SSN.
+//
+// This is the deliberate overlap: the file produces a finding through the metadata channel, so
+// it counts as scanned, and its body yielded no text, so it also counts as not-examined.
+func writeMetaOnlyDocx(t *testing.T, path string) {
+	t.Helper()
+
+	const contentTypes = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+		`<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+		`<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+		`<Default Extension="xml" ContentType="application/xml"/>` +
+		`<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>` +
+		`<Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/>` +
+		`</Types>`
+	const rels = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+		`<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+		`<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>` +
+		`<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" Target="docProps/core.xml"/>` +
+		`</Relationships>`
+	const core = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+		`<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" ` +
+		`xmlns:dc="http://purl.org/dc/elements/1.1/"><dc:creator>SSN: 452-11-9384</dc:creator></cp:coreProperties>`
+	const emptyBody = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+		`<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body/></w:document>`
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for _, p := range []struct{ name, content string }{
+		{"[Content_Types].xml", contentTypes},
+		{"_rels/.rels", rels},
+		{"word/document.xml", emptyBody},
+		{"docProps/core.xml", core},
+	} {
+		w, err := zw.Create(p.name)
+		if err != nil {
+			t.Fatalf("create zip entry %s: %v", p.name, err)
+		}
+		if _, err := w.Write([]byte(p.content)); err != nil {
+			t.Fatalf("write zip entry %s: %v", p.name, err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSummaryCountersReconcileOnRealPipeline(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds a binary and 100MB sparse fixtures")
+	}
+	bin := buildForExitTest(t)
+
+	cases := []struct {
+		name string
+		// wantGap is the number of DELIBERATE overlaps the fixture contains, by construction.
+		wantGap int
+		build   func(t *testing.T, dir string)
+	}{
+		{
+			name:    "plain files only",
+			wantGap: 0,
+			build: func(t *testing.T, dir string) {
+				writeTextFile(t, filepath.Join(dir, "a.txt"))
+				writeTextFile(t, filepath.Join(dir, "b.txt"))
+			},
+		},
+		{
+			// #342's own repro. This is the case that was off by one.
+			name:    "one discovery-time skip",
+			wantGap: 0,
+			build: func(t *testing.T, dir string) {
+				writeTextFile(t, filepath.Join(dir, "a.txt"))
+				writeOversizeUnprocessable(t, filepath.Join(dir, "blob.bin"))
+			},
+		},
+		{
+			// The gap scaled with the number of skips, so more than one is worth pinning.
+			name:    "three discovery-time skips",
+			wantGap: 0,
+			build: func(t *testing.T, dir string) {
+				writeTextFile(t, filepath.Join(dir, "a.txt"))
+				for i := 0; i < 3; i++ {
+					writeOversizeUnprocessable(t, filepath.Join(dir, fmt.Sprintf("blob%d.bin", i)))
+				}
+			},
+		},
+		{
+			name:    "one metadata-only file (deliberate overlap)",
+			wantGap: 1,
+			build: func(t *testing.T, dir string) {
+				writeTextFile(t, filepath.Join(dir, "a.txt"))
+				writeMetaOnlyDocx(t, filepath.Join(dir, "meta.docx"))
+			},
+		},
+		{
+			name:    "two metadata-only files",
+			wantGap: 2,
+			build: func(t *testing.T, dir string) {
+				writeTextFile(t, filepath.Join(dir, "a.txt"))
+				writeMetaOnlyDocx(t, filepath.Join(dir, "m1.docx"))
+				writeMetaOnlyDocx(t, filepath.Join(dir, "m2.docx"))
+			},
+		},
+		{
+			// Both correction sources at once: the term that was missing and the term that is
+			// deliberate. Only the deliberate one may remain.
+			name:    "discovery skip and metadata-only together",
+			wantGap: 1,
+			build: func(t *testing.T, dir string) {
+				writeTextFile(t, filepath.Join(dir, "a.txt"))
+				writeOversizeUnprocessable(t, filepath.Join(dir, "blob.bin"))
+				writeMetaOnlyDocx(t, filepath.Join(dir, "meta.docx"))
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			tc.build(t, dir)
+
+			stats, stderr := runStats(t, bin, dir)
+
+			if got := stats.gap(); got != tc.wantGap {
+				t.Errorf("reconciliation gap = %+d, want %+d\n  %s\n"+
+					"  identity: files_processed + files_skipped + files_not_examined "+
+					"== total_files + overlaps\n"+
+					"  A positive gap beyond the fixture's deliberate overlaps means a category is "+
+					"counted in a sub-total but excluded from total_files, so the printed numbers "+
+					"cannot be reconciled and an operator cannot use them to confirm coverage.\n"+
+					"  stderr:\n%s", got, tc.wantGap, stats, indent(stderr))
+			}
+
+			// Sanity floors: a fixture that stopped producing the shape it describes would make
+			// the assertion above vacuous.
+			if stats.TotalFiles == 0 {
+				t.Errorf("total_files = 0, so the identity is trivially satisfied: %s", stats)
+			}
+			if stats.TotalFindings == 0 {
+				t.Errorf("no findings, so nothing in this fixture was actually scanned: %s", stats)
+			}
+		})
+	}
+}
+
+// A file whose validator coverage is cut short is counted BOTH as processed and as
+// not-examined. That overlap is real, is not mentioned in #342, and is not the defect fixed
+// here — it is asserted so the identity's second term is pinned rather than assumed.
+func TestCutShortCoverageIsTheOtherOverlapTerm(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds a binary")
+	}
+	bin := buildForExitTest(t)
+	dir := t.TempDir()
+
+	// Large enough that the validators are still running when the budget expires. A tiny file
+	// can finish first, which would make this measure nothing.
+	var body strings.Builder
+	for i := 0; i < 4000; i++ {
+		fmt.Fprintf(&body, "record %d ssn 452-11-%04d ref %d\n", i, i%10000, i*7)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "big.txt"), []byte(body.String()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stats, stderr := runStats(t, bin, dir, "--validator-budget", "all=1ns")
+
+	if stats.FilesNotExamined == 0 {
+		t.Skipf("the validator budget did not expire on this machine, so there is no cut-short "+
+			"file to reconcile: %s", stats)
+	}
+	if got, want := stats.gap(), stats.FilesNotExamined; got != want {
+		t.Errorf("reconciliation gap = %+d, want %+d (one per cut-short file)\n  %s\n"+
+			"  A cut-short file is counted in files_processed (the pool leaves Result.Error nil) "+
+			"AND in files_not_examined, so the gap should equal the number of such files and "+
+			"nothing more.\n  stderr:\n%s", got, want, stats, indent(stderr))
+	}
+	if !strings.Contains(strings.ToLower(stderr), "cut short") {
+		t.Errorf("stderr does not disclose the cut-short coverage:\n%s", indent(stderr))
+	}
+}
+
+func indent(s string) string {
+	if s == "" {
+		return "    (empty)"
+	}
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	for i := range lines {
+		lines[i] = "    " + lines[i]
+	}
+	return strings.Join(lines, "\n")
+}


### PR DESCRIPTION
Closes #342.

## The defect

Every `result.SkippedFiles` entry increments `totalSkipped` and feeds `files_skipped`, but none of those paths is ever appended to `filesToProcess` — so they were absent from `consideredFiles = len(filesToProcess) + len(discoveryUnexamined)`, which is `total_files`.

#342's own repro, one small `.txt` plus one oversize unprocessable file:

| | total_files | files_processed | files_skipped | gap |
|---|---|---|---|---|
| before | 1 | 1 | 1 | **+1** |
| after | 2 | 1 | 1 | **0** |

The gap scaled — three such files gave +3. No coverage is lost; the harm is that an operator cannot use the summary to confirm a scan was complete.

## The identity is now written down next to the computation, and asserted

```
files_processed + files_skipped + files_not_examined
    == total_files + overlapMetaOnly + overlapCutShort
```

#342 asked for one ledger to be picked and stated. Both correction terms are **deliberate** double counts, where one file legitimately occupies two categories because it was both examined and incompletely examined:

- **`overlapMetaOnly`** — a body-empty file whose *metadata* produced a surviving finding. Counted as scanned (it produced findings) and as not-examined (its body was unread). This is the one the `silentEmpty` comment already documented.
- **`overlapCutShort`** — a file whose validator coverage was cut short by a budget, cancellation, or match-budget stop. The worker pool leaves `Result.Error` nil for these, so the file lands in `ProcessedFiles` **and** in `IncompleteFiles`.

### The second term is not in #342, and it was documented nowhere

It breaks the naive sum with **no discovery-time skip involved at all**. One file under `--validator-budget all=1ns` measures `total_files=1, files_processed=1, files_not_examined=1`. It is not a defect and is not "fixed" here — it is stated, so a future reader doesn't delete it as an off-by-one.

Two things deliberately **absent** from the identity, both verified rather than assumed:

- unreadable and failed-processing files sit in `total_files` and `files_not_examined` but in **neither** `files_processed` nor `files_skipped`. They need no correction term — they are what makes the sum close. So an assertion of the form `files_processed + files_skipped == total_files` would be wrong.
- the `scannedFiles` clamp cannot fire: `silentEmpty` counts a subset of `emptyExtractionFiles`, every one of which is already counted in `processedFiles`.

The identity is over **entries**, not distinct paths — `collectUnscanned` does not deduplicate, so a file that is both body-empty and cut short contributes two entries.

## Why the existing test couldn't catch it

`internal/formatters/text.TestSummaryCountsReconcile` builds `ScanStats` **by hand** and asserts `processed + notExamined + skipped <= total`, failing with *"the caller must not hand the formatter overlapping categories"* — while the real caller hands it overlapping categories deliberately. The fixture was internally consistent while contradicting the pipeline it stood in for. It still passes and is untouched.

The counters only interact in `cmd/main.go`, so the new test drives the **real binary** and states each fixture's deliberate overlap count *by construction*, which asserts the term rather than assuming it. Six shapes plus the cut-short case: plain files, one skip, three skips, one and two metadata-only files, and both sources at once.

## Verification

- Three mutations tested, each compiling and failing a test: dropping the new term, double-counting it, and adding the **wrong** counter (`skippedFiles`, which is already inside `filesToProcess`).
- 66 packages pass; `-race` clean on `./cmd`; `gofmt` clean repo-wide; the pre-existing formatter test still passes.
- **Cross-checked against open PR #351**, which adds two more `result.SkippedFiles` routes: on its branch a glob-matched directory without `--recursive` measures gap **+1**; with this change merged it is **0**. The ledger fix is generic, so it covers those routes whichever merges first. Union of both branches: 66 packages pass, `gofmt` clean.
- The test defeats pre-commit auto-detection explicitly (temp cwd outside any repo, trigger variables emptied). Without that it would measure pre-commit's forced text format on Windows only — the failure mode #351 hit.

## Noted, not fixed here

- `cmd/main.go` has an unreachable `scanMalfunction` branch: `ProcessFilesWithProgress` has a single return and it is always `nil`.
- The directory walk records `--exclude`/`.gitignore` refusals nowhere at all (plain `return nil`), so in a recursive scan they reach no counter — distinct from the skip ledger this PR corrects.