### PR TITLE
fix(redactors): redact any file whose bytes are text, not eleven extensions

### DIFF
--- a/internal/core/redact_test.go
+++ b/internal/core/redact_test.go
@@ -4,6 +4,7 @@
 package core
 
 import (
+	"encoding/binary"
 	"io"
 	"os"
 	"path/filepath"
@@ -92,8 +93,19 @@ func TestRedactFile_UnredactableFileTypeIsAnError(t *testing.T) {
 	in := t.TempDir()
 	out := t.TempDir()
 	// Reserved documentation values, in a file type with no redactor.
-	src := writeTemp(t, in, "creds.go",
-		"package main\n\nconst key = \"AKIAIOSFODNN7EXAMPLE\" // jordan@example.com\n")
+	//
+	// A VIDEO file, not a .go source file. Source files used to have no redactor, which made
+	// them a convenient stand-in here — but a .go file holding a hardcoded key is exactly a
+	// file that should be redacted, and text files of any extension now are (#315). Video is
+	// scanned (there is a video metadata preprocessor) and has no redactor, so it keeps
+	// exercising the guard this test exists for rather than becoming redactable under it.
+	//
+	// A video redactor IS now planned (#358). When it lands this fixture stops being
+	// unredactable and this test fails — loudly, which is the intended behaviour. The
+	// invariant is what matters, not the format: keep the assertion and re-fixture. If
+	// nothing scanned is left unredactable by then, a manager with a deliberately limited
+	// redactor set is the honest replacement.
+	src := writeUnredactableVideo(t, in, "creds.mp4")
 
 	res, err := RedactFile(RedactConfig{
 		FilePath:  src,
@@ -149,4 +161,32 @@ func TestRedactFile_DefaultsToFormatPreserving(t *testing.T) {
 	if res.Strategy != "format_preserving" {
 		t.Errorf("expected default strategy format_preserving, got %q", res.Strategy)
 	}
+}
+
+// writeUnredactableVideo writes a minimal MP4 whose udta/ilst metadata carries reserved
+// documentation values, for tests that need a file which IS scanned but has no redactor.
+//
+// Hand-built rather than produced by ffmpeg, which is not on every CI runner. 95 bytes is
+// enough: ftyp plus moov>udta>meta>ilst>©cmt is what the metadata extractor walks.
+func writeUnredactableVideo(t *testing.T, dir, name string) string {
+	t.Helper()
+
+	atom := func(kind string, payload []byte) []byte {
+		out := make([]byte, 4)
+		binary.BigEndian.PutUint32(out, uint32(8+len(payload)))
+		out = append(out, []byte(kind)...)
+		return append(out, payload...)
+	}
+
+	data := append([]byte{0, 0, 0, 1, 0, 0, 0, 0},
+		[]byte("key AKIAIOSFODNN7EXAMPLE contact jordan@example.com")...)
+	body := atom("moov", atom("udta", atom("meta",
+		append([]byte{0, 0, 0, 0}, atom("ilst", atom("\xa9cmt", atom("data", data)))...))))
+	out := append(atom("ftyp", []byte("isomiso2mp41")), body...)
+
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, out, 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return p
 }

--- a/internal/parallel/redaction_failure_test.go
+++ b/internal/parallel/redaction_failure_test.go
@@ -4,7 +4,9 @@
 package parallel
 
 import (
+	"encoding/binary"
 	"io"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -22,13 +24,25 @@ import (
 // The regression they guard is a silent one. Redaction failure used to be folded
 // into Result.Error, whose branch in the result collector neither appends
 // matches nor increments processedCount — so scanning a directory with
-// --enable-redaction dropped every finding in every file whose extension has no
-// registered redactor (.go, .py, ...) while still reporting "0 skipped" and
-// exiting 0. A CI gate saw a clean pass over unredacted cleartext.
+// --enable-redaction dropped every finding in every file with no registered
+// redactor, while still reporting "0 skipped" and exiting 0. A CI gate saw a
+// clean pass over unredacted cleartext.
+//
+// The unredactable fixture is a VIDEO file. It used to be a .go source file,
+// which worked only because source files had no redactor — and a .go file
+// holding a hardcoded key is exactly a file that should be redacted, so text
+// files of any extension now are (#315). Video is scanned and has no redactor,
+// so it keeps these tests measuring the dispatch boundary rather than a coverage
+// gap that has since closed.
+//
+// A video redactor IS now planned (#358). When it lands these fixtures stop being
+// unredactable and these tests fail — loudly, which is intended. Keep the
+// assertions and re-fixture; if nothing scanned is left unredactable, register a
+// deliberately limited redactor set instead of hunting for another format.
 
-// newRedactionManagerWithPlaintextOnly builds a manager that can redact .txt but
-// NOT .go — the real-world shape of the bug, since the default redactor set
-// covers text/PDF/Office/image extensions and nothing else.
+// newRedactionManagerWithPlaintextOnly builds a manager that can redact text but
+// NOT video — the real-world shape of the bug, since the default redactor set
+// covers text, PDF, Office, image and audio and nothing else.
 func newRedactionManagerWithPlaintextOnly(t *testing.T, outDir string) *redactors.RedactionManager {
 	t.Helper()
 	observer := observability.NewStandardObserver(observability.ObservabilityMetrics, io.Discard)
@@ -53,8 +67,8 @@ func newRedactionManagerWithPlaintextOnly(t *testing.T, outDir string) *redactor
 func TestRedaction_UnredactableFileKeepsItsMatches(t *testing.T) {
 	dir := t.TempDir()
 	txt := writeTxt(t, dir, "notes.txt", "alpha content")
-	// .go has no registered redactor in the manager built above.
-	gofile := writeTxt(t, dir, "creds.go", "package main // beta content")
+	// video has no registered redactor in the manager built above.
+	gofile := writeUnredactableVideo(t, dir, "clip.mp4")
 
 	v := &batchStubValidator{}
 	observer := observability.NewStandardObserver(observability.ObservabilityMetrics, io.Discard)
@@ -74,7 +88,7 @@ func TestRedaction_UnredactableFileKeepsItsMatches(t *testing.T) {
 	for _, m := range matches {
 		byFile[filepath.Base(m.Filename)]++
 	}
-	if byFile["creds.go"] == 0 {
+	if byFile["clip.mp4"] == 0 {
 		t.Errorf("unredactable file's matches were DROPPED (the leak): got %v", byFile)
 	}
 	if byFile["notes.txt"] == 0 {
@@ -91,7 +105,7 @@ func TestRedaction_UnredactableFileKeepsItsMatches(t *testing.T) {
 	if len(stats.UnredactedFiles) != 1 {
 		t.Fatalf("UnredactedFiles = %d, want 1: %+v", len(stats.UnredactedFiles), stats.UnredactedFiles)
 	}
-	if filepath.Base(stats.UnredactedFiles[0].FilePath) != "creds.go" {
+	if filepath.Base(stats.UnredactedFiles[0].FilePath) != "clip.mp4" {
 		t.Errorf("wrong unredacted file: %q", stats.UnredactedFiles[0].FilePath)
 	}
 	if stats.UnredactedFiles[0].Reason == "" {
@@ -106,7 +120,7 @@ func TestRedaction_UnredactableFileKeepsItsMatches(t *testing.T) {
 // operator to re-scan when the scan was in fact complete.
 func TestRedaction_FailureIsNotACoverageFailure(t *testing.T) {
 	dir := t.TempDir()
-	gofile := writeTxt(t, dir, "creds.go", "package main // beta content")
+	gofile := writeUnredactableVideo(t, dir, "clip.mp4")
 
 	v := &batchStubValidator{}
 	observer := observability.NewStandardObserver(observability.ObservabilityMetrics, io.Discard)
@@ -143,8 +157,8 @@ func TestRedaction_UnredactableFileIsNotAFailedFile(t *testing.T) {
 	dir := t.TempDir()
 	files := []string{
 		writeTxt(t, dir, "notes.txt", "alpha content"),
-		writeTxt(t, dir, "creds.go", "package main // beta content"),
-		writeTxt(t, dir, "app.py", "# gamma content"),
+		writeUnredactableVideo(t, dir, "clip.mp4"),
+		writeUnredactableVideo(t, dir, "clip2.mp4"),
 	}
 
 	v := &batchStubValidator{}
@@ -206,7 +220,7 @@ func TestRedaction_SuccessReportsNoUnredactedFiles(t *testing.T) {
 // byte-identical for every consumer of ProcessingStats.
 func TestRedaction_DisabledLeavesDiagnosticEmpty(t *testing.T) {
 	dir := t.TempDir()
-	gofile := writeTxt(t, dir, "creds.go", "package main // beta content")
+	gofile := writeUnredactableVideo(t, dir, "clip.mp4")
 
 	v := &batchStubValidator{}
 	observer := observability.NewStandardObserver(observability.ObservabilityMetrics, io.Discard)
@@ -224,4 +238,28 @@ func TestRedaction_DisabledLeavesDiagnosticEmpty(t *testing.T) {
 	if stats.ProcessedFiles != 1 {
 		t.Errorf("ProcessedFiles = %d, want 1", stats.ProcessedFiles)
 	}
+}
+
+// writeUnredactableVideo writes a minimal MP4 for tests that need a file which IS routed and
+// scanned but has no registered redactor. Hand-built rather than produced by ffmpeg, which is
+// not on every CI runner.
+func writeUnredactableVideo(t *testing.T, dir, name string) string {
+	t.Helper()
+
+	atom := func(kind string, payload []byte) []byte {
+		out := make([]byte, 4)
+		binary.BigEndian.PutUint32(out, uint32(8+len(payload)))
+		out = append(out, []byte(kind)...)
+		return append(out, payload...)
+	}
+	data := append([]byte{0, 0, 0, 1, 0, 0, 0, 0}, []byte("beta content")...)
+	body := atom("moov", atom("udta", atom("meta",
+		append([]byte{0, 0, 0, 0}, atom("ilst", atom("\xa9cmt", atom("data", data)))...))))
+	out := append(atom("ftyp", []byte("isomiso2mp41")), body...)
+
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, out, 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return p
 }

--- a/internal/redactors/manager.go
+++ b/internal/redactors/manager.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/awslabs/ferret-scan/v2/internal/detector"
 	"github.com/awslabs/ferret-scan/v2/internal/observability"
+	"github.com/awslabs/ferret-scan/v2/internal/preprocessors"
 )
 
 // RedactionManager coordinates all redaction operations and manages multiple redactors
@@ -303,12 +304,39 @@ func (rm *RedactionManager) GetRedactorForFile(filePath string) (Redactor, error
 	defer rm.mu.RUnlock()
 
 	ext := strings.ToLower(filepath.Ext(filePath))
-	if ext == "" {
-		return nil, fmt.Errorf("file has no extension: %s", filePath)
-	}
 
 	redactor, exists := rm.redactors[ext]
 	if !exists {
+		// A file whose BYTES are text is redactable as text, whatever it is named.
+		//
+		// The scanner admits files by SNIFFING them — router.isTextFile reads the first 512
+		// bytes and asks preprocessors.LooksLikeText — so it happily scans .env, .tfvars, .sql,
+		// .py, .sh, .properties, .toml, .pem, Dockerfile and Makefile. Redactor selection
+		// instead matched an eleven-extension allowlist, so every one of those was scanned,
+		// reported findings, and could never produce a redacted copy. Measured on a file
+		// holding an AWS secret key and a database password: 3 findings, no output file,
+		// exit 0, for all eleven names above, while the same content in a .txt redacted fine.
+		//
+		// This is the same "reported but unredactable" failure as #306, and .env is the single
+		// likeliest file in a repository to hold a live credential.
+		//
+		// The fix reuses the SNIFF rather than lengthening the list, so the two decisions
+		// cannot drift apart again: whatever the scanner is willing to read as text, the
+		// redactor is willing to write as text. A longer allowlist is a list of names someone
+		// thought of, and the failure being fixed is a name nobody thought of.
+		//
+		// Binary files are not at risk. LooksLikeText is the null-byte-and-encoding sniff the
+		// text preprocessor uses, and it returns false for every binary container this tool
+		// handles — verified against real .mp3, .m4a, .flac, .wav, .jpg, .png, .zip and
+		// arbitrary byte soup. Those keep falling through to the refusal below, which is
+		// disclosed. It returns TRUE for UTF-16 text, which a naive null-byte check would
+		// have rejected.
+		if plain, ok := rm.redactors[".txt"]; ok && looksLikeTextFile(filePath) {
+			return plain, nil
+		}
+		if ext == "" {
+			return nil, fmt.Errorf("file has no extension and its bytes are not text: %s", filePath)
+		}
 		return nil, fmt.Errorf("no redactor registered for file type: %s", ext)
 	}
 
@@ -331,6 +359,34 @@ func (rm *RedactionManager) GetRedactorForFile(filePath string) (Redactor, error
 	}
 
 	return redactor, nil
+}
+
+// looksLikeTextFile reports whether a file's leading bytes are text, using the SAME sniff that
+// decided to scan it.
+//
+// Shared deliberately rather than reimplemented: preprocessors.LooksLikeText is what
+// router.isTextFile calls to admit a file for scanning, so routing this through it makes scan
+// coverage and redact coverage agree by construction. Two local definitions of "text" would
+// eventually disagree, and the direction they disagree in is a file that gets scanned and
+// cannot be redacted — which is the bug this exists to close.
+//
+// A read failure is false, not an error: the caller's next step is a refusal that gets
+// disclosed either way, and a file that cannot be opened here cannot be redacted anyway.
+// A zero-byte file is false too — router.isTextFile calls an empty file text so it is not
+// reported as unreadable, but an empty file has no findings to remove.
+func looksLikeTextFile(filePath string) bool {
+	f, err := os.Open(filepath.Clean(filePath)) // #nosec G304 -- path already vetted by the router
+	if err != nil {
+		return false
+	}
+	defer func() { _ = f.Close() }()
+
+	buf := make([]byte, 512)
+	n, _ := f.Read(buf)
+	if n == 0 {
+		return false
+	}
+	return preprocessors.LooksLikeText(buf[:n])
 }
 
 // containerRedactorExtensions are the extensions handled by a redactor that

--- a/internal/redactors/text_fallback_test.go
+++ b/internal/redactors/text_fallback_test.go
@@ -1,0 +1,216 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package redactors
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The scanner admits files by SNIFFING their bytes; redactor selection matched an
+// eleven-extension allowlist. So a growing set of file types was scanned, reported findings,
+// and could never produce a redacted copy — at exit 0.
+//
+// Measured on a file holding an AWS secret key, a database password, an SSN and an email:
+//
+//	.txt .json                                        3 findings, redacted copy written
+//	.env .tfvars .tf .sql .py .sh .properties .toml
+//	.pem Dockerfile Makefile                          3 findings, NO redacted copy, exit 0
+//
+// `.env` is the single likeliest file in a repository to hold a live credential. Same
+// "reported but unredactable" shape as #306, and the general statement of it is #315.
+
+const textualContent = "AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\npassword=hunter2\n"
+
+// Any file whose BYTES are text must resolve to the text redactor, whatever it is named.
+//
+// Asserted over the names the allowlist missed, including two with NO extension at all —
+// those failed even earlier, on an `ext == ""` guard that returned before any sniff.
+func TestTextBytesResolveToTheTextRedactorWhateverTheExtension(t *testing.T) {
+	rm := newTestManager(t)
+	plain := &stubRedactor{exts: []string{".txt"}}
+	if err := rm.RegisterRedactor(plain); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	for _, name := range []string{
+		"secret.env", "secret.tfvars", "secret.tf", "secret.sql", "secret.py",
+		"secret.sh", "secret.properties", "secret.toml", "secret.pem",
+		"Dockerfile", "Makefile",
+	} {
+		t.Run(name, func(t *testing.T) {
+			p := filepath.Join(dir, name)
+			if err := os.WriteFile(p, []byte(textualContent), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := rm.GetRedactorForFile(p)
+			if err != nil {
+				t.Fatalf("no redactor for a text file named %q: %v\n"+
+					"The scanner reads this file and reports its findings, so refusing to redact it "+
+					"leaves the values in cleartext while the report says they were handled.", name, err)
+			}
+			if got != Redactor(plain) {
+				t.Errorf("resolved to %q, want the text redactor", got.GetName())
+			}
+		})
+	}
+}
+
+// Binary bytes with an unregistered extension must still be REFUSED.
+//
+// This is the guard that makes the fallback safe. Diverting a binary file to the text
+// redactor would do byte-level string replacement on it and corrupt it, while reporting
+// success — worse than the refusal it replaced. The refusal is disclosed by the caller
+// through stats.UnredactedFiles.
+func TestBinaryBytesWithUnknownExtensionAreStillRefused(t *testing.T) {
+	rm := newTestManager(t)
+	if err := rm.RegisterRedactor(&stubRedactor{exts: []string{".txt"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	cases := map[string][]byte{
+		// A NUL early in the buffer is the classic binary tell.
+		"blob.xyz": append([]byte{0x00, 0x01, 0x02}, []byte("some trailing text")...),
+		// Byte soup across the whole range.
+		"soup.dat": func() []byte {
+			b := make([]byte, 512)
+			for i := range b {
+				b[i] = byte(i)
+			}
+			return b
+		}(),
+	}
+
+	for name, content := range cases {
+		t.Run(name, func(t *testing.T) {
+			p := filepath.Join(dir, name)
+			if err := os.WriteFile(p, content, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := rm.GetRedactorForFile(p); err == nil {
+				t.Error("a binary file was routed to the text redactor; byte-level replacement " +
+					"would corrupt it while reporting success")
+			}
+		})
+	}
+}
+
+// A registered redactor must keep its files. The fallback fires only when NOTHING is
+// registered for the extension, so adding it must not divert formats that already have an
+// owner — including a container file whose bytes happen to sniff as text, which the separate
+// container-divert rule governs.
+func TestRegisteredRedactorIsNotDivertedByTheFallback(t *testing.T) {
+	rm := newTestManager(t)
+	plain := &stubRedactor{exts: []string{".txt"}}
+	jpeg := &stubRedactor{exts: []string{".jpg"}}
+	if err := rm.RegisterRedactor(plain); err != nil {
+		t.Fatal(err)
+	}
+	if err := rm.RegisterRedactor(jpeg); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	p := filepath.Join(dir, "photo.jpg")
+	// Deliberately TEXT bytes under a registered binary extension: the fallback must not
+	// reach this file, because .jpg has an owner.
+	if err := os.WriteFile(p, []byte(textualContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := rm.GetRedactorForFile(p)
+	if err != nil {
+		t.Fatalf("GetRedactorForFile: %v", err)
+	}
+	if got != Redactor(jpeg) {
+		t.Error("a registered extension was diverted to the text redactor; the fallback must " +
+			"only apply where nothing is registered")
+	}
+}
+
+// An empty file must not be diverted.
+//
+// router.isTextFile deliberately calls a zero-byte file text, so it is not reported as
+// unreadable. For redaction that reasoning does not carry: an empty file has no findings to
+// remove, so there is nothing to route.
+func TestEmptyFileIsNotDiverted(t *testing.T) {
+	rm := newTestManager(t)
+	if err := rm.RegisterRedactor(&stubRedactor{exts: []string{".txt"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	p := filepath.Join(t.TempDir(), "empty.env")
+	if err := os.WriteFile(p, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := rm.GetRedactorForFile(p); err == nil {
+		t.Error("an empty file resolved to a redactor; it has no findings to remove")
+	}
+}
+
+// The fallback needs the text redactor to be registered. With none, an unknown extension must
+// report the original "no redactor registered" error rather than panic or resolve to nil.
+func TestFallbackIsSkippedWhenNoTextRedactorIsRegistered(t *testing.T) {
+	rm := newTestManager(t)
+	if err := rm.RegisterRedactor(&stubRedactor{exts: []string{".jpg"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	p := filepath.Join(t.TempDir(), "secret.env")
+	if err := os.WriteFile(p, []byte(textualContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := rm.GetRedactorForFile(p)
+	if err == nil {
+		t.Errorf("resolved to %v with no text redactor registered", got)
+	}
+}
+
+// looksLikeTextFile is the safety guard, so its contract is pinned directly — including the
+// UTF-16 case, which a naive null-byte check would reject even though it is text.
+func TestLooksLikeTextFile(t *testing.T) {
+	dir := t.TempDir()
+
+	write := func(name string, b []byte) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, b, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	utf16 := []byte{0xFF, 0xFE}
+	for _, r := range "password=hunter2" {
+		utf16 = append(utf16, byte(r), 0x00)
+	}
+
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"ascii text", write("a.env", []byte(textualContent)), true},
+		{"utf-16 text", write("b.env", utf16), true},
+		{"leading NUL", write("c.env", append([]byte{0x00}, []byte("text after")...)), false},
+		{"byte soup", write("d.env", func() []byte {
+			b := make([]byte, 512)
+			for i := range b {
+				b[i] = byte(i)
+			}
+			return b
+		}()), false},
+		{"empty", write("e.env", nil), false},
+		{"missing", filepath.Join(dir, "nope.env"), false},
+	}
+
+	for _, tc := range cases {
+		if got := looksLikeTextFile(tc.path); got != tc.want {
+			t.Errorf("looksLikeTextFile(%s) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Refs #315.

## The gap

The scanner admits files by **sniffing** them (`router.isTextFile` reads 512 bytes and asks `preprocessors.LooksLikeText`), so it happily scans `.env`, `.tfvars`, `.tf`, `.sql`, `.py`, `.sh`, `.properties`, `.toml`, `.pem`, `Dockerfile`, `Makefile`. Redactor selection instead matched an **eleven-extension allowlist**, so all of those were scanned, reported findings, and could never produce a redacted copy.

Measured on a file holding an AWS secret key, a DB password, an SSN and an email:

| files | findings | redacted copy | exit |
|---|---|---|---|
| `.txt` `.json` | 3 | yes | 0 |
| `.env` `.tfvars` `.tf` `.sql` `.py` `.sh` `.properties` `.toml` `.pem` `Dockerfile` `Makefile` | 3 | **none** | **0** |

`.env` is the single likeliest file in a repository to hold a live credential. Same "reported but unredactable" shape as #306.

Files with **no extension** (`Dockerfile`, `Makefile`) failed even earlier, on an `ext == ""` guard that returned before any sniff.

## Reusing the sniff rather than lengthening the list

The fallback calls `preprocessors.LooksLikeText` — the *same* function that admitted the file for scanning — so the two decisions cannot drift apart again: whatever the scanner will read as text, the redactor will write as text. A longer allowlist is a list of names someone thought of, and the failure being fixed is a name nobody thought of.

## Why this cannot corrupt a binary

`LooksLikeText` is the null-byte-and-encoding sniff the text preprocessor already uses. Verified against real files:

| bytes | sniff | outcome |
|---|---|---|
| `.mp3` `.m4a` `.flac` `.wav` `.jpg` `.png` `.zip`, byte soup | **false** | falls through to the refusal, which is disclosed |
| `.env` `.py` `Dockerfile`, **UTF-16** text | **true** | diverted to the text redactor |

UTF-16 returning true matters — a naive null-byte check would have rejected it. An empty file is **not** diverted: `router.isTextFile` deliberately calls a zero-byte file text so it is not reported unreadable, but an empty file has no findings to remove.

A **registered** extension is never diverted — the fallback runs only where nothing is registered, so the existing container-divert rule (a `.docx` whose bytes are not a zip) still governs those. Pinned by a test.

## Four existing tests changed fixture, not intent

Four tests used a `.go`/`.py` file as their "scanned but unredactable" example — which is precisely the defect being fixed, since a `.go` file with a hardcoded key is exactly a file that should be redacted. **Their invariants are unchanged and still asserted**; only the fixture moved, to a hand-built **95-byte MP4** (video is scanned and has no redactor). ffmpeg is not on every CI runner, so it is built from atoms in-test.

```
internal/core/redact_test.go       TestRedactFile_UnredactableFileTypeIsAnError
internal/parallel/redaction_...    TestRedaction_UnredactableFileKeepsItsMatches
                                   TestRedaction_FailureIsNotACoverageFailure
                                   TestRedaction_UnredactableFileIsNotAFailedFile
```

A video redactor is now planned (**#358**), and when it lands those four fixtures stop being unredactable and fail **loudly**. Both test files say so, and #358 records the obligation with the recommended replacement.

## Verification

- **Six mutations, all six fail a test**: removing the fallback, diverting without the sniff, forcing the sniff true, forcing it false, treating an empty file as text, and running the fallback *before* the registered lookup.
- 67 packages pass; `-race` clean on redactors and core; golden corpus forced; `gofmt`/`vet` clean.
- **Union with the other three open PRs** (#354, #356, #357) builds and passes **67/0**. Verified specifically that #357's audio redactor claims only `mp3/wav/m4a/flac` and not `.mp4`, so it does not make this PR's fixtures redactable.

## Scope

`#315` also covers the general principle; this closes its text half. Referenced rather than closed in case its author wants the remaining framing kept open.

Separately found while verifying and **not** part of this PR: generic secret assignments (`password=`, `PASSWORD=`, `db_password:`, `secret=`, `api_key=`, `token=`) are not detected at all, in `.txt` or `.env`, at any confidence — despite `internal/validators/secrets/validator.go:754` saying it catches `password:secret123`. Filed separately.