### PR TITLE
test(cmd): scrub every pre-commit trigger, and derive the list from the detector

### DIFF
--- a/cmd/discovery_scope_test.go
+++ b/cmd/discovery_scope_test.go
@@ -280,10 +280,7 @@ func runIsolated(t *testing.T, bin, dir string, extra ...string) exitRun {
 
 	cmd := exec.Command(bin, args...)
 	cmd.Dir = t.TempDir()
-	cmd.Env = append(os.Environ(),
-		"PRE_COMMIT=", "_PRE_COMMIT_RUNNING=", "PRE_COMMIT_HOME=",
-		"PRE_COMMIT_HOOK=", "GIT_HOOK_TYPE=", "GIT_EXEC_PATH=", "GITHUB_DESKTOP=",
-	)
+	cmd.Env = precommitFreeEnv()
 	var so, se strings.Builder
 	cmd.Stdout, cmd.Stderr = &so, &se
 	err := cmd.Run()
@@ -345,11 +342,18 @@ func TestExplicitFormatOutranksPrecommitDetection(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// The control run has to start from a pre-commit-FREE environment, and the working
+	// directory has to sit outside any repository. Otherwise the control is not a control: on
+	// Windows, Git Bash sets MSYSTEM and GIT_EXEC_PATH, detection fires, and the config's json
+	// format is overridden by pre-commit's own default — so the fixture check below failed
+	// there with "config defaults.format=json did not produce JSON" while the real subject of
+	// the test was fine. See precommitFreeEnv.
 	runCfg := func(env []string, extra ...string) string {
 		t.Helper()
 		args := append([]string{"--file", dir, "--recursive", "--config", cfg, "--checks", "SSN"}, extra...)
 		c := exec.Command(bin, args...)
-		c.Env = append(os.Environ(), env...)
+		c.Dir = t.TempDir()
+		c.Env = append(precommitFreeEnv(), env...)
 		var so strings.Builder
 		c.Stdout = &so
 		_ = c.Run() // a findings exit code is expected; only stdout matters here

--- a/cmd/precommit_isolation_test.go
+++ b/cmd/precommit_isolation_test.go
@@ -1,0 +1,148 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os"
+	"regexp"
+	"sort"
+	"testing"
+)
+
+// Pre-commit mode is inferred from the environment, and a test that means to exercise ORDINARY
+// CLI behaviour has to switch that inference off — otherwise it measures pre-commit behaviour
+// on some machines and not others.
+//
+// The mode is not cosmetic. It forces quiet output, and the json/csv/yaml formatters
+// deliberately return an EMPTY document in pre-commit mode when there are no findings
+// (internal/formatters/json/formatter.go:63 and siblings), on the stated grounds that
+// pre-commit signals out of band through the exit code and stderr. So a test asserting on a
+// machine artifact gets zero bytes rather than a parse error, and the failure names the test's
+// own subject rather than the environment.
+//
+// This list has now gone stale twice, each time producing a windows-only CI failure whose cause
+// had nothing to do with the failing test:
+//
+//	#351  scrubbed nothing, so GIT_EXEC_PATH (always set by Git Bash) forced text output
+//	#354  scrubbed GIT_EXEC_PATH but missed MSYSTEM, so quiet mode emptied two artifacts
+//
+// Both times the CI step ran under C:\Program Files\Git\bin\bash.EXE, which sets MSYSTEM,
+// MINGW_PREFIX and GIT_EXEC_PATH. Reproduced locally by forcing the platform branch on: with
+// MSYSTEM set, an all-inputs-refused scan wrote a 0-byte --output file where a clean
+// environment wrote 264 bytes.
+//
+// TestPrecommitTriggerListIsComplete below keeps the list honest by deriving it from the
+// detector's own source, so a trigger added there fails here instead of on one runner.
+
+// precommitTriggerEnv is every environment variable whose presence can put the tool into
+// pre-commit mode. See TestPrecommitTriggerListIsComplete.
+var precommitTriggerEnv = []string{
+	// Set by pre-commit itself.
+	"PRE_COMMIT",
+	"_PRE_COMMIT_RUNNING",
+	"PRE_COMMIT_HOME",
+	// Batch/hook context indicators.
+	"PRE_COMMIT_HOOK",
+	"GIT_HOOK_TYPE",
+	// Git Bash / MSYS, which is how most people run this tool on Windows. These are the ones
+	// that make detection fire without anyone opting in.
+	"MSYSTEM",
+	"MINGW_PREFIX",
+	"GIT_EXEC_PATH",
+	"GITHUB_DESKTOP",
+}
+
+// precommitFreeEnv returns the current environment with every pre-commit trigger emptied.
+//
+// Emptied rather than removed because that is enough — the detector tests each with
+// `os.Getenv(x) != ""` — and because Go's exec applies last-wins deduplication, so appending
+// overrides an inherited value on every platform, including Windows where the names are
+// case-insensitive.
+//
+// Callers must ALSO run the binary with a working directory outside any git repository. Two
+// detection paths shell out to `git rev-parse --git-dir` and look for a pre-commit hook beside
+// it, and this package's own directory is a repository that has one. No environment variable
+// can switch that off.
+func precommitFreeEnv() []string {
+	env := os.Environ()
+	for _, k := range precommitTriggerEnv {
+		env = append(env, k+"=")
+	}
+	return env
+}
+
+// TestPrecommitTriggerListIsComplete derives the trigger set from the detector's source and
+// fails if precommitTriggerEnv has drifted from it.
+//
+// Reading the source rather than calling the detector is deliberate: detectEnvironment's Git
+// Bash branch is compiled for every platform but only REACHED on Windows, so a table-driven
+// test of the real function cannot observe those triggers on a Linux or macOS runner — which is
+// exactly where this list gets edited.
+func TestPrecommitTriggerListIsComplete(t *testing.T) {
+	const detectorPath = "../internal/precommit/detector.go"
+
+	src, err := os.ReadFile(detectorPath)
+	if err != nil {
+		t.Fatalf("cannot read %s: %v — if the detector moved, this guard must move with it, or "+
+			"the trigger list silently stops being checked", detectorPath, err)
+	}
+
+	// Variables that do NOT cause detection and so must not be scrubbed.
+	notATrigger := map[string]string{
+		// These only tune an ALREADY-detected pre-commit config (batch size, exit policy).
+		// Emptying them would change nothing about whether the mode is entered.
+		"FERRET_PRECOMMIT_BATCH_SIZE":    "tunes an already-detected config",
+		"FERRET_PRECOMMIT_EXIT_ON":       "tunes an already-detected config",
+		"FERRET_PRECOMMIT_EXIT_ON_FIRST": "tunes an already-detected config",
+		// Only raises BatchSize from 50 to 75 inside applyWindowsConfigOptimizations. It is
+		// read AFTER the mode has been decided, so it cannot cause detection. Listed here
+		// because this guard found it on its first run — a case-insensitive name that a
+		// hand-written [A-Z_]+ grep of the detector had silently skipped.
+		"PSModulePath": "tunes BatchSize after the mode is already decided",
+		// COMSPEC is a trigger only in combination with PRE_COMMIT_HOOK or GIT_HOOK_TYPE, both
+		// of which ARE scrubbed, so the combination cannot fire. It is left alone on purpose:
+		// it is a core Windows variable and blanking it could affect anything the tool shells
+		// out to.
+		"COMSPEC": "only triggers together with PRE_COMMIT_HOOK/GIT_HOOK_TYPE, which are scrubbed",
+	}
+
+	scrubbed := make(map[string]bool, len(precommitTriggerEnv))
+	for _, k := range precommitTriggerEnv {
+		scrubbed[k] = true
+	}
+
+	seen := map[string]bool{}
+	var missing []string
+	for _, m := range regexp.MustCompile(`os\.Getenv\("([A-Za-z_][A-Za-z0-9_]*)"\)`).FindAllStringSubmatch(string(src), -1) {
+		name := m[1]
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		if _, ok := notATrigger[name]; ok {
+			continue
+		}
+		if !scrubbed[name] {
+			missing = append(missing, name)
+		}
+	}
+
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		t.Errorf("%s reads %v, which precommitTriggerEnv does not scrub.\n"+
+			"Add each one to precommitTriggerEnv, or to notATrigger with the reason it cannot "+
+			"cause detection.\n"+
+			"An unscrubbed trigger does not fail here — it fails as an unrelated assertion on "+
+			"whichever runner happens to set it, which has already cost two windows-only CI "+
+			"failures.", detectorPath, missing)
+	}
+
+	// The reverse direction: a name scrubbed here but no longer read by the detector is dead
+	// weight that suggests the list is being maintained by guesswork.
+	for _, k := range precommitTriggerEnv {
+		if !seen[k] {
+			t.Errorf("precommitTriggerEnv scrubs %q but %s no longer reads it", k, detectorPath)
+		}
+	}
+}


### PR DESCRIPTION
## main is red on windows-latest

Two tests merged in #351 fail there, and neither failure is about what the test asserts:

```
TestExplicitFormatOutranksPrecommitDetection            "config defaults.format=json did not produce JSON"
TestMachineFormatEmitsValidJSONWhenEveryInputIsRefused  "unexpected end of JSON input"
```

Both tests mean to exercise **ordinary** CLI behaviour, so they switch pre-commit auto-detection off. The scrub list missed **`MSYSTEM`**, which Git Bash always sets — and the CI test step runs under `C:\Program Files\Git\bin\bash.EXE`. Detection fired, and the json/csv/yaml formatters *deliberately* return an empty document in pre-commit mode when there are no findings (`internal/formatters/json/formatter.go:63`), so the artifact was **zero bytes** rather than wrong.

The format half was already correct — #351's fix means an explicit `--format` still wins. This is purely the emptiness.

## Reproduced locally, without Windows

By building a binary with the platform branch forced on and scanning a fixture whose inputs are all refused:

| environment | `--output` file |
|---|---|
| Git Bash (`MSYSTEM`+`MINGW_PREFIX`+`GIT_EXEC_PATH`) | **0 bytes** |
| all triggers emptied | 266 bytes |
| old scrub, `MSYSTEM` left set | **0 bytes** |

The last row is the CI failure exactly.

## The fix is a guard, not two more names

The list has gone stale twice — #351 scrubbed nothing, #354 scrubbed `GIT_EXEC_PATH` but missed `MSYSTEM` — so this derives the trigger set from `internal/precommit/detector.go` and fails when the list drifts.

It earned its place on its first run: it found **`PSModulePath`**, which my hand-written `[A-Z_]+` grep of the detector had silently skipped because of its lowercase letters. That one only tunes `BatchSize` *after* the mode is decided, so it is recorded as a non-trigger **with that reason** rather than left unexamined. `COMSPEC` is likewise documented as conditional (it only triggers together with `PRE_COMMIT_HOOK`/`GIT_HOOK_TYPE`, both scrubbed) and deliberately not blanked, since it is a core Windows variable.

The guard reads the source rather than calling the detector because the Git Bash branch is compiled everywhere but only **reached** on Windows — so a table-driven test of the real function cannot observe those triggers on the runner where the list actually gets edited.

It also checks the reverse direction: a name scrubbed here that the detector no longer reads is dead weight suggesting the list is being maintained by guesswork.

## Also fixed

The control run inside `TestExplicitFormatOutranksPrecommitDetection` used a bare `os.Environ()`, so on Windows it was not a control at all — detection fired and overrode the config's json format, failing the fixture-sanity check while the behaviour under test was fine. It now starts from `precommitFreeEnv()` and runs **outside any repository**, because two detection paths shell out to `git rev-parse --git-dir` and look for a pre-commit hook beside it, and this package's own directory is a repository that has one. No environment variable can switch that off.

## Verification

- Removing `MSYSTEM` from the list **fails** the new guard (mutation-tested).
- 66 packages pass; `-race` clean on `./cmd`; `gofmt` and `vet` clean.
- **Test-only change** — no production code touched.

The pre-commit empty-artifact behaviour itself is a policy question (an explicitly requested `--output` arguably should always be written); that is tracked in #353 and deliberately not changed here.

Note: #354 is red on Windows for the same reason and will be updated to use `precommitFreeEnv()` once this lands.

## Tracking

**Refs #353** — that issue holds the two product questions this exposed, neither changed here: the detection heuristic itself (Git Bash is not a hook invocation) and the fact that pre-commit mode leaves an **explicitly requested** `--output` file empty, which is what turns an incomplete scrub from cosmetic into fatal.

This PR is the only thing tracking `main` being red on `windows-latest` at `efc4884` — there is no separate issue for it, so merging this is what closes it out.

**Known residual:** the drift guard catches a *new trigger added to the detector*. It does not catch a *new test that forgets to isolate* — someone can still write `exec.Command(bin, …)` with a bare `os.Environ()` and be red on Windows only, which is how both of these tests arose. Worth a follow-up guard over `cmd/*_test.go` if this recurs a third time.
