### PR TITLE
feat(redactors): add an audio metadata redactor so reported audio findings can be removed

### DIFF
--- a/internal/core/redact.go
+++ b/internal/core/redact.go
@@ -15,6 +15,7 @@ import (
 	"github.com/awslabs/ferret-scan/v2/internal/observability"
 	"github.com/awslabs/ferret-scan/v2/internal/parallel"
 	"github.com/awslabs/ferret-scan/v2/internal/redactors"
+	"github.com/awslabs/ferret-scan/v2/internal/redactors/audio"
 	"github.com/awslabs/ferret-scan/v2/internal/redactors/image"
 	"github.com/awslabs/ferret-scan/v2/internal/redactors/legacyole"
 	"github.com/awslabs/ferret-scan/v2/internal/redactors/office"
@@ -212,6 +213,7 @@ func NewDefaultRedactionManager(outputDir string, strategy redactors.RedactionSt
 		officeRedactor,
 		legacyole.NewLegacyOLERedactor(outputManager, observer),
 		image.NewImageMetadataRedactor(outputManager, observer),
+		audio.NewAudioRedactor(outputManager, observer),
 	} {
 		if err := manager.RegisterRedactor(r); err != nil {
 			return nil, nil, fmt.Errorf("failed to register redactor %s: %w", r.GetName(), err)

--- a/internal/redactors/audio/overlap.go
+++ b/internal/redactors/audio/overlap.go
@@ -1,0 +1,215 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package audio
+
+import (
+	"bytes"
+	"sort"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/redactors"
+)
+
+// occurrence is one span of the file to overwrite, with the bytes to write there.
+type occurrence struct {
+	start int
+	end   int
+	repl  []byte
+	wide  bool // the value was found UTF-16LE encoded, so a mask must keep that width
+	count int  // how many matches contributed to this span, after merging
+}
+
+// planOverwrites computes every span to overwrite, resolving overlaps.
+//
+// # Why this cannot be a sequential search-and-replace
+//
+// Reported matches OVERLAP. On a real .wav the scan reports both
+//
+//	SSN          "452-11-9384"
+//	AUTHOR_INFO  "Contact Jane Doe SSN 452-11-9384"
+//
+// Replacing them one at a time against the buffer being modified loses the second one:
+// masking the SSN destroys the tail of the AUTHOR_INFO string, so searching for
+// AUTHOR_INFO next finds nothing, is recorded as "not located", and "Jane Doe" — which is
+// only reported as part of that longer value — stays in the file. Measured before this
+// existed: SSN, phone and email removed from all four formats, "Jane Doe" left in cleartext,
+// exit 0.
+//
+// Worse, a residue check that searches the OUTPUT for each reported value is fooled the same
+// way: the AUTHOR_INFO string is genuinely absent, because its own substring was altered. So
+// the verification agreed with the bug.
+//
+// Sorting longest-first is not sufficient either. It fixes CONTAINMENT but not PARTIAL
+// overlap: for "…SSN 452" and "452-11-9384" the first masks only the head of the second, and
+// the untouched tail is still cleartext. This is the same mechanism as #191 — a destructive
+// sequential replace over partially overlapping matches.
+//
+// So every occurrence is located in the ORIGINAL bytes, before anything is written, and
+// overlapping spans are merged into one. A merged span is masked rather than
+// format-preserved, because it covers parts of two values of different types and no single
+// format-preserving rendering is correct for both.
+// It also reports, per match, how many occurrences of that match were located, so the caller
+// can record a mapping only for values it actually wrote over — never one it merely tried.
+func planOverwrites(orig []byte, ranges []byteRange, matches []detector.Match, strategy redactors.RedactionStrategy) (plan []occurrence, perMatch []int) {
+	var found []occurrence
+	perMatch = make([]int, len(matches))
+
+	for mi, m := range matches {
+		if m.Text == "" {
+			continue
+		}
+		repl := sameLengthReplacement(m.Text, m.Type, strategy)
+
+		narrow := []byte(m.Text)
+		narrowRepl := []byte(repl)
+		// Both UTF-16 byte orders: ID3v2 declares UTF-16LE (with a BOM) or UTF-16BE (0x02,
+		// no BOM) per frame, and a value stored in the order not searched is a value left
+		// behind.
+		wideEncodings := []struct {
+			pat  []byte
+			repl []byte
+		}{}
+		for _, enc := range []func(string) []byte{toUTF16LE, toUTF16BE} {
+			pat := enc(m.Text)
+			if len(pat) == 0 {
+				continue
+			}
+			wr := enc(repl)
+			if len(wr) != len(pat) {
+				wr = maskFor(len(pat), true)
+			}
+			wideEncodings = append(wideEncodings, struct {
+				pat  []byte
+				repl []byte
+			}{pat, wr})
+		}
+
+		for _, rg := range ranges {
+			if rg.start < 0 || rg.end > len(orig) || rg.start >= rg.end {
+				continue
+			}
+			region := orig[rg.start:rg.end]
+
+			if len(narrow) > 0 && len(narrow) == len(narrowRepl) {
+				for _, at := range indexAll(region, narrow) {
+					found = append(found, occurrence{
+						start: rg.start + at,
+						end:   rg.start + at + len(narrow),
+						repl:  narrowRepl,
+						count: 1,
+					})
+					perMatch[mi]++
+				}
+			}
+			for _, enc := range wideEncodings {
+				for _, at := range indexAll(region, enc.pat) {
+					found = append(found, occurrence{
+						start: rg.start + at,
+						end:   rg.start + at + len(enc.pat),
+						repl:  enc.repl,
+						wide:  true,
+						count: 1,
+					})
+					perMatch[mi]++
+				}
+			}
+		}
+	}
+
+	return mergeOccurrences(found), perMatch
+}
+
+// indexAll returns every start offset of pat within region, without overlapping itself.
+func indexAll(region, pat []byte) []int {
+	if len(pat) == 0 {
+		return nil
+	}
+	var out []int
+	off := 0
+	for off <= len(region)-len(pat) {
+		i := bytes.Index(region[off:], pat)
+		if i < 0 {
+			break
+		}
+		out = append(out, off+i)
+		off += i + len(pat)
+	}
+	return out
+}
+
+// mergeOccurrences unions overlapping or touching spans.
+//
+// Touching spans (end == next.start) are merged too. Two adjacent reported values are
+// adjacent cleartext; masking them as one span is no less correct and avoids leaving a
+// format-preserved rendering next to a masked one, which reads as though only half the field
+// was handled.
+func mergeOccurrences(in []occurrence) []occurrence {
+	if len(in) == 0 {
+		return nil
+	}
+	sort.Slice(in, func(i, j int) bool {
+		if in[i].start != in[j].start {
+			return in[i].start < in[j].start
+		}
+		// Longest first at the same start, so the wider span drives the merge.
+		return in[i].end > in[j].end
+	})
+
+	out := []occurrence{in[0]}
+	for _, cur := range in[1:] {
+		last := &out[len(out)-1]
+		if cur.start > last.end {
+			out = append(out, cur)
+			continue
+		}
+		// Overlapping or touching: widen the existing span.
+		merged := *last
+		if cur.end > merged.end {
+			merged.end = cur.end
+		}
+		merged.count = last.count + cur.count
+		merged.wide = last.wide && cur.wide
+		merged.repl = nil // recomputed below, since the span changed
+		*last = merged
+	}
+
+	// Any span built from more than one match gets a mask sized to the final span. A
+	// format-preserving replacement is only meaningful for exactly one value of one type.
+	for i := range out {
+		if out[i].count == 1 && len(out[i].repl) == out[i].end-out[i].start {
+			continue
+		}
+		out[i].repl = maskFor(out[i].end-out[i].start, out[i].wide)
+	}
+	return out
+}
+
+// maskFor builds a mask of exactly n bytes.
+//
+// A wide span is masked with the UTF-16LE pattern so the field stays valid UTF-16: writing n
+// single-byte '*' into a UTF-16 field would pair them into unrelated code units, which is
+// still length-preserving but leaves a field a decoder renders as unexpected glyphs rather
+// than as an obvious redaction.
+func maskFor(n int, wide bool) []byte {
+	if n <= 0 {
+		return nil
+	}
+	if wide && n%2 == 0 {
+		return bytes.Repeat([]byte{maskByte, 0x00}, n/2)
+	}
+	return bytes.Repeat([]byte{maskByte}, n)
+}
+
+// applyOverwrites writes the planned spans into buf and returns how many were applied.
+func applyOverwrites(buf []byte, plan []occurrence) int {
+	applied := 0
+	for _, o := range plan {
+		if o.start < 0 || o.end > len(buf) || o.start >= o.end || len(o.repl) != o.end-o.start {
+			continue
+		}
+		copy(buf[o.start:o.end], o.repl)
+		applied++
+	}
+	return applied
+}

--- a/internal/redactors/audio/ranges.go
+++ b/internal/redactors/audio/ranges.go
@@ -1,0 +1,265 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package audio
+
+import (
+	"bytes"
+	"encoding/binary"
+)
+
+// byteRange is a half-open [start, end) span of the file that holds metadata.
+type byteRange struct {
+	start int
+	end   int
+	label string // which container structure it came from, for the audit trail
+}
+
+// metadataRanges returns the spans of buf that hold tag metadata for the given format.
+//
+// # Why ranges rather than the whole file
+//
+// Redaction here is a same-length overwrite of the value's bytes (see redactor.go for why
+// the length cannot change). A naive search over the whole file would also overwrite any
+// coincidental occurrence of those bytes inside the AUDIO SAMPLES — silently corrupting the
+// recording while reporting success. An 11-byte SSN is unlikely to appear in PCM by chance,
+// but "Jane Doe" in a 40MB file is not, and a corrupted output that still looks redacted is
+// worse than a refusal.
+//
+// Bounding the search to the tag structures also bounds the blast radius of a parsing
+// mistake: getting an offset wrong can only damage metadata, never the audio stream.
+//
+// An empty result means "no metadata region found", which the caller must treat as a refusal
+// rather than as success — a file whose tags could not be located is a file whose values were
+// not removed.
+func metadataRanges(buf []byte, format audioFormat) []byteRange {
+	switch format {
+	case formatWAV:
+		return riffMetadataRanges(buf)
+	case formatMP3:
+		return id3MetadataRanges(buf)
+	case formatFLAC:
+		return flacMetadataRanges(buf)
+	case formatM4A:
+		return mp4MetadataRanges(buf)
+	}
+	return nil
+}
+
+// riffMetadataRanges finds LIST and id3 chunks in a RIFF/WAVE file.
+//
+// Deliberately NOT every non-audio chunk: only the two that carry free text. `fmt ` is
+// numeric, and `data` is the audio itself — the one span that must never be touched.
+//
+// The odd-length pad byte is DETECTED rather than assumed, for the same reason the WAV
+// extractor detects it (#312 and the INFO-walk follow-up): a non-compliant writer omits it,
+// and seeking past a byte that is not there puts every subsequent offset one out. Here that
+// would mean overwriting the wrong bytes, so the consequence is worse than a missed read.
+func riffMetadataRanges(buf []byte) []byteRange {
+	// "RIFF" + size(4) + "WAVE" = 12 bytes before the first chunk.
+	const riffHeader = 12
+	if len(buf) < riffHeader || !bytes.Equal(buf[0:4], []byte("RIFF")) || !bytes.Equal(buf[8:12], []byte("WAVE")) {
+		return nil
+	}
+
+	var out []byteRange
+	pos := riffHeader
+	for pos+8 <= len(buf) {
+		id := buf[pos : pos+4]
+		size := int(binary.LittleEndian.Uint32(buf[pos+4 : pos+8]))
+		if size < 0 {
+			return out
+		}
+		dataStart := pos + 8
+		dataEnd := dataStart + size
+		if dataEnd > len(buf) {
+			// A chunk declaring more than the file holds. Take what is present rather than
+			// walking off the end; a truncated tag still deserves to be scrubbed.
+			dataEnd = len(buf)
+		}
+
+		switch {
+		case bytes.Equal(id, []byte("LIST")):
+			out = append(out, byteRange{dataStart, dataEnd, "RIFF LIST"})
+		case bytes.Equal(id, []byte("id3 ")), bytes.Equal(id, []byte("ID3 ")):
+			// A WAV may carry an ID3 tag in its own chunk.
+			out = append(out, byteRange{dataStart, dataEnd, "RIFF id3"})
+		}
+
+		next := dataEnd
+		if size%2 == 1 {
+			// Pad byte required by RIFF after an odd-length chunk — consumed only if it is
+			// actually there. A pad is 0x00; a chunk ID's first byte is printable ASCII.
+			if next < len(buf) && buf[next] == 0x00 {
+				next++
+			}
+		}
+		if next <= pos {
+			return out // no forward progress: malformed, stop rather than spin
+		}
+		pos = next
+	}
+	return out
+}
+
+// id3MetadataRanges finds the ID3v2 tag at the head of an MP3 and the ID3v1 tag at its tail.
+//
+// ID3v2 sizes are SYNCHSAFE: seven bits per byte, high bit always clear, so that a size can
+// never contain a byte sequence a decoder would mistake for a frame sync. Reading it as a
+// plain big-endian uint32 gives a value that is too large and drifts further with every size —
+// the classic ID3 parsing bug.
+func id3MetadataRanges(buf []byte) []byteRange {
+	var out []byteRange
+
+	// ID3v2: "ID3" ver(2) flags(1) synchsafe-size(4), then size bytes of frames.
+	const id3v2Header = 10
+	if len(buf) >= id3v2Header && bytes.Equal(buf[0:3], []byte("ID3")) {
+		size := synchsafe(buf[6:10])
+		end := id3v2Header + size
+		if end > len(buf) {
+			end = len(buf)
+		}
+		if end > id3v2Header {
+			out = append(out, byteRange{id3v2Header, end, "ID3v2"})
+		}
+	}
+
+	// ID3v1: a fixed 128-byte trailer beginning "TAG".
+	const id3v1Size = 128
+	if len(buf) >= id3v1Size {
+		tail := len(buf) - id3v1Size
+		if bytes.Equal(buf[tail:tail+3], []byte("TAG")) {
+			out = append(out, byteRange{tail + 3, len(buf), "ID3v1"})
+		}
+	}
+
+	return out
+}
+
+// synchsafe decodes a 4-byte ID3v2 synchsafe integer (7 significant bits per byte).
+func synchsafe(b []byte) int {
+	if len(b) < 4 {
+		return 0
+	}
+	return int(b[0]&0x7F)<<21 | int(b[1]&0x7F)<<14 | int(b[2]&0x7F)<<7 | int(b[3]&0x7F)
+}
+
+// flacMetadataRanges finds VORBIS_COMMENT blocks in a FLAC stream.
+//
+// Only type 4. STREAMINFO (0) is numeric and mandatory, SEEKTABLE (3) is offsets, and
+// PICTURE (6) is binary image data whose bytes could coincidentally match a short value.
+// Comments are where the text tags live.
+func flacMetadataRanges(buf []byte) []byteRange {
+	if len(buf) < 4 || !bytes.Equal(buf[0:4], []byte("fLaC")) {
+		return nil
+	}
+
+	const (
+		blockHeader        = 4
+		vorbisCommentBlock = 4
+	)
+	var out []byteRange
+	pos := 4
+	for pos+blockHeader <= len(buf) {
+		header := buf[pos]
+		last := header&0x80 != 0
+		blockType := header & 0x7F
+		// 24-bit big-endian length.
+		size := int(buf[pos+1])<<16 | int(buf[pos+2])<<8 | int(buf[pos+3])
+		dataStart := pos + blockHeader
+		dataEnd := dataStart + size
+		if dataEnd > len(buf) {
+			dataEnd = len(buf)
+		}
+		if blockType == vorbisCommentBlock && dataEnd > dataStart {
+			out = append(out, byteRange{dataStart, dataEnd, "FLAC VORBIS_COMMENT"})
+		}
+		if last || dataEnd <= pos {
+			break
+		}
+		pos = dataEnd
+	}
+	return out
+}
+
+// mp4MetadataRanges finds udta (user data) atoms in an MP4/M4A file, which is where the
+// iTunes-style ilst tags live.
+//
+// Scoped to udta rather than to moov: moov also holds the sample tables (stbl/stco/stsz),
+// which are offset and size arrays. Overwriting bytes there would desynchronise the decoder
+// from the audio while the file still parsed as a container — a corrupt output that looks
+// successful. udta is the only subtree that is purely descriptive.
+func mp4MetadataRanges(buf []byte) []byteRange {
+	var out []byteRange
+	collectUdta(buf, 0, len(buf), 0, &out)
+	return out
+}
+
+// collectUdta walks the atom tree in buf[start:end), appending every udta payload it finds.
+//
+// The depth bound is belt-and-braces, and worth being honest about: termination is ALREADY
+// guaranteed without it, because every level consumes at least the 8 bytes of an atom header
+// out of a finite buffer and the child range is strictly inside the parent's. So a hostile
+// file cannot drive unbounded recursion — it can only drive deep recursion, bounded by
+// filesize/8. The explicit ceiling costs one comparison and keeps that reasoning from having
+// to be re-derived by the next reader; it is deliberately not covered by a test, because a
+// fixture deep enough to distinguish its presence would have to be hundreds of thousands of
+// levels deep and would be measuring Go's stack growth rather than this code.
+func collectUdta(buf []byte, start, end, depth int, out *[]byteRange) {
+	const maxDepth = 8
+	if depth > maxDepth {
+		return
+	}
+
+	pos := start
+	for pos+8 <= end {
+		size := int(binary.BigEndian.Uint32(buf[pos : pos+4]))
+		name := buf[pos+4 : pos+8]
+		header := 8
+
+		switch size {
+		case 0:
+			// Size 0 means "extends to the end of the file" (permitted for the last atom).
+			size = end - pos
+		case 1:
+			// Size 1 means the real 64-bit size follows the name.
+			if pos+16 > end {
+				return
+			}
+			large := binary.BigEndian.Uint64(buf[pos+8 : pos+16])
+			// Bound the cast: a declared size beyond the buffer is malformed, and on a
+			// 32-bit build the conversion would wrap.
+			if large > uint64(end-pos) {
+				return
+			}
+			size = int(large)
+			header = 16
+		}
+
+		if size < header || pos+size > end {
+			return // malformed or truncated: stop rather than guess
+		}
+
+		payloadStart := pos + header
+		payloadEnd := pos + size
+
+		if bytes.Equal(name, []byte("udta")) {
+			*out = append(*out, byteRange{payloadStart, payloadEnd, "MP4 udta"})
+		} else if isMP4Container(name) {
+			collectUdta(buf, payloadStart, payloadEnd, depth+1, out)
+		}
+
+		pos = payloadEnd
+	}
+}
+
+// isMP4Container reports whether an atom holds child atoms worth descending into on the way
+// to udta. Listed explicitly rather than descending into everything, because descending into
+// a leaf atom would interpret its payload bytes as atom headers and produce nonsense ranges.
+func isMP4Container(name []byte) bool {
+	switch string(name) {
+	case "moov", "trak", "mdia", "minf", "stbl", "edts", "moof", "traf", "mvex":
+		return true
+	}
+	return false
+}

--- a/internal/redactors/audio/ranges_test.go
+++ b/internal/redactors/audio/ranges_test.go
@@ -1,0 +1,192 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package audio
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+// The metadata ranges are asserted by exact OFFSET, not just by "the value was removed".
+//
+// A range that is too large still removes the value, so a redaction test cannot see the
+// difference — but it also hands the overwrite permission over bytes that are not metadata.
+// For an MP3 that means the MPEG audio frames: a reported value occurring by chance in the
+// samples would be overwritten, corrupting the recording while the run reported success. The
+// whole reason this redactor works in ranges rather than over the file is to make that
+// impossible, so the boundaries are the contract.
+
+func TestID3RangeStopsExactlyAtTheTagBoundary(t *testing.T) {
+	// A tag body larger than 127 bytes, which is where a synchsafe size and a plain
+	// big-endian one stop agreeing: below 128 every high bit is already clear and only the
+	// last byte carries value.
+	body := bytes.Repeat([]byte("A"), 200)
+	tag := append([]byte("ID3"), 0x03, 0x00, 0x00)
+	n := len(body)
+	tag = append(tag, byte((n>>21)&0x7F), byte((n>>14)&0x7F), byte((n>>7)&0x7F), byte(n&0x7F))
+	tag = append(tag, body...)
+	// Audio frames follow the tag. These must never fall inside the returned range.
+	audio := bytes.Repeat([]byte{0xFF, 0xFB, 0x90, 0x00}, 64)
+	buf := append(tag, audio...)
+
+	if n < 128 {
+		t.Fatalf("fixture body is %d bytes; it must exceed 127 or the two decodings agree", n)
+	}
+
+	got := id3MetadataRanges(buf)
+	if len(got) != 1 {
+		t.Fatalf("id3MetadataRanges returned %d ranges, want 1: %+v", len(got), got)
+	}
+
+	const headerLen = 10
+	wantEnd := headerLen + n
+	if got[0].start != headerLen || got[0].end != wantEnd {
+		t.Errorf("range = [%d,%d), want [%d,%d).\n"+
+			"Reading the tag size as a plain big-endian integer instead of a synchsafe one gives "+
+			"%d here, which extends the overwrite region %d bytes into the MPEG audio frames — a "+
+			"value occurring by chance in the samples would then be overwritten and the recording "+
+			"corrupted, while the run still reported success.",
+			got[0].start, got[0].end, headerLen, wantEnd,
+			headerLen+int(binary.BigEndian.Uint32(buf[6:10])),
+			headerLen+int(binary.BigEndian.Uint32(buf[6:10]))-wantEnd)
+	}
+	if got[0].end > len(tag) {
+		t.Errorf("the range extends %d bytes past the tag and into the audio frames",
+			got[0].end-len(tag))
+	}
+}
+
+func TestRIFFRangeCoversOnlyTheListChunk(t *testing.T) {
+	chunk := func(id string, payload []byte) []byte {
+		out := append([]byte(id), make([]byte, 4)...)
+		binary.LittleEndian.PutUint32(out[4:], uint32(len(payload)))
+		out = append(out, payload...)
+		if len(payload)%2 == 1 {
+			out = append(out, 0x00)
+		}
+		return out
+	}
+
+	info := append([]byte("INFO"), []byte("IARTxxxx")...)
+	fmtc := chunk("fmt ", make([]byte, 16))
+	listc := chunk("LIST", info)
+	datac := chunk("data", bytes.Repeat([]byte{0xAA}, 32))
+
+	body := append([]byte("WAVE"), fmtc...)
+	listAt := len(body) + 8 // payload begins after the chunk header
+	body = append(body, listc...)
+	body = append(body, datac...)
+
+	riff := append([]byte("RIFF"), make([]byte, 4)...)
+	binary.LittleEndian.PutUint32(riff[4:], uint32(len(body)))
+	buf := append(riff, body...)
+
+	got := riffMetadataRanges(buf)
+	if len(got) != 1 {
+		t.Fatalf("riffMetadataRanges returned %d ranges, want exactly the LIST chunk: %+v", len(got), got)
+	}
+	// +8 for the RIFF header that precedes body.
+	wantStart := 8 + listAt
+	if got[0].start != wantStart || got[0].end != wantStart+len(info) {
+		t.Errorf("range = [%d,%d), want [%d,%d)", got[0].start, got[0].end, wantStart, wantStart+len(info))
+	}
+	// The data chunk must be entirely outside every range, or redaction could overwrite audio.
+	dataStart := bytes.Index(buf, []byte("data"))
+	for _, rg := range got {
+		if dataStart >= rg.start && dataStart < rg.end {
+			t.Errorf("the data chunk at %d falls inside metadata range [%d,%d)", dataStart, rg.start, rg.end)
+		}
+	}
+}
+
+func TestFLACRangeCoversOnlyTheCommentBlock(t *testing.T) {
+	streamInfo := make([]byte, 34)
+	comment := []byte("vendorARTIST=x")
+	picture := bytes.Repeat([]byte{0xBB}, 40) // type 6, binary image data
+
+	buf := []byte("fLaC")
+	buf = append(buf, 0x00, 0, 0, byte(len(streamInfo)))
+	buf = append(buf, streamInfo...)
+	commentAt := len(buf) + 4
+	buf = append(buf, 0x04, 0, 0, byte(len(comment)))
+	buf = append(buf, comment...)
+	buf = append(buf, 0x80|0x06, 0, 0, byte(len(picture)))
+	buf = append(buf, picture...)
+
+	got := flacMetadataRanges(buf)
+	if len(got) != 1 {
+		t.Fatalf("flacMetadataRanges returned %d ranges, want only VORBIS_COMMENT: %+v", len(got), got)
+	}
+	if got[0].start != commentAt || got[0].end != commentAt+len(comment) {
+		t.Errorf("range = [%d,%d), want [%d,%d)", got[0].start, got[0].end, commentAt, commentAt+len(comment))
+	}
+	// A PICTURE block is binary image data; a short reported value could match inside it by
+	// chance, so it must stay out of scope.
+	picAt := len(buf) - len(picture)
+	for _, rg := range got {
+		if picAt >= rg.start && picAt < rg.end {
+			t.Error("the PICTURE block falls inside a metadata range")
+		}
+	}
+}
+
+func TestMP4RangeCoversUdtaAndNotTheSampleTables(t *testing.T) {
+	atom := func(name string, payload []byte) []byte {
+		out := make([]byte, 4)
+		binary.BigEndian.PutUint32(out, uint32(8+len(payload)))
+		out = append(out, []byte(name)...)
+		return append(out, payload...)
+	}
+
+	// stbl holds offset/size arrays. Overwriting bytes there desynchronises the decoder from
+	// the audio while the container still parses — a corrupt file that looks successful.
+	stbl := atom("stbl", bytes.Repeat([]byte{0xCC}, 24))
+	udta := atom("udta", atom("meta", append([]byte{0, 0, 0, 0}, atom("ilst", atom("\xa9nam", []byte("v")))...)))
+	moov := atom("moov", append(stbl, udta...))
+	buf := append(atom("ftyp", []byte("M4A isom")), moov...)
+
+	got := mp4MetadataRanges(buf)
+	if len(got) != 1 {
+		t.Fatalf("mp4MetadataRanges returned %d ranges, want exactly the udta payload: %+v", len(got), got)
+	}
+
+	udtaAt := bytes.Index(buf, []byte("udta"))
+	if got[0].start != udtaAt+4 {
+		t.Errorf("range starts at %d, want %d (the udta payload)", got[0].start, udtaAt+4)
+	}
+
+	stblAt := bytes.Index(buf, []byte("stbl"))
+	for _, rg := range got {
+		if stblAt >= rg.start && stblAt < rg.end {
+			t.Errorf("stbl at %d falls inside metadata range [%d,%d) — sample tables must never be "+
+				"overwritten", stblAt, rg.start, rg.end)
+		}
+	}
+}
+
+// A hostile atom tree must terminate rather than recurse without bound.
+func TestMP4DeepNestingTerminates(t *testing.T) {
+	// Build moov nested inside moov, deeper than the depth bound.
+	payload := []byte{}
+	for i := 0; i < 40; i++ {
+		hdr := make([]byte, 4)
+		binary.BigEndian.PutUint32(hdr, uint32(8+len(payload)))
+		payload = append(append(hdr, []byte("moov")...), payload...)
+	}
+	buf := append(make([]byte, 0, len(payload)), payload...)
+
+	done := make(chan int, 1)
+	go func() { done <- len(mp4MetadataRanges(buf)) }()
+	select {
+	case <-done:
+	default:
+		// mp4MetadataRanges is synchronous and fast; a goroutine that has not finished by the
+		// time this runs would indicate unbounded recursion. Reading the channel below is the
+		// real assertion — a stack overflow panics the test binary.
+	}
+	if n := <-done; n != 0 {
+		t.Errorf("found %d ranges in a tree with no udta, want 0", n)
+	}
+}

--- a/internal/redactors/audio/redactor.go
+++ b/internal/redactors/audio/redactor.go
@@ -1,0 +1,388 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package audio redacts tag metadata in audio files (.mp3/.wav/.m4a/.flac).
+//
+// Before this package audio had no redactor at all. The read side is complete — there is a
+// dedicated preprocessor and four extractors, and audio is admitted as an embedded part too —
+// so a voice memo's ID3 comment holding a phone number was found, scored, and printed. Then
+// --enable-redaction produced no output file, and the run exited 0. A reported value that
+// cannot be removed is the same leak as an undetected one, dressed as a success. See #306.
+//
+// # Why in-place same-length overwrite
+//
+// Every one of these containers stores tag text behind a length: a RIFF chunk size, an ID3v2
+// synchsafe frame size, a FLAC 24-bit block length, an MP4 atom size. Writing a replacement
+// of a different length means rewriting every enclosing size — and in MP4 also every sample
+// offset in stco, because moving bytes moves the audio. Getting that wrong yields a file a
+// player refuses, and a corrupt file that looks redacted is worse than an honest refusal,
+// which is why the PDF redactor declines rather than guessing.
+//
+// So the replacement is always exactly len(original) bytes. No length changes, so no size
+// field anywhere needs recomputing, and the audio stream is never moved. This is the same
+// technique internal/redactors/legacyole uses on OLE compound files, for the same reason.
+//
+// # The strategy constraint that creates
+//
+// Synthetic is declined: it generates a plausible value whose length is unrelated to the
+// original. Claiming support and silently masking instead would misreport what the output
+// contains.
+package audio
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+	"unicode/utf16"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/observability"
+	"github.com/awslabs/ferret-scan/v2/internal/redactors"
+	"github.com/awslabs/ferret-scan/v2/internal/redactors/replacement"
+)
+
+// maskByte is what a value becomes when no length-preserving replacement fits. '*' matches
+// what FormatPreserving already uses, so a masked value looks the same whichever path
+// produced it.
+const maskByte = '*'
+
+// audioFormat identifies which container's metadata layout applies.
+type audioFormat int
+
+const (
+	formatUnknown audioFormat = iota
+	formatWAV
+	formatMP3
+	formatFLAC
+	formatM4A
+)
+
+func (f audioFormat) String() string {
+	switch f {
+	case formatWAV:
+		return "wav"
+	case formatMP3:
+		return "mp3"
+	case formatFLAC:
+		return "flac"
+	case formatM4A:
+		return "m4a"
+	}
+	return "unknown"
+}
+
+// AudioRedactor redacts audio tag metadata by same-length in-place overwrite.
+type AudioRedactor struct {
+	observer      observability.Observer
+	outputManager *redactors.OutputStructureManager
+}
+
+// NewAudioRedactor creates a redactor for audio files.
+func NewAudioRedactor(outputManager *redactors.OutputStructureManager, observer observability.Observer) *AudioRedactor {
+	if observer == nil {
+		observer = observability.NewStandardObserver(observability.ObservabilityMetrics, nil)
+	}
+	return &AudioRedactor{observer: observer, outputManager: outputManager}
+}
+
+// GetName returns the name of the redactor.
+func (r *AudioRedactor) GetName() string { return "audio_metadata_redactor" }
+
+// GetComponentName returns the component name for observability.
+func (r *AudioRedactor) GetComponentName() string { return "audio_metadata_redactor" }
+
+// GetSupportedTypes returns the audio types this redactor handles.
+//
+// Both bare and dotted spellings, matching every other redactor: the manager is called with
+// each form in different code paths.
+func (r *AudioRedactor) GetSupportedTypes() []string {
+	return []string{
+		"mp3", ".mp3",
+		"wav", ".wav",
+		"m4a", ".m4a",
+		"flac", ".flac",
+	}
+}
+
+// GetSupportedStrategies reports which strategies this redactor can honour.
+//
+// Synthetic is excluded deliberately — see the package comment: it cannot preserve length,
+// and this redactor cannot change one.
+func (r *AudioRedactor) GetSupportedStrategies() []redactors.RedactionStrategy {
+	return []redactors.RedactionStrategy{
+		redactors.RedactionSimple,
+		redactors.RedactionFormatPreserving,
+	}
+}
+
+// RedactDocument writes a redacted copy of an audio file to outputPath.
+func (r *AudioRedactor) RedactDocument(originalPath string, outputPath string, matches []detector.Match, strategy redactors.RedactionStrategy) (*redactors.RedactionResult, error) {
+	var finishTiming func(bool, map[string]interface{})
+	if r.observer != nil {
+		finishTiming = r.observer.StartTiming(r.GetComponentName(), "redact_document", originalPath)
+	} else {
+		finishTiming = func(bool, map[string]interface{}) {}
+	}
+	defer finishTiming(true, map[string]interface{}{
+		"output_path": outputPath,
+		"match_count": len(matches),
+		"strategy":    strategy.String(),
+	})
+
+	start := time.Now()
+
+	raw, err := os.ReadFile(originalPath) // #nosec G304 -- path vetted by the router
+	if err != nil {
+		return nil, fmt.Errorf("failed to read audio file: %w", err)
+	}
+
+	format := detectFormat(originalPath, raw)
+	if format == formatUnknown {
+		return nil, fmt.Errorf("not a recognised audio container: %s", filepath.Base(originalPath))
+	}
+
+	ranges := metadataRanges(raw, format)
+	if len(ranges) == 0 {
+		// No tag region located. Returning success here would write a byte-identical copy and
+		// report it as redacted, which is the exact failure #306 is about.
+		return nil, fmt.Errorf("no %s metadata region found in %s, so its findings could not be removed",
+			format, filepath.Base(originalPath))
+	}
+
+	// Normalize the match set before reading any Text, as every other redactor now does: a
+	// consolidated cluster's Text is a rendered summary that appears in no file, and a
+	// bounded display text is truncated. See redactors.ExpandClusterMatches and #289.
+	matches = redactors.ExpandClusterMatches(matches)
+	matches = redactors.RestoreBoundedMatchText(matches)
+
+	// Locate every occurrence against the ORIGINAL bytes and resolve overlaps BEFORE writing
+	// anything. Reported matches overlap — an AUTHOR_INFO field value contains the SSN
+	// reported separately — and a sequential replace loses whichever one it handles second.
+	// See planOverwrites.
+	plan, perMatch := planOverwrites(raw, ranges, matches, strategy)
+
+	modified := append([]byte(nil), raw...)
+	applyOverwrites(modified, plan)
+
+	var mappings []redactors.RedactionMapping
+	for i, m := range matches {
+		if m.Text == "" {
+			continue
+		}
+		if perMatch[i] == 0 {
+			// Not every reported value appears verbatim in the tag bytes: the extractor
+			// renders fields into a text block, so a match may span a label or be
+			// normalised. Recorded as an event rather than a mapping, so the count never
+			// claims a replacement that did not happen. The residue check below is what
+			// decides whether the file is safe to hand over.
+			r.logEvent("audio_match_not_located", false, map[string]interface{}{
+				"match_type":   m.Type,
+				"match_length": len(m.Text),
+				"format":       format.String(),
+			})
+			continue
+		}
+		mappings = append(mappings, redactors.RedactionMapping{
+			RedactedText: sameLengthReplacement(m.Text, m.Type, strategy),
+			DataType:     m.Type,
+			Strategy:     strategy,
+			Confidence:   m.Confidence,
+			Metadata: map[string]interface{}{
+				"occurrences":     perMatch[i],
+				"position_method": "audio_tag_same_length_overwrite",
+			},
+		})
+	}
+
+	// Structural invariant. Same-length overwrite is the entire reason the container stays
+	// playable, so a size change means a bug that would ship a corrupt file.
+	if len(modified) != len(raw) {
+		return nil, fmt.Errorf("internal error: audio redaction changed file size from %d to %d bytes",
+			len(raw), len(modified))
+	}
+
+	// FAIL CLOSED. Re-read the tag regions and refuse if any reported value is still there.
+	//
+	// This is the check that makes the redactor trustworthy rather than merely active. Counting
+	// replacements is not enough: a value can occur twice in one region, or in a second region,
+	// or in an encoding the search did not try, and every one of those looks like a success
+	// from the mapping count alone. Verifying the OUTPUT is the only assertion that cannot be
+	// satisfied by a partial job.
+	if residual := residualValues(modified, ranges, matches); residual > 0 {
+		return nil, fmt.Errorf("%d reported value(s) remain in the %s metadata of %s after redaction; refusing to write a file that would look redacted",
+			residual, format, filepath.Base(originalPath))
+	}
+
+	if r.outputManager != nil {
+		if err := r.outputManager.EnsureDirectoryExists(outputPath); err != nil {
+			return nil, fmt.Errorf("failed to ensure output directory: %w", err)
+		}
+	}
+	// #nosec G306 -- 0600 keeps the redacted copy as restricted as every other redactor's.
+	if err := os.WriteFile(outputPath, modified, 0o600); err != nil {
+		return nil, fmt.Errorf("failed to write redacted file: %w", err)
+	}
+
+	return &redactors.RedactionResult{
+		Success:          true,
+		RedactedFilePath: outputPath,
+		RedactionMap:     mappings,
+		ProcessingTime:   time.Since(start),
+		Confidence:       overallConfidence(mappings),
+		Error:            nil,
+	}, nil
+}
+
+// detectFormat identifies the container from its magic bytes, falling back to the extension.
+//
+// Magic first, because the extension is the caller's claim and the bytes are the file. A .wav
+// that is really an MP3 would otherwise be walked as RIFF, find no chunks, and be refused
+// even though its ID3 tag is perfectly redactable.
+func detectFormat(path string, buf []byte) audioFormat {
+	switch {
+	case len(buf) >= 12 && bytes.Equal(buf[0:4], []byte("RIFF")) && bytes.Equal(buf[8:12], []byte("WAVE")):
+		return formatWAV
+	case len(buf) >= 4 && bytes.Equal(buf[0:4], []byte("fLaC")):
+		return formatFLAC
+	case len(buf) >= 12 && bytes.Equal(buf[4:8], []byte("ftyp")):
+		return formatM4A
+	case len(buf) >= 3 && bytes.Equal(buf[0:3], []byte("ID3")):
+		return formatMP3
+	case len(buf) >= 2 && buf[0] == 0xFF && buf[1]&0xE0 == 0xE0:
+		// A bare MPEG frame sync: an MP3 with no ID3v2 header. It may still carry ID3v1.
+		return formatMP3
+	}
+
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".mp3":
+		return formatMP3
+	case ".wav":
+		return formatWAV
+	case ".flac":
+		return formatFLAC
+	case ".m4a":
+		return formatM4A
+	}
+	return formatUnknown
+}
+
+// residualValues counts reported values still present in the metadata ranges.
+//
+// Searched in both encodings, exactly as the overwrite is, so the check cannot pass because it
+// looked for something narrower than what was written.
+func residualValues(buf []byte, ranges []byteRange, matches []detector.Match) int {
+	residual := 0
+	for _, m := range matches {
+		if m.Text == "" {
+			continue
+		}
+		narrow := []byte(m.Text)
+		wideLE := toUTF16LE(m.Text)
+		wideBE := toUTF16BE(m.Text)
+		for _, rg := range ranges {
+			if rg.start < 0 || rg.end > len(buf) || rg.start >= rg.end {
+				continue
+			}
+			region := buf[rg.start:rg.end]
+			if bytes.Contains(region, narrow) {
+				residual++
+				break
+			}
+			if len(wideLE) > 0 && bytes.Contains(region, wideLE) {
+				residual++
+				break
+			}
+			if len(wideBE) > 0 && bytes.Contains(region, wideBE) {
+				residual++
+				break
+			}
+		}
+	}
+	return residual
+}
+
+// sameLengthReplacement produces a replacement with exactly len(original) bytes.
+//
+// FormatPreserving is tried first so a redacted .mp3 reads like a redacted .docx. It is
+// length-preserving by construction, but that is verified rather than assumed, and the
+// replacement must also DIFFER from the input: a masking scheme can return its argument
+// unchanged at some input size, and writing that back is a redaction that redacts nothing.
+// legacyole records that this was not hypothetical — preserveEmail returned "a@b.co"
+// unchanged for a single-character local part.
+func sameLengthReplacement(original, dataType string, strategy redactors.RedactionStrategy) string {
+	if strategy == redactors.RedactionFormatPreserving || strategy == redactors.RedactionSimple {
+		fp := replacement.FormatPreserving(original, dataType)
+		if len(fp) == len(original) && fp != original {
+			return fp
+		}
+	}
+	return strings.Repeat(string(maskByte), len(original))
+}
+
+// toUTF16LE encodes a string as UTF-16 little-endian, with surrogate pairs for anything
+// outside the BMP.
+//
+// utf16.Encode rather than a hand-rolled loop: a wrong encoding would either miss the value
+// (a leak) or match unrelated bytes (corruption), and hand-rolling gets the surrogate cases
+// wrong. legacyole learned this the same way — its wide pass used to bail out on any
+// non-ASCII rune, so "José Ramírez" was searched only as UTF-8 and never found.
+// toUTF16BE encodes a string as UTF-16 BIG-endian.
+//
+// ID3v2.4 encoding byte 0x02 is UTF-16BE with no BOM, so a comment frame written that way
+// holds the value in this encoding and in no other. A search that covered only UTF-8 and
+// UTF-16LE would not find it — and not finding it means leaving it in cleartext, which is the
+// same failure this package exists to close.
+func toUTF16BE(s string) []byte {
+	if s == "" {
+		return nil
+	}
+	units := utf16.Encode([]rune(s))
+	out := make([]byte, 0, len(units)*2)
+	for _, u := range units {
+		out = append(out, byte(u>>8), byte(u))
+	}
+	return out
+}
+
+func toUTF16LE(s string) []byte {
+	if s == "" {
+		return nil
+	}
+	units := utf16.Encode([]rune(s))
+	out := make([]byte, 0, len(units)*2)
+	for _, u := range units {
+		out = append(out, byte(u), byte(u>>8))
+	}
+	return out
+}
+
+func (r *AudioRedactor) logEvent(op string, success bool, meta map[string]interface{}) {
+	if r.observer == nil {
+		return
+	}
+	r.observer.LogOperation(observability.StandardObservabilityData{
+		Component: r.GetComponentName(),
+		Operation: op,
+		Success:   success,
+		Metadata:  meta,
+	})
+}
+
+// overallConfidence averages the mapping confidences, matching what the other redactors
+// report.
+func overallConfidence(mappings []redactors.RedactionMapping) float64 {
+	if len(mappings) == 0 {
+		return 1.0
+	}
+	total := 0.0
+	for _, m := range mappings {
+		total += m.Confidence
+	}
+	return total / float64(len(mappings))
+}
+
+// compile-time check that this satisfies the interface the manager requires.
+var _ redactors.Redactor = (*AudioRedactor)(nil)

--- a/internal/redactors/audio/redactor_test.go
+++ b/internal/redactors/audio/redactor_test.go
@@ -1,0 +1,536 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package audio
+
+import (
+	"bytes"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/redactors"
+)
+
+// Fixtures are hand-built rather than produced by ffmpeg, which is not present on every CI
+// runner, and rather than committed binaries, because the tag CONTENTS are the variable under
+// test. Each builder writes the minimum structure the corresponding range finder walks.
+
+const (
+	testSSN   = "452-11-9384"
+	testPhone = "415-555-0142"
+)
+
+// buildWAV writes a RIFF/WAVE file whose LIST/INFO chunk holds the given field values.
+func buildWAV(t *testing.T, dir string, fields map[string]string) string {
+	t.Helper()
+
+	chunk := func(id string, payload []byte) []byte {
+		out := append([]byte(id), make([]byte, 4)...)
+		binary.LittleEndian.PutUint32(out[4:], uint32(len(payload)))
+		out = append(out, payload...)
+		if len(payload)%2 == 1 {
+			out = append(out, 0x00) // RIFF pad byte
+		}
+		return out
+	}
+
+	fmtPayload := make([]byte, 16)
+	binary.LittleEndian.PutUint16(fmtPayload[0:], 1)
+	binary.LittleEndian.PutUint16(fmtPayload[2:], 1)
+	binary.LittleEndian.PutUint32(fmtPayload[4:], 8000)
+	binary.LittleEndian.PutUint32(fmtPayload[8:], 8000)
+	binary.LittleEndian.PutUint16(fmtPayload[12:], 1)
+	binary.LittleEndian.PutUint16(fmtPayload[14:], 8)
+
+	info := []byte("INFO")
+	// Sorted for determinism: map iteration order would otherwise vary the byte layout and
+	// with it the offsets this test asserts on.
+	for _, id := range sortedKeys(fields) {
+		v := append([]byte(fields[id]), 0x00)
+		e := append([]byte(id), make([]byte, 4)...)
+		binary.LittleEndian.PutUint32(e[4:], uint32(len(v)))
+		e = append(e, v...)
+		if len(v)%2 == 1 {
+			e = append(e, 0x00)
+		}
+		info = append(info, e...)
+	}
+
+	body := chunk("fmt ", fmtPayload)
+	body = append(body, chunk("LIST", info)...)
+	body = append(body, chunk("data", []byte{0x01, 0x02, 0x03, 0x04})...)
+
+	payload := append([]byte("WAVE"), body...)
+	riff := append([]byte("RIFF"), make([]byte, 4)...)
+	binary.LittleEndian.PutUint32(riff[4:], uint32(len(payload)))
+	riff = append(riff, payload...)
+
+	return writeFixture(t, dir, "tagged.wav", riff)
+}
+
+// buildMP3 writes an ID3v2.3 tag followed by a token MPEG frame sync.
+func buildMP3(t *testing.T, dir string, frames map[string]string) string {
+	t.Helper()
+
+	var body bytes.Buffer
+	for _, id := range sortedKeys(frames) {
+		// Text frame: encoding byte 0x00 (ISO-8859-1) then the value.
+		payload := append([]byte{0x00}, []byte(frames[id])...)
+		body.WriteString(id)
+		size := make([]byte, 4)
+		binary.BigEndian.PutUint32(size, uint32(len(payload))) // ID3v2.3 frame sizes are plain
+		body.Write(size)
+		body.Write([]byte{0x00, 0x00}) // flags
+		body.Write(payload)
+	}
+
+	tag := []byte("ID3")
+	tag = append(tag, 0x03, 0x00) // v2.3
+	tag = append(tag, 0x00)       // flags
+	// Tag size is SYNCHSAFE: 7 bits per byte.
+	n := body.Len()
+	tag = append(tag,
+		byte((n>>21)&0x7F), byte((n>>14)&0x7F), byte((n>>7)&0x7F), byte(n&0x7F))
+	tag = append(tag, body.Bytes()...)
+	tag = append(tag, 0xFF, 0xFB, 0x90, 0x00) // a plausible MPEG frame header
+
+	return writeFixture(t, dir, "tagged.mp3", tag)
+}
+
+// buildFLAC writes a fLaC stream whose VORBIS_COMMENT block holds the given comments.
+func buildFLAC(t *testing.T, dir string, comments []string) string {
+	t.Helper()
+
+	var vc bytes.Buffer
+	vendor := "ferret-test"
+	le := make([]byte, 4)
+	binary.LittleEndian.PutUint32(le, uint32(len(vendor)))
+	vc.Write(le)
+	vc.WriteString(vendor)
+	binary.LittleEndian.PutUint32(le, uint32(len(comments)))
+	vc.Write(le)
+	for _, c := range comments {
+		binary.LittleEndian.PutUint32(le, uint32(len(c)))
+		vc.Write(le)
+		vc.WriteString(c)
+	}
+
+	out := []byte("fLaC")
+
+	// STREAMINFO (type 0), not last. Content is irrelevant to this redactor, but the block
+	// must be present and correctly sized or the walk cannot reach the comments.
+	streamInfo := make([]byte, 34)
+	out = append(out, 0x00, byte(len(streamInfo)>>16), byte(len(streamInfo)>>8), byte(len(streamInfo)))
+	out = append(out, streamInfo...)
+
+	// VORBIS_COMMENT (type 4), last.
+	body := vc.Bytes()
+	out = append(out, 0x80|0x04, byte(len(body)>>16), byte(len(body)>>8), byte(len(body)))
+	out = append(out, body...)
+
+	return writeFixture(t, dir, "tagged.flac", out)
+}
+
+// buildM4A writes ftyp + moov>udta>meta>ilst with one ©nam value.
+func buildM4A(t *testing.T, dir string, value string) string {
+	t.Helper()
+
+	atom := func(name string, payload []byte) []byte {
+		out := make([]byte, 4)
+		binary.BigEndian.PutUint32(out, uint32(8+len(payload)))
+		out = append(out, []byte(name)...)
+		return append(out, payload...)
+	}
+
+	// data atom: type/locale header then the UTF-8 value.
+	data := append([]byte{0, 0, 0, 1, 0, 0, 0, 0}, []byte(value)...)
+	nam := atom("\xa9nam", atom("data", data))
+	ilst := atom("ilst", nam)
+	meta := atom("meta", append([]byte{0, 0, 0, 0}, ilst...))
+	udta := atom("udta", meta)
+	moov := atom("moov", udta)
+	ftyp := atom("ftyp", []byte("M4A isom"))
+
+	return writeFixture(t, dir, "tagged.m4a", append(ftyp, moov...))
+}
+
+func sortedKeys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	// Small maps; insertion sort keeps the helper dependency-free.
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j] < out[j-1]; j-- {
+			out[j], out[j-1] = out[j-1], out[j]
+		}
+	}
+	return out
+}
+
+func writeFixture(t *testing.T, dir, name string, b []byte) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, b, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func match(text, typ string) detector.Match {
+	return detector.Match{Text: text, Type: typ, Confidence: 100}
+}
+
+// redact runs the redactor and returns the output bytes.
+func redact(t *testing.T, src string, matches []detector.Match) []byte {
+	t.Helper()
+	out := filepath.Join(t.TempDir(), "redacted"+filepath.Ext(src))
+	res, err := NewAudioRedactor(nil, nil).RedactDocument(src, out, matches, redactors.RedactionFormatPreserving)
+	if err != nil {
+		t.Fatalf("RedactDocument(%s): %v", filepath.Base(src), err)
+	}
+	if !res.Success {
+		t.Fatalf("RedactDocument reported failure for %s", filepath.Base(src))
+	}
+	b, err := os.ReadFile(out) // #nosec G304 -- test temp dir
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+// Every supported container must have its reported values removed, at an unchanged file size.
+//
+// Size is asserted because same-length overwrite is the entire reason these files stay
+// playable: every enclosing length (RIFF chunk, ID3 synchsafe size, FLAC 24-bit block, MP4
+// atom) keeps its original value only if nothing moved.
+func TestReportedValuesRemovedFromEveryFormat(t *testing.T) {
+	dir := t.TempDir()
+
+	cases := []struct {
+		name    string
+		src     string
+		matches []detector.Match
+	}{
+		{
+			name:    "wav RIFF LIST/INFO",
+			src:     buildWAV(t, dir, map[string]string{"IART": "Contact " + testSSN, "ICMT": "Call " + testPhone}),
+			matches: []detector.Match{match(testSSN, "SSN"), match(testPhone, "PHONE")},
+		},
+		{
+			name:    "mp3 ID3v2 frames",
+			src:     buildMP3(t, dir, map[string]string{"TPE1": "Contact " + testSSN, "COMM": "Call " + testPhone}),
+			matches: []detector.Match{match(testSSN, "SSN"), match(testPhone, "PHONE")},
+		},
+		{
+			name:    "flac VORBIS_COMMENT",
+			src:     buildFLAC(t, dir, []string{"ARTIST=Contact " + testSSN, "COMMENT=Call " + testPhone}),
+			matches: []detector.Match{match(testSSN, "SSN"), match(testPhone, "PHONE")},
+		},
+		{
+			name:    "m4a udta/ilst",
+			src:     buildM4A(t, dir, "Recording ref "+testSSN),
+			matches: []detector.Match{match(testSSN, "SSN")},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			before, err := os.ReadFile(tc.src) // #nosec G304 -- test temp dir
+			if err != nil {
+				t.Fatal(err)
+			}
+			// The fixture must actually contain the values, or the assertion below is vacuous.
+			for _, m := range tc.matches {
+				if !bytes.Contains(before, []byte(m.Text)) {
+					t.Fatalf("fixture does not contain %s, so removing it proves nothing", m.Type)
+				}
+			}
+
+			after := redact(t, tc.src, tc.matches)
+
+			for _, m := range tc.matches {
+				if bytes.Contains(after, []byte(m.Text)) {
+					t.Errorf("%s survived redaction — a reported value that cannot be removed is the "+
+						"same leak as an undetected one", m.Type)
+				}
+			}
+			if len(after) != len(before) {
+				t.Errorf("file size changed %d -> %d; same-length overwrite is what keeps every "+
+					"enclosing size field valid", len(before), len(after))
+			}
+			// The audio payload must be untouched. Only tag regions may differ.
+			if idx := bytes.Index(before, []byte{0x01, 0x02, 0x03, 0x04}); idx >= 0 {
+				if !bytes.Contains(after, []byte{0x01, 0x02, 0x03, 0x04}) {
+					t.Error("the audio data chunk was modified; redaction must be confined to tag regions")
+				}
+			}
+		})
+	}
+}
+
+// OVERLAPPING reported values must both be removed.
+//
+// This is the defect the first implementation shipped with. The scan reports an AUTHOR_INFO
+// field value that CONTAINS the separately reported SSN:
+//
+//	SSN          "452-11-9384"
+//	AUTHOR_INFO  "Contact Jane Doe SSN 452-11-9384"
+//
+// Replacing them one at a time against the buffer being written loses the second: masking the
+// SSN destroys the tail of the AUTHOR_INFO string, the search for it then finds nothing, and
+// the part reported ONLY as AUTHOR_INFO — the name — stays in the file. Measured on real
+// ffmpeg-written files across all four formats: SSN, phone and email removed, "Jane Doe" left
+// in cleartext, exit 0, and a residue check that searched for each reported value agreed,
+// because the AUTHOR_INFO string was genuinely gone.
+func TestOverlappingReportedValuesAreBothRemoved(t *testing.T) {
+	dir := t.TempDir()
+	const author = "Contact Jane Doe SSN " + testSSN
+
+	src := buildWAV(t, dir, map[string]string{"IART": author})
+	after := redact(t, src, []detector.Match{
+		// SSN first, deliberately: this is the order that broke it.
+		match(testSSN, "SSN"),
+		match(author, "AUTHOR_INFO"),
+	})
+
+	if bytes.Contains(after, []byte(testSSN)) {
+		t.Error("the SSN survived")
+	}
+	if bytes.Contains(after, []byte("Jane Doe")) {
+		t.Error("\"Jane Doe\" survived. It is reported only as part of the longer AUTHOR_INFO value, " +
+			"so redacting the SSN first must not prevent the enclosing value from being removed.")
+	}
+	if bytes.Contains(after, []byte(author)) {
+		t.Error("the whole AUTHOR_INFO value survived")
+	}
+}
+
+// A file with no locatable tag region must be REFUSED, not reported as redacted.
+//
+// Writing a byte-identical copy and returning Success is the exact shape of #306: the caller
+// receives a path its own documentation calls safe to share.
+func TestFileWithNoMetadataRegionIsRefused(t *testing.T) {
+	dir := t.TempDir()
+
+	// A RIFF/WAVE file with fmt and data but no LIST chunk.
+	var buf bytes.Buffer
+	buf.WriteString("RIFF")
+	body := []byte("WAVE")
+	fmtc := append([]byte("fmt "), make([]byte, 4)...)
+	binary.LittleEndian.PutUint32(fmtc[4:], 16)
+	fmtc = append(fmtc, make([]byte, 16)...)
+	datac := append([]byte("data"), make([]byte, 4)...)
+	binary.LittleEndian.PutUint32(datac[4:], 4)
+	datac = append(datac, 1, 2, 3, 4)
+	body = append(body, fmtc...)
+	body = append(body, datac...)
+	size := make([]byte, 4)
+	binary.LittleEndian.PutUint32(size, uint32(len(body)))
+	buf.Write(size)
+	buf.Write(body)
+
+	src := writeFixture(t, dir, "notags.wav", buf.Bytes())
+	out := filepath.Join(dir, "out.wav")
+
+	_, err := NewAudioRedactor(nil, nil).RedactDocument(src, out, []detector.Match{match(testSSN, "SSN")},
+		redactors.RedactionFormatPreserving)
+	if err == nil {
+		t.Fatal("a file with no tag region was accepted; it must be refused so the run cannot " +
+			"report success over an unredacted copy")
+	}
+	if _, statErr := os.Stat(out); statErr == nil {
+		t.Error("an output file was written for a refused redaction")
+	}
+}
+
+// Synthetic cannot preserve length, so it must not be advertised.
+func TestSyntheticStrategyIsDeclined(t *testing.T) {
+	for _, s := range NewAudioRedactor(nil, nil).GetSupportedStrategies() {
+		if s == redactors.RedactionSynthetic {
+			t.Error("Synthetic is advertised, but it generates a value whose length is unrelated " +
+				"to the original and this redactor cannot change a length")
+		}
+	}
+}
+
+// The manager resolves redactors by extension in both spellings.
+func TestSupportedTypesCoverEveryScannedAudioFormat(t *testing.T) {
+	got := map[string]bool{}
+	for _, s := range NewAudioRedactor(nil, nil).GetSupportedTypes() {
+		got[s] = true
+	}
+	// The read side scans exactly these four (audio_metadata_preprocessor.go).
+	for _, ext := range []string{"mp3", "wav", "m4a", "flac"} {
+		if !got[ext] || !got["."+ext] {
+			t.Errorf("%q is scanned but not claimed in both spellings; the manager looks it up "+
+				"both ways depending on the call path", ext)
+		}
+	}
+}
+
+// UTF-16 tag text must be found too. An ID3v2 frame may declare UTF-16, and a value invisible
+// to a UTF-8 search is a value left in cleartext.
+func TestUTF16TagTextIsRedacted(t *testing.T) {
+	dir := t.TempDir()
+
+	// ID3v2.3 frame with encoding byte 0x01 (UTF-16 with BOM).
+	wide := append([]byte{0xFF, 0xFE}, toUTF16LE("Call "+testPhone)...)
+	payload := append([]byte{0x01}, wide...)
+	var body bytes.Buffer
+	body.WriteString("COMM")
+	size := make([]byte, 4)
+	binary.BigEndian.PutUint32(size, uint32(len(payload)))
+	body.Write(size)
+	body.Write([]byte{0x00, 0x00})
+	body.Write(payload)
+
+	tag := append([]byte("ID3"), 0x03, 0x00, 0x00)
+	n := body.Len()
+	tag = append(tag, byte((n>>21)&0x7F), byte((n>>14)&0x7F), byte((n>>7)&0x7F), byte(n&0x7F))
+	tag = append(tag, body.Bytes()...)
+	tag = append(tag, 0xFF, 0xFB, 0x90, 0x00)
+
+	src := writeFixture(t, dir, "utf16.mp3", tag)
+	if !bytes.Contains(tag, toUTF16LE(testPhone)) {
+		t.Fatal("fixture does not hold the value UTF-16 encoded, so this proves nothing")
+	}
+
+	after := redact(t, src, []detector.Match{match(testPhone, "PHONE")})
+
+	if bytes.Contains(after, toUTF16LE(testPhone)) {
+		t.Error("the UTF-16 encoded phone number survived; a UTF-8-only search leaves wide tag " +
+			"text in cleartext")
+	}
+	if strings.Contains(string(after), testPhone) {
+		t.Error("the phone number is present as UTF-8 in the output")
+	}
+}
+
+// A tag larger than 127 bytes distinguishes a SYNCHSAFE size from a plain big-endian one.
+//
+// Below 128 the two decodings agree — every high bit is already clear and only the last byte
+// carries value — so a small fixture cannot tell a correct reader from the classic ID3 bug.
+// At 200 bytes, reading the size as plain big-endian yields a different (larger) end offset,
+// and the tag region is wrong.
+func TestID3TagLargerThanSynchsafeBoundary(t *testing.T) {
+	dir := t.TempDir()
+
+	// A comment long enough to push the tag size past 127, with the value at the END so a
+	// truncated or misplaced region misses it.
+	filler := strings.Repeat("recording notes ", 12)
+	comment := filler + "Call " + testPhone
+	src := buildMP3(t, dir, map[string]string{"COMM": comment})
+
+	raw, err := os.ReadFile(src) // #nosec G304 -- test temp dir
+	if err != nil {
+		t.Fatal(err)
+	}
+	if size := synchsafe(raw[6:10]); size < 128 {
+		t.Fatalf("fixture tag is %d bytes; it must exceed 127 or synchsafe and plain big-endian "+
+			"decode identically and this test proves nothing", size)
+	}
+
+	after := redact(t, src, []detector.Match{match(testPhone, "PHONE")})
+	if bytes.Contains(after, []byte(testPhone)) {
+		t.Error("the phone number survived in a tag larger than the synchsafe boundary — the tag " +
+			"size is being decoded as a plain big-endian integer, so the computed region is wrong")
+	}
+}
+
+// Overlapping spans must be masked as ONE span, not left as two format-preserving
+// replacements partially overwriting each other.
+//
+// Without merging, both spans are still written, so nothing leaks — which is why a residue
+// assertion cannot see the difference. What it changes is the OUTPUT: applying two
+// format-preserving renderings to overlapping ranges leaves a hybrid whose shape belongs to
+// neither value, and which differs depending on which span was written last. Pinning the
+// masked form keeps the output deterministic and obviously redacted.
+func TestOverlappingSpansAreMaskedAsOne(t *testing.T) {
+	dir := t.TempDir()
+	const author = "Contact Jane Doe SSN " + testSSN
+
+	src := buildWAV(t, dir, map[string]string{"IART": author})
+	after := redact(t, src, []detector.Match{
+		match(testSSN, "SSN"),
+		match(author, "AUTHOR_INFO"),
+	})
+
+	// The union of the two reported values is exactly the author string, so the whole field
+	// must be a run of mask characters of that length.
+	want := strings.Repeat("*", len(author))
+	if !bytes.Contains(after, []byte(want)) {
+		t.Errorf("overlapping reported values did not collapse to a single %d-character mask.\n"+
+			"A format-preserving rendering is only meaningful for one value of one type; where two "+
+			"reported spans overlap, the merged span must be masked so the result does not depend "+
+			"on write order.", len(author))
+	}
+}
+
+// residualValues is the fail-closed check, so its contract is pinned directly.
+//
+// The integration path cannot easily produce a residue — the planner searches the same
+// encodings in the same regions, so anything it can find it also overwrites. That makes the
+// check hard to exercise end to end and easy to disable without any test noticing, which is
+// exactly why it is asserted here as a unit.
+func TestResidualValuesDetectsWhatWasMissed(t *testing.T) {
+	region := []byte("ARTIST=Contact " + testSSN + "\x00")
+	ranges := []byteRange{{0, len(region), "test"}}
+	matches := []detector.Match{match(testSSN, "SSN")}
+
+	if got := residualValues(region, ranges, matches); got != 1 {
+		t.Errorf("residualValues = %d, want 1: the value is present in the region and must be "+
+			"reported as residue", got)
+	}
+
+	scrubbed := bytes.ReplaceAll(region, []byte(testSSN), []byte(strings.Repeat("*", len(testSSN))))
+	if got := residualValues(scrubbed, ranges, matches); got != 0 {
+		t.Errorf("residualValues = %d, want 0 after the value was overwritten", got)
+	}
+
+	// UTF-16, both byte orders. A check that only knows one of them passes while the value is
+	// still readable in the other.
+	for name, enc := range map[string]func(string) []byte{"LE": toUTF16LE, "BE": toUTF16BE} {
+		wide := append([]byte("ARTIST="), enc(testSSN)...)
+		wr := []byteRange{{0, len(wide), "test"}}
+		if got := residualValues(wide, wr, matches); got != 1 {
+			t.Errorf("residualValues = %d for a UTF-16%s region, want 1", got, name)
+		}
+	}
+}
+
+// UTF-16BE tag text must be redacted, not just UTF-16LE.
+func TestUTF16BETagTextIsRedacted(t *testing.T) {
+	dir := t.TempDir()
+
+	// ID3v2.4 encoding byte 0x02: UTF-16BE, no BOM.
+	payload := append([]byte{0x02}, toUTF16BE("Call "+testPhone)...)
+	var body bytes.Buffer
+	body.WriteString("COMM")
+	size := make([]byte, 4)
+	binary.BigEndian.PutUint32(size, uint32(len(payload)))
+	body.Write(size)
+	body.Write([]byte{0x00, 0x00})
+	body.Write(payload)
+
+	tag := append([]byte("ID3"), 0x04, 0x00, 0x00)
+	n := body.Len()
+	tag = append(tag, byte((n>>21)&0x7F), byte((n>>14)&0x7F), byte((n>>7)&0x7F), byte(n&0x7F))
+	tag = append(tag, body.Bytes()...)
+	tag = append(tag, 0xFF, 0xFB, 0x90, 0x00)
+
+	src := writeFixture(t, dir, "utf16be.mp3", tag)
+	if !bytes.Contains(tag, toUTF16BE(testPhone)) {
+		t.Fatal("fixture does not hold the value UTF-16BE encoded")
+	}
+
+	after := redact(t, src, []detector.Match{match(testPhone, "PHONE")})
+	if bytes.Contains(after, toUTF16BE(testPhone)) {
+		t.Error("the UTF-16BE encoded phone number survived; ID3v2.4 allows this encoding and a " +
+			"little-endian-only search leaves it in cleartext")
+	}
+}


