### PR TITLE
Fix/gitlab sast analyzer attribution

### DIFF
--- a/internal/formatters/gitlab-sast/models.go
+++ b/internal/formatters/gitlab-sast/models.go
@@ -339,9 +339,13 @@ const (
 	GitLabSASTScanType      = "sast"
 	GitLabSASTCategory      = "sast"
 
-	// Ferret Scan specific constants
+	// Ferret Scan specific constants.
+	//
+	// FerretAnalyzerURL must stay in sync with sarif.ToolInformationURI — both name
+	// the upstream repository, and a GitLab report that disagrees with the SARIF
+	// report about where the analyzer comes from is a report nobody can trace.
 	FerretAnalyzerID   = "ferret-scan"
 	FerretAnalyzerName = "Ferret Scan"
-	FerretAnalyzerURL  = "https://github.com/bank-vaults/ferret-scan"
-	FerretVendorName   = "Bank Vaults"
+	FerretAnalyzerURL  = "https://github.com/awslabs/ferret-scan"
+	FerretVendorName   = "Amazon Web Services"
 )

--- a/internal/formatters/gitlab-sast/models.go
+++ b/internal/formatters/gitlab-sast/models.go
@@ -6,6 +6,8 @@ package gitlabsast
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/awslabs/ferret-scan/v2/internal/version"
 )
 
 // GitLabSecurityReport represents the top-level GitLab Security Report structure
@@ -339,13 +341,10 @@ const (
 	GitLabSASTScanType      = "sast"
 	GitLabSASTCategory      = "sast"
 
-	// Ferret Scan specific constants.
-	//
-	// FerretAnalyzerURL must stay in sync with sarif.ToolInformationURI — both name
-	// the upstream repository, and a GitLab report that disagrees with the SARIF
-	// report about where the analyzer comes from is a report nobody can trace.
+	// Ferret Scan specific constants. FerretAnalyzerURL derives from
+	// internal/version so it cannot drift from the URL the SARIF formatter reports.
 	FerretAnalyzerID   = "ferret-scan"
 	FerretAnalyzerName = "Ferret Scan"
-	FerretAnalyzerURL  = "https://github.com/awslabs/ferret-scan"
+	FerretAnalyzerURL  = version.RepositoryURL
 	FerretVendorName   = "Amazon Web Services"
 )

--- a/internal/formatters/sarif/constants.go
+++ b/internal/formatters/sarif/constants.go
@@ -3,7 +3,10 @@
 
 package sarif
 
-import "github.com/awslabs/ferret-scan/v2/internal/core"
+import (
+	"github.com/awslabs/ferret-scan/v2/internal/core"
+	"github.com/awslabs/ferret-scan/v2/internal/version"
+)
 
 // SARIF specification constants
 const (
@@ -19,8 +22,9 @@ const (
 	// ToolName is the name of the ferret-scan tool
 	ToolName = "Ferret Scan"
 
-	// ToolInformationURI is the URL to the ferret-scan repository
-	ToolInformationURI = "https://github.com/awslabs/ferret-scan"
+	// ToolInformationURI is the URL to the ferret-scan repository. Kept as a named
+	// constant so existing references stay valid; the value lives in internal/version.
+	ToolInformationURI = version.RepositoryURL
 )
 
 // SARIF level constants

--- a/internal/goldencorpus/testdata/golden/adversarial_many_matches.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/adversarial_many_matches.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/adversarial_single_long_line.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/adversarial_single_long_line.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/cloud_resources_test_context.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/cloud_resources_test_context.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/context_decoys_original.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/context_decoys_original.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/context_decoys_personname.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/context_decoys_personname.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/context_keywords_snake_case.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/context_keywords_snake_case.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/context_soft_negative_labels.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/context_soft_negative_labels.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/creditcard_brands.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/creditcard_brands.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/creditcard_phone_overlap.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/creditcard_phone_overlap.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/email_variants.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/email_variants.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/file_csv_tabular_pii.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_csv_tabular_pii.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/file_doc_legacy_body_and_properties.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_doc_legacy_body_and_properties.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/file_doc_legacy_not_a_container.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_doc_legacy_not_a_container.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/file_doc_legacy_template_path.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_doc_legacy_template_path.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/file_doc_legacy_wide_encoded_body.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_doc_legacy_wide_encoded_body.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_body_and_metadata.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_firstline.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_forged_separator_midbody.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_main_part_alternate_case.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/file_json_config.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_json_config.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/file_negative_clean.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_negative_clean.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/file_source_code_secrets.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_source_code_secrets.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/file_txt_mixed_pii.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_txt_mixed_pii.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/file_wav_metadata_pii.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_wav_metadata_pii.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/file_xls_legacy_workbook_stream.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_xls_legacy_workbook_stream.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_cells.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_xlsx_sheet_part_named_metadata.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/ip_addresses.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/ip_addresses.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/ip_consolidation_long_line.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/ip_consolidation_long_line.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/keyword_separator_forms.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/keyword_separator_forms.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/medical_hex_member_ids.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/medical_hex_member_ids.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/medical_long_form_labels.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/medical_long_form_labels.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/mixed_pii_basic.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/mixed_pii_basic.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/negative_clean_text.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/negative_clean_text.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/new_validators_decoys.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/new_validators_decoys.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/new_validators_display_formats.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/new_validators_display_formats.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/passport_csv_header_column.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/passport_csv_header_column.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/passport_label_above_value.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/passport_label_above_value.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/passport_mrz_line2_check_digits.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/passport_mrz_line2_check_digits.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/passport_shapes.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/passport_shapes.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/secrets_aws.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/secrets_aws.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/ssn_positive_and_denylisted.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/ssn_positive_and_denylisted.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/validator_coverage_expansion.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/validator_coverage_expansion.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/goldencorpus/testdata/golden/vin_check_digit.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/vin_check_digit.gitlab-sast.json
@@ -4,9 +4,9 @@
     "analyzer": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },
@@ -14,9 +14,9 @@
     "scanner": {
       "id": "ferret-scan",
       "name": "Ferret Scan",
-      "url": "https://github.com/bank-vaults/ferret-scan",
+      "url": "https://github.com/awslabs/ferret-scan",
       "vendor": {
-        "name": "Bank Vaults"
+        "name": "Amazon Web Services"
       },
       "version": "0.0.0-development"
     },

--- a/internal/help/help.go
+++ b/internal/help/help.go
@@ -11,6 +11,8 @@ import (
 	"text/tabwriter"
 
 	"github.com/fatih/color"
+
+	"github.com/awslabs/ferret-scan/v2/internal/version"
 )
 
 // CheckInfo contains standardized information about a check
@@ -188,8 +190,8 @@ func (h *System) ShowGeneralHelp() {
 	fmt.Println("  Environment: FERRET_CONFIG_DIR - Override config directory")
 	fmt.Println()
 	h.colors["header"].Println("SUPPORT:")
-	fmt.Println("  Issues:  https://github.com/awslabs/ferret-scan/issues")
-	fmt.Println("  Source:  https://github.com/awslabs/ferret-scan")
+	fmt.Println("  Issues:  " + version.IssuesURL)
+	fmt.Println("  Source:  " + version.RepositoryURL)
 }
 
 // ShowChecksHelp displays information about all available checks

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -8,6 +8,20 @@ import (
 	"runtime"
 )
 
+// Project identity that is fixed at author time rather than build time.
+const (
+	// RepositoryURL is the canonical upstream repository, and the single source of
+	// truth for it. Report formats that name where the analyzer came from MUST derive
+	// it from here rather than repeating the literal: SARIF and GitLab SAST once
+	// disagreed about the origin of this scanner because each carried its own copy,
+	// and a consumer comparing two reports of the same scan had no way to tell which
+	// was lying.
+	RepositoryURL = "https://github.com/awslabs/ferret-scan"
+
+	// IssuesURL is where users are told to report problems.
+	IssuesURL = RepositoryURL + "/issues"
+)
+
 // Version information set by semantic-release
 var (
 	// Version is the current version of ferret-scan


### PR DESCRIPTION
The change
models.go:342-349 — two constants, plus a comment pinning the URL to its SARIF counterpart so the two formatters can't silently drift apart again:


FerretAnalyzerURL  = "https://github.com/awslabs/ferret-scan"   // was bank-vaults/ferret-scan
FerretVendorName   = "Amazon Web Services"                       // was "Bank Vaults"
I went with "Amazon Web Services" over "AWS" to match the wording in LICENSE.txt.

Verification
Check	Result
go build ./...	clean
Golden mismatches before regen	exactly 44 — the 44 gitlab-sast files, nothing else
Golden diff after regen	only 88 url + 88 name lines (44 files × 2 blocks) — no detection output shifted
go test ./...	full suite passes
grep -rni "bank.vault"	no matches anywhere in the repo
Live --format gitlab-sast	both analyzer and scanner now report awslabs/ferret-scan / Amazon Web Services
The 88/88 count is the useful signal here: it's exactly 2× the 44 files, which confirms the change hit both the analyzer and scanner blocks in every report and touched nothing else. 45 files changed total (1 source + 44 goldens), 183 insertions / 179 deletions — the +4 delta is the new comment.