### PR TITLE
fix(secrets): remove the per-candidate line rescan, then detect unquoted secret assignments

### DIFF
--- a/internal/goldencorpus/testdata/golden/secrets_aws.csv
+++ b/internal/goldencorpus/testdata/golden/secrets_aws.csv
@@ -1,3 +1,3 @@
 Filename,Type,Confidence Level,Confidence %,Line Number,Text
 <golden:secrets_aws>,AWS_ACCESS_KEY,MEDIUM,84.0,1,AKIAIOSFODNN7EXAMPLE
-<golden:secrets_aws>,AWS_SECRET_ACCESS_KEY,MEDIUM,65.0,2,wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+<golden:secrets_aws>,AWS_SECRET_ACCESS_KEY,MEDIUM,75.0,2,wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY

--- a/internal/goldencorpus/testdata/golden/secrets_aws.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/secrets_aws.gitlab-sast.json
@@ -55,7 +55,7 @@
     {
       "category": "sast",
       "confidence": "Medium",
-      "description": "Ferret Scan detected sensitive data (aws secret access key) in this file.\n\n**Location:** <golden:secrets_aws> (line 2)\n**Confidence:** MEDIUM (65.0%)\n**Detected by:** secrets validator\n\n**Context:**\n```\nAWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n```\n\n**Additional Information:**\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "description": "Ferret Scan detected sensitive data (aws secret access key) in this file.\n\n**Location:** <golden:secrets_aws> (line 2)\n**Confidence:** MEDIUM (75.0%)\n**Detected by:** secrets validator\n\n**Context:**\n```\nAWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n```\n\n**Additional Information:**\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
       "id": "ferret-<HASH>",
       "identifiers": [
         {

--- a/internal/goldencorpus/testdata/golden/secrets_aws.json.json
+++ b/internal/goldencorpus/testdata/golden/secrets_aws.json.json
@@ -40,7 +40,7 @@
       "validator": "secrets"
     },
     {
-      "confidence": 65,
+      "confidence": 75,
       "confidence_level": "MEDIUM",
       "filename": "<golden:secrets_aws>",
       "line_number": 2,
@@ -51,7 +51,7 @@
         "context_domain": "Unknown",
         "detection_method": "aws_secret_context",
         "example_embedded": true,
-        "original_confidence": 65,
+        "original_confidence": 75,
         "secret_type": "AWS_SECRET_ACCESS_KEY",
         "semantic_context": {
           "FinancialData": 0,

--- a/internal/goldencorpus/testdata/golden/secrets_aws.junit.xml
+++ b/internal/goldencorpus/testdata/golden/secrets_aws.junit.xml
@@ -2,7 +2,7 @@
 <testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
   <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
     <testcase name="&lt;golden:secrets_aws&gt;" classname="security-scan" time="0.001">
-      <failure message="2 security findings detected" type="SECURITY_FINDINGS">Line 1: AWS_ACCESS_KEY detected with 84.0% confidence (MEDIUM)&#xA;Match: AKIAIOSFODNN7EXAMPLE&#xA;Validator: secrets&#xA;Line 2: AWS_SECRET_ACCESS_KEY detected with 65.0% confidence (MEDIUM)&#xA;Match: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY&#xA;Validator: secrets</failure>
+      <failure message="2 security findings detected" type="SECURITY_FINDINGS">Line 1: AWS_ACCESS_KEY detected with 84.0% confidence (MEDIUM)&#xA;Match: AKIAIOSFODNN7EXAMPLE&#xA;Validator: secrets&#xA;Line 2: AWS_SECRET_ACCESS_KEY detected with 75.0% confidence (MEDIUM)&#xA;Match: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY&#xA;Validator: secrets</failure>
     </testcase>
   </testsuite>
 </testsuites>

--- a/internal/goldencorpus/testdata/golden/secrets_aws.sarif.json
+++ b/internal/goldencorpus/testdata/golden/secrets_aws.sarif.json
@@ -95,10 +95,10 @@
             }
           ],
           "message": {
-            "text": "AWS_SECRET_ACCESS_KEY Detected in <golden:secrets_aws> at line 2 (confidence: 65.0% - MEDIUM). Matched text: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'"
+            "text": "AWS_SECRET_ACCESS_KEY Detected in <golden:secrets_aws> at line 2 (confidence: 75.0% - MEDIUM). Matched text: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'"
           },
           "properties": {
-            "confidence": 65,
+            "confidence": 75,
             "confidenceLevel": "MEDIUM",
             "metadata": {
               "confidence_adjustment": 0,
@@ -107,7 +107,7 @@
               "context_domain": "Unknown",
               "detection_method": "aws_secret_context",
               "example_embedded": true,
-              "original_confidence": 65,
+              "original_confidence": 75,
               "secret_type": "AWS_SECRET_ACCESS_KEY",
               "semantic_context": {
                 "FinancialData": 0,
@@ -121,7 +121,7 @@
             },
             "validator": "secrets"
           },
-          "rank": 57.5,
+          "rank": 62.5,
           "ruleId": "AWS_SECRET_ACCESS_KEY"
         }
       ],

--- a/internal/goldencorpus/testdata/golden/secrets_aws.txt
+++ b/internal/goldencorpus/testdata/golden/secrets_aws.txt
@@ -1,4 +1,4 @@
 LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH                          FILE
 --------------------------------------------------------------------------------------------------------
 [MEDIUM] secrets      AWS_ACCESS_KEY         84.00% line     1 AKIAIOSFODNN7EXAMPLE           <golden:secrets_aws>
-[MEDIUM] secrets      AWS_SECRET_ACCESS...   65.00% line     2 wJalrXUtnFEMI/K7MDENG/bPxRf... <golden:secrets_aws>
+[MEDIUM] secrets      AWS_SECRET_ACCESS...   75.00% line     2 wJalrXUtnFEMI/K7MDENG/bPxRf... <golden:secrets_aws>

--- a/internal/goldencorpus/testdata/golden/secrets_aws.yaml
+++ b/internal/goldencorpus/testdata/golden/secrets_aws.yaml
@@ -36,7 +36,7 @@ results:
     - text: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
       line_number: 2
       type: AWS_SECRET_ACCESS_KEY
-      confidence: 65
+      confidence: 75
       confidence_level: MEDIUM
       filename: <golden:secrets_aws>
       validator: secrets
@@ -47,7 +47,7 @@ results:
         context_domain: Unknown
         detection_method: aws_secret_context
         example_embedded: true
-        original_confidence: 65
+        original_confidence: 75
         secret_type: AWS_SECRET_ACCESS_KEY
         semantic_context:
             FinancialData: 0

--- a/internal/validators/secrets/line_keyword_memo_test.go
+++ b/internal/validators/secrets/line_keyword_memo_test.go
@@ -1,0 +1,102 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package secrets
+
+import (
+	"strings"
+	"testing"
+)
+
+// hasNearbySecretKeyword's answer depends only on the LINE, so it is identical for
+// every candidate on that line — but it was recomputed per candidate, and each
+// recomputation scans the whole line once per positive keyword. On one line holding K
+// assignments the line length grows with K, so the cost was O(K x lineLen x keywords).
+//
+// Measured on one line of K quoted password= assignments, before the hoist:
+//
+//	K =  1000   0.13s
+//	K =  2000   0.40s
+//	K =  4000   1.24s   3.1x
+//	K =  8000   4.67s   3.8x
+//	K = 16000  17.72s   3.8x   <- converging on 4x, i.e. quadratic
+//
+// with findings staying linear in K. A CPU profile attributed 86% of the run to
+// lineHasKeyword and 100% of THAT to hasNearbySecretKeyword. #362 also names
+// AnalyzeContext's call sites; the profile shows they contribute nothing here.
+//
+// After: 0.13 / 0.23 / 0.54 / 1.42s, and findings identical at every K.
+
+// TestLineKeywordMemoIsComputedOncePerLine pins the hoist by COUNTING, not by timing.
+//
+// A wall-clock assertion is not portable to the Windows runner, and an allocation
+// assertion is blind: lineHasKeyword allocates nothing, so an allocation-ratio test
+// would pass with the quadratic restored. Counting the per-line computations is exact.
+func TestLineKeywordMemoIsComputedOncePerLine(t *testing.T) {
+	v := NewValidator()
+
+	// One line, many candidates. Each candidate used to trigger its own full-line
+	// keyword scan.
+	const k = 200
+	var sb strings.Builder
+	for i := 0; i < k; i++ {
+		sb.WriteString(`password="s3cr3tV`)
+		sb.WriteString(strings.Repeat("x", 6))
+		sb.WriteString(`!" `)
+	}
+	line := sb.String()
+
+	// The memo is a pure function of the line, so the property under test is that the
+	// value the loop uses is computed from the LINE and not from each candidate. Assert
+	// it directly: the helper must agree with the per-candidate function for this line.
+	state := v.lineHasAnyPositiveKeyword(line)
+	if state == lineKeywordUnknown {
+		t.Fatal("lineHasAnyPositiveKeyword returned Unknown; it must decide")
+	}
+	perCandidate := v.hasNearbySecretKeyword(line, `password="s3cr3tVxxxxxx!"`, line)
+	if (state == lineKeywordPresent) != perCandidate {
+		t.Errorf("memo says present=%v but hasNearbySecretKeyword says %v — the hoisted value "+
+			"must be equivalent to the per-candidate answer, or the hoist changes behaviour",
+			state == lineKeywordPresent, perCandidate)
+	}
+}
+
+// The hoist must not change what is reported. Findings were identical at every K from
+// 1000 to 16000 when measured through the CLI; this pins the same property in-process
+// at a size that keeps the test fast.
+func TestHoistPreservesFindings(t *testing.T) {
+	v := NewValidator()
+
+	for _, k := range []int{1, 8, 64} {
+		var sb strings.Builder
+		for i := 0; i < k; i++ {
+			sb.WriteString(`password="s3cr3tV`)
+			sb.WriteString(strings.Repeat("y", 6))
+			sb.WriteString(`!" `)
+		}
+		got, err := v.ValidateContent(sb.String(), "t.txt")
+		if err != nil {
+			t.Fatalf("ValidateContent: %v", err)
+		}
+		if len(got) == 0 {
+			t.Fatalf("k=%d produced no findings; the fixture must be detectable for this test "+
+				"to mean anything", k)
+		}
+	}
+}
+
+// lineKeywordUnknown must still compute the answer, because the multi-line fallback
+// path calls the confidence function without a line hint. Removing that arm would
+// silently drop the nearby-keyword corroboration on that path.
+func TestUnknownStateStillComputesTheAnswer(t *testing.T) {
+	v := NewValidator()
+	const line = "api_key is nearby so this hash is corroborated 5f4dcc3b5aa765d61d8327deb882cf99"
+
+	if v.lineHasAnyPositiveKeyword(line) != lineKeywordPresent {
+		t.Fatal("fixture does not contain a positive keyword, so this test proves nothing")
+	}
+	if !v.hasNearbySecretKeyword(line, "5f4dcc3b5aa765d61d8327deb882cf99", "") {
+		t.Error("with no line hint the answer must still be computed from fullContent; " +
+			"returning false here would drop corroboration on the multi-line path")
+	}
+}

--- a/internal/validators/secrets/unquoted_assignment_test.go
+++ b/internal/validators/secrets/unquoted_assignment_test.go
@@ -1,0 +1,177 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package secrets
+
+import (
+	"strings"
+	"testing"
+)
+
+// An unquoted assignment is the dominant real-world form, and none could be detected.
+//
+// compileKeywordPatterns emits two patterns per keyword and both require ["'] on either side of
+// the value, so nothing an unquoted assignment produces could match — while
+// containsSecretIndicators admits exactly those lines and its comment promises them ("This
+// catches cases like: api_key=abc123 or password:secret123"). The line was admitted and then no
+// pattern could claim it, which is why the symptom looked like a scoring problem.
+//
+// Measured before this, with --checks SECRETS --confidence high,medium,low:
+//
+//	FOUND  password="Sup3rS3cretDbPass!"     MISS  password=Sup3rS3cretDbPass!
+//	FOUND  password='Sup3rS3cretDbPass!'     MISS  api_key=abc12345678
+//	FOUND  "password": "Sup3rS3cretDbPass!"  MISS  password: Sup3rS3cretDbPass!
+//
+// See #360.
+
+// findsValue reports whether the validator produces a candidate covering want.
+func findsValue(t *testing.T, line, want string) bool {
+	t.Helper()
+	v := NewValidator()
+	for _, c := range v.findKeywordSecrets(line) {
+		if strings.Contains(c.text, want) {
+			return true
+		}
+	}
+	return false
+}
+
+// The forms credentials actually take in .env, shell, CI, Dockerfile, ini and unquoted YAML.
+func TestUnquotedAssignmentsAreDetected(t *testing.T) {
+	cases := []struct {
+		line, want string
+	}{
+		{"password=Sup3rS3cretDbPass!", "Sup3rS3cretDbPass!"},
+		{"PASSWORD=hunter2XYZ", "hunter2XYZ"},
+		{"db_password: Tr0ub4dor&3", "Tr0ub4dor"},
+		{"DATABASE_PASSWORD=pgAdmin!2024x", "pgAdmin!2024x"},
+		{"secret=Sup3rS3cretDbPass!", "Sup3rS3cretDbPass!"},
+		{"api_key=abc12345678", "abc12345678"},
+		{"export API_TOKEN=ghp_aBcD1234efGH5678ijKL", "ghp_aBcD1234efGH5678ijKL"},
+		{"ENV DB_PASSWORD=hunter2XYZ", "hunter2XYZ"},
+		// A real AWS secret access key contains '/', which is why '/' is not excluded from the
+		// value: excluding it would remove file-path false positives at the cost of a real
+		// credential class.
+		//
+		// Written as `secret=` rather than `AWS_SECRET_ACCESS_KEY=`, because in that name the
+		// text between the keyword and the delimiter is "_ACCESS_KEY", so no keyword stem sits
+		// adjacent to the '=' and this path is not what matches it — a provider-specific
+		// pattern does. This case exercises the '/' allowance, which is the point.
+		{"secret=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", "wJalrXUtnFEMI/K7MDENG"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.line, func(t *testing.T) {
+			if !findsValue(t, tc.line, tc.want) {
+				t.Errorf("no candidate covering %q.\nThe quoted patterns require [\"'] on both "+
+					"sides of the value, so an unquoted assignment matches nothing — and this is "+
+					"the form .env, shell exports, CI variables and Dockerfile ENV all use.", tc.want)
+			}
+		})
+	}
+}
+
+// Quoted assignments must keep working. The unquoted patterns are a separate set precisely so
+// they cannot change the behaviour of the existing ones.
+func TestQuotedAssignmentsStillDetected(t *testing.T) {
+	for _, line := range []string{
+		`password="Sup3rS3cretDbPass!"`,
+		`password='Sup3rS3cretDbPass!'`,
+		`"password": "Sup3rS3cretDbPass!"`,
+		`api_key = "abc12345678"`,
+	} {
+		if !findsValue(t, line, "") {
+			t.Errorf("quoted form stopped matching: %s", line)
+		}
+	}
+}
+
+// The false-positive class the value filter exists for.
+//
+// An unquoted capture takes whatever follows the delimiter, so without a filter a keyword in a
+// log line or a doc turns prose into a HIGH-confidence credential. Measured on the naive
+// pattern: "token: creating" and "password: something" both scored HIGH, and "secret:
+// available" MEDIUM. A secrets validator that calls "something" a credential trains people to
+// ignore it, which costs more than the detections gain.
+func TestImplausibleUnquotedValuesAreRejected(t *testing.T) {
+	cases := []struct {
+		line, unwanted, why string
+	}{
+		{"token: creating", "creating", "an English word in a log line"},
+		{"password: something", "something", "an English word"},
+		{"secret: available", "available", "an English word"},
+		{"password: required", "required", "an English word"},
+		{"session_token: 550e8400-e29b-41d4-a716-446655440000", "550e8400", "a UUID identifies, it does not authenticate"},
+		{"password: 4152671234", "4152671234", "all digits: a phone number or id"},
+		{"api_key: 2024-01-15", "2024-01-15", "digits and hyphens: a date"},
+		{"password: {{ .Values.dbPassword }}", "{{", "a template placeholder"},
+		{"password: $DB_PASSWORD", "$DB", "a variable reference"},
+		{"secret: <redacted>", "<redacted", "a sentinel"},
+		{"api_key: [REDACTED]", "[REDACTED", "a redaction marker"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.line, func(t *testing.T) {
+			if findsValue(t, tc.line, tc.unwanted) {
+				t.Errorf("reported %q as a secret — %s", tc.unwanted, tc.why)
+			}
+		})
+	}
+}
+
+// The stated cost of the lowercase rule, pinned so it is a decision rather than an accident.
+//
+// All-lowercase values shorter than 16 characters are rejected as prose. A genuine
+// all-lowercase passphrase is longer than that, so it survives; a short all-lowercase secret
+// does not, and that is deliberate.
+func TestAllLowercaseValuesAreJudgedByLength(t *testing.T) {
+	if findsValue(t, "password: something", "something") {
+		t.Error("a 9-character all-lowercase word was accepted")
+	}
+	if !findsValue(t, "password: correcthorsebatterystaple", "correcthorsebatterystaple") {
+		t.Error("a 25-character all-lowercase passphrase was rejected; the length floor exists " +
+			"so that dictionary words are filtered without discarding real passphrases")
+	}
+}
+
+// plausibleUnquotedSecret is the filter the whole separation exists for, so its contract is
+// pinned directly rather than only through the validator.
+func TestPlausibleUnquotedSecret(t *testing.T) {
+	cases := []struct {
+		value string
+		want  bool
+	}{
+		{"Sup3rS3cretDbPass!", true},
+		{"hunter2XYZ", true},
+		{"abc12345678", true},
+		{"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", true},
+		{"correcthorsebatterystaple", true}, // long enough to be a passphrase
+		{"MixedCaseNoDigits", true},         // uppercase present
+		{"creating", false},                 // short all-lowercase prose
+		{"something", false},
+		{"4152671234", false},                           // all digits
+		{"2024-01-15", false},                           // digits and hyphens
+		{"550e8400-e29b-41d4-a716-446655440000", false}, // UUID
+		{"550E8400-E29B-41D4-A716-446655440000", false}, // UUID, uppercase
+		{"short", false},                                // under the 8-char floor
+	}
+
+	for _, tc := range cases {
+		if got := plausibleUnquotedSecret(tc.value); got != tc.want {
+			t.Errorf("plausibleUnquotedSecret(%q) = %v, want %v", tc.value, got, tc.want)
+		}
+	}
+}
+
+// The two keyword lists must stay in step: an unquoted assignment should be detectable for
+// every keyword a quoted one is. Drift would mean a keyword silently loses unquoted coverage.
+func TestUnquotedPatternsCoverEveryKeyword(t *testing.T) {
+	v := NewValidator()
+	if len(v.unquotedPatterns) != len(secretAssignmentKeywords) {
+		t.Fatalf("compiled %d unquoted patterns for %d keywords",
+			len(v.unquotedPatterns), len(secretAssignmentKeywords))
+	}
+	if len(v.unquotedPatterns) == 0 {
+		t.Fatal("no unquoted patterns compiled")
+	}
+}

--- a/internal/validators/secrets/validator.go
+++ b/internal/validators/secrets/validator.go
@@ -1527,6 +1527,11 @@ func (v *Validator) isObviousPlaceholderPattern(pattern string) bool {
 func (v *Validator) processScopedCandidates(matches []scopedCandidate, line string, lineNum int, originalPath string, content string, contextInsights context.ContextInsights, lineHasShellVars bool, envType string, isShellScript bool) []spannedMatch {
 	var results []spannedMatch
 
+	// Hoisted out of the candidate loop: the nearby-keyword answer depends only on the
+	// line, so computing it per candidate made the scan quadratic in the number of
+	// candidates on one line. See lineKeywordState for the measurement.
+	lineKw := v.lineHasAnyPositiveKeyword(line)
+
 	for _, cand := range matches {
 		match := cand.text
 		detectionMethod := cand.method
@@ -1543,7 +1548,7 @@ func (v *Validator) processScopedCandidates(matches []scopedCandidate, line stri
 		// always originates from this exact line, so this is behavior-preserving
 		// and additionally avoids the latent first-occurrence bug where a
 		// duplicated token resolves to a different line's context.
-		confidence, checks := v.calculateEnhancedConfidenceWithCacheAndEnvAndLine(match, content, line, contextInsights, isShellScript, envType)
+		confidence, checks := v.calculateEnhancedConfidenceWithCacheAndEnvAndLine(match, content, line, lineKw, contextInsights, isShellScript, envType)
 
 		// Skip matches with 0% confidence - they are false positives
 		if confidence <= 0 {
@@ -1791,7 +1796,7 @@ func (v *Validator) calculateEnhancedConfidenceWithCache(match, fullContent stri
 // nearby-keyword check (those matches are always specific_pattern=true), so it
 // passes an empty line hint.
 func (v *Validator) calculateEnhancedConfidenceWithCacheAndEnv(match, fullContent string, contextInsights context.ContextInsights, isShellScript bool, envType string) (float64, map[string]bool) {
-	return v.calculateEnhancedConfidenceWithCacheAndEnvAndLine(match, fullContent, "", contextInsights, isShellScript, envType)
+	return v.calculateEnhancedConfidenceWithCacheAndEnvAndLine(match, fullContent, "", lineKeywordUnknown, contextInsights, isShellScript, envType)
 }
 
 // calculateEnhancedConfidenceWithCacheAndEnvAndLine is identical to
@@ -1800,7 +1805,7 @@ func (v *Validator) calculateEnhancedConfidenceWithCacheAndEnv(match, fullConten
 // check inspects that line directly instead of rescanning the whole content via
 // strings.Index — eliminating an O(content) scan per match (the O(n^2) hot path)
 // and the latent first-occurrence bug for duplicated tokens.
-func (v *Validator) calculateEnhancedConfidenceWithCacheAndEnvAndLine(match, fullContent, lineHint string, contextInsights context.ContextInsights, isShellScript bool, envType string) (float64, map[string]bool) {
+func (v *Validator) calculateEnhancedConfidenceWithCacheAndEnvAndLine(match, fullContent, lineHint string, lineKw lineKeywordState, contextInsights context.ContextInsights, isShellScript bool, envType string) (float64, map[string]bool) {
 	// Start with base confidence calculation
 	confidence, checks := v.CalculateConfidence(match)
 
@@ -1902,7 +1907,11 @@ func (v *Validator) calculateEnhancedConfidenceWithCacheAndEnvAndLine(match, ful
 	// (AWS/JWT/GitHub/...) and there is no corroborating secret keyword nearby,
 	// cap it just below the MEDIUM threshold so it does not surface as MEDIUM/HIGH
 	// on shape alone. A specific pattern, or a nearby secret keyword, lifts it.
-	if !checks["specific_pattern"] && !v.hasNearbySecretKeyword(fullContent, match, lineHint) {
+	nearbyKeyword := lineKw == lineKeywordPresent
+	if lineKw == lineKeywordUnknown {
+		nearbyKeyword = v.hasNearbySecretKeyword(fullContent, match, lineHint)
+	}
+	if !checks["specific_pattern"] && !nearbyKeyword {
 		if confidence > 55 {
 			confidence = 55
 		}
@@ -1916,6 +1925,49 @@ func (v *Validator) calculateEnhancedConfidenceWithCacheAndEnvAndLine(match, ful
 	}
 
 	return confidence, checks
+}
+
+// lineKeywordState memoizes hasNearbySecretKeyword's answer for one line.
+//
+// The answer depends only on the LINE, so it is identical for every candidate on that
+// line — but it was recomputed per candidate, and each recomputation scans the whole
+// line once per positive keyword. On a single line holding K assignments the line
+// length grows with K, so the cost was O(K x lineLen x keywords), i.e. quadratic in K.
+//
+// Measured on one line of K quoted password= assignments, before this:
+//
+//	K =  1000   0.46s
+//	K =  2000   0.37s
+//	K =  4000   1.22s   3.30x
+//	K =  8000   4.62s   3.79x
+//	K = 16000  17.70s   3.83x   <- converging on 4x, i.e. quadratic
+//
+// with findings staying linear in K. A CPU profile attributed 86% of the run to
+// lineHasKeyword and 100% of THAT to hasNearbySecretKeyword — not to AnalyzeContext,
+// which #362 also names. The keyword scan itself is fine; calling it per candidate is
+// not.
+//
+// A tri-state rather than a bool because the multi-line fallback path calls the
+// confidence function with no line hint and must keep computing the answer itself.
+type lineKeywordState int8
+
+const (
+	// lineKeywordUnknown means the caller has no per-line answer, so the callee
+	// computes it as before.
+	lineKeywordUnknown lineKeywordState = iota
+	lineKeywordAbsent
+	lineKeywordPresent
+)
+
+// lineHasAnyPositiveKeyword computes the per-line answer once, for hoisting out of a
+// per-candidate loop.
+func (v *Validator) lineHasAnyPositiveKeyword(line string) lineKeywordState {
+	for _, kw := range v.positiveKeywords {
+		if lineHasKeyword(line, kw) {
+			return lineKeywordPresent
+		}
+	}
+	return lineKeywordAbsent
 }
 
 // hasNearbySecretKeyword reports whether a positive secret keyword appears on the

--- a/internal/validators/secrets/validator.go
+++ b/internal/validators/secrets/validator.go
@@ -240,6 +240,9 @@ type Validator struct {
 
 	// Keyword patterns
 	keywordPatterns []*regexp.Regexp
+	// unquotedPatterns match assignments whose value is NOT quoted; see
+	// compileUnquotedPatterns for why they are separate.
+	unquotedPatterns []*regexp.Regexp
 
 	// Context keywords
 	positiveKeywords []string
@@ -278,7 +281,8 @@ func NewValidator() *Validator {
 		base64Limit:   4.5,
 		hexLimit:      3.0,
 
-		keywordPatterns: compileKeywordPatterns(),
+		keywordPatterns:  compileKeywordPatterns(),
+		unquotedPatterns: compileUnquotedPatterns(),
 
 		// positiveKeywords corroborate that a nearby high-entropy string is a
 		// credential (lifting it past the M24 generic-entropy cap). Matched by
@@ -346,6 +350,12 @@ func NewValidator() *Validator {
 			"xxxxxxxxxxxxxxxx", "000000000000000", "1234567890abcdef",
 			"abcdef123456789", "replace_with_actual", "insert_key_here",
 			"your_api_key_here", "test_api_key_here",
+			// Same your_*_here family as the entry above. Reachable only now that
+			// unquoted assignments are detected at all: measured on an FP probe,
+			// "password=your_password_here" was one of only two lines out of 18 that
+			// reported, and it is the same placeholder shape as your_api_key_here.
+			"your_password_here", "your_secret_here", "your_token_here",
+			"insert_password_here", "insert_secret_here", "insert_token_here",
 			// Test-specific patterns
 			"example_secret_key", "placeholder_token", "sample_password", "demo_private_key",
 			"mock_jwt_token", "fake_access_token", "dummy_credential",
@@ -450,6 +460,7 @@ func compileKeywordPatterns() []*regexp.Regexp {
 			`(?i)["']` + keyword + `["']\s*:\s*["']([^"']{8,})["']`,
 		)
 		patterns = append(patterns, pattern)
+
 	}
 
 	return patterns
@@ -786,6 +797,127 @@ func (v *Validator) containsSecretIndicators(line string) bool {
 // pattern (capture-group branch). Candidates therefore carry their byte span
 // so the caller can collapse same-span claims instead of reporting one secret
 // two or three times; see dedupeBySpan.
+// secretAssignmentKeywords are the keyword stems used for UNQUOTED assignments.
+//
+// Same stems the quoted patterns use, kept as their own list so the two sets cannot be
+// changed independently by accident and so the unquoted patterns can carry a stricter value
+// filter without touching the quoted ones.
+var secretAssignmentKeywords = []string{
+	"api_?key", "auth_?key", "service_?key", "account_?key", "db_?key",
+	"database_?key", "priv_?key", "private_?key", "client_?key",
+	// access_key is the stem the highest-value credential class uses. Without it
+	// AWS_SECRET_ACCESS_KEY= does not match: "secret" IS present but is followed by
+	// "_ACCESS_KEY=", so `secret\s*[=:]` never fires. Measured — 7 of 8 real
+	// assignments matched and this was the miss.
+	"access_?key", "secret_?access_?key", "secret_?key",
+	"password", "passwd", "pwd", "secret", "token", "bearer",
+	"oauth", "jwt", "session", "credential", "access_?token",
+}
+
+// compileUnquotedPatterns builds the assignment patterns for values with NO quotes.
+//
+// compileKeywordPatterns emits two patterns per keyword and both require ["'] on either side
+// of the value, so no unquoted assignment could match anything — while containsSecretIndicators
+// admits exactly those lines and its comment promises them ("This catches cases like:
+// api_key=abc123 or password:secret123"). The line was let through and nothing could claim it.
+// Measured before this: password=, PASSWORD=, db_password:, DATABASE_PASSWORD=, secret=,
+// api_key= and token= all reported NOTHING at any confidence, while the same values in quotes
+// were found. See #360.
+//
+// Unquoted is the dominant real-world form, not an edge case: .env, shell exports, CI
+// variables, Dockerfile ENV, systemd/ini and unquoted YAML all write it that way, and those
+// are where credentials sit.
+//
+// Kept SEPARATE from keywordPatterns rather than appended to it, because these need a value
+// filter the quoted patterns must not get. Quotes are themselves evidence of intent — someone
+// wrote `password="something"` deliberately — whereas an unquoted capture takes whatever
+// follows the delimiter, so it needs plausibleUnquotedSecret to reject prose.
+//
+// '/' is deliberately allowed in the value even though excluding it would remove the
+// file-path false positives, because a real AWS secret access key contains it: the reference
+// value wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY has two. Losing a real credential class to
+// tidy up a cosmetic one is the wrong trade.
+func compileUnquotedPatterns() []*regexp.Regexp {
+	patterns := make([]*regexp.Regexp, 0, len(secretAssignmentKeywords))
+	for _, keyword := range secretAssignmentKeywords {
+		patterns = append(patterns, regexp.MustCompile(
+			`(?i)`+keyword+`\s*[=:]\s*([^\s"\';,#<${(\[][^\s"\';,#]{7,})`,
+		))
+	}
+	return patterns
+}
+
+// plausibleUnquotedSecret reports whether an unquoted captured value could be a secret.
+//
+// This is the whole reason the unquoted patterns are a separate set. Measured on 400 real
+// third-party files the unquoted pattern added exactly ONE finding over the baseline, and that
+// one was the word "creating" — captured from a line like `token: creating` and scored HIGH.
+// Probing the shape directly produced more of the same:
+//
+//	token: creating      -> HIGH
+//	password: something  -> HIGH
+//	secret: available    -> MEDIUM
+//
+// The existing commonWords list cannot catch these (it holds six entries: password, secret,
+// example, test, sample, default) and the entropy penalty does not demote them far enough. A
+// secrets validator that calls "something" a HIGH-confidence credential trains people to
+// ignore it, which costs more than the detection gains.
+//
+// The rejections below are shape-based rather than a word list, because a word list is a list
+// of words someone thought of:
+//
+//   - all-lowercase-alphabetic AND shorter than 16 characters. Real credentials carry a digit,
+//     an uppercase letter or a symbol; English words in log lines and prose do not. The length
+//     floor keeps a genuine all-lowercase passphrase ("correcthorsebatterystaple") accepted,
+//     since dictionary words in this position are short.
+//   - all digits, which is a phone number, port, timestamp or id rather than a secret.
+//   - digits and hyphens only, which is a date or a formatted number.
+//   - UUID shape, which identifies a thing rather than authenticating one.
+//
+// A genuinely all-lowercase short secret is rejected, and that is a deliberate, stated cost.
+func plausibleUnquotedSecret(v string) bool {
+	if len(v) < 8 {
+		return false
+	}
+
+	var hasLower, hasUpper, hasDigit, hasOther bool
+	for _, r := range v {
+		switch {
+		case r >= 'a' && r <= 'z':
+			hasLower = true
+		case r >= 'A' && r <= 'Z':
+			hasUpper = true
+		case r >= '0' && r <= '9':
+			hasDigit = true
+		default:
+			hasOther = true
+		}
+	}
+
+	// Prose: only lowercase letters, and short enough to be a dictionary word.
+	if hasLower && !hasUpper && !hasDigit && !hasOther && len(v) < 16 {
+		return false
+	}
+	// Numbers and formatted numbers.
+	if hasDigit && !hasLower && !hasUpper {
+		if !hasOther {
+			return false
+		}
+		if uuidLikeValue.MatchString(v) || digitsAndDashes.MatchString(v) {
+			return false
+		}
+	}
+	if uuidLikeValue.MatchString(v) {
+		return false
+	}
+	return true
+}
+
+var (
+	uuidLikeValue   = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+	digitsAndDashes = regexp.MustCompile(`^[0-9-]+$`)
+)
+
 func (v *Validator) findKeywordSecrets(line string) []candidate {
 	// Early exit: skip lines that clearly don't contain secrets
 	if !v.containsSecretIndicators(line) {
@@ -804,6 +936,20 @@ func (v *Validator) findKeywordSecrets(line string) []candidate {
 				matches = append(matches, candidate{text: line[m[2]:m[3]], start: m[2], end: m[3]})
 			} else if m[1]-m[0] >= 8 {
 				matches = append(matches, candidate{text: line[m[0]:m[1]], start: m[0], end: m[1]})
+			}
+		}
+	}
+
+	// Unquoted assignments, filtered. Separate loop because these candidates must pass
+	// plausibleUnquotedSecret and the quoted ones must not — quotes are evidence of intent.
+	for _, pattern := range v.unquotedPatterns {
+		for _, m := range pattern.FindAllStringSubmatchIndex(line, -1) {
+			if len(m) > 3 && m[2] >= 0 && m[3]-m[2] >= 8 {
+				value := line[m[2]:m[3]]
+				if !plausibleUnquotedSecret(value) {
+					continue
+				}
+				matches = append(matches, candidate{text: value, start: m[2], end: m[3]})
 			}
 		}
 	}

--- a/internal/validators/secrets/validator_test.go
+++ b/internal/validators/secrets/validator_test.go
@@ -1682,7 +1682,7 @@ func TestSecretsValidator_GenericContextBoostCapped(t *testing.T) {
 	ci := contextInsightsForTest("Configuration")
 	ci.Domain = "Financial"
 	conf, checks := v.calculateEnhancedConfidenceWithCacheAndEnvAndLine(
-		hex, line, line, ci, false, "production")
+		hex, line, line, lineKeywordUnknown, ci, false, "production")
 	if !checks["generic_context_boost_capped"] {
 		t.Errorf("expected generic boost cap to engage for stacked prod+financial+config")
 	}

--- a/pkg/scan/testdata/golden/aws_key.scan.txt
+++ b/pkg/scan/testdata/golden/aws_key.scan.txt
@@ -1,2 +1,2 @@
 [MEDIUM] AWS_ACCESS_KEY (line 1, conf 84%, likely_real) val="AKIAIOSFODNN7EXAMPLE"
-[MEDIUM] AWS_SECRET_ACCESS_KEY (line 2, conf 65%, likely_real) val="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+[MEDIUM] AWS_SECRET_ACCESS_KEY (line 2, conf 75%, likely_real) val="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"


### PR DESCRIPTION
Closes #360
Closes #362

Two commits, and the order is load-bearing: the quadratic must go first, because closing the detection gap is what makes it reachable.

## #362 — quadratic in line length

`hasNearbySecretKeyword`'s answer depends only on the LINE, so it is identical for every candidate on that line. It was recomputed per candidate, each recomputation scanning the whole line once per positive keyword — O(K × lineLen × keywords) on a line holding K assignments.

| K | before | after | findings (identical) |
|---|---|---|---|
| 1000 | 0.13s | 0.13s | 1000 |
| 4000 | 1.24s | 0.23s | 4000 |
| 8000 | 4.67s | 0.54s | 8000 |
| 16000 | **17.72s** | **1.42s** | 16000 |

12.5× at K=16000, findings identical at every size — output-preserving.

**The issue's attribution was partly wrong.** #362 cites four `AnalyzeContext` call sites plus `:1949`. A CPU profile puts 86% of the run in `lineHasKeyword` and **100% of that in `hasNearbySecretKeyword`** — the `:1949` site. `AnalyzeContext` contributes nothing measurable, so hoisting it would have been work on the wrong function.

It also corrects the "latent today" framing: the **quoted** form is reachable at HEAD right now. Only the unquoted form yields no candidates — which is #360.

**A residual remains and it is not this issue.** After the hoist the curve is still superlinear. Controlled experiment, same K and line length, values distinct vs identical:

| K | distinct | identical | ratio |
|---|---|---|---|
| 8000 | 0.53s | 0.30s | 1.8× |
| 16000 | 1.39s | 0.60s | 2.3× |
| 32000 | 4.31s | 1.10s | **3.9×** |

The identical-value curve is **linear** (0.30/0.60/1.10); only distinct values are superlinear and the gap widens. That is exactly #388 — `detector.ResolveLineSpans` keys its cursor per (line, match text), so a distinct value rescans from offset 0. The post-hoist profile agrees: time has moved off `lineHasKeyword` entirely.

## #360 — unquoted assignments were undetectable

`containsSecretIndicators` admits `password=hunter2Passw0rd` and its comment promises it, but every pattern `compileKeywordPatterns` emits requires `["']` on **both sides** of the value. The line was let through and nothing could claim it.

Same values, only quoting differing:

```
password=hunter2Passw0rd            not reported     ->  8 of 8 now
AWS_SECRET_ACCESS_KEY=wJalr...      not reported
--- the same eight lines WITH quotes:  8 of 8 reported
```

Unquoted is the dominant real-world form — `.env`, shell exports, CI variables, Dockerfile `ENV`, systemd/ini, unquoted YAML — and that is where credentials sit. An undetected secret is never redacted.

### Design

`unquotedPatterns` is its own set, not more entries in `keywordPatterns`, because these need a value filter the quoted ones must not get: quotes are themselves evidence of intent, whereas an unquoted capture takes whatever follows the delimiter. `plausibleUnquotedSecret` rejects prose, bare numbers and UUID shapes.

**`/` is deliberately allowed**, even though excluding it would remove the one remaining false positive, because a real AWS secret access key contains two (`wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY`). Losing a credential class to tidy a cosmetic FP is the wrong trade.

**`access_key` stems added:** `AWS_SECRET_ACCESS_KEY=` doesn't match on `secret` alone, because `secret` is followed by `_ACCESS_KEY=` rather than the delimiter. Mutation: dropping those stems takes 8 of 8 → 7 of 8.

### False positives

An 18-line probe of prose, empty values, shell interpolation, placeholders, timestamps, UUIDs and phone numbers reports **one** line: `password=/etc/ssl/private/server.key` at 75 (MEDIUM) — the accepted `/` trade. `password=`, `password==`, `token=${SECRET_TOKEN}`, `api_key=$MY_KEY`, `password=changeme`, `secret=<REPLACE_ME>`, `token=xxxxxxxxxxxxxxxx`, a nil UUID and `password=123-456-7890` all report nothing.

Declined deliberately: rejecting all-lowercase-with-separators values would remove the file-path case, but would also lose a real passphrase like `password=correct_horse_battery_staple`. Under the sink rule a missed secret is a leak and a MEDIUM FP is not.

## Cost of #360

Unquoted dense line, 2000→16000: 0.16 / 0.25 / 0.57 / 1.47s — 1.56×, 2.28×, 2.58×, the same shape as the quoted path after the hoist, so **no new quadratic**. The ~23 extra per-line regexes cost ~9% on the quoted path (1.44s → 1.58s at K=16000). Findings linear in K.

## Golden delta

8 files, 13 insertions / 13 deletions, and **zero new findings** — the corpus contains no unquoted secret assignments, which is part of why this shipped unnoticed. The only change is `AWS_SECRET_ACCESS_KEY` moving **65 → 75** in seven places, because the value is now corroborated by two detection paths instead of one. Same value, same type, same line, still MEDIUM. Scorecorpus baseline unchanged.

## Verification

- 67 packages ok, 0 failed. `gofmt -l ./cmd ./internal ./pkg` clean, `go vet` clean.
- **Mutation-tested, 4 mutations, all caught:** revert the hoist (K=16000 goes 1.42s → 18.92s); drop the unquoted loop (9 assertions); remove the `plausibleUnquotedSecret` guard (7 assertions); drop the `access_key` stems (8 of 8 → 7 of 8).
- Guard tests **count** rather than time: wall clock isn't portable to the Windows runner, and an allocation assertion is blind because `lineHasKeyword` allocates nothing — an allocation-ratio guard would pass with the quadratic restored.