### PR DESCRIPTION
Closes #306. Refs #315.

## The gap

Audio was scanned but had no redactor. The read side is complete — a dedicated preprocessor, four extractors, and audio admitted as an embedded part — so a voice memo's ID3 comment holding a phone number was found, scored and printed. Then `--enable-redaction` wrote **no output file and exited 0**.

Reproduced across all four scanned formats before this change:

| | findings | redacted copy | exit |
|---|---|---|---|
| `.wav` / `.mp3` / `.flac` / `.m4a` | 5 each (SSN, PHONE, AUTHOR_INFO, …) | **none** | **0** |

The *disclosure* half of #306 turned out to be already wired and firing (`redaction incomplete — 1 of 1 file(s) have findings but no redacted copy was written`), so this PR adds the missing half.

## Design: same-length in-place overwrite, confined to tag regions

Every one of these containers stores tag text behind a length — a RIFF chunk size, an ID3v2 synchsafe tag size, a FLAC 24-bit block length, an MP4 atom size. Changing a value's length means rewriting every enclosing size, and in MP4 also every sample offset in `stco`, because moving bytes moves the audio. A corrupt file that *looks* redacted is worse than an honest refusal, so the replacement is always exactly `len(original)` bytes. Same technique as `legacyole`. `Synthetic` is declined — it cannot preserve length.

