### PR TITLE
fix(office): close three ways a value hides from Office redaction — escaped, numeric-referenced, and numeric-typed

### DIFF
--- a/internal/goldencorpus/corpus.go
+++ b/internal/goldencorpus/corpus.go
@@ -642,6 +642,24 @@ var FileCases = []FileCase{
 		EnablePreprocessors: true,
 	},
 	{
+		Name: "file_docx_numeric_character_reference",
+		Description: "Tier 3: a .docx whose w:t runs spell SSN digits as XML numeric character references (&#57; and &#x37;). " +
+			"Word renders them as the digits, so this locks BOTH halves of the escaped-value leak: the extractor must decode " +
+			"them (#371) and the redactor must remove them from the part bytes (#368). Before the extractor fix the scan " +
+			"reported 1 of 4; before the redactor fix 3 of 4 survived --enable-redaction in a file reported as successfully " +
+			"redacted. Diff against file_docx_body_and_metadata, which is the same shape with no references.",
+		Checks:   []string{"SSN", "METADATA"},
+		Filename: "numrefs.docx",
+		Content: BuildDOCXWithRawRuns("Jane Analyst", "Ops Reviewer", []string{
+			"Employee SSN 449-87-4100 on file.",
+			"Employee SSN 51&#57;-42-8836 on file.",
+			"Employee SSN &#53;&#54;&#51;-&#49;&#56;-&#55;&#50;&#52;&#57; on file.",
+			"Employee SSN 60&#x37;-31-9284 on file.",
+		}),
+		Tier1Parity:         false, // container extraction has no content-mode equivalent
+		EnablePreprocessors: true,
+	},
+	{
 		Name:        "file_xlsx_sheet_cells",
 		Description: "Tier 3 control: an .xlsx with PII in worksheet cells at the conventional sheet part name.",
 		Checks:      []string{"SSN", "CREDIT_CARD", "METADATA"},
@@ -904,6 +922,20 @@ func BuildDOCX(creator, lastModifiedBy string, paras []string) []byte {
 	return buildOOXML(docxParts("word/document.xml", creator, lastModifiedBy, paras))
 }
 
+// BuildDOCXWithRawRuns is BuildDOCX with the paragraph text inserted VERBATIM into <w:t>.
+//
+// BuildDOCX escapes its paragraphs, which is right for every case whose subject is the document's
+// content. It is wrong for a case whose subject is the ESCAPING itself: a paragraph written
+// "51&#57;-42-8836" would be stored as "51&amp;#57;-42-8836", i.e. the literal five characters
+// "&#57;", and the case would test nothing. Word renders a numeric character reference as the
+// character it names, so the reference form is what a real evasion looks like on disk.
+//
+// The caller is therefore responsible for the argument being valid XML character data. It exists
+// for exactly one kind of case; anything about a document's content should use BuildDOCX.
+func BuildDOCXWithRawRuns(creator, lastModifiedBy string, rawParas []string) []byte {
+	return buildOOXML(docxPartsRaw("word/document.xml", creator, lastModifiedBy, rawParas))
+}
+
 // BuildDOCXWithMainPart is BuildDOCX with control over the main part's NAME, so a
 // case can lock what happens when the document body is not at the conventional
 // path. It also points the package relationship at that name, as a real producer
@@ -924,6 +956,36 @@ func docxParts(mainPart, creator, lastModifiedBy string, paras []string) []ooxml
 	for _, p := range paras {
 		body.WriteString(`<w:p><w:r><w:t xml:space="preserve">`)
 		body.WriteString(escapeXML(p))
+		body.WriteString(`</w:t></w:r></w:p>`)
+	}
+	doc := xmlDecl + `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>` +
+		body.String() + `</w:body></w:document>`
+
+	contentTypes := xmlDecl + `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+		`<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+		`<Default Extension="xml" ContentType="application/xml"/>` +
+		`<Override PartName="/` + mainPart + `" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>` +
+		`<Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/>` +
+		`</Types>`
+
+	rels := xmlDecl + `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+		`<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="` + mainPart + `"/>` +
+		`<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" Target="docProps/core.xml"/>` +
+		`</Relationships>`
+
+	return []ooxmlPart{
+		{"[Content_Types].xml", contentTypes},
+		{"_rels/.rels", rels},
+		{"docProps/core.xml", coreProps(creator, lastModifiedBy)},
+		{mainPart, doc},
+	}
+}
+
+func docxPartsRaw(mainPart, creator, lastModifiedBy string, paras []string) []ooxmlPart {
+	var body strings.Builder
+	for _, p := range paras {
+		body.WriteString(`<w:p><w:r><w:t xml:space="preserve">`)
+		body.WriteString(p) // verbatim: see BuildDOCXWithRawRuns
 		body.WriteString(`</w:t></w:r></w:p>`)
 	}
 	doc := xmlDecl + `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>` +

--- a/internal/goldencorpus/testdata/golden/file_docx_numeric_character_reference.csv
+++ b/internal/goldencorpus/testdata/golden/file_docx_numeric_character_reference.csv
@@ -1,0 +1,7 @@
+Filename,Type,Confidence Level,Confidence %,Line Number,Text
+<TMPDIR>/numrefs.docx,SSN,HIGH,100.0,1,449-87-4100
+<TMPDIR>/numrefs.docx,SSN,HIGH,100.0,3,519-42-8836
+<TMPDIR>/numrefs.docx,SSN,HIGH,100.0,5,563-18-7249
+<TMPDIR>/numrefs.docx,SSN,HIGH,100.0,7,607-31-9284
+<TMPDIR>/numrefs.docx,AUTHOR_INFO,MEDIUM,60.0,1,Jane Analyst
+<TMPDIR>/numrefs.docx,LAST_MODIFIED_BY,MEDIUM,60.0,2,Ops Reviewer

--- a/internal/goldencorpus/testdata/golden/file_docx_numeric_character_reference.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_numeric_character_reference.gitlab-sast.json
@@ -1,0 +1,186 @@
+{
+  "remediations": [],
+  "scan": {
+    "analyzer": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/awslabs/ferret-scan",
+      "vendor": {
+        "name": "Amazon Web Services"
+      },
+      "version": "0.0.0-development"
+    },
+    "end_time": "<TIMESTAMP>",
+    "scanner": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/awslabs/ferret-scan",
+      "vendor": {
+        "name": "Amazon Web Services"
+      },
+      "version": "0.0.0-development"
+    },
+    "start_time": "<TIMESTAMP>",
+    "status": "success",
+    "type": "sast"
+  },
+  "version": "15.0.4",
+  "vulnerabilities": [
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <TMPDIR>/numrefs.docx (line 1)\n**Confidence:** HIGH (100.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\nEmployee SSN 449-87-4100 on file.\n```\n\n**Additional Information:**\n- context_impact: 45\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "SSN"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "ssn"
+        }
+      ],
+      "location": {
+        "end_line": 1,
+        "file": "numrefs.docx",
+        "start_line": 1
+      },
+      "message": "Social Security Number detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Social Security Number Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <TMPDIR>/numrefs.docx (line 3)\n**Confidence:** HIGH (100.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\nEmployee SSN 519-42-8836 on file.\n```\n\n**Additional Information:**\n- context_impact: 45\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "SSN"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "ssn"
+        }
+      ],
+      "location": {
+        "end_line": 3,
+        "file": "numrefs.docx",
+        "start_line": 3
+      },
+      "message": "Social Security Number detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Social Security Number Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <TMPDIR>/numrefs.docx (line 5)\n**Confidence:** HIGH (100.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\nEmployee SSN 563-18-7249 on file.\n```\n\n**Additional Information:**\n- context_impact: 45\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "SSN"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "ssn"
+        }
+      ],
+      "location": {
+        "end_line": 5,
+        "file": "numrefs.docx",
+        "start_line": 5
+      },
+      "message": "Social Security Number detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Social Security Number Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <TMPDIR>/numrefs.docx (line 7)\n**Confidence:** HIGH (100.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\nEmployee SSN 607-31-9284 on file.\n```\n\n**Additional Information:**\n- context_impact: 45\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "SSN"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "ssn"
+        }
+      ],
+      "location": {
+        "end_line": 7,
+        "file": "numrefs.docx",
+        "start_line": 7
+      },
+      "message": "Social Security Number detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Social Security Number Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected author information in this file.\n\n**Location:** <TMPDIR>/numrefs.docx (line 1)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nAuthor: Jane Analyst\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "AUTHOR_INFO"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "metadata"
+        }
+      ],
+      "location": {
+        "end_line": 1,
+        "file": "numrefs.docx",
+        "start_line": 1
+      },
+      "message": "Author information detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Author Info Detected",
+      "severity": "High"
+    },
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected sensitive data (last modified by) in this file.\n\n**Location:** <TMPDIR>/numrefs.docx (line 2)\n**Confidence:** MEDIUM (60.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nLastModifiedBy: Ops Reviewer\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "LAST_MODIFIED_BY"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "metadata"
+        }
+      ],
+      "location": {
+        "end_line": 2,
+        "file": "numrefs.docx",
+        "start_line": 2
+      },
+      "message": "Sensitive data (last modified by) detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Last Modified By Detected",
+      "severity": "High"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/file_docx_numeric_character_reference.json.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_numeric_character_reference.json.json
@@ -1,0 +1,224 @@
+{
+  "results": [
+    {
+      "confidence": 100,
+      "confidence_level": "HIGH",
+      "filename": "<TMPDIR>/numrefs.docx",
+      "line_number": 1,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 45,
+        "original_confidence": 100,
+        "original_file": "<TMPDIR>/numrefs.docx",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "format": true,
+          "not_common_pattern": true,
+          "not_repeating": true,
+          "not_sequential": true,
+          "not_test_number": true,
+          "valid_area": true
+        },
+        "validation_path": "document"
+      },
+      "text": "449-87-4100",
+      "type": "SSN",
+      "validator": "ssn"
+    },
+    {
+      "confidence": 100,
+      "confidence_level": "HIGH",
+      "filename": "<TMPDIR>/numrefs.docx",
+      "line_number": 3,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 45,
+        "original_confidence": 100,
+        "original_file": "<TMPDIR>/numrefs.docx",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "format": true,
+          "not_common_pattern": true,
+          "not_repeating": true,
+          "not_sequential": true,
+          "not_test_number": true,
+          "valid_area": true
+        },
+        "validation_path": "document"
+      },
+      "text": "519-42-8836",
+      "type": "SSN",
+      "validator": "ssn"
+    },
+    {
+      "confidence": 100,
+      "confidence_level": "HIGH",
+      "filename": "<TMPDIR>/numrefs.docx",
+      "line_number": 5,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 45,
+        "original_confidence": 100,
+        "original_file": "<TMPDIR>/numrefs.docx",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "format": true,
+          "not_common_pattern": true,
+          "not_repeating": true,
+          "not_sequential": true,
+          "not_test_number": true,
+          "valid_area": true
+        },
+        "validation_path": "document"
+      },
+      "text": "563-18-7249",
+      "type": "SSN",
+      "validator": "ssn"
+    },
+    {
+      "confidence": 100,
+      "confidence_level": "HIGH",
+      "filename": "<TMPDIR>/numrefs.docx",
+      "line_number": 7,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 45,
+        "original_confidence": 100,
+        "original_file": "<TMPDIR>/numrefs.docx",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "format": true,
+          "not_common_pattern": true,
+          "not_repeating": true,
+          "not_sequential": true,
+          "not_test_number": true,
+          "valid_area": true
+        },
+        "validation_path": "document"
+      },
+      "text": "607-31-9284",
+      "type": "SSN",
+      "validator": "ssn"
+    },
+    {
+      "confidence": 60.00000000000001,
+      "confidence_level": "MEDIUM",
+      "filename": "<TMPDIR>/numrefs.docx",
+      "line_number": 1,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 0,
+        "full_field": "Author: Jane Analyst",
+        "metadata_type": "AUTHOR_INFO",
+        "original_confidence": 60.00000000000001,
+        "original_file": "<TMPDIR>/numrefs.docx",
+        "preprocessor_adjustment": 0,
+        "preprocessor_name": "Office Metadata Extractor",
+        "preprocessor_type": "office_metadata",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "source_file": "<TMPDIR>/numrefs.docx",
+        "source_preprocessor": "office_metadata",
+        "total_adjustment": 0,
+        "validation_checks": {
+          "contains_author_field": true
+        },
+        "validation_path": "metadata"
+      },
+      "text": "Jane Analyst",
+      "type": "AUTHOR_INFO",
+      "validator": "metadata"
+    },
+    {
+      "confidence": 60.00000000000001,
+      "confidence_level": "MEDIUM",
+      "filename": "<TMPDIR>/numrefs.docx",
+      "line_number": 2,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "HR_Payroll",
+        "context_impact": 0,
+        "full_field": "LastModifiedBy: Ops Reviewer",
+        "metadata_type": "LAST_MODIFIED_BY",
+        "original_confidence": 60.00000000000001,
+        "original_file": "<TMPDIR>/numrefs.docx",
+        "preprocessor_adjustment": 0,
+        "preprocessor_name": "Office Metadata Extractor",
+        "preprocessor_type": "office_metadata",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "source_file": "<TMPDIR>/numrefs.docx",
+        "source_preprocessor": "office_metadata",
+        "total_adjustment": 0,
+        "validation_checks": {
+          "contains_modifier_field": true
+        },
+        "validation_path": "metadata"
+      },
+      "text": "Ops Reviewer",
+      "type": "LAST_MODIFIED_BY",
+      "validator": "metadata"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/file_docx_numeric_character_reference.junit.xml
+++ b/internal/goldencorpus/testdata/golden/file_docx_numeric_character_reference.junit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
+  <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
+    <testcase name="numrefs.docx" classname="security-scan" time="0.001">
+      <failure message="6 security findings detected" type="SECURITY_FINDINGS">Line 1: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 3: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 519-42-8836&#xA;Validator: ssn&#xA;Line 5: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 563-18-7249&#xA;Validator: ssn&#xA;Line 7: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 607-31-9284&#xA;Validator: ssn&#xA;Line 1: AUTHOR_INFO detected with 60.0% confidence (MEDIUM)&#xA;Match: Jane Analyst&#xA;Validator: metadata&#xA;Line 2: LAST_MODIFIED_BY detected with 60.0% confidence (MEDIUM)&#xA;Match: Ops Reviewer&#xA;Validator: metadata</failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/internal/goldencorpus/testdata/golden/file_docx_numeric_character_reference.sarif.json
+++ b/internal/goldencorpus/testdata/golden/file_docx_numeric_character_reference.sarif.json
@@ -1,0 +1,450 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/refs/heads/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/numrefs.docx"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "Employee SSN \nEmployee SSN 449-87-4100 on file.\n on file."
+                  },
+                  "startLine": 1
+                },
+                "region": {
+                  "endColumn": 25,
+                  "snippet": {
+                    "text": "Employee SSN 449-87-4100 on file."
+                  },
+                  "startColumn": 14,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Social Security Number Detected in numrefs.docx at line 1 (confidence: 100.0% - HIGH). Matched text: '449-87-4100'"
+          },
+          "properties": {
+            "confidence": 100,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 45,
+              "original_confidence": 100,
+              "original_file": "<TMPDIR>/numrefs.docx",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "digits": true,
+                "format": true,
+                "not_common_pattern": true,
+                "not_repeating": true,
+                "not_sequential": true,
+                "not_test_number": true,
+                "valid_area": true
+              },
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "ssn"
+            ],
+            "validator": "ssn"
+          },
+          "rank": 100,
+          "ruleId": "SSN"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/numrefs.docx"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "Employee SSN \nEmployee SSN 519-42-8836 on file.\n on file."
+                  },
+                  "startLine": 3
+                },
+                "region": {
+                  "endColumn": 25,
+                  "snippet": {
+                    "text": "Employee SSN 519-42-8836 on file."
+                  },
+                  "startColumn": 14,
+                  "startLine": 3
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Social Security Number Detected in numrefs.docx at line 3 (confidence: 100.0% - HIGH). Matched text: '519-42-8836'"
+          },
+          "properties": {
+            "confidence": 100,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 45,
+              "original_confidence": 100,
+              "original_file": "<TMPDIR>/numrefs.docx",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "digits": true,
+                "format": true,
+                "not_common_pattern": true,
+                "not_repeating": true,
+                "not_sequential": true,
+                "not_test_number": true,
+                "valid_area": true
+              },
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "ssn"
+            ],
+            "validator": "ssn"
+          },
+          "rank": 100,
+          "ruleId": "SSN"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/numrefs.docx"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "Employee SSN \nEmployee SSN 563-18-7249 on file.\n on file."
+                  },
+                  "startLine": 5
+                },
+                "region": {
+                  "endColumn": 25,
+                  "snippet": {
+                    "text": "Employee SSN 563-18-7249 on file."
+                  },
+                  "startColumn": 14,
+                  "startLine": 5
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Social Security Number Detected in numrefs.docx at line 5 (confidence: 100.0% - HIGH). Matched text: '563-18-7249'"
+          },
+          "properties": {
+            "confidence": 100,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 45,
+              "original_confidence": 100,
+              "original_file": "<TMPDIR>/numrefs.docx",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "digits": true,
+                "format": true,
+                "not_common_pattern": true,
+                "not_repeating": true,
+                "not_sequential": true,
+                "not_test_number": true,
+                "valid_area": true
+              },
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "ssn"
+            ],
+            "validator": "ssn"
+          },
+          "rank": 100,
+          "ruleId": "SSN"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/numrefs.docx"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "Employee SSN \nEmployee SSN 607-31-9284 on file.\n on file."
+                  },
+                  "startLine": 7
+                },
+                "region": {
+                  "endColumn": 25,
+                  "snippet": {
+                    "text": "Employee SSN 607-31-9284 on file."
+                  },
+                  "startColumn": 14,
+                  "startLine": 7
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Social Security Number Detected in numrefs.docx at line 7 (confidence: 100.0% - HIGH). Matched text: '607-31-9284'"
+          },
+          "properties": {
+            "confidence": 100,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 45,
+              "original_confidence": 100,
+              "original_file": "<TMPDIR>/numrefs.docx",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "digits": true,
+                "format": true,
+                "not_common_pattern": true,
+                "not_repeating": true,
+                "not_sequential": true,
+                "not_test_number": true,
+                "valid_area": true
+              },
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "ssn"
+            ],
+            "validator": "ssn"
+          },
+          "rank": 100,
+          "ruleId": "SSN"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/numrefs.docx"
+                },
+                "region": {
+                  "endColumn": 21,
+                  "snippet": {
+                    "text": "Author: Jane Analyst"
+                  },
+                  "startColumn": 9,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "AUTHOR_INFO Detected in numrefs.docx at line 1 (confidence: 60.0% - MEDIUM). Matched text: 'Jane Analyst'"
+          },
+          "properties": {
+            "confidence": 60,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 0,
+              "full_field": "Author: Jane Analyst",
+              "metadata_type": "AUTHOR_INFO",
+              "original_confidence": 60,
+              "original_file": "<TMPDIR>/numrefs.docx",
+              "preprocessor_adjustment": 0,
+              "preprocessor_name": "Office Metadata Extractor",
+              "preprocessor_type": "office_metadata",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "source_file": "<TMPDIR>/numrefs.docx",
+              "source_preprocessor": "office_metadata",
+              "total_adjustment": 0,
+              "validation_checks": {
+                "contains_author_field": true
+              },
+              "validation_path": "metadata"
+            },
+            "validator": "metadata"
+          },
+          "rank": 55,
+          "ruleId": "AUTHOR_INFO"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/numrefs.docx"
+                },
+                "region": {
+                  "endColumn": 29,
+                  "snippet": {
+                    "text": "LastModifiedBy: Ops Reviewer"
+                  },
+                  "startColumn": 17,
+                  "startLine": 2
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "LAST_MODIFIED_BY Detected in numrefs.docx at line 2 (confidence: 60.0% - MEDIUM). Matched text: 'Ops Reviewer'"
+          },
+          "properties": {
+            "confidence": 60,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "HR_Payroll",
+              "context_impact": 0,
+              "full_field": "LastModifiedBy: Ops Reviewer",
+              "metadata_type": "LAST_MODIFIED_BY",
+              "original_confidence": 60,
+              "original_file": "<TMPDIR>/numrefs.docx",
+              "preprocessor_adjustment": 0,
+              "preprocessor_name": "Office Metadata Extractor",
+              "preprocessor_type": "office_metadata",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "source_file": "<TMPDIR>/numrefs.docx",
+              "source_preprocessor": "office_metadata",
+              "total_adjustment": 0,
+              "validation_checks": {
+                "contains_modifier_field": true
+              },
+              "validation_path": "metadata"
+            },
+            "validator": "metadata"
+          },
+          "rank": 55,
+          "ruleId": "LAST_MODIFIED_BY"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/awslabs/ferret-scan",
+          "name": "Ferret Scan",
+          "rules": [
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type AUTHOR_INFO was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/AUTHOR_INFO.md",
+              "id": "AUTHOR_INFO",
+              "shortDescription": {
+                "text": "AUTHOR_INFO Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type LAST_MODIFIED_BY was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/LAST_MODIFIED_BY.md",
+              "id": "LAST_MODIFIED_BY",
+              "shortDescription": {
+                "text": "LAST_MODIFIED_BY Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "A Social Security Number (SSN) pattern was detected in the scanned content. SSNs are highly sensitive personally identifiable information (PII) that must be protected under various regulations."
+              },
+              "help": {
+                "text": "Social Security Numbers are protected under numerous regulations including GDPR, HIPAA, and various state privacy laws. SSNs should never be stored in source code, configuration files, or logs. Remove this SSN immediately and ensure it is stored in a secure, encrypted system with appropriate access controls. Consider implementing tokenization or other data protection mechanisms."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/SSN.md",
+              "id": "SSN",
+              "shortDescription": {
+                "text": "Social Security Number Detected"
+              }
+            }
+          ],
+          "semanticVersion": "0.0.0-development",
+          "version": "0.0.0-development"
+        }
+      },
+      "versionControlProvenance": [
+        {
+          "mappedTo": {
+            "uriBaseId": "%SRCROOT%"
+          },
+          "repositoryUri": "https://github.com/awslabs/ferret-scan",
+          "revisionId": "0.0.0-development"
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/internal/goldencorpus/testdata/golden/file_docx_numeric_character_reference.txt
+++ b/internal/goldencorpus/testdata/golden/file_docx_numeric_character_reference.txt
@@ -1,0 +1,8 @@
+LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH        FILE
+--------------------------------------------------------------------------------------
+[HIGH  ] ssn          SSN                   100.00% line     1 449-87-4100  numrefs.docx
+[HIGH  ] ssn          SSN                   100.00% line     3 519-42-8836  numrefs.docx
+[HIGH  ] ssn          SSN                   100.00% line     5 563-18-7249  numrefs.docx
+[HIGH  ] ssn          SSN                   100.00% line     7 607-31-9284  numrefs.docx
+[MEDIUM] metadata     AUTHOR_INFO            60.00% line     1 Jane Analyst numrefs.docx
+[MEDIUM] metadata     LAST_MODIFIED_BY       60.00% line     2 Ops Reviewer numrefs.docx

--- a/internal/goldencorpus/testdata/golden/file_docx_numeric_character_reference.yaml
+++ b/internal/goldencorpus/testdata/golden/file_docx_numeric_character_reference.yaml
@@ -1,0 +1,191 @@
+results:
+    - text: 449-87-4100
+      line_number: 1
+      type: SSN
+      confidence: 100
+      confidence_level: HIGH
+      filename: <TMPDIR>/numrefs.docx
+      validator: ssn
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 45
+        original_confidence: 100
+        original_file: <TMPDIR>/numrefs.docx
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            format: true
+            not_common_pattern: true
+            not_repeating: true
+            not_sequential: true
+            not_test_number: true
+            valid_area: true
+        validation_path: document
+    - text: 519-42-8836
+      line_number: 3
+      type: SSN
+      confidence: 100
+      confidence_level: HIGH
+      filename: <TMPDIR>/numrefs.docx
+      validator: ssn
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 45
+        original_confidence: 100
+        original_file: <TMPDIR>/numrefs.docx
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            format: true
+            not_common_pattern: true
+            not_repeating: true
+            not_sequential: true
+            not_test_number: true
+            valid_area: true
+        validation_path: document
+    - text: 563-18-7249
+      line_number: 5
+      type: SSN
+      confidence: 100
+      confidence_level: HIGH
+      filename: <TMPDIR>/numrefs.docx
+      validator: ssn
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 45
+        original_confidence: 100
+        original_file: <TMPDIR>/numrefs.docx
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            format: true
+            not_common_pattern: true
+            not_repeating: true
+            not_sequential: true
+            not_test_number: true
+            valid_area: true
+        validation_path: document
+    - text: 607-31-9284
+      line_number: 7
+      type: SSN
+      confidence: 100
+      confidence_level: HIGH
+      filename: <TMPDIR>/numrefs.docx
+      validator: ssn
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 45
+        original_confidence: 100
+        original_file: <TMPDIR>/numrefs.docx
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            format: true
+            not_common_pattern: true
+            not_repeating: true
+            not_sequential: true
+            not_test_number: true
+            valid_area: true
+        validation_path: document
+    - text: Jane Analyst
+      line_number: 1
+      type: AUTHOR_INFO
+      confidence: 60.00000000000001
+      confidence_level: MEDIUM
+      filename: <TMPDIR>/numrefs.docx
+      validator: metadata
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 0
+        full_field: 'Author: Jane Analyst'
+        metadata_type: AUTHOR_INFO
+        original_confidence: 60.00000000000001
+        original_file: <TMPDIR>/numrefs.docx
+        preprocessor_adjustment: 0
+        preprocessor_name: Office Metadata Extractor
+        preprocessor_type: office_metadata
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        source_file: <TMPDIR>/numrefs.docx
+        source_preprocessor: office_metadata
+        total_adjustment: 0
+        validation_checks:
+            contains_author_field: true
+        validation_path: metadata
+    - text: Ops Reviewer
+      line_number: 2
+      type: LAST_MODIFIED_BY
+      confidence: 60.00000000000001
+      confidence_level: MEDIUM
+      filename: <TMPDIR>/numrefs.docx
+      validator: metadata
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: HR_Payroll
+        context_impact: 0
+        full_field: 'LastModifiedBy: Ops Reviewer'
+        metadata_type: LAST_MODIFIED_BY
+        original_confidence: 60.00000000000001
+        original_file: <TMPDIR>/numrefs.docx
+        preprocessor_adjustment: 0
+        preprocessor_name: Office Metadata Extractor
+        preprocessor_type: office_metadata
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        source_file: <TMPDIR>/numrefs.docx
+        source_preprocessor: office_metadata
+        total_adjustment: 0
+        validation_checks:
+            contains_modifier_field: true
+        validation_path: metadata

--- a/internal/preprocessors/text-extractors/text-extract-officetextlib/numeric_character_reference_test.go
+++ b/internal/preprocessors/text-extractors/text-extract-officetextlib/numeric_character_reference_test.go
@@ -1,0 +1,193 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package textextractofficetextlib
+
+import (
+	"strings"
+	"testing"
+)
+
+// A numeric character reference is a legitimate XML spelling of an ordinary character, and Word
+// renders it as that character — so `51&#57;-42-8836` is an SSN on screen and was invisible to
+// every validator.
+//
+// decodeXMLEntities has handled both reference forms since the xlsx path was written, and three
+// other paths kept a hand-rolled five-call strings.Replace chain instead. Measured on a .docx
+// holding four paragraphs (plain, one decimal reference, every digit a reference, one hex
+// reference): the scan reported the plain SSN and NOTHING else — a 75% miss — while a
+// byte-identical .xlsx reported all four at HIGH 100. See #371.
+//
+// These values are the same four the issue measured, so a reader can line the tests up with it.
+const (
+	ncrPlain  = "449-87-4100"
+	ncrDec    = "519-42-8836" // 51&#57;-42-8836
+	ncrAllDec = "563-18-7249" // every digit a decimal reference
+	ncrHex    = "607-31-9284" // 60&#x37;-31-9284
+)
+
+// ncrRawParagraphs is the RAW w:t content: references written as references, which is the whole
+// point. A helper that escaped them would produce `&amp;#57;` and test nothing.
+var ncrRawParagraphs = []string{
+	"Employee SSN: " + ncrPlain,
+	"Employee SSN: 51&#57;-42-8836",
+	"Employee SSN: &#53;&#54;&#51;-&#49;&#56;-&#55;&#50;&#52;&#57;",
+	"Employee SSN: 60&#x37;-31-9284",
+}
+
+func wordDocument(paras []string) string {
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0" encoding="UTF-8"?>` +
+		`<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>`)
+	for _, p := range paras {
+		b.WriteString(`<w:p><w:r><w:t xml:space="preserve">` + p + `</w:t></w:r></w:p>`)
+	}
+	b.WriteString(`</w:body></w:document>`)
+	return b.String()
+}
+
+func assertAllDecoded(t *testing.T, where, text string) {
+	t.Helper()
+	for _, want := range []string{ncrPlain, ncrDec, ncrAllDec, ncrHex} {
+		if !strings.Contains(text, want) {
+			t.Errorf("%s: %q is not in the extracted text, so no validator can ever see it.\n"+
+				"Only reported findings are redacted, so a value invisible here survives "+
+				"--enable-redaction in a file the tool calls clean.\ngot: %q", where, want, text)
+		}
+	}
+	// The references must not survive alongside their decoded form either: text still holding
+	// "&#57;" means something decoded a copy rather than the value the validators will scan.
+	if strings.Contains(text, "&#57;") || strings.Contains(text, "&#x37;") {
+		t.Errorf("%s: an undecoded reference remains in the extracted text: %q", where, text)
+	}
+}
+
+// TestDocxBodyDecodesNumericCharacterReferences covers extractDocxText — the path the issue
+// measured.
+func TestDocxBodyDecodesNumericCharacterReferences(t *testing.T) {
+	path := writeZip(t, t.TempDir(), "ncr.docx", []part{
+		{"[Content_Types].xml", ctypesDocx},
+		{"word/document.xml", wordDocument(ncrRawParagraphs)},
+	})
+
+	got, err := ExtractText(path)
+	if err != nil {
+		t.Fatalf("ExtractText: %v", err)
+	}
+	assertAllDecoded(t, "docx body", got.Text)
+}
+
+// TestDocxHeaderAndFooterDecodeNumericCharacterReferences covers extractWordXMLText, the third
+// hand-rolled chain. A header is where a document template puts the account or case number it
+// stamps on every page, so a miss here is not an exotic case.
+func TestDocxHeaderAndFooterDecodeNumericCharacterReferences(t *testing.T) {
+	path := writeZip(t, t.TempDir(), "hdr.docx", []part{
+		{"[Content_Types].xml", ctypesDocx},
+		{"word/document.xml", wordDocument([]string{"Body text with nothing sensitive."})},
+		{"word/header1.xml", wordDocument([]string{"Case ref 51&#57;-42-8836"})},
+		{"word/footer1.xml", wordDocument([]string{"Account 60&#x37;-31-9284"})},
+	})
+
+	got, err := ExtractText(path)
+	if err != nil {
+		t.Fatalf("ExtractText: %v", err)
+	}
+	for _, want := range []string{ncrDec, ncrHex} {
+		if !strings.Contains(got.Text, want) {
+			t.Errorf("%q is not in the extracted header/footer text: %q", want, got.Text)
+		}
+	}
+}
+
+// TestPresentationAndOpenDocumentDecodeNumericCharacterReferences covers extractTextFromXML, the
+// second chain — it serves .pptx slides, notes and masters, plus .odt/.ods/.odp.
+func TestPresentationAndOpenDocumentDecodeNumericCharacterReferences(t *testing.T) {
+	slide := `<?xml version="1.0" encoding="UTF-8"?>` +
+		`<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" ` +
+		`xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><p:cSld><p:spTree>` +
+		`<p:sp><p:txBody><a:p><a:r><a:t>Employee SSN: 51&#57;-42-8836</a:t></a:r></a:p></p:txBody></p:sp>` +
+		`</p:spTree></p:cSld></p:sld>`
+	pptx := writeZip(t, t.TempDir(), "deck.pptx", []part{
+		{"[Content_Types].xml", ctypesPptx},
+		{"ppt/presentation.xml", `<?xml version="1.0"?><p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"/>`},
+		{"ppt/slides/slide1.xml", slide},
+	})
+
+	got, err := ExtractText(pptx)
+	if err != nil {
+		t.Fatalf("pptx ExtractText: %v", err)
+	}
+	if !strings.Contains(got.Text, ncrDec) {
+		t.Errorf("pptx: %q is not in the extracted slide text: %q", ncrDec, got.Text)
+	}
+
+	odtContent := `<?xml version="1.0" encoding="UTF-8"?>` +
+		`<office:document-content xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" ` +
+		`xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"><office:body><office:text>` +
+		`<text:p>Employee SSN: 60&#x37;-31-9284</text:p></office:text></office:body></office:document-content>`
+	odt := writeZip(t, t.TempDir(), "notes.odt", []part{
+		{"mimetype", "application/vnd.oasis.opendocument.text"},
+		{"content.xml", odtContent},
+	})
+
+	got, err = ExtractText(odt)
+	if err != nil {
+		t.Fatalf("odt ExtractText: %v", err)
+	}
+	if !strings.Contains(got.Text, ncrHex) {
+		t.Errorf("odt: %q is not in the extracted text: %q", ncrHex, got.Text)
+	}
+}
+
+// TestASingleNonOverlappingPassDoesNotReReadItsOwnOutput is the second defect the chains had,
+// and the issue's description of it needed correcting.
+//
+// The chain ran lt, gt, amp, quot, apos in that order, so only the entities AFTER &amp; could be
+// re-read: `&amp;quot;` became `"` and `&amp;apos;` became `'`, both wrong — the document says
+// the literal text `&quot;`. The issue's own example, `&amp;lt;`, does NOT reproduce, because
+// &lt; is replaced before &amp; creates one. Measured both ways before writing this.
+//
+// It matters beyond tidiness: a value written `&amp;#57;` means the literal five characters
+// `&#57;`, and a decoder that re-read its own output would turn it into a digit — inventing a
+// number the document does not contain, in the text the validators score.
+func TestASingleNonOverlappingPassDoesNotReReadItsOwnOutput(t *testing.T) {
+	cases := map[string]string{
+		"&amp;lt;":         "&lt;",   // the chain got this one right
+		"&amp;gt;":         "&gt;",   // and this one
+		"&amp;amp;":        "&amp;",  // and this one
+		"&amp;quot;":       "&quot;", // the chain returned `"`
+		"&amp;apos;":       "&apos;", // the chain returned `'`
+		"&amp;#57;":        "&#57;",  // must stay text, not become "9"
+		"&lt;tag&gt;":      "<tag>",  // ordinary decoding still works
+		"no entities here": "no entities here",
+	}
+	for in, want := range cases {
+		if got := decodeXMLEntities(in); got != want {
+			t.Errorf("decodeXMLEntities(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestAnUnparseableReferenceIsLeftAsWritten is the non-vacuity floor for the decoder's own
+// guard: a reference naming no valid code point must reach the validators as the raw text it is,
+// not as U+FFFD, which would be unsearchable and unredactable.
+func TestAnUnparseableReferenceIsLeftAsWritten(t *testing.T) {
+	for _, in := range []string{"&#0;", "&#xD800;", "&#999999999;", "&#x110000;"} {
+		if got := decodeXMLEntities(in); got != in {
+			t.Errorf("decodeXMLEntities(%q) = %q, want it left as written", in, got)
+		}
+	}
+}
+
+const ctypesDocx = `<?xml version="1.0" encoding="UTF-8"?>` +
+	`<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+	`<Default Extension="xml" ContentType="application/xml"/>` +
+	`<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>` +
+	`</Types>`
+
+const ctypesPptx = `<?xml version="1.0" encoding="UTF-8"?>` +
+	`<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+	`<Default Extension="xml" ContentType="application/xml"/>` +
+	`<Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>` +
+	`<Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>` +
+	`</Types>`

--- a/internal/preprocessors/text-extractors/text-extract-officetextlib/office-text-extractor.go
+++ b/internal/preprocessors/text-extractors/text-extract-officetextlib/office-text-extractor.go
@@ -235,12 +235,7 @@ func extractDocxText(filePath string, content *TextContent) (*TextContent, error
 	// Remove all remaining XML tags
 	cleanedXML = regexp.MustCompile(`<[^>]*>`).ReplaceAllString(cleanedXML, "")
 
-	// Clean up XML entities
-	cleanedXML = strings.Replace(cleanedXML, "&lt;", "<", -1)
-	cleanedXML = strings.Replace(cleanedXML, "&gt;", ">", -1)
-	cleanedXML = strings.Replace(cleanedXML, "&amp;", "&", -1)
-	cleanedXML = strings.Replace(cleanedXML, "&quot;", "\"", -1)
-	cleanedXML = strings.Replace(cleanedXML, "&apos;", "'", -1)
+	cleanedXML = decodeXMLEntities(cleanedXML)
 
 	// Clean up whitespace while preserving tabs and structure
 	// Convert non-breaking spaces to regular spaces
@@ -686,13 +681,7 @@ func extractTextFromXML(file *zip.File, pattern string) (string, error) {
 
 	for _, match := range matches {
 		if len(match) > 1 {
-			// Clean up XML entities
-			text := string(match[1])
-			text = strings.Replace(text, "&lt;", "<", -1)
-			text = strings.Replace(text, "&gt;", ">", -1)
-			text = strings.Replace(text, "&amp;", "&", -1)
-			text = strings.Replace(text, "&quot;", "\"", -1)
-			text = strings.Replace(text, "&apos;", "'", -1)
+			text := decodeXMLEntities(string(match[1]))
 
 			// Remove any XML tags that might be inside the text
 			text = regexp.MustCompile(`<[^>]*>`).ReplaceAllString(text, "")
@@ -1162,12 +1151,7 @@ func extractWordXMLText(file *zip.File) (string, error) {
 	cleanedXML = regexp.MustCompile(`<w:tab[^>]*/?>`).ReplaceAllString(cleanedXML, "\t")
 	cleanedXML = regexp.MustCompile(`<[^>]*>`).ReplaceAllString(cleanedXML, "")
 
-	// Clean up XML entities
-	cleanedXML = strings.Replace(cleanedXML, "&lt;", "<", -1)
-	cleanedXML = strings.Replace(cleanedXML, "&gt;", ">", -1)
-	cleanedXML = strings.Replace(cleanedXML, "&amp;", "&", -1)
-	cleanedXML = strings.Replace(cleanedXML, "&quot;", "\"", -1)
-	cleanedXML = strings.Replace(cleanedXML, "&apos;", "'", -1)
+	cleanedXML = decodeXMLEntities(cleanedXML)
 
 	// Clean up whitespace
 	cleanedXML = regexp.MustCompile(`[ ]+`).ReplaceAllString(cleanedXML, " ")

--- a/internal/redactors/office/entity_escaping_test.go
+++ b/internal/redactors/office/entity_escaping_test.go
@@ -414,3 +414,80 @@ func TestResidueIdentificationStaysOffTheCleanPath(t *testing.T) {
 			"counter cannot detect a regression")
 	}
 }
+
+// A refusal must not publish the values it is refusing over.
+//
+// The residue message reaches stderr and every machine format with no --show-match, so listing
+// the residual values there would hand out the exact data the refusal exists to protect. It did:
+// measured on a .docx whose value sits in a vt:blob property, the message read
+//
+//	refusing to write blobbed.docx: 2 reported value(s) still present in the document's own
+//	parts: 449-87-4100, SSN 449-87-4100 payload
+//
+// This is the same rule that keeps a matched value out of a validator's debug log and a scanned
+// path out of a failed-extraction line (#367). The count and the TYPES are what an operator acts
+// on; the value is what they already have in the original.
+func TestResidueRefusalNamesTypesNotValues(t *testing.T) {
+	const ssn = "449-87-4100"
+	contents := &OfficeZipContents{Files: map[string][]byte{
+		"docProps/custom.xml": []byte(`<?xml version="1.0"?><Properties><property name="X">` +
+			`<vt:blob>SSN ` + ssn + ` payload</vt:blob></property></Properties>`),
+	}}
+	matches := []detector.Match{
+		{Text: ssn, Type: "SSN"},
+		{Text: "SSN " + ssn + " payload", Type: "CUSTOM_PROPERTY"},
+	}
+
+	residue := parentPartResidue(contents, matches)
+	if len(residue) != 2 {
+		t.Fatalf("parentPartResidue = %d entries, want 2; the rest of this test would be vacuous", len(residue))
+	}
+
+	types := residueTypes(residue)
+	if strings.Join(types, ",") != "CUSTOM_PROPERTY,SSN" {
+		t.Errorf("residueTypes = %v, want the distinct types sorted", types)
+	}
+	for _, tp := range types {
+		if strings.Contains(tp, ssn) || strings.Contains(tp, "payload") {
+			t.Errorf("residueTypes leaked a value: %q", tp)
+		}
+	}
+
+	// A match with no type must still be counted, or the message would understate what is
+	// left in the file.
+	untyped := residueTypes([]detector.Match{{Text: ssn}})
+	if len(untyped) != 1 || untyped[0] != "unknown" {
+		t.Errorf("residueTypes for an untyped match = %v, want [unknown]", untyped)
+	}
+
+	// And the assertion that actually matters is on the OPERATOR-VISIBLE string, not on the
+	// helper: this error is what reaches stderr and every machine format. Asserting only on
+	// residueTypes let a mutation that restored the value-joining message survive.
+	dir := t.TempDir()
+	src := filepath.Join(dir, "in.docx")
+	custom := `<?xml version="1.0"?>` +
+		`<Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/custom-properties" ` +
+		`xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes">` +
+		`<property fmtid="{D5CDD505-2E9C-101B-9397-08002B2CF9AE}" pid="2" name="Blobbed">` +
+		`<vt:blob>SSN ` + ssn + ` payload</vt:blob></property></Properties>`
+	if err := os.WriteFile(src, buildPkg(t, "Body text with nothing sensitive.",
+		map[string][]byte{"docProps/custom.xml": []byte(custom)}), 0o600); err != nil {
+		t.Fatalf("writing fixture: %v", err)
+	}
+
+	r := NewOfficeRedactor(nil, nil)
+	_, err := r.RedactDocument(src, filepath.Join(dir, "out.docx"),
+		[]detector.Match{{Text: ssn, Type: "SSN", Confidence: 90, LineNumber: 1}},
+		redactors.RedactionSimple)
+	if err == nil {
+		t.Fatal("a value inside a vt:blob must be refused, not written — the binary families are " +
+			"deliberately not rewritten in place, because a same-length replacement inside base64 " +
+			"produces invalid base64")
+	}
+	if strings.Contains(err.Error(), ssn) {
+		t.Errorf("the refusal published the value it is refusing over:\n  %v", err)
+	}
+	if !strings.Contains(err.Error(), "types:") || !strings.Contains(err.Error(), "SSN") {
+		t.Errorf("the refusal does not name the finding TYPE, which is what an operator acts on:\n  %v", err)
+	}
+}

--- a/internal/redactors/office/entity_escaping_test.go
+++ b/internal/redactors/office/entity_escaping_test.go
@@ -1,0 +1,288 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package office
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/xml"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/redactors"
+)
+
+// Office redaction used to string-match the DECODED value against the RAW part
+// bytes, so any value whose stored spelling differed from its decoded form was
+// never found — while RedactDocument still returned success.
+//
+// extractTextFromXML reads part text through encoding/xml, so the value the report
+// names is "Fairbanks & Kettleworth", never the "Fairbanks &amp; Kettleworth" that
+// is on disk. Measured before the fix, on a .docx whose Company property held an
+// ampersand: --enable-redaction exited 0, the audit log recorded
+// successful_redactions:4 / failed_redactions:0, and exiftool read the company name
+// straight out of the "redacted" copy.
+//
+// This needs no attacker. XML REQUIRES '&' in character data to be written "&amp;".
+//
+// The numeric forms generalise it: '&' also introduces character references, so any
+// character at any offset can be respelled. "449-87-41&#48;0", "&#52;49-87-4100" and
+// the &#x30; hex form are all the same value, which is why enumerating escaped
+// spellings as extra replacer keys cannot close this and canonicalising through the
+// codec can.
+
+// decodedCharData returns the concatenated, entity-DECODED character data of a part
+// inside an OOXML package.
+//
+// Decoding is the whole point: asserting on the raw bytes is what let this defect
+// ship. Grepping the .docx itself is worse still — that searches COMPRESSED bytes
+// and always "finds nothing".
+func decodedCharData(t *testing.T, pkg []byte, part string) string {
+	t.Helper()
+
+	zr, err := zip.NewReader(bytes.NewReader(pkg), int64(len(pkg)))
+	if err != nil {
+		t.Fatalf("opening package: %v", err)
+	}
+	for _, f := range zr.File {
+		if f.Name != part {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("opening %s: %v", part, err)
+		}
+		raw, err := io.ReadAll(rc)
+		rc.Close()
+		if err != nil {
+			t.Fatalf("reading %s: %v", part, err)
+		}
+
+		var sb strings.Builder
+		dec := xml.NewDecoder(bytes.NewReader(raw))
+		for {
+			tok, err := dec.Token()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				t.Fatalf("%s is not well-formed XML after redaction: %v", part, err)
+			}
+			if cd, ok := tok.(xml.CharData); ok {
+				sb.Write(cd)
+			}
+		}
+		return sb.String()
+	}
+	t.Fatalf("part %s not found in package", part)
+	return ""
+}
+
+// TestEscapedValueIsRedacted is the regression gate. Every case fails before the
+// fix, because the stored spelling of the value never occurs literally in the part.
+func TestEscapedValueIsRedacted(t *testing.T) {
+	cases := []struct {
+		name string
+		// stored is written verbatim into <w:t>, i.e. the on-disk spelling.
+		stored string
+		// reported is what the validators see and what the report names, i.e. the
+		// decoded form. RedactDocument is given this, exactly as the scanner gives it.
+		reported string
+		typ      string
+	}{
+		{
+			name:     "predefined entity amp inside the value",
+			stored:   "Company: Fairbanks &amp; Kettleworth Holdings",
+			reported: "Fairbanks & Kettleworth Holdings",
+			typ:      "COMPANY_INFO",
+		},
+		{
+			name:     "predefined entity apos inside the value",
+			stored:   "Patient name: Patrick O&apos;Connor",
+			reported: "Patrick O'Connor",
+			typ:      "PERSON_NAME",
+		},
+		{
+			name:     "decimal character reference mid-value",
+			stored:   "Employee SSN: 449-87-41&#48;0 on file",
+			reported: "449-87-4100",
+			typ:      "SSN",
+		},
+		{
+			name:     "hex character reference mid-value",
+			stored:   "Employee SSN: 449-87-41&#x30;0 on file",
+			reported: "449-87-4100",
+			typ:      "SSN",
+		},
+		{
+			name:     "character reference at the first byte of the value",
+			stored:   "Employee SSN: &#52;49-87-4100 on file",
+			reported: "449-87-4100",
+			typ:      "SSN",
+		},
+		{
+			name:     "every separator respelled",
+			stored:   "Employee SSN: 449&#45;87&#45;4100 on file",
+			reported: "449-87-4100",
+			typ:      "SSN",
+		},
+		{
+			name:     "lt and gt around the value",
+			stored:   "Owner &lt;Fairbanks &amp; Kettleworth Holdings&gt; noted",
+			reported: "Fairbanks & Kettleworth Holdings",
+			typ:      "COMPANY_INFO",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			src := filepath.Join(dir, "in.docx")
+			if err := os.WriteFile(src, buildPkg(t, tc.stored, nil), 0o600); err != nil {
+				t.Fatalf("writing fixture: %v", err)
+			}
+
+			out := filepath.Join(dir, "out.docx")
+			matches := []detector.Match{{
+				Text: tc.reported, Type: tc.typ, Confidence: 100, LineNumber: 1,
+				Context: detector.ContextInfo{FullLine: tc.stored},
+			}}
+			r := NewOfficeRedactor(nil, nil)
+			if _, err := r.RedactDocument(src, out, matches, redactors.RedactionSimple); err != nil {
+				t.Fatalf("RedactDocument: %v", err)
+			}
+
+			pkg, err := os.ReadFile(out)
+			if err != nil {
+				t.Fatalf("reading output: %v", err)
+			}
+			got := decodedCharData(t, pkg, "word/document.xml")
+
+			if strings.Contains(got, tc.reported) {
+				t.Errorf("the reported value survived redaction.\n  stored on disk: %s\n  reported as:    %s\n  decoded output: %s\n"+
+					"Only reported findings are redacted, so this value is left in cleartext in a file the tool called successfully redacted.",
+					tc.stored, tc.reported, got)
+			}
+		})
+	}
+}
+
+// The rewrite must not damage anything it was not asked to change: the part stays
+// well-formed, unmatched text survives, and a value with no entities is unaffected.
+//
+// Without this, "redact everything" would pass the test above.
+func TestRewritePreservesTheRestOfThePart(t *testing.T) {
+	const stored = "Keep this prose. Company: Fairbanks &amp; Kettleworth Holdings. Keep this too."
+	const reported = "Fairbanks & Kettleworth Holdings"
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "in.docx")
+	if err := os.WriteFile(src, buildPkg(t, stored, nil), 0o600); err != nil {
+		t.Fatalf("writing fixture: %v", err)
+	}
+	out := filepath.Join(dir, "out.docx")
+	r := NewOfficeRedactor(nil, nil)
+	if _, err := r.RedactDocument(src, out, []detector.Match{{
+		Text: reported, Type: "COMPANY_INFO", Confidence: 100, LineNumber: 1,
+	}}, redactors.RedactionSimple); err != nil {
+		t.Fatalf("RedactDocument: %v", err)
+	}
+	pkg, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("reading output: %v", err)
+	}
+	// decodedCharData fails the test if the part is no longer well-formed.
+	got := decodedCharData(t, pkg, "word/document.xml")
+
+	for _, keep := range []string{"Keep this prose.", "Keep this too."} {
+		if !strings.Contains(got, keep) {
+			t.Errorf("surrounding text %q was lost; decoded output: %s", keep, got)
+		}
+	}
+	if strings.Contains(got, reported) {
+		t.Errorf("the value was not redacted; decoded output: %s", got)
+	}
+}
+
+// rewritePartText is exercised directly for the properties the end-to-end tests
+// cannot reach.
+func TestRewritePartText(t *testing.T) {
+	t.Run("a value in an ATTRIBUTE is still replaced", func(t *testing.T) {
+		// Attribute values are not character data. A CharData-only rewrite would
+		// silently stop redacting these, turning a leak fix into a new leak — so the
+		// bytes outside character data keep going through the raw replacer.
+		in := []byte(`<r><p w:val="449-87-4100"/><t>nothing here</t></r>`)
+		got, _ := rewritePartText(in, strings.NewReplacer("449-87-4100", "***-**-4100"))
+		if strings.Contains(string(got), "449-87-4100") {
+			t.Errorf("attribute-resident value survived: %s", got)
+		}
+	})
+
+	t.Run("a part encoding/xml refuses falls back to the raw replacer", func(t *testing.T) {
+		// "&foo;" is an undefined entity and the tokenizer errors on it. The previous
+		// behaviour must be preserved rather than the document failing.
+		in := []byte(`<t>449-87-4100 and &foo; trailing</t>`)
+		got, rewrites := rewritePartText(in, strings.NewReplacer("449-87-4100", "***-**-4100"))
+		if strings.Contains(string(got), "449-87-4100") {
+			t.Errorf("value survived in an untokenizable part: %s", got)
+		}
+		if rewrites != 0 {
+			t.Errorf("rewrites = %d, want 0 — the decoded path cannot run on a part that does not tokenize", rewrites)
+		}
+	})
+
+	t.Run("no match means byte-identical output", func(t *testing.T) {
+		in := []byte(`<t>Fairbanks &amp; Kettleworth</t>`)
+		got, rewrites := rewritePartText(in, strings.NewReplacer("449-87-4100", "***-**-4100"))
+		if !bytes.Equal(got, in) {
+			t.Errorf("part was rewritten with no match to make.\n got: %s\nwant: %s", got, in)
+		}
+		if rewrites != 0 {
+			t.Errorf("rewrites = %d, want 0", rewrites)
+		}
+	})
+}
+
+// escapeCharData must escape '&' unconditionally. A decoded value can contain an
+// ampersand followed by entity-looking text — "&amp;lt;" decodes to the literal
+// "&lt;" — so an escaper that skipped '&' before a known entity name would corrupt
+// that value on the way out, and the corruption would only appear in documents that
+// were redacted.
+func TestEscapeCharDataRoundTrips(t *testing.T) {
+	for _, s := range []string{
+		"plain text",
+		"Fairbanks & Kettleworth",
+		"&lt;",  // a LITERAL ampersand followed by "lt;"
+		"&amp;", // a literal ampersand followed by "amp;"
+		"a < b > c",
+		"&&&",
+		"O'Connor \"quoted\"",
+		"line\nbreak\ttab",
+	} {
+		var buf bytes.Buffer
+		escapeCharData(&buf, s)
+
+		var back strings.Builder
+		dec := xml.NewDecoder(strings.NewReader("<t>" + buf.String() + "</t>"))
+		for {
+			tok, err := dec.Token()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				t.Fatalf("escapeCharData(%q) produced %q, which is not well-formed: %v", s, buf.String(), err)
+			}
+			if cd, ok := tok.(xml.CharData); ok {
+				back.Write(cd)
+			}
+		}
+		if back.String() != s {
+			t.Errorf("round trip lost data: %q -> %q -> %q", s, buf.String(), back.String())
+		}
+	}
+}

--- a/internal/redactors/office/entity_escaping_test.go
+++ b/internal/redactors/office/entity_escaping_test.go
@@ -491,3 +491,50 @@ func TestResidueRefusalNamesTypesNotValues(t *testing.T) {
 		t.Errorf("the refusal does not name the finding TYPE, which is what an operator acts on:\n  %v", err)
 	}
 }
+
+// A reported value in a NUMERIC custom property must be masked, not skipped.
+//
+// A custom property named MemberId or RecordId is routinely written as <vt:i4>. The redactor
+// extracted only the string-typed elements, so no replacement was ever registered for the part
+// and the value came back byte-identical at rc 0 — measured on a .docx whose only property is
+// <vt:i4>729183640</vt:i4>. See #373.
+//
+// The same fixture in <vt:lpwstr> already redacted, which is what makes this an element-list
+// defect rather than a rewriting one.
+func TestNumericDocPropsValueIsRedacted(t *testing.T) {
+	for _, element := range []string{"i4", "i8", "int", "ui4", "r8", "decimal", "lpwstr"} {
+		t.Run(element, func(t *testing.T) {
+			const value = "729183640"
+			dir := t.TempDir()
+			src := filepath.Join(dir, "in.docx")
+			custom := `<?xml version="1.0"?>` +
+				`<Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/custom-properties" ` +
+				`xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes">` +
+				`<property fmtid="{D5CDD505-2E9C-101B-9397-08002B2CF9AE}" pid="2" name="RecordId">` +
+				`<vt:` + element + `>` + value + `</vt:` + element + `></property></Properties>`
+			if err := os.WriteFile(src, buildPkg(t, "Body text with nothing sensitive.",
+				map[string][]byte{"docProps/custom.xml": []byte(custom)}), 0o600); err != nil {
+				t.Fatalf("writing fixture: %v", err)
+			}
+
+			out := filepath.Join(dir, "out.docx")
+			r := NewOfficeRedactor(nil, nil)
+			if _, err := r.RedactDocument(src, out, []detector.Match{{
+				Text: value, Type: "SSN", Confidence: 50, LineNumber: 1,
+			}}, redactors.RedactionFormatPreserving); err != nil {
+				t.Fatalf("RedactDocument: %v", err)
+			}
+
+			pkg, err := os.ReadFile(out) // #nosec G304 -- test-controlled temp path
+			if err != nil {
+				t.Fatalf("reading output: %v", err)
+			}
+			got := decodedCharData(t, pkg, "docProps/custom.xml")
+			if strings.Contains(got, value) {
+				t.Errorf("<vt:%s> still holds the reported value after redaction: %q\n"+
+					"A value the redactor cannot locate is a value it silently leaves behind, in a "+
+					"file the tool reports as redacted.", element, got)
+			}
+		})
+	}
+}

--- a/internal/redactors/office/entity_escaping_test.go
+++ b/internal/redactors/office/entity_escaping_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -284,5 +285,132 @@ func TestEscapeCharDataRoundTrips(t *testing.T) {
 		if back.String() != s {
 			t.Errorf("round trip lost data: %q -> %q -> %q", s, buf.String(), back.String())
 		}
+	}
+}
+
+// The parent document had NO residue check at all. That absence is what let the
+// entity-escaping defect attest success: applyPendingRedactions could no-op for a
+// value and RedactDocument still returned Success with failed_redactions:0, because
+// nothing ever asked whether the value was gone.
+//
+// The check must compare on DECODED text. A raw-byte search for the reported value
+// would not find "Fairbanks &amp; Kettleworth" while looking for
+// "Fairbanks & Kettleworth", so it would certify the exact leak it exists to catch.
+
+func TestParentPartResidueComparesDecoded(t *testing.T) {
+	const reported = "Fairbanks & Kettleworth Holdings"
+
+	cases := []struct {
+		name    string
+		stored  string
+		wantHit bool
+	}{
+		{"escaped ampersand is still residue", `<t>Company: Fairbanks &amp; Kettleworth Holdings</t>`, true},
+		{"decimal reference is still residue", `<t>Company: Fairbanks &#38; Kettleworth Holdings</t>`, true},
+		// A bare '&' is not well-formed XML, so this part does not tokenize and is
+		// skipped. Kept as a case because it documents the interaction: for a value
+		// CONTAINING an ampersand, a "plain spelling" cannot exist in a valid part.
+		{"a bare ampersand does not tokenize, so the part is skipped", `<t>Company: Fairbanks & Kettleworth Holdings</t>`, false},
+		{"redacted value is not residue", `<t>Company: ********************************</t>`, false},
+		{"value in an attribute is residue", `<p w:val="Fairbanks &amp; Kettleworth Holdings"/>`, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &OfficeZipContents{Files: map[string][]byte{"word/document.xml": []byte("<r>" + tc.stored + "</r>")}}
+			got := parentPartResidue(c, []detector.Match{{Text: reported, Type: "COMPANY_INFO"}})
+			if tc.wantHit && len(got) == 0 {
+				t.Errorf("residue not detected in %s — a missed rewrite would be attested as success", tc.stored)
+			}
+			if !tc.wantHit && len(got) != 0 {
+				t.Errorf("residue falsely reported %v in %s — a false refusal turns a working redaction into an error", got, tc.stored)
+			}
+		})
+	}
+}
+
+// A raw-byte search cannot do this job. Pinned so nobody "simplifies" the decode away.
+func TestResidueRawByteSearchWouldMiss(t *testing.T) {
+	const reported = "Fairbanks & Kettleworth Holdings"
+	stored := []byte(`<r><t>Company: Fairbanks &amp; Kettleworth Holdings</t></r>`)
+
+	if strings.Contains(string(stored), reported) {
+		t.Fatal("fixture is wrong: the reported value occurs literally, so this proves nothing")
+	}
+	c := &OfficeZipContents{Files: map[string][]byte{"word/document.xml": stored}}
+	if got := parentPartResidue(c, []detector.Match{{Text: reported}}); len(got) == 0 {
+		t.Error("parentPartResidue missed a value that is present only in escaped form — the decode is load-bearing")
+	}
+}
+
+// A part that does not tokenize is skipped, not treated as residue: absence cannot be
+// established there, but neither can presence, and refusing on a malformed part the
+// redactor never claimed to rewrite would fail closed on the wrong thing.
+func TestResidueSkipsUntokenizableParts(t *testing.T) {
+	c := &OfficeZipContents{Files: map[string][]byte{
+		"word/document.xml": []byte(`<t>value 449-87-4100 and &foo; trailing</t>`),
+	}}
+	if got := parentPartResidue(c, []detector.Match{{Text: "449-87-4100"}}); len(got) != 0 {
+		t.Errorf("parentPartResidue = %v on an untokenizable part, want none", got)
+	}
+}
+
+// Values below the embedded value set's floor are not searched for, matching
+// embeddedValueSet. A three-character value produces meaningless hits.
+func TestResidueIgnoresShortValues(t *testing.T) {
+	c := &OfficeZipContents{Files: map[string][]byte{"word/document.xml": []byte(`<t>abc</t>`)}}
+	if got := parentPartResidue(c, []detector.Match{{Text: "abc"}}); len(got) != 0 {
+		t.Errorf("parentPartResidue = %v for a value shorter than minResidueValueLen, want none", got)
+	}
+}
+
+// The residue check must not be quadratic in the number of reported values.
+//
+// The first version did one strings.Contains per value per part. Measured on a real
+// .docx as the reported-value count doubled through 500/1000/2000/4000, the residue
+// check added +0.00s, +0.01s, +0.02s then +0.09s — about 4.5x per doubling.
+//
+// It is now two stages: one strings.Replacer trie pass, whose cost does not grow with
+// the value count, decides whether ANY value is present; the per-value identification
+// loop runs only when the document is already going to be refused.
+//
+// This asserts the STRUCTURE via a counter, not a duration or an allocation figure.
+// Both alternatives were tried and both are blind here:
+//
+//   - allocation: the quadratic is pure strings.Contains work and allocates nothing.
+//     An allocation-ratio version of this test PASSED with the quadratic restored.
+//   - wall clock: not portable to the Windows runner, and this repo has already had a
+//     locally-tuned timing guard fail on CI at 6.1x its local ratio.
+func TestResidueIdentificationStaysOffTheCleanPath(t *testing.T) {
+	part := []byte(`<r><t>` + strings.Repeat("ordinary document prose that matches nothing. ", 400) + `</t></r>`)
+	contents := &OfficeZipContents{Files: map[string][]byte{"word/document.xml": part}}
+
+	matches := make([]detector.Match, 2000)
+	for i := range matches {
+		matches[i] = detector.Match{Text: "absent-value-" + strconv.Itoa(i), Type: "SSN"}
+	}
+
+	before := residueIdentifyPasses.Load()
+	if got := parentPartResidue(contents, matches); len(got) != 0 {
+		t.Fatalf("parentPartResidue reported %v on a part containing none of the values", got)
+	}
+	if after := residueIdentifyPasses.Load(); after != before {
+		t.Errorf("the per-value identification loop ran %d time(s) with no residue present. "+
+			"It is O(values x text) and must stay on the refusal path only: the trie probe "+
+			"decides presence in a single pass.", after-before)
+	}
+
+	// Non-vacuity: the counter must actually move when there IS residue, otherwise the
+	// assertion above would pass against a function that never identifies anything.
+	withResidue := &OfficeZipContents{Files: map[string][]byte{
+		"word/document.xml": []byte(`<r><t>Employee SSN: 449-87-4100 on file</t></r>`),
+	}}
+	before = residueIdentifyPasses.Load()
+	if got := parentPartResidue(withResidue, []detector.Match{{Text: "449-87-4100"}}); len(got) != 1 {
+		t.Fatalf("parentPartResidue = %v, want the one present value", got)
+	}
+	if after := residueIdentifyPasses.Load(); after == before {
+		t.Error("the identification loop did not run even though residue was present, so the " +
+			"counter cannot detect a regression")
 	}
 }

--- a/internal/redactors/office/redactor.go
+++ b/internal/redactors/office/redactor.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/awslabs/ferret-scan/v2/internal/detector"
@@ -230,6 +231,22 @@ func (or *OfficeRedactor) RedactDocument(originalPath string, outputPath string,
 		return nil, fmt.Errorf(
 			"refusing to write %s: %d embedded part(s) still contain reported values: %s",
 			filepath.Base(outputPath), len(unredacted), embeddedFailureSummary(unredacted))
+	}
+
+	// Refuse to write a document whose OWN parts still hold a reported value.
+	//
+	// The embedded refusal above covers children only. The parent document was never
+	// checked at all, which is what let the entity-escaping defect attest success:
+	// applyPendingRedactions could no-op for a value and RedactDocument still returned
+	// Success with failed_redactions:0, because nothing ever asked whether the value
+	// was gone. A missed rewrite is now a refusal rather than a false attestation, on
+	// the same fail-closed policy and for the same reason — the artefact a user
+	// forwards must not be a document containing an SSN in a directory named
+	// "redacted".
+	if residue := parentPartResidue(modifiedContents, matches); len(residue) > 0 {
+		return nil, fmt.Errorf(
+			"refusing to write %s: %d reported value(s) still present in the document's own parts: %s",
+			filepath.Base(outputPath), len(residue), strings.Join(residue, ", "))
 	}
 
 	// Repackage ZIP with modified contents
@@ -859,6 +876,169 @@ func (or *OfficeRedactor) applyPendingRedactions(zipContents *OfficeZipContents,
 	}
 
 	return nil
+}
+
+// residueIdentifyPasses counts how many times the residue check has entered its
+// per-value identification loop.
+//
+// It exists for one guard: the identification loop is O(values x text) and must stay
+// off the successful path. Measured when it was NOT: +0.00s, +0.01s, +0.02s then
+// +0.09s as the reported-value count doubled through 500/1000/2000/4000, i.e. about
+// 4.5x per doubling.
+//
+// A counter rather than a timing assertion, because the quadratic here is pure
+// strings.Contains work that allocates nothing — so an allocation-based guard is blind
+// to it (verified: restoring the quadratic passed an allocation ratio test) — and
+// wall-clock thresholds are not portable to the Windows runner.
+var residueIdentifyPasses atomic.Uint64
+
+// parentPartResidue returns the reported values still present in the document's own
+// XML parts after redaction, comparing on DECODED text.
+//
+// Decoding is the whole point. The defect this guards against is a value whose stored
+// spelling differs from its reported form, so a raw-byte search for the reported value
+// would not find "Fairbanks &amp; Kettleworth" while looking for
+// "Fairbanks & Kettleworth" and would cheerfully report no residue — certifying the
+// exact leak it exists to catch. Tokenizing and comparing the decoded character data
+// and attribute values is what makes the check mean anything.
+//
+// Scope is deliberately narrow, because a false refusal turns a working redaction into
+// an error:
+//
+//   - Only XML parts. Binary entries (thumbnails, embedded media) belong to the
+//     embedded path, which has its own residue check and its own refusal.
+//   - Only values at or above minResidueValueLen, matching the embedded value set. A
+//     shorter value produces meaningless hits and is not something redaction targets.
+//   - A part that does not tokenize is SKIPPED rather than treated as residue. Absence
+//     cannot be established there, but neither can presence, and refusing on a
+//     malformed part the redactor never claimed to rewrite would fail closed on the
+//     wrong thing.
+//
+// # Cost
+//
+// Two stages, and the split is deliberate. A naive "one strings.Contains per value per
+// part" is O(values x text) and measured quadratic: on a .docx with 4000 distinct
+// reported values the identification scan cost +0.00s, +0.01s, +0.02s then +0.09s as
+// the value count doubled — about 4.5x per doubling. Small in absolute terms, but this
+// repo has repeatedly been bitten by exactly that shape once inputs grew.
+//
+// So the common case pays only a single trie pass. strings.Replacer builds one trie
+// over all the values and scans each part once, independent of how many values there
+// are; if nothing matched, there is no residue and we are done. The per-value
+// identification loop runs ONLY when a hit has already been found, i.e. only on the
+// path that is about to refuse to write the document, where an extra pass is free
+// relative to failing the run.
+func parentPartResidue(contents *OfficeZipContents, matches []detector.Match) []string {
+	if contents == nil || len(matches) == 0 {
+		return nil
+	}
+
+	wanted := make([]string, 0, len(matches))
+	seen := make(map[string]struct{}, len(matches))
+	for _, m := range matches {
+		if len(m.Text) < minResidueValueLen {
+			continue
+		}
+		if _, dup := seen[m.Text]; dup {
+			continue
+		}
+		seen[m.Text] = struct{}{}
+		wanted = append(wanted, m.Text)
+	}
+	if len(wanted) == 0 {
+		return nil
+	}
+
+	// Sorted part order so the reported residue list is stable run to run.
+	names := make([]string, 0, len(contents.Files))
+	for name := range contents.Files {
+		if strings.HasSuffix(strings.ToLower(name), ".xml") {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+
+	// Stage 1: one trie pass per part over ALL values at once. Replacing every value
+	// with nothing and comparing is a presence oracle whose cost does not grow with the
+	// number of values.
+	probeArgs := make([]string, 0, len(wanted)*2)
+	for _, v := range wanted {
+		probeArgs = append(probeArgs, v, "")
+	}
+	probe := strings.NewReplacer(probeArgs...)
+
+	texts := make([]string, 0, len(names))
+	anyHit := false
+	for _, name := range names {
+		text, ok := decodedPartText(contents.Files[name])
+		if !ok {
+			continue
+		}
+		texts = append(texts, text)
+		if !anyHit && probe.Replace(text) != text {
+			anyHit = true
+		}
+	}
+	if !anyHit {
+		return nil
+	}
+
+	// Stage 2: name the offenders. Only reached when the document is already going to
+	// be refused, so the per-value scan is not on any successful path.
+	residueIdentifyPasses.Add(1)
+	found := make(map[string]struct{}, len(wanted))
+	for _, text := range texts {
+		for _, v := range wanted {
+			if _, already := found[v]; already {
+				continue
+			}
+			if strings.Contains(text, v) {
+				found[v] = struct{}{}
+			}
+		}
+	}
+
+	out := make([]string, 0, len(found))
+	for _, v := range wanted {
+		if _, ok := found[v]; ok {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// decodedPartText concatenates a part's entity-decoded character data and attribute
+// values. It reports false when the part cannot be tokenized, so the caller can skip
+// it rather than guess.
+func decodedPartText(content []byte) (string, bool) {
+	var sb strings.Builder
+	sb.Grow(len(content) / 2)
+
+	dec := xml.NewDecoder(bytes.NewReader(content))
+	for {
+		tok, err := dec.Token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return "", false
+		}
+		switch t := tok.(type) {
+		case xml.CharData:
+			sb.Write(t)
+			// A separator keeps two adjacent runs from concatenating into a value that
+			// is in neither of them.
+			sb.WriteByte('\n')
+		case xml.StartElement:
+			// Attribute values are covered because the raw replacer rewrites them, so a
+			// value living in one is in scope for the refusal too.
+			for _, a := range t.Attr {
+				sb.WriteString(a.Value)
+				sb.WriteByte('\n')
+			}
+		}
+	}
+	return sb.String(), true
 }
 
 // rewritePartText applies repl to an XML part, matching character data on its

--- a/internal/redactors/office/redactor.go
+++ b/internal/redactors/office/redactor.go
@@ -600,10 +600,53 @@ var docPropsValueElements = map[string]bool{
 	"TitlesOfParts":      true,
 	"HeadingPairs":       true,
 
-	// docProps/custom.xml — author-defined property values
-	"lpwstr": true,
-	"lpstr":  true,
-	"bstr":   true,
+	// docProps/custom.xml — author-defined property values.
+	//
+	// Every SCALAR value type, not only the string ones. A custom property named
+	// "MemberId" or "RecordId" is routinely written as <vt:i4>, and with only the string
+	// types listed the redactor never extracted that character data, so no replacement
+	// was ever registered for the part and a reported value was skipped. Measured on a
+	// .docx whose only property is <vt:i4>729183640</vt:i4>: the scan reports it, and
+	// before this the value came back byte-identical from --enable-redaction at rc 0.
+	// See #373.
+	//
+	// Numeric here does not mean harmless: an account, member, patient or case number is
+	// a number, and a date of birth is a date. Which of them is SENSITIVE is the
+	// validators' decision, not this map's — nothing here creates a finding. This list
+	// only decides where an ALREADY REPORTED value can be located and masked, so a wider
+	// list cannot over-redact; it can only stop a reported value being missed.
+	"lpwstr":   true,
+	"lpstr":    true,
+	"bstr":     true,
+	"i1":       true,
+	"i2":       true,
+	"i4":       true,
+	"i8":       true,
+	"int":      true,
+	"ui1":      true,
+	"ui2":      true,
+	"ui4":      true,
+	"ui8":      true,
+	"uint":     true,
+	"r4":       true,
+	"r8":       true,
+	"decimal":  true,
+	"cy":       true,
+	"date":     true,
+	"filetime": true,
+	"clsid":    true,
+	"error":    true,
+	// Excluded, deliberately: "bool" (true/false carries nothing reportable) and the
+	// binary families — blob, oblob, storage, stream, ostorage, ostream, vstream, cf. A
+	// same-length text replacement inside base64 produces invalid base64, so a value
+	// reported from one of those must NOT be rewritten in place. If it ever is reported,
+	// parentPartResidue refuses the document rather than shipping a corrupt part, which
+	// is the honest outcome.
+	//
+	// That refusal is also why this list being incomplete is no longer a leak: since the
+	// residue check landed, a value the redactor cannot locate makes the write fail
+	// loudly instead of attesting success. The list decides whether redaction can
+	// SUCCEED, not whether a miss is disclosed.
 }
 
 // isDocPropsValueElement reports whether an element's character data is a

--- a/internal/redactors/office/redactor.go
+++ b/internal/redactors/office/redactor.go
@@ -244,9 +244,14 @@ func (or *OfficeRedactor) RedactDocument(originalPath string, outputPath string,
 	// forwards must not be a document containing an SSN in a directory named
 	// "redacted".
 	if residue := parentPartResidue(modifiedContents, matches); len(residue) > 0 {
+		// TYPES, never the values. This message reaches stderr and every machine format
+		// with no --show-match, so listing the residual values would publish the exact
+		// data the refusal exists to protect — the same rule that keeps a matched value
+		// out of a validator's debug log, and out of #367's failed-extraction line.
+		// The count and the types are what an operator acts on.
 		return nil, fmt.Errorf(
-			"refusing to write %s: %d reported value(s) still present in the document's own parts: %s",
-			filepath.Base(outputPath), len(residue), strings.Join(residue, ", "))
+			"refusing to write %s: %d reported value(s) still present in the document's own parts (types: %s)",
+			filepath.Base(outputPath), len(residue), strings.Join(residueTypes(residue), ", "))
 	}
 
 	// Repackage ZIP with modified contents
@@ -928,21 +933,21 @@ var residueIdentifyPasses atomic.Uint64
 // identification loop runs ONLY when a hit has already been found, i.e. only on the
 // path that is about to refuse to write the document, where an extra pass is free
 // relative to failing the run.
-func parentPartResidue(contents *OfficeZipContents, matches []detector.Match) []string {
+func parentPartResidue(contents *OfficeZipContents, matches []detector.Match) []detector.Match {
 	if contents == nil || len(matches) == 0 {
 		return nil
 	}
 
 	wanted := make([]string, 0, len(matches))
-	seen := make(map[string]struct{}, len(matches))
+	byText := make(map[string]detector.Match, len(matches))
 	for _, m := range matches {
 		if len(m.Text) < minResidueValueLen {
 			continue
 		}
-		if _, dup := seen[m.Text]; dup {
+		if _, dup := byText[m.Text]; dup {
 			continue
 		}
-		seen[m.Text] = struct{}{}
+		byText[m.Text] = m
 		wanted = append(wanted, m.Text)
 	}
 	if len(wanted) == 0 {
@@ -998,12 +1003,36 @@ func parentPartResidue(contents *OfficeZipContents, matches []detector.Match) []
 		}
 	}
 
-	out := make([]string, 0, len(found))
+	out := make([]detector.Match, 0, len(found))
 	for _, v := range wanted {
 		if _, ok := found[v]; ok {
-			out = append(out, v)
+			out = append(out, byText[v])
 		}
 	}
+	return out
+}
+
+// residueTypes lists the distinct finding types of a residue set, sorted, for a message
+// that must not carry the values themselves.
+//
+// A match with no Type still has to be counted as something an operator can see, so it
+// is named "unknown" rather than dropped — a residue that reports fewer types than
+// values would understate what is still in the file.
+func residueTypes(residue []detector.Match) []string {
+	seen := make(map[string]struct{}, len(residue))
+	out := make([]string, 0, len(residue))
+	for _, m := range residue {
+		t := m.Type
+		if t == "" {
+			t = "unknown"
+		}
+		if _, dup := seen[t]; dup {
+			continue
+		}
+		seen[t] = struct{}{}
+		out = append(out, t)
+	}
+	sort.Strings(out)
 	return out
 }
 

--- a/internal/redactors/office/redactor.go
+++ b/internal/redactors/office/redactor.go
@@ -845,18 +845,138 @@ func (or *OfficeRedactor) applyPendingRedactions(zipContents *OfficeZipContents,
 			args = append(args, v, pr.repl[v])
 		}
 
-		modifiedContent := []byte(strings.NewReplacer(args...).Replace(string(xmlContent)))
+		replacer := strings.NewReplacer(args...)
+		modifiedContent, charDataRewrites := rewritePartText(xmlContent, replacer)
 		zipContents.addFile(name, modifiedContent)
 
 		or.logEvent("xml_content_modified", true, map[string]interface{}{
-			"file_name":     name,
-			"original_size": len(xmlContent),
-			"modified_size": len(modifiedContent),
-			"values":        len(values),
+			"file_name":         name,
+			"original_size":     len(xmlContent),
+			"modified_size":     len(modifiedContent),
+			"values":            len(values),
+			"chardata_rewrites": charDataRewrites,
 		})
 	}
 
 	return nil
+}
+
+// rewritePartText applies repl to an XML part, matching character data on its
+// DECODED form so a value's stored spelling cannot hide it.
+//
+// # The defect this exists for
+//
+// extractTextFromXML reads part text through encoding/xml, so the text offered to
+// the validators is entity-decoded: the value the report names is "Fairbanks &
+// Kettleworth", never the "Fairbanks &amp; Kettleworth" that is actually on disk.
+// Rewriting used to run the replacer over the RAW part bytes, so the literal never
+// occurred, the replacer was a no-op for that value, and RedactDocument still
+// returned Success with failed_redactions:0. Measured before this: a .docx whose
+// Company property held an ampersand came back from --enable-redaction with the
+// company name intact — confirmed by exiftool reading it out of the "redacted"
+// copy — while a sibling value in the same part masked correctly.
+//
+// This needs no attacker. XML REQUIRES '&' in character data to be written "&amp;",
+// so every document whose text or properties contain an ampersand was affected.
+//
+// # Why enumerating escaped spellings cannot fix it
+//
+// embedded.XMLEscapeVariants offers the "&amp;"/"&apos;" spellings as extra
+// replacer keys, which covers the predefined entities and nothing else. '&' also
+// introduces character references, so ANY character at ANY offset can be respelled:
+// "449-87-41&#48;0", "&#52;49-87-4100" and "449&#45;87&#45;4100" are all the same
+// value, as is the &#x30; hex form. The spellings are combinatorial, so only letting
+// the codec canonicalize them is complete.
+//
+// # Why this is a strict superset of the old behaviour
+//
+// Character data is matched on its decoded form and re-emitted escaped. Everything
+// else — markup, attribute values, and any character data that did not change — is
+// handed to the SAME raw replacer the old code used, over the byte ranges between
+// rewrites. So every replacement the old code made is still made (including a value
+// sitting in an attribute, which is not character data and would otherwise have been
+// lost), and the entity-spelled cases are newly covered.
+//
+// A tokenizer error is not fatal: encoding/xml rejects an undefined entity such as
+// "&foo;", and a part that cannot be tokenized simply falls through to the raw
+// replacer for its remainder, which is exactly what shipped before. The residue
+// check is what turns a miss into a refusal rather than a silent success.
+//
+// # Cost
+//
+// One tokenizing pass plus the replacer applied to disjoint regions summing to at
+// most len(content), so the work stays linear in part size — the same order as the
+// single whole-part Replace it replaces. The replacer is built ONCE per part by the
+// caller and must stay that way: building it per token would make this quadratic in
+// the number of values, which is the shape that has bitten this repo repeatedly.
+//
+// Returns the rewritten part and the number of character-data spans rewritten
+// through the decoded path, which the caller logs.
+func rewritePartText(content []byte, repl *strings.Replacer) ([]byte, int) {
+	dec := xml.NewDecoder(bytes.NewReader(content))
+
+	var out bytes.Buffer
+	out.Grow(len(content) + len(content)/8)
+
+	prev, rewrites := 0, 0
+	for {
+		// InputOffset gives the end of the last token and the start of the next, so
+		// reading it either side of Token() brackets the token's byte span exactly.
+		start := int(dec.InputOffset())
+		tok, err := dec.Token()
+		if err != nil {
+			// io.EOF, or a part encoding/xml refuses. Either way the tail is emitted
+			// below through the raw replacer, preserving the previous behaviour.
+			break
+		}
+		end := int(dec.InputOffset())
+
+		cd, ok := tok.(xml.CharData)
+		if !ok {
+			continue
+		}
+		decoded := string(cd)
+		replaced := repl.Replace(decoded)
+		if replaced == decoded {
+			continue
+		}
+
+		// Everything since the last rewrite, still through the raw replacer.
+		out.WriteString(repl.Replace(string(content[prev:start])))
+		escapeCharData(&out, replaced)
+		prev = end
+		rewrites++
+	}
+
+	out.WriteString(repl.Replace(string(content[prev:])))
+	return out.Bytes(), rewrites
+}
+
+// escapeCharData writes s as XML character data.
+//
+// Only '&', '<' and '>' are escaped — the set character data actually requires —
+// rather than using xml.EscapeText, which also rewrites quotes and turns newlines
+// into "&#xA;". Keeping the escaping minimal keeps the rewritten part as close to the
+// original bytes as possible, so a redaction shows up in a diff as the redaction and
+// nothing else.
+//
+// '&' is escaped UNCONDITIONALLY. A decoded value can legitimately contain an
+// ampersand followed by entity-looking text — "&amp;lt;" decodes to the literal
+// "&lt;" — so an escaper that tried to be clever and skip '&' before a known entity
+// name would silently corrupt that value on the way back out.
+func escapeCharData(out *bytes.Buffer, s string) {
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '&':
+			out.WriteString("&amp;")
+		case '<':
+			out.WriteString("&lt;")
+		case '>':
+			out.WriteString("&gt;")
+		default:
+			out.WriteByte(s[i])
+		}
+	}
 }
 
 // positionForOffset returns the extracted-text position covering off.

--- a/internal/validators/metadata/metadata_validator.go
+++ b/internal/validators/metadata/metadata_validator.go
@@ -2951,6 +2951,18 @@ func isValuelessProperty(value string) bool {
 	// Bare integers ("0"), integer tuples ("50, 3, 0, 1"), GUIDs, and ISO
 	// timestamps are all machine identifiers or counters. A value made only of
 	// digits, hex, and structural punctuation has no prose in it to disclose.
+	//
+	// EXCEPT when the digits are an identifier. This used to be a blanket
+	// "no letter -> nothing to disclose", which swallowed exactly the values a
+	// custom property is most likely to leak:
+	//
+	//	Custom_ControlText = "Ledger 8291746350284"  -> CUSTOM_PROPERTY 60
+	//	Custom_BillingRef  = "8291746350284"         -> nothing at all
+	//
+	// Same digits, same part; one English word was the whole difference. A 9-digit
+	// case number, a 13-digit billing reference and "449-87-4100" under a property
+	// named SubscriberSSN were all reported by nothing, and a value reported by
+	// nothing is never redacted. See #373.
 	hasLetter := false
 	for _, r := range trimmed {
 		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
@@ -2959,7 +2971,7 @@ func isValuelessProperty(value string) bool {
 		}
 	}
 	if !hasLetter {
-		return true
+		return !isIdentifierDigitRun(trimmed)
 	}
 
 	// Everything below is a machine identifier of some shape, and all of those
@@ -2988,6 +3000,89 @@ func isValuelessProperty(value string) bool {
 	// T/Z separators, so the hasLetter check above does not catch these.
 	return isoTimestampPattern.MatchString(trimmed)
 }
+
+// isIdentifierDigitRun reports whether a letterless value is long enough, and shaped
+// enough, to be an identifier rather than a counter.
+//
+// # The measurement this is sized against
+//
+// 150 real Office documents from this machine, 117 of them carrying
+// docProps/custom.xml, 908 custom properties, of which 193 values contain no ASCII
+// letter and are therefore invisible today. By shape:
+//
+//	98  bare integers of 4 digits or fewer   <- Purview MSIP_Label ContentBits
+//	89  integer tuples ("11, 2, 1, 0")       <- Purview MSIP_Label Tag
+//	 2  unbroken runs of 7-8 digits
+//	 4  one 5-6 digit run, one date-ish, two bracket literals
+//
+// This rule admits 2 of those 193, and 0 of the 187 Purview bookkeeping rows —
+// they are all either short or comma-separated. The two it admits are a 7-digit value
+// under a property named "db_document_id" (a document identifier, which is the point)
+// and a 7-digit sort key under "Order" (a false positive, one across 150 documents).
+// That is the whole false-positive budget, and it is why the rule tests the VALUE's
+// shape rather than the property's NAME: a name vocabulary would have to be maintained
+// and would still miss a digit run under "Ref" or "Field3".
+//
+// # What stays valueless, and what enforces it
+//
+// The two patterns are anchored and accept ONLY digits, hyphens and spaces, so almost
+// every exclusion follows from them rather than needing its own check:
+//
+//   - fewer than 7 digits: rejected by the floor. Page counts, Purview ContentBits and
+//     sort positions all live here — every bare integer in the measured corpus was 4
+//     digits or fewer.
+//   - integer tuples ("11, 2, 1, 0"): rejected because a comma is not a separator the
+//     grouped pattern accepts. This is the commonest bookkeeping shape in the corpus,
+//     89 of the 193 letterless values.
+//   - versions, times and slash-dates ("1.2.3.4567", "12:34:56", "2026/01/14", and the
+//     measured "2026-01-14.0002" under db_template_version): same reason.
+//   - a plain calendar date, "YYYY-MM-DD": this one DOES need its own check, because 8
+//     digits in hyphen-separated groups is exactly what the grouped pattern accepts.
+//
+// An earlier version also rejected any value containing ".,:/" up front. That check was
+// unreachable — no string containing one of those can match either anchored pattern —
+// and a mutation removing it changed no behaviour, which is how it was found. The
+// exclusions are still asserted as BEHAVIOUR by the tests, so removing the redundant
+// guard did not remove their coverage.
+//
+// Hyphens and spaces ARE allowed as separators, because that is how a real identifier is
+// written: "449-87-4100" and "415 892 4471" are the shapes this exists to recover.
+func isIdentifierDigitRun(trimmed string) bool {
+	if plainDatePattern.MatchString(trimmed) {
+		return false
+	}
+	if unbrokenDigitRunPattern.MatchString(trimmed) {
+		return true
+	}
+	if !groupedDigitRunPattern.MatchString(trimmed) {
+		return false
+	}
+	digits := 0
+	for _, r := range trimmed {
+		if r >= '0' && r <= '9' {
+			digits++
+		}
+	}
+	return digits >= identifierDigitFloor
+}
+
+// identifierDigitFloor is the fewest digits an identifier is assumed to carry.
+//
+// Seven, because that is where real schemes start (a 7-digit member or case number)
+// and because everything shorter in the measured corpus is a counter: every one of the
+// 98 bare integers was 4 digits or fewer.
+const identifierDigitFloor = 7
+
+var (
+	// An unbroken run of digits, nothing else. The floor is identifierDigitFloor, spelled
+	// out here because a regexp built by string concatenation is harder to read than the
+	// one thing it expresses; the test asserts the two agree.
+	unbrokenDigitRunPattern = regexp.MustCompile(`^\d{7,}$`)
+	// Digit groups separated by single hyphens or spaces: 449-87-4100, 415 892 4471.
+	groupedDigitRunPattern = regexp.MustCompile(`^\d+(?:[- ]\d+)+$`)
+	// A plain calendar date, which the grouped form would otherwise admit.
+	plainDatePattern = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
+)
 
 var (
 	guidPattern         = regexp.MustCompile(`^\{?[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\}?$`)

--- a/internal/validators/metadata/value_shape_risk_test.go
+++ b/internal/validators/metadata/value_shape_risk_test.go
@@ -112,6 +112,20 @@ func TestValuelessPropertiesAreSkipped(t *testing.T) {
 		"5280104a-472d-4538-9ccf-1e1d0efe8b1b", // _SiteId GUID
 		"2026-01-14T21:22:37Z",                 // _SetDate
 		"0x010100D3F06DC058215A4D90BF",         // SharePoint ContentTypeId
+
+		// Letterless values that must STAY unreported after #373 admitted
+		// identifier-length digit runs. Every one of these was measured in the
+		// 150-document corpus that sized that rule, and each is the reason for one
+		// clause of it.
+		"1234",        // a counter: below the 7-digit floor
+		"999999",      // 6 digits, still below the floor
+		"11, 2, 1, 0", // MSIP_Label _Tag, the commonest shape in the corpus (89 rows)
+		"2026-01-14",  // a plain date: 8 digits with hyphens, which the grouped form
+		// would otherwise admit
+		"2026-01-14.0002", // measured under db_template_version: a dot means a version
+		"1.2.3.4567",      // a version, not an identifier
+		"12:34:56",        // a time
+		"2026/01/14",      // a date with slashes
 	}
 	for _, v := range valueless {
 		if !isValuelessProperty(v) {
@@ -130,6 +144,18 @@ func TestValuelessPropertiesAreSkipped(t *testing.T) {
 		"Nasdaq - Internal Use: Distribution limited to personnel",
 		"SECRET - Project Nightjar",
 		"CC-99213-NIGHTJAR",
+
+		// Identifier-length digit runs (#373). These carry no ASCII letter and were
+		// therefore never scored, which is how a case number, a billing reference and an
+		// SSN under a property named SubscriberSSN reached no validator at all. The
+		// sharpest pair measured: "Ledger 8291746350284" scored CUSTOM_PROPERTY 60 while
+		// the bare "8291746350284" scored nothing — one English word was the whole
+		// difference.
+		"923456781",     // a 9-digit member id that no other validator claims
+		"8291746350284", // a 13-digit billing reference
+		"9999999",       // exactly at the 7-digit floor
+		"449-87-4100",   // measured under a property named SubscriberSSN
+		"415 892 4471",  // space-separated groups are how a phone-shaped id is written
 	}
 	for _, v := range meaningful {
 		if isValuelessProperty(v) {
@@ -205,4 +231,90 @@ func TestCustomPropertyIDIsWholeWord(t *testing.T) {
 			t.Errorf("property %q produced no risk factors: an employee/badge identifier must still be recognised", name)
 		}
 	}
+}
+
+// The digit-run rule is sized against a corpus, so the corpus's own distribution is what
+// the test asserts — not a handful of invented strings.
+//
+// 150 real Office documents from this machine, 117 carrying docProps/custom.xml, 908 custom
+// properties, 193 of whose values contain no ASCII letter and were therefore invisible:
+//
+//	98  bare integers of 4 digits or fewer   <- Purview MSIP_Label ContentBits
+//	89  integer tuples ("11, 2, 1, 0")       <- Purview MSIP_Label Tag
+//	 2  unbroken runs of 7-8 digits
+//	 4  one 5-6 digit run, one date-ish, two bracket literals
+//
+// The rule admits 2 of 193 and 0 of the 187 Purview rows. End to end over the same 150
+// documents the finding count went 1956 -> 1958. That is the false-positive budget, and this
+// test pins the two properties that keep it: the floor, and the exclusions.
+func TestIdentifierDigitRunFloorAndExclusions(t *testing.T) {
+	// The floor is what keeps the 187 Purview bookkeeping rows out. A rule that admitted
+	// 4-digit values would report one finding per label per document.
+	if identifierDigitFloor != 7 {
+		t.Errorf("identifierDigitFloor = %d; the corpus measurement that sized this rule "+
+			"assumed 7, and every bare integer it found was 4 digits or fewer",
+			identifierDigitFloor)
+	}
+	// The pattern and the constant have to agree, or the floor is decorative.
+	for _, below := range []string{"1", "12", "123456"} {
+		if unbrokenDigitRunPattern.MatchString(below) {
+			t.Errorf("unbrokenDigitRunPattern matched %q, shorter than identifierDigitFloor=%d",
+				below, identifierDigitFloor)
+		}
+	}
+	if !unbrokenDigitRunPattern.MatchString("1234567") {
+		t.Errorf("unbrokenDigitRunPattern rejects a %d-digit run, so the floor is wrong",
+			identifierDigitFloor)
+	}
+
+	// Each exclusion, asserted through the function an operator's findings depend on.
+	for _, c := range []struct {
+		value  string
+		reason string
+	}{
+		{"11, 2, 1, 0", "a comma makes it an integer tuple, the commonest bookkeeping shape measured"},
+		{"2026-01-14", "a plain date is 8 digits with hyphens and would otherwise be admitted"},
+		{"2026-01-14.0002", "a dot means a version; measured under db_template_version"},
+		{"1.2.3.4567", "a version"},
+		{"12:34:56", "a time"},
+		{"2026/01/14", "a slash-separated date"},
+		{"123456", "below the floor"},
+	} {
+		if isIdentifierDigitRun(c.value) {
+			t.Errorf("isIdentifierDigitRun(%q) = true, want false: %s", c.value, c.reason)
+		}
+	}
+
+	for _, c := range []struct {
+		value  string
+		reason string
+	}{
+		{"1234567", "exactly at the floor"},
+		{"923456781", "a 9-digit member id that no other validator claims"},
+		{"8291746350284", "a 13-digit billing reference"},
+		{"449-87-4100", "hyphen-grouped, measured under a property named SubscriberSSN"},
+		{"415 892 4471", "space-grouped groups, how a phone-shaped id is written"},
+	} {
+		if !isIdentifierDigitRun(c.value) {
+			t.Errorf("isIdentifierDigitRun(%q) = false, want true: %s", c.value, c.reason)
+		}
+	}
+}
+
+// A letterless value that IS admitted must be admitted for the right reason: the shape of the
+// VALUE, never the property's name.
+//
+// A name vocabulary would have to be maintained, and it would still miss a digit run under
+// "Ref" or "Field3" — while the corpus shows the value shape alone costs 2 findings in 150
+// documents. This pins that the decision does not consult a name, so nobody later "improves"
+// the rule into a keyword list without noticing it changes what the measurement covered.
+func TestIdentifierAdmissionDoesNotDependOnThePropertyName(t *testing.T) {
+	const value = "923456781"
+	if isValuelessProperty(value) {
+		t.Fatalf("isValuelessProperty(%q) = true; the rest of this test would be vacuous", value)
+	}
+	// isValuelessProperty takes only the value — there is no name parameter to consult.
+	// This compiles as an assertion of that fact; if a name is ever threaded through, this
+	// call fails to build and the author has to come and read the comment above.
+	var _ func(string) bool = isValuelessProperty
 }

--- a/tests/integration/numeric_character_reference_test.go
+++ b/tests/integration/numeric_character_reference_test.go
@@ -1,0 +1,199 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"archive/zip"
+	"bytes"
+	"html"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// The two halves of the escaped-value leak, composed, through the real binary.
+//
+// A numeric character reference is a legitimate XML spelling of an ordinary character and Word
+// renders it as that character, so `51&#57;-42-8836` is an SSN on screen. Measured on this exact
+// fixture, at three points in this change:
+//
+//	main                      1 of 4 reported; 3 readable in the redacted copy
+//	redactor fix alone        1 of 4 reported; 3 readable
+//	extractor fix alone       4 of 4 reported; 3 STILL readable, no warning  <- worse
+//	both (this branch)        4 of 4 reported; none readable
+//
+// The third row is why these ship together. Fixing detection alone converts a silent miss into
+// "4 SSNs found and handled" while Word still renders three of them — a report that is now
+// actively misleading. A unit test on either side passes in that state; only the pipeline shows
+// it.
+//
+// Residue is checked on the DECODED part text. Grepping the .docx searches COMPRESSED bytes and
+// always "finds nothing"; grepping the raw XML misses the escaped spelling, which is the whole
+// defect.
+func TestNumericCharacterReferencesAreDetectedAndRedacted(t *testing.T) {
+	bin := numrefBinary(t)
+	dir := t.TempDir()
+
+	values := []string{"449-87-4100", "519-42-8836", "563-18-7249", "607-31-9284"}
+	src := filepath.Join(dir, "numrefs.docx")
+	if err := os.WriteFile(src, buildNumrefDocx(), 0o600); err != nil {
+		t.Fatalf("writing fixture: %v", err)
+	}
+
+	stdout, _, code := runNumref(t, bin, "--file", src, "--confidence", "all", "--format", "csv")
+	if code != 0 {
+		t.Fatalf("scan exit = %d, want 0\n%s", code, stdout)
+	}
+	if n := strings.Count(stdout, ",SSN,"); n != len(values) {
+		t.Fatalf("reported %d SSNs, want %d. Every value below the count is invisible to every "+
+			"validator, and only reported findings are redacted.\n%s", n, len(values), stdout)
+	}
+
+	outDir := filepath.Join(dir, "out")
+	if _, _, code = runNumref(t, bin, "--file", src, "--confidence", "all",
+		"--enable-redaction", "--redaction-output-dir", outDir, "--format", "csv"); code != 0 {
+		t.Fatalf("redaction exit = %d, want 0", code)
+	}
+
+	var redacted string
+	err := filepath.Walk(outDir, func(p string, info os.FileInfo, werr error) error {
+		if werr != nil || info.IsDir() || filepath.Base(p) != "numrefs.docx" {
+			return werr
+		}
+		redacted = p
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking output: %v", err)
+	}
+	if redacted == "" {
+		t.Fatal("no redacted copy was written, so nothing can be verified")
+	}
+
+	decoded := html.UnescapeString(numrefPartText(t, redacted, "word/document.xml"))
+	var survived []string
+	for _, v := range values {
+		if strings.Contains(decoded, v) {
+			survived = append(survived, v)
+		}
+	}
+	if len(survived) > 0 {
+		t.Errorf("%d of %d values survived in word/document.xml of a file the tool reported as "+
+			"successfully redacted: %v\nWord renders every one of them as the real digits, so the "+
+			"document a human opens still shows the SSN.\ndecoded part text: %s",
+			len(survived), len(values), survived, decoded)
+	}
+}
+
+// buildNumrefDocx writes the paragraphs VERBATIM: references spelled as references is the point,
+// and an escaping helper would store "&amp;#57;" and test nothing.
+func buildNumrefDocx() []byte {
+	paras := []string{
+		"Employee SSN: 449-87-4100",
+		"Employee SSN: 51&#57;-42-8836",
+		"Employee SSN: &#53;&#54;&#51;-&#49;&#56;-&#55;&#50;&#52;&#57;",
+		"Employee SSN: 60&#x37;-31-9284",
+	}
+	var body strings.Builder
+	for _, p := range paras {
+		body.WriteString(`<w:p><w:r><w:t xml:space="preserve">` + p + `</w:t></w:r></w:p>`)
+	}
+	doc := `<?xml version="1.0" encoding="UTF-8"?>` +
+		`<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>` +
+		body.String() + `</w:body></w:document>`
+	ctypes := `<?xml version="1.0" encoding="UTF-8"?>` +
+		`<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+		`<Default Extension="xml" ContentType="application/xml"/>` +
+		`<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>` +
+		`</Types>`
+
+	buf := new(bytes.Buffer)
+	zw := zip.NewWriter(buf)
+	for _, e := range []struct{ name, body string }{
+		{"[Content_Types].xml", ctypes},
+		{"word/document.xml", doc},
+	} {
+		w, err := zw.Create(e.name)
+		if err != nil {
+			panic(err)
+		}
+		if _, err := io.WriteString(w, e.body); err != nil {
+			panic(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		panic(err)
+	}
+	return buf.Bytes()
+}
+
+// numrefPartText returns one part's raw bytes from an OOXML package on disk.
+func numrefPartText(t *testing.T, pkgPath, part string) string {
+	t.Helper()
+	zr, err := zip.OpenReader(pkgPath)
+	if err != nil {
+		t.Fatalf("opening %s: %v", pkgPath, err)
+	}
+	defer func() { _ = zr.Close() }()
+
+	for _, f := range zr.File {
+		if f.Name != part {
+			continue
+		}
+		rc, oerr := f.Open()
+		if oerr != nil {
+			t.Fatalf("opening %s: %v", part, oerr)
+		}
+		defer func() { _ = rc.Close() }()
+		b, rerr := io.ReadAll(rc)
+		if rerr != nil {
+			t.Fatalf("reading %s: %v", part, rerr)
+		}
+		return string(b)
+	}
+	t.Fatalf("%s not found in %s", part, pkgPath)
+	return ""
+}
+
+// numrefBinary builds ferret-scan for this file's tests.
+//
+// Deliberately its own helper rather than a shared one: package integration has several
+// independent binary builders, and a name shared across files that arrive on different branches
+// is a merge that compiles apart and fails together.
+func numrefBinary(t *testing.T) string {
+	t.Helper()
+	name := "ferret-scan"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	bin := filepath.Join(t.TempDir(), name)
+	cmd := exec.Command("go", "build", "-o", bin, "../../cmd")
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to build ferret-scan: %v\n%s", err, out)
+	}
+	return bin
+}
+
+func runNumref(t *testing.T, bin string, args ...string) (string, string, int) {
+	t.Helper()
+	cmd := exec.Command(bin, args...) //nolint:gosec // bin is built by the test
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	code := 0
+	if err != nil {
+		ee, ok := err.(*exec.ExitError)
+		if !ok {
+			t.Fatalf("unexpected exec error: %v\nstderr=%s", err, stderr.String())
+		}
+		code = ee.ExitCode()
+	}
+	return stdout.String(), stderr.String(), code
+}


### PR DESCRIPTION
Closes #368

Two commits: the rewrite that closes the leak, then the residue check that makes a future miss a refusal instead of a false attestation.

## The defect

`extractTextFromXML` reads part text through `encoding/xml`, so the value handed to the validators — and named in the report — is entity **decoded**. The rewrite then ran `strings.NewReplacer` over the **raw** part bytes, so a value whose stored spelling differs from its decoded form never occurred literally, the replacer was a no-op for it, and `RedactDocument` still returned success.

Measured on a `.docx` whose Company property holds an ampersand:

| | |
|---|---|
| scan | `[LOW] metadata COMPANY_INFO  Fairbanks & Kettleworth Holdings` |
| after redaction | `<Company>Fairbanks &amp; Kettleworth Holdings</Company>` |
| **exiftool on the redacted copy** | `Company : Fairbanks & Kettleworth Holdings` |
| audit log | `"successful_redactions": 4, "failed_redactions": 0` |
| exit code | `0` |

A sibling value in the same part (`dc:creator`, no entity) masked correctly, which isolates the cause to the spelling rather than to part selection.

This needs no attacker: XML **requires** `&` in character data to be written `&amp;`. An apostrophe does it too — `Patrick O&apos;Connor`, reported at HIGH 100, came back verbatim.

## Why enumerating escaped spellings cannot fix it

`embedded.XMLEscapeVariants` offers the `&amp;`/`&apos;` forms as extra replacer keys, covering the five predefined entities and nothing else. `&` also introduces character references, so any character at any offset can be respelled. Verified against `encoding/xml` that all of these decode to the same value:

```
449-87-41&#48;0    449-87-41&#x30;0    &#52;49-87-4100    449&#45;87&#45;4100
```

The spellings are combinatorial, so only canonicalising through the codec is complete. On an `.xlsx` inline string holding `449-87-41&#48;0`: before, the cell was reported as `SSN 449-87-4100` at HIGH 100 and left untouched, so **Excel read the real SSN out of the redacted workbook**; after, it reads `***-**-4100`.

## Strict superset, not a swap

`rewritePartText` matches each character-data span on its decoded form and re-emits it escaped. Everything **outside** character data — markup and attribute values — plus any character data that did not change still goes through the **same raw replacer** the old code used, over the byte ranges between rewrites.

So every replacement the old code made is still made. That matters concretely: a value in an attribute is not character data, and a character-data-only rewrite would have stopped redacting it — turning a leak fix into a new leak. A test pins it.

A tokenizer error is not fatal. `encoding/xml` rejects an undefined entity like `&foo;`, and such a part falls through to the raw replacer for its remainder, exactly as before.

`escapeCharData` escapes only `&`, `<`, `>` — not `xml.EscapeText`, which also rewrites quotes and turns newlines into `&#xA;` — so a redaction diff shows the redaction and nothing else. `&` is escaped **unconditionally**: `&amp;lt;` decodes to a literal `&lt;`, so an escaper that skipped `&` before a known entity name would silently corrupt that value.

## Verification

- **67 packages ok, 0 failed.** `gofmt -l ./cmd ./internal ./pkg` clean, `go vet` clean.
- **The golden corpus passes with zero regenerated files**, so the rewrite is byte-identical on every existing case. That is the strict-superset claim measured, not asserted.
- **Mutation-tested, 5 mutations, all caught:** revert to the raw whole-part `Replace` (7 subtests fail); drop the raw pass over the gap regions (attribute + untokenizable-part tests fail); make `escapeCharData` skip `&` when it looks like an entity (round-trip fails); revert the rewrite with the residue check present (the redactor now **refuses and writes 0 files**); remove the residue early return (the anti-quadratic guard fails).
- **Cost**, A/B against the pre-fix binary on a `.docx` where *every* paragraph rewrites through the new path (worst case):

  | matches | before | after |
  |---|---|---|
  | 500 | 0.08 s / 35 MB | 0.08 s / 35 MB |
  | 1000 | 0.13 s / 36 MB | 0.14 s / 38 MB |
  | 2000 | 0.25 s / 40 MB | 0.25 s / 41 MB |
  | 4000 | 0.50 s / 48 MB | 0.51 s / 53 MB |

  Linear in both, 2.0× per doubling. The replacer is still built **once per part**; building it per token would be quadratic in the value count.

## A quadratic caught and removed before it shipped

The residue check's first version did one `strings.Contains` per value per part: +0.00s, +0.01s, +0.02s, **+0.09s** as the value count doubled through 500/1000/2000/4000 — about 4.5× per doubling. It is now two stages, a trie probe that decides presence in one pass and a per-value identification loop reserved for the refusal path. Re-measured flat: +0.00s, +0.00s, +0.01s.

The guard for it is a **counter**, because both obvious alternatives are blind: allocation cannot see it (the quadratic allocates nothing — an allocation-ratio test *passed* with the quadratic restored, i.e. it was vacuous), and wall clock is not portable to the Windows runner.

## Notes

- The process still exits 0 on a refusal. Propagating that to the exit code is the open residual on #315 and is deliberately untouched here.
- #371 is the same entity-handling class in the **opposite** direction (extraction never decodes numeric references on the `.docx` path). Fixing one leaves the other open; they are cross-referenced.


---

# Second half added: #371 — the same evasion on the READ side

Closes #371

`&` introduces every reference form, so the escaped-value problem has two directions. #368 (above) is the write side: match the decoded form against the escaped part bytes. #371 is the read side: **decode the references at all**, on the three Office text paths that never did.

The correct decoder already existed — `decodeXMLEntities`, with its own unit test — and only the xlsx path used it. Three other paths kept a hand-rolled five-call `strings.Replace` chain with no numeric-reference handling: `extractDocxText` (the body), `extractTextFromXML` (pptx slides/notes/masters, odt, ods, odp) and `extractWordXMLText` (docx headers and footers).

```
.docx   1 of 4 SSNs reported      <- 75% miss
.xlsx   4 of 4 at HIGH 100        <- same references, byte-identical values
```

A header is where a template stamps the account or case number on every page, so that path is not exotic.

## Why the two halves are one PR

Measured on the same fixture at four points, residue read from the **decoded** part text:

| | detection | readable in the "redacted" copy |
|---|---|---|
| `main` | 1 of 4 | 3 |
| **#368 alone** (this PR before today) | 1 of 4 | 3 |
| **#371 alone** | **4 of 4** | **3 — file written, no warning** |
| **both** | **4 of 4** | **none** |

Row three is the reason. Fixing detection alone converts a silent miss into a report that says *four SSNs were found and handled* while Word still renders three of them — actively misleading rather than merely incomplete. A unit test on either side passes in that state; only the pipeline shows it, which is what the new integration test drives.

It also removes a golden-snapshot ordering hazard: a `.redact_*` snapshot for this fixture is only correct when both halves are present, so landing them separately would have made whichever merged second go red on `main`.

## The issue's second claim, corrected

#371 also says the chains re-read their own output, with `&amp;lt;` becoming `<`. That **does not reproduce** — the chain runs lt, gt, amp, quot, apos, so `&lt;` is replaced before the `&amp;` step can create one. The bug is real for the entities *after* `&amp;`:

```
&amp;quot;  ->  "     (should be the literal &quot;)
&amp;apos;  ->  '     (should be the literal &apos;)
&amp;#57;   ->  &#57; (correct — and must NOT become "9", which would invent a digit)
```

Both directions are now pinned, including the invent-a-digit direction, which is the same mistake pointing the other way.

## Coverage

- One test per call site, each **mutation-tested by restoring its own chain** — three mutations, three catches.
- A fourth mutation makes `decodeXMLEntities` itself sequential; the corrected-claim test catches it.
- The decoder's own guard: a reference naming no valid code point (`&#0;`, `&#xD800;`, `&#x110000;`) is left as written rather than becoming U+FFFD, which would be unsearchable and unredactable.
- Golden `FileCase file_docx_numeric_character_reference` locks detection at 4 of 4 through `ScanFile` and the real routing. FileCases carry **no** redaction snapshot (0 of the 54 in the corpus belong to a file case), so the sink is locked by the integration test — which is also the only place the two halves compose. Both halves are mutation-tested there: reverting the extractor fails on the count, reverting the redactor fails on the residue.
- `BuildDOCXWithRawRuns` is new because `BuildDOCX` escapes its paragraphs — right for every case about a document's *content*, wrong for the one case whose subject **is** the escaping.

## Cross-PR verification

- No file shared with any other open PR (#394–#397, #403).
- Union of `main` + all six open PRs: **builds clean, `go vet` clean** (which compiles every `_test.go`, so the three independent binary-builder helpers in `tests/integration` do not collide), **69/0**, gofmt clean.
- Behavioural matrix, 8 binaries × 8 fixtures: effects compose **additively**, no PR suppresses or doubles another's. On the union, `b_numrefs.docx` goes 1 → 4 findings with **zero** decoded residue and `w:t` runs reading `***-**-8836`.


---

# Third issue added: #373 — a numeric custom property

Closes #373

`&` was one way an Office value hides from redaction; being a **number** is another. Both halves of #373 are here, and they compose the same way #368 and #371 do — either alone leaves the tool worse off than both.

## Part 1 — a letterless value was never scored

`isValuelessProperty` treated **any** value with no ASCII letter as bookkeeping. The sharpest measured pair:

```
Custom_ControlText = "Ledger 8291746350284"  ->  CUSTOM_PROPERTY 60
Custom_BillingRef  = "8291746350284"         ->  nothing at all
```

Same digits, same part; one English word was the whole difference. A 9-digit case number, a 13-digit billing reference and `449-87-4100` under a property literally named `SubscriberSSN` reached no validator at all.

**The false-positive budget, measured before choosing the rule.** 150 real Office documents from this machine — 117 carrying `docProps/custom.xml`, 908 custom properties, 193 letterless values:

| count | shape |
|---|---|
| 98 | bare integers ≤ 4 digits — Purview `MSIP_Label_*_ContentBits` |
| 89 | integer tuples (`11, 2, 1, 0`) — Purview `MSIP_Label_*_Tag` |
| **2** | unbroken runs of 7-8 digits |
| 4 | one 5-6 digit run, one date-ish, two bracket literals |

The rule admits **2 of 193**, and **0 of the 187 Purview rows**. End to end over the same 150 documents: **1956 → 1958 findings, 2 documents changed**, identical at the default confidence. The two are a 7-digit value under `db_document_id` (a document identifier — the point) and a 7-digit sort key under `Order` (one false positive across 150 documents).

It tests the **value's** shape, not the property's **name**: a name vocabulary would need maintaining and would still miss a digit run under `Ref` or `Field3`. A test asserts `isValuelessProperty`'s signature so nobody later turns it into a keyword list without noticing that invalidates the measurement.

## Part 2 — a `vt:i4` was never rewritten

A property named `MemberId` or `RecordId` is routinely written as `<vt:i4>`. The redactor extracted only the string-typed docProps elements, so no replacement was ever registered for the part:

| build | `<vt:i4>729183640</vt:i4>` after `--enable-redaction` |
|---|---|
| `main` | **byte-identical, rc 0, no warning** — silent leak |
| this PR before today | **NO OUTPUT** — refused, and the refusal disclosed |
| now | `<vt:i4>*****3640</vt:i4>` |

The middle row matters and is worth being explicit about: **the residue check earlier in this PR had already closed the leak** — but it did so by making the document unredactable, which cost the redaction of every *other* value in it. On the issue's own mixed fixture, `main` left three numeric values in cleartext and masked one; this PR then refused the whole file; now all four are masked:

```
main   923456781 | 8291746350284 | 729183640 | ********************
now    ********* | ************* | *****3640 | ********************
```

Every **scalar** value type is listed, not a hand-picked few, because the failure mode is a list missing the next type someone uses. Numeric does not mean harmless — an account, member, patient or case number is a number, a date of birth is a date — but which of them is *sensitive* stays the validators' decision: nothing in that map creates a finding, so a wider list cannot over-redact. `bool` and the binary families are excluded deliberately, and a test pins that a value in a `vt:blob` is **refused** rather than rewritten, because a same-length replacement inside base64 produces invalid base64.

## And a defect in this PR itself, found by measuring it

The residue refusal listed the residual **values** in its error — and that error reaches stderr and every machine format with **no `--show-match`**:

```
refusing to write blobbed.docx: 2 reported value(s) still present in the document's own
parts: 449-87-4100, SSN 449-87-4100 payload
```

A guard added to protect a value was handing it out. It now reports `(types: CUSTOM_PROPERTY, SSN)`. Same rule as the rest of the tool: a matched value stays out of a debug log, a scanned path stays out of a failed-extraction line (#367), and the audio and video redactors name a match's **type** when they cannot locate it. The test asserts the operator-visible error, not just the helper — asserting the helper alone let a mutation restoring the value-joining message survive.

## Verification for this half

- **67 packages ok, 0 failed**; `gofmt`, `go vet`, `-race` clean. Golden corpus and score baseline **unchanged** — no corpus case carries a letterless custom property.
- **Union of `main` + all seven open PRs: builds clean, vet clean, gofmt clean, 69/0.**
- **Mutations, all caught**: revert to blanket letterless-is-valueless; drop the digit floor to 4 (which would admit every Purview `ContentBits`); widen the unbroken pattern to 4+; widen the grouped separator set to `,.:/` (which would admit versions and slash-dates); drop the plain-date exclusion; reject grouped forms (which loses the `SubscriberSSN` case); restore the value-joining refusal message; drop `i4`, `i8`, `int`, `ui4`, `r8` or `decimal` from the element list; drop untyped matches from the type list; leave the type list unsorted.
- One mutation **survived and was right to**: an up-front `ContainsAny(".,:/")` guard turned out to be **unreachable** — no string containing one of those can match either anchored pattern — so it was deleted rather than left claiming to matter. The exclusions are still asserted as behaviour.