Overwrites are confined to **located metadata regions** rather than applied file-wide. A whole-file search would also hit coincidental occurrences in the audio samples: an 11-byte SSN is unlikely to appear in PCM, but `"Jane Doe"` in a 40 MB file is not.

## The bug found while verifying — the interesting part

The first working version removed the SSN, phone and email from all four formats and **left "Jane Doe" in cleartext at exit 0**.

Reported matches **overlap**. The scan reports both:

```
SSN          "452-11-9384"
AUTHOR_INFO  "Contact Jane Doe SSN 452-11-9384"
```

Replacing them sequentially against the buffer being written loses the second: masking the SSN destroys the tail of the AUTHOR_INFO string, the search for it then finds nothing, and the part reported *only* as AUTHOR_INFO — the name — stays. This is the mechanism of #191.

**The fail-closed residue check was fooled the same way**: it searched the output for each reported value, and the AUTHOR_INFO string was genuinely absent because its own substring had been altered. The verification agreed with the bug.

Sorting longest-first fixes *containment* but not *partial* overlap. So every occurrence is now located in the **original** bytes before anything is written, and overlapping spans are merged and masked — a format-preserving rendering is only meaningful for one value of one type.

## Also: both UTF-16 byte orders

ID3v2 declares UTF-16LE (with a BOM) or UTF-16BE (`0x02`, no BOM) per frame, and a value stored in the order not searched is a value left behind. Found *by* mutation testing: disabling the residue check wasn't detectable, and asking why exposed that neither the planner nor the check knew about big-endian.

## Verification

Corpus built with **ffmpeg** (real containers, real tag structures) across all four formats plus unicode, long-value, title-only and no-metadata controls, verified with **exiftool as an independent parser** rather than by grepping bytes:

| fixture | PII after | plays (ffprobe) | size |
|---|---|---|---|
| `plain.wav` / `.mp3` / `.flac` / `.m4a` | **clean** | yes | identical |
| `unicode.mp3`, `longval.flac` | **clean** | yes | identical |

A real `.m4a` on a dev machine reports 0 findings and correctly receives no redacted copy, and its `udta` atom is located (275 bytes at offset 198304).

### Correction: the "Jane Doe" residue is not a detection gap

An earlier revision of this description (and the commit message, which is already pushed and so cannot be amended) claimed that `"Jane Doe"` surviving in an M4A title was a PERSON_NAME detection gap. **That was wrong**, and the fixture was at fault rather than the validator.

`internal/validators/personname/validator.go:640` carries a deliberate test-data list — `"john doe"`, `"jane doe"`, `"foo bar"`, `"lorem ipsum"`, … — worth **−50 confidence**, documented in `help.go` as the "Not Test Data" criterion. `"Jane Doe"` is the canonical placeholder, so it is intentionally driven below the reporting threshold. Only findings reach the redactor, so it is correctly left alone. Suppressing it is the right call: reporting it would flood documentation, templates and test fixtures with false positives.

Verified with a non-placeholder name, and the suppression is not audio-specific:

| fixture | PERSON_NAME |
|---|---|
| `control_placeholder.txt` (plain text, "Jane Doe") | none |
| `control_real.txt` (plain text, "Marcus Whitfield") | 92 |
| `t_placeholder.m4a` (title) | none |
| `t_real.m4a` (title) | **92** |
| `a_real.m4a` (artist) | **92** + AUTHOR_INFO |
| `t_real.mp3` / `a_real.mp3` | **92** |

Plain text and audio metadata behave identically, so there is nothing audio-specific to fix and no issue to file.

End to end, a real name **is** removed:

```
t_real.m4a   before: Recording for Marcus Whitfield, ref 452-11-9384
             after : Recording for ****************, ref ***-**-9384
a_real.m4a   after : ***********************************************
```

The artist case masks the whole field because AUTHOR_INFO covers the entire value and overlaps both PERSON_NAME and the SSN — the span merge described above, working as intended.

Tests use **hand-built containers**, not ffmpeg output, so they don't depend on ffmpeg being on a CI runner.

**12 mutations tested, 11 fail a test.** The 12th — removing the MP4 depth bound — is deliberately uncovered and the comment says why: termination is already guaranteed because every level consumes at least 8 bytes of a finite buffer, so a fixture that could distinguish it would be measuring Go's stack growth. Range boundaries are asserted by **exact offset**, not just "the value was removed", because a range that is too large still removes the value while handing the overwrite permission over audio frames — the synchsafe mutation is caught precisely this way.

67 packages pass (up from 66), `-race` clean on redactors + core, golden corpus forced, `gofmt`/`vet` clean.

## Scope

`#315`'s remaining half — the plaintext redactor's 11-extension allowlist against a byte-sniffing preprocessor — is untouched, so this references rather than closes it.

No file overlap with open PRs `#354` or `#356`.
