### PR TITLE
fix(validators): let a column header and a bare label above count as context for label-gated types

### DIFF
--- a/internal/goldencorpus/testdata/golden/passport_label_above_value.csv
+++ b/internal/goldencorpus/testdata/golden/passport_label_above_value.csv
@@ -1,1 +1,3 @@
 Filename,Type,Confidence Level,Confidence %,Line Number,Text
+<golden:passport_label_above_value>,PASSPORT,MEDIUM,80.0,4,512345678
+<golden:passport_label_above_value>,PASSPORT,MEDIUM,75.0,2,987654321

--- a/internal/goldencorpus/testdata/golden/passport_label_above_value.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/passport_label_above_value.gitlab-sast.json
@@ -25,5 +25,58 @@
     "type": "sast"
   },
   "version": "15.0.4",
-  "vulnerabilities": []
+  "vulnerabilities": [
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected sensitive data (passport) in this file.\n\n**Location:** <golden:passport_label_above_value> (line 4)\n**Confidence:** MEDIUM (80.0%)\n**Detected by:** passport validator\n\n**Context:**\n```\nValue: 512345678\n```\n\n**Additional Information:**\n- context_impact: 20\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "PASSPORT"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "passport"
+        }
+      ],
+      "location": {
+        "end_line": 4,
+        "file": "<golden:passport_label_above_value>",
+        "start_line": 4
+      },
+      "message": "Sensitive data (passport) detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Passport Number Detected",
+      "severity": "High"
+    },
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected sensitive data (passport) in this file.\n\n**Location:** <golden:passport_label_above_value> (line 2)\n**Confidence:** MEDIUM (75.0%)\n**Detected by:** passport validator\n\n**Context:**\n```\n987654321\n```\n\n**Additional Information:**\n- context_impact: 15\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "PASSPORT"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "passport"
+        }
+      ],
+      "location": {
+        "end_line": 2,
+        "file": "<golden:passport_label_above_value>",
+        "start_line": 2
+      },
+      "message": "Sensitive data (passport) detected: [HIDDEN] (confidence: MEDIUM)",
+      "name": "Passport Number Detected",
+      "severity": "High"
+    }
+  ]
 }

--- a/internal/goldencorpus/testdata/golden/passport_label_above_value.json.json
+++ b/internal/goldencorpus/testdata/golden/passport_label_above_value.json.json
@@ -1,3 +1,78 @@
 {
-  "results": []
+  "results": [
+    {
+      "confidence": 80,
+      "confidence_level": "MEDIUM",
+      "filename": "<golden:passport_label_above_value>",
+      "line_number": 4,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "Government",
+        "context_impact": 20,
+        "country": "UK",
+        "original_confidence": 80,
+        "original_file": "<golden:passport_label_above_value>",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "format": true,
+          "length": true,
+          "not_common_word": true,
+          "not_sequential": true,
+          "not_test_number": true,
+          "valid_characters": true,
+          "valid_country_code": false
+        },
+        "validation_path": "document"
+      },
+      "text": "512345678",
+      "type": "PASSPORT",
+      "validator": "passport"
+    },
+    {
+      "confidence": 75,
+      "confidence_level": "MEDIUM",
+      "filename": "<golden:passport_label_above_value>",
+      "line_number": 2,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 1,
+        "context_doctype": "Unknown",
+        "context_domain": "Government",
+        "context_impact": 15,
+        "country": "UK",
+        "original_confidence": 75,
+        "original_file": "<golden:passport_label_above_value>",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "format": true,
+          "length": true,
+          "not_common_word": true,
+          "not_sequential": true,
+          "not_test_number": true,
+          "valid_characters": true,
+          "valid_country_code": false
+        },
+        "validation_path": "document"
+      },
+      "text": "987654321",
+      "type": "PASSPORT",
+      "validator": "passport"
+    }
+  ]
 }

--- a/internal/goldencorpus/testdata/golden/passport_label_above_value.junit.xml
+++ b/internal/goldencorpus/testdata/golden/passport_label_above_value.junit.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="ferret-scan" tests="0" failures="0" errors="0" time="0.000">
-  <testsuite name="security-scan" tests="0" failures="0" errors="0" time="0.000"></testsuite>
+<testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
+  <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
+    <testcase name="&lt;golden:passport_label_above_value&gt;" classname="security-scan" time="0.001">
+      <failure message="2 security findings detected" type="SECURITY_FINDINGS">Line 4: PASSPORT detected with 80.0% confidence (MEDIUM)&#xA;Match: 512345678&#xA;Validator: passport&#xA;Line 2: PASSPORT detected with 75.0% confidence (MEDIUM)&#xA;Match: 987654321&#xA;Validator: passport</failure>
+    </testcase>
+  </testsuite>
 </testsuites>

--- a/internal/goldencorpus/testdata/golden/passport_label_above_value.redact_format_preserving.txt
+++ b/internal/goldencorpus/testdata/golden/passport_label_above_value.redact_format_preserving.txt
@@ -1,8 +1,10 @@
 === REDACTED ===
 passport_number
-987654321
+*********
 Field: Passport Number
-Value: 512345678
+Value: *********
 name,email,passport_number,country
 Jane,jane.smith@acmecorp.io,512345671,US
 === FINDINGS (sorted) ===
+type=PASSPORT line=2 conf=medium match=987654321
+type=PASSPORT line=4 conf=medium match=512345678

--- a/internal/goldencorpus/testdata/golden/passport_label_above_value.redact_simple.txt
+++ b/internal/goldencorpus/testdata/golden/passport_label_above_value.redact_simple.txt
@@ -1,8 +1,10 @@
 === REDACTED ===
 passport_number
-987654321
+[PASSPORT-REDACTED]
 Field: Passport Number
-Value: 512345678
+Value: [PASSPORT-REDACTED]
 name,email,passport_number,country
 Jane,jane.smith@acmecorp.io,512345671,US
 === FINDINGS (sorted) ===
+type=PASSPORT line=2 conf=medium match=987654321
+type=PASSPORT line=4 conf=medium match=512345678

--- a/internal/goldencorpus/testdata/golden/passport_label_above_value.sarif.json
+++ b/internal/goldencorpus/testdata/golden/passport_label_above_value.sarif.json
@@ -2,11 +2,149 @@
   "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/refs/heads/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
   "runs": [
     {
-      "results": [],
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:passport_label_above_value>"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "Value: \nValue: 512345678"
+                  },
+                  "startLine": 4
+                },
+                "region": {
+                  "endColumn": 17,
+                  "snippet": {
+                    "text": "Value: 512345678"
+                  },
+                  "startColumn": 8,
+                  "startLine": 4
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Passport Number Detected in <golden:passport_label_above_value> at line 4 (confidence: 80.0% - MEDIUM). Matched text: '512345678'"
+          },
+          "properties": {
+            "confidence": 80,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "Government",
+              "context_impact": 20,
+              "country": "UK",
+              "original_confidence": 80,
+              "original_file": "<golden:passport_label_above_value>",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "format": true,
+                "length": true,
+                "not_common_word": true,
+                "not_sequential": true,
+                "not_test_number": true,
+                "valid_characters": true,
+                "valid_country_code": false
+              },
+              "validation_path": "document"
+            },
+            "validator": "passport"
+          },
+          "rank": 90,
+          "ruleId": "PASSPORT"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<golden:passport_label_above_value>"
+                },
+                "region": {
+                  "endColumn": 10,
+                  "snippet": {
+                    "text": "987654321"
+                  },
+                  "startColumn": 1,
+                  "startLine": 2
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Passport Number Detected in <golden:passport_label_above_value> at line 2 (confidence: 75.0% - MEDIUM). Matched text: '987654321'"
+          },
+          "properties": {
+            "confidence": 75,
+            "confidenceLevel": "MEDIUM",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 1,
+              "context_doctype": "Unknown",
+              "context_domain": "Government",
+              "context_impact": 15,
+              "country": "UK",
+              "original_confidence": 75,
+              "original_file": "<golden:passport_label_above_value>",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "format": true,
+                "length": true,
+                "not_common_word": true,
+                "not_sequential": true,
+                "not_test_number": true,
+                "valid_characters": true,
+                "valid_country_code": false
+              },
+              "validation_path": "document"
+            },
+            "validator": "passport"
+          },
+          "rank": 87.5,
+          "ruleId": "PASSPORT"
+        }
+      ],
       "tool": {
         "driver": {
           "informationUri": "https://github.com/awslabs/ferret-scan",
           "name": "Ferret Scan",
+          "rules": [
+            {
+              "fullDescription": {
+                "text": "A passport number pattern was detected in the scanned content. Passport numbers are highly sensitive personally identifiable information that must be protected."
+              },
+              "help": {
+                "text": "Passport numbers are protected under various privacy and identity theft prevention regulations. They should never be stored in source code or logs. Remove this passport number immediately and ensure it is stored in a secure, encrypted system with strict access controls and audit logging."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/PASSPORT.md",
+              "id": "PASSPORT",
+              "shortDescription": {
+                "text": "Passport Number Detected"
+              }
+            }
+          ],
           "semanticVersion": "0.0.0-development",
           "version": "0.0.0-development"
         }

--- a/internal/goldencorpus/testdata/golden/passport_label_above_value.txt
+++ b/internal/goldencorpus/testdata/golden/passport_label_above_value.txt
@@ -1,1 +1,4 @@
-No matches found.
+LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH      FILE
+------------------------------------------------------------------------------------
+[MEDIUM] passport     PASSPORT               80.00% line     4 512345678  <golden:passport_label_above_value>
+[MEDIUM] passport     PASSPORT               75.00% line     2 987654321  <golden:passport_label_above_value>

--- a/internal/goldencorpus/testdata/golden/passport_label_above_value.yaml
+++ b/internal/goldencorpus/testdata/golden/passport_label_above_value.yaml
@@ -1,1 +1,65 @@
-results: []
+results:
+    - text: "512345678"
+      line_number: 4
+      type: PASSPORT
+      confidence: 80
+      confidence_level: MEDIUM
+      filename: <golden:passport_label_above_value>
+      validator: passport
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: Government
+        context_impact: 20
+        country: UK
+        original_confidence: 80
+        original_file: <golden:passport_label_above_value>
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            format: true
+            length: true
+            not_common_word: true
+            not_sequential: true
+            not_test_number: true
+            valid_characters: true
+            valid_country_code: false
+        validation_path: document
+    - text: "987654321"
+      line_number: 2
+      type: PASSPORT
+      confidence: 75
+      confidence_level: MEDIUM
+      filename: <golden:passport_label_above_value>
+      validator: passport
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 1
+        context_doctype: Unknown
+        context_domain: Government
+        context_impact: 15
+        country: UK
+        original_confidence: 75
+        original_file: <golden:passport_label_above_value>
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            format: true
+            length: true
+            not_common_word: true
+            not_sequential: true
+            not_test_number: true
+            valid_characters: true
+            valid_country_code: false
+        validation_path: document

--- a/internal/validators/driverslicense/adversarial_test.go
+++ b/internal/validators/driverslicense/adversarial_test.go
@@ -589,17 +589,50 @@ func TestAdversarial_EdgeCases(t *testing.T) {
 		}
 	})
 
-	t.Run("DL on line with keyword on different line", func(t *testing.T) {
-		// Keywords only matter on the SAME line
+	t.Run("DL under a bare field label on the line above DOES match", func(t *testing.T) {
+		// CONTRACT CHANGE, deliberate. This case previously asserted that "keywords only
+		// matter on the SAME line", and the fixture below is exactly the form layout that
+		// rule made undetectable:
+		//
+		//	driver's license information:
+		//	12345678
+		//
+		// A licence has no checksum, so a label is the only evidence — and the label
+		// search stopped at the newline, so this reported nothing and the value was left
+		// in cleartext by --enable-redaction. The window is bounded to ONE line back and
+		// gated on kwmatch.LooksLikeFieldLabel, so only a bare label qualifies; the
+		// sibling case below pins that prose still does not.
 		content := "driver's license information:\n12345678"
 		matches, err := validator.ValidateContent(content, "test.txt")
 		if err != nil {
 			t.Fatalf("error: %v", err)
 		}
-		// Line 2 has no keyword, so should not match
+		found := false
 		for _, m := range matches {
 			if m.LineNumber == 2 {
-				t.Errorf("Number on line without keywords should not match, got %q confidence=%.1f", m.Text, m.Confidence)
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("a value under a bare field label was not matched; an unreported value "+
+				"is never redacted (got %d matches)", len(matches))
+		}
+	})
+
+	t.Run("DL under PROSE on the line above does NOT match", func(t *testing.T) {
+		// The other half of the contract, and the reason the window is gated on line
+		// SHAPE rather than on keyword presence. This line is the same length as the
+		// label above, carries the same keyword and has no digits — only its shape
+		// differs.
+		content := "Please renew your driver's license soon.\n12345678"
+		matches, err := validator.ValidateContent(content, "test.txt")
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		for _, m := range matches {
+			if m.LineNumber == 2 {
+				t.Errorf("a value under PROSE was matched (%q at %.0f); a keyword in a sentence "+
+					"must not vouch for the next line", m.Text, m.Confidence)
 			}
 		}
 	})

--- a/internal/validators/driverslicense/column_header_test.go
+++ b/internal/validators/driverslicense/column_header_test.go
@@ -1,0 +1,72 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package driverslicense
+
+import "testing"
+
+// DRIVERS_LICENSE is label-gated — a driver's licence has no checksum, so context is the only evidence — and the keyword search stops at the newline. In a
+// CSV export the label IS the header row, so a drivers_license column produced NO finding while
+// the identical value written inline is reported. An unreported value is never handed to
+// the redactor, so the redacted copy of such an export still held the value in cleartext.
+//
+// PASSPORT and SSN already consume tabular.HeaderAt; this is the same mechanism for the
+// remaining label-gated types. Checksum-bearing types do not need it: CREDIT_CARD reports
+// VISA 100 from a CSV column with no inline label, because Luhn stands on the value.
+
+func hdrDetect(t *testing.T, content string) map[string]float64 {
+	t.Helper()
+	v := NewValidator()
+	ms, err := v.ValidateContent(content, "t.csv")
+	if err != nil {
+		t.Fatalf("ValidateContent: %v", err)
+	}
+	out := make(map[string]float64, len(ms))
+	for _, m := range ms {
+		if c, seen := out[m.Text]; !seen || m.Confidence > c {
+			out[m.Text] = m.Confidence
+		}
+	}
+	return out
+}
+
+func TestColumnHeaderAdmitsValues(t *testing.T) {
+	got := hdrDetect(t, "name,drivers_license,notes\nMarcus Whitfield,D12345678901234,ok\nElena Papadopoulos,S98765432109876,ok\n")
+	for _, want := range []string{"D12345678901234", "S98765432109876"} {
+		if _, ok := got[want]; !ok {
+			t.Errorf("%q in a drivers_license column was not reported; the label is the header row, "+
+				"and an unreported value is never redacted (got %v)", want, got)
+		}
+	}
+}
+
+// The header must vouch for its OWN column only. Row-level admission is deliberately
+// permissive so candidates can be found at all, so without a per-column check an
+// unlabelled column's values ride in on a sibling's header. Measured: the two routing_number values were reported as licences at 40 purely because the row had been admitted for the licence column.
+func TestColumnHeaderDoesNotVouchAcrossColumns(t *testing.T) {
+	got := hdrDetect(t, "name,drivers_license,routing_number\nMarcus Whitfield,D12345678901234,121000248\n")
+	if _, ok := got["D12345678901234"]; !ok {
+		t.Fatal("the labelled column value was not reported, so this test cannot detect bleed")
+	}
+	for _, leak := range []string{"121000248"} {
+		if c, ok := got[leak]; ok {
+			t.Errorf("%q from an unlabelled column was reported at %.0f — a header must not "+
+				"lend its standing to another column", leak, c)
+		}
+	}
+}
+
+// Non-tabular documents must be untouched.
+func TestNonTabularBehaviourIsUnchanged(t *testing.T) {
+	if got := hdrDetect(t, "Driver's License Number: D12345678901234\n"); len(got) == 0 {
+		t.Error("an inline-labelled value stopped being reported")
+	}
+	if got := hdrDetect(t, "D12345678901234"+"\n"); len(got) != 0 {
+		t.Errorf("a bare unlabelled value was reported %v; context is the only evidence here, "+
+			"so this must stay silent", got)
+	}
+	if got := hdrDetect(t, "drivers_license\n"+"D12345678901234"+"\n"); len(got) != 0 {
+		t.Errorf("a two-line non-table was treated as tabular: %v. tabular.Analyze requires "+
+			">=3 fields and a consistent delimiter precisely so prose is not reinterpreted", got)
+	}
+}

--- a/internal/validators/driverslicense/column_header_test.go
+++ b/internal/validators/driverslicense/column_header_test.go
@@ -65,8 +65,8 @@ func TestNonTabularBehaviourIsUnchanged(t *testing.T) {
 		t.Errorf("a bare unlabelled value was reported %v; context is the only evidence here, "+
 			"so this must stay silent", got)
 	}
-	if got := hdrDetect(t, "drivers_license\n"+"D12345678901234"+"\n"); len(got) != 0 {
-		t.Errorf("a two-line non-table was treated as tabular: %v. tabular.Analyze requires "+
-			">=3 fields and a consistent delimiter precisely so prose is not reinterpreted", got)
+	if got := hdrDetect(t, "col_a\n"+"D12345678901234"+"\n"); len(got) != 0 {
+		t.Errorf("a two-line file with a NON-label first line was admitted: %v. neither mechanism should fire: tabular.Analyze needs >=3 fields, and "+
+			"the label window needs a bare field LABEL, which \"col_a\" is not", got)
 	}
 }

--- a/internal/validators/driverslicense/validator.go
+++ b/internal/validators/driverslicense/validator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/awslabs/ferret-scan/v2/internal/detector"
 	"github.com/awslabs/ferret-scan/v2/internal/execguard"
 	"github.com/awslabs/ferret-scan/v2/internal/observability"
+	"github.com/awslabs/ferret-scan/v2/internal/tabular"
 	"github.com/awslabs/ferret-scan/v2/internal/validators/kwmatch"
 )
 
@@ -156,6 +157,17 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 
 	lines := strings.Split(content, "\n")
 
+	// In a CSV export the label IS the header row, one or more lines above the value,
+	// and the keyword search stops at the newline. Measured: "Driver's License Number:
+	// D12345678901234" scores 80, the identical value in a drivers_license COLUMN scores
+	// nothing, and an unreported value is never handed to the redactor — the redacted
+	// copy of that export still held the licence number in cleartext.
+	//
+	// tabular.Analyze is conservative (>=3 fields, consistent delimiter, word-like
+	// header row), so a non-table document yields a nil table and behaviour is
+	// unchanged. Analyzed ONCE per document.
+	table := tabular.Analyze(content)
+
 	for lineNum, line := range lines {
 		if execguard.LineLoopCancelled(ctx, lineNum) {
 			return matches, ctx.Err()
@@ -164,7 +176,20 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 		// Quick pre-check: does the line contain any DL-related keyword?
 		// Because DL formats are extremely ambiguous (8 digits, 9 digits, etc.),
 		// we ONLY scan lines that have at least one positive keyword present.
-		if !v.lineHasPositiveKeyword(line) {
+		//
+		// A table data row is admitted when the HEADER ROW carries the keyword, because
+		// in a CSV export that is where the label lives. Without this arm the row was
+		// never scanned at all, so the per-column header boost below could not run and
+		// a drivers_license column reported nothing — while the identical value written
+		// inline as "Driver's License Number: D12345678901234" scores 80. Measured base
+		// confidence for that value is 5 and the header contributes 55, so the value is
+		// well clear of the emit threshold once the row is scanned.
+		//
+		// Admission is per ROW and deliberately permissive; whether a given candidate
+		// actually sits in a labelled column is decided per COLUMN by impactForColumn,
+		// so a notes column does not inherit the licence column's standing.
+		lineKeyworded := v.lineHasPositiveKeyword(line)
+		if !lineKeyworded && !v.tableHeaderHasPositiveKeyword(table, lineNum) {
 			continue
 		}
 
@@ -188,6 +213,42 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 		// checked in emit via markerOpensAsideAfter, which reads only the handful
 		// of bytes after the span and so does not reintroduce the quadratic.
 		lineImpact := v.AnalyzeContext("", detector.ContextInfo{FullLine: line})
+
+		// Column bounds for this row, plus a memo of the per-header impact.
+		//
+		// The header is scored with the SAME keyword logic as a line, so a
+		// drivers_license column carries exactly the weight the inline label would.
+		// It is resolved per MATCH because the header varies along the row — folding
+		// the row's headers together would let one column vouch for another's values.
+		// The memo keys on the header cell, of which there are only as many as there
+		// are columns, and each is a short string: this cannot reintroduce the
+		// per-match whole-line scan that made this validator quadratic before.
+		var lineBounds *tabular.LineBounds
+		if table.IsTable() && lineNum != table.HeaderLine() {
+			lineBounds = table.Bounds(line)
+		}
+		headerImpact := make(map[string]float64, 4)
+		impactForColumn := func(off int) float64 {
+			if lineBounds == nil {
+				return 0
+			}
+			h := table.HeaderAt(lineBounds, off)
+			if h == "" {
+				return 0
+			}
+			if v, ok := headerImpact[h]; ok {
+				return v
+			}
+			imp := v.AnalyzeContext("", detector.ContextInfo{FullLine: h})
+			if imp < 0 {
+				// A header only ever ADDS the standing an inline label would. It must
+				// not penalise: a column named "notes" is not evidence against the
+				// value in the drivers_license column beside it.
+				imp = 0
+			}
+			headerImpact[h] = imp
+			return imp
+		}
 		linePositiveKeywords := v.findKeywordsOnLine(line, v.positiveKeywords)
 		lineNegativeKeywords := v.findKeywordsOnLine(line, v.negativeKeywords)
 
@@ -232,6 +293,18 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 			}
 
 			confidence += contextImpact
+
+			// A row admitted ONLY by its header row must have the label in the
+			// candidate's OWN column. Without this the permissive row-level admission
+			// leaks across columns: measured on a
+			// name,member_id,drivers_license,routing_number export, the two
+			// routing_number values were reported as driver's licences at 40 purely
+			// because the row had been admitted for the licence column.
+			columnImpact := impactForColumn(spanStart)
+			if !lineKeyworded && columnImpact <= 0 {
+				return
+			}
+			confidence += columnImpact
 
 			// Store keywords found (per-line invariant)
 			contextInfo.PositiveKeywords = linePositiveKeywords
@@ -652,6 +725,23 @@ func keywordIndexIn(s, kw string) int {
 func isWordByte(b byte) bool {
 	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') ||
 		(b >= '0' && b <= '9') || b == '_'
+}
+
+// tableHeaderHasPositiveKeyword reports whether any column header of a delimited table
+// carries a DL keyword, for admitting a DATA row whose label sits in the header.
+//
+// Used only for admission. The precise per-column decision is impactForColumn, which
+// scores the header of the match's own column.
+func (v *Validator) tableHeaderHasPositiveKeyword(table *tabular.Table, lineNum int) bool {
+	if !table.IsTable() || lineNum == table.HeaderLine() {
+		return false
+	}
+	for _, h := range table.Headers() {
+		if v.lineHasPositiveKeyword(h) {
+			return true
+		}
+	}
+	return false
 }
 
 // AnalyzeContext analyzes context around a match and returns a confidence adjustment.

--- a/internal/validators/driverslicense/validator.go
+++ b/internal/validators/driverslicense/validator.go
@@ -188,7 +188,26 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 		// Admission is per ROW and deliberately permissive; whether a given candidate
 		// actually sits in a labelled column is decided per COLUMN by impactForColumn,
 		// so a notes column does not inherit the licence column's standing.
-		lineKeyworded := v.lineHasPositiveKeyword(line)
+		// A bare field LABEL on the line above is context for this line's value.
+		//
+		// DRIVERS_LICENSE is label-gated — a licence has no checksum, and the formats are
+		// ambiguous enough that this validator refuses to scan a line with no keyword at
+		// all — so a two-line form
+		//
+		//	Driver's License Number
+		//	D12345678901234
+		//
+		// reported nothing and the value was left in cleartext. Gated on
+		// kwmatch.LooksLikeFieldLabel rather than on a keyword being present: measured,
+		// "Please renew your driver's license soon." is the same length, carries the
+		// keyword and has no digits, and the line after it is not a licence. Bounded to
+		// exactly one line back, like the secrets validator's AWS-key window.
+		labelAbove := ""
+		if lineNum > 0 && kwmatch.LooksLikeFieldLabel(lines[lineNum-1], v.positiveKeywords) {
+			labelAbove = lines[lineNum-1]
+		}
+
+		lineKeyworded := v.lineHasPositiveKeyword(line) || labelAbove != ""
 		if !lineKeyworded && !v.tableHeaderHasPositiveKeyword(table, lineNum) {
 			continue
 		}
@@ -300,6 +319,15 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 			// name,member_id,drivers_license,routing_number export, the two
 			// routing_number values were reported as driver's licences at 40 purely
 			// because the row had been admitted for the licence column.
+			if labelAbove != "" {
+				// Scored with the same keyword logic as a line, so a label above carries
+				// exactly the weight the inline form would. Never negative: a label
+				// cannot be evidence AGAINST the value it names.
+				if imp := v.AnalyzeContext("", detector.ContextInfo{FullLine: labelAbove}); imp > 0 {
+					confidence += imp
+				}
+			}
+
 			columnImpact := impactForColumn(spanStart)
 			if !lineKeyworded && columnImpact <= 0 {
 				return

--- a/internal/validators/kwmatch/fieldlabel.go
+++ b/internal/validators/kwmatch/fieldlabel.go
@@ -1,0 +1,162 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package kwmatch
+
+import "strings"
+
+// LooksLikeFieldLabel reports whether a line is a bare form-field LABEL rather than
+// prose that happens to mention a keyword.
+//
+// # Why this exists
+//
+// The label-gated validators (PASSPORT, MEDICAL_ID, DRIVERS_LICENSE) report nothing
+// without a nearby label, and the keyword search stops at the newline. In a form or
+// two-column layout the label sits on the line ABOVE its value:
+//
+//	Field: Passport Number
+//	Value: 512345678
+//
+// which produced no passport finding at all — the number was reported as an SSN at 50
+// instead, so it was redacted under SSN's partial-mask rule and four digits stayed
+// readable. Member IDs and licences in the same shape were reported as nothing and left
+// in cleartext.
+//
+// # Why a keyword on the previous line is not sufficient
+//
+// Simply consulting the previous line for a keyword admits prose. Measured, these two
+// shapes are indistinguishable on length, keyword presence and digit absence:
+//
+//	Please renew your driver's license soon.   <- prose; the next line is NOT a licence
+//	Driver's License Number                    <- a label; the next line IS one
+//
+// So the test is on the SHAPE of the candidate label line, not merely on its content.
+//
+// # The rule
+//
+// A field label is short, is not a sentence, and consists of label vocabulary. Prose
+// fails on at least one of those. Each condition earns its place:
+//
+//   - non-empty after trimming, and at most maxFieldLabelLen bytes. A bare field label
+//     is short; a sentence usually is not.
+//   - does not end in '.', '!' or '?'. A cheap fast path, NOT the discriminator: with it
+//     removed the vocabulary rule below still rejects every prose case in the tests, so
+//     it earns its place by skipping the tokenizing pass on obvious sentences rather than
+//     by catching anything the purity check would miss. Verified by mutation.
+//   - contains at least one of the caller's positive keywords, so an unrelated short
+//     line cannot open the window.
+//   - EVERY alphabetic word is either one of those keywords or generic label vocabulary.
+//     This is the discriminator: "Driver's License Number" is all label words, while
+//     "Please renew your driver's license soon" carries please/renew/your/soon.
+//
+// Digits are permitted (a label may read "ID Number (2 of 3)"), but a word containing a
+// digit is not treated as label vocabulary, so a data row does not qualify.
+//
+// The caller supplies its own keywords, so this stays a shape test and does not become a
+// second, divergent copy of any validator's vocabulary.
+func LooksLikeFieldLabel(line string, keywords []string) bool {
+	t := strings.TrimSpace(line)
+	if t == "" || len(t) > maxFieldLabelLen {
+		return false
+	}
+	switch t[len(t)-1] {
+	case '.', '!', '?':
+		return false
+	}
+	// Lowercased before the keyword checks: ContainsAny matches whole words but is
+	// case-SENSITIVE on the text (ContainsLower is its case-folding sibling), so
+	// "Driver's License Number" missed every keyword while its individual lowercased
+	// words matched — the bug this ordering fixes.
+	lower := strings.ToLower(t)
+	if !ContainsAny(lower, keywords) {
+		return false
+	}
+	for _, w := range strings.FieldsFunc(lower, func(r rune) bool {
+		return !(r >= 'a' && r <= 'z') && !(r >= '0' && r <= '9') && r != '\''
+	}) {
+		if hasDigit(w) {
+			// A short digit run is label decoration ("2 of 3", "line 1"). A LONG one is
+			// a value, and a line that already carries its value must not open a window
+			// for the next line — otherwise "member 449871234567" would vouch for
+			// whatever follows it.
+			if digitRun(w) >= valueDigitRun {
+				return false
+			}
+			continue
+		}
+		if genericLabelWords[w] {
+			continue
+		}
+		if keywordWord(w, keywords) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// keywordWord reports whether w appears as one of the WORDS of any keyword.
+//
+// Per-word rather than ContainsAny(w, keywords), because most of these vocabularies are
+// multi-word: "member id", "driver's license", "medical record". Testing the whole
+// keyword against a single word can never match, so "Member ID" was rejected as
+// non-label vocabulary even though "member id" is a keyword — the bug this fixes.
+func keywordWord(w string, keywords []string) bool {
+	for _, kw := range keywords {
+		for _, part := range strings.FieldsFunc(strings.ToLower(kw), func(r rune) bool {
+			return !(r >= 'a' && r <= 'z') && !(r >= '0' && r <= '9') && r != '\''
+		}) {
+			if part == w {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// maxFieldLabelLen bounds a candidate label line. Long enough for the real forms
+// ("Driver's License Number", "Insurance Member Identification"), short enough that a
+// sentence rarely fits.
+const maxFieldLabelLen = 48
+
+// genericLabelWords are the words that decorate a field label without naming the field.
+// They are what lets "Field: Passport Number" and "Member ID (primary)" qualify while
+// keeping the vocabulary check strict about everything else.
+var genericLabelWords = map[string]bool{
+	"field": true, "value": true, "number": true, "no": true, "num": true,
+	"id": true, "identifier": true, "identification": true, "code": true,
+	"primary": true, "secondary": true, "optional": true, "required": true,
+	"of": true, "or": true, "and": true, "the": true, "a": true, "an": true,
+	"details": true, "detail": true, "info": true, "information": true,
+	"type": true, "name": true, "date": true, "issued": true, "expiry": true,
+	"state": true, "country": true, "region": true, "status": true,
+}
+
+// valueDigitRun is the digit-run length at which a token reads as a value rather than
+// as label decoration. Deliberately low: every identifier this guards is longer.
+const valueDigitRun = 4
+
+// digitRun returns the longest consecutive digit run in s.
+func digitRun(s string) int {
+	best, cur := 0, 0
+	for i := 0; i < len(s); i++ {
+		if s[i] >= '0' && s[i] <= '9' {
+			cur++
+			if cur > best {
+				best = cur
+			}
+			continue
+		}
+		cur = 0
+	}
+	return best
+}
+
+func hasDigit(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= '0' && s[i] <= '9' {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/validators/kwmatch/fieldlabel_test.go
+++ b/internal/validators/kwmatch/fieldlabel_test.go
@@ -1,0 +1,69 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package kwmatch
+
+import "testing"
+
+// The discriminator that makes a previous-line label window safe. Both directions are
+// asserted in one table, because the whole difficulty is that the two shapes are
+// indistinguishable on length, keyword presence and digit absence.
+func TestLooksLikeFieldLabel(t *testing.T) {
+	dl := []string{"driver", "license", "licence", "dl", "dmv", "driver's license"}
+	pp := []string{"passport"}
+	ins := []string{"member", "insurance", "policy", "subscriber"}
+
+	cases := []struct {
+		line string
+		kws  []string
+		want bool
+		why  string
+	}{
+		// Real form layouts.
+		{"Driver's License Number", dl, true, "bare label, all label vocabulary"},
+		{"Field: Passport Number", pp, true, "the shape from the issue"},
+		{"Passport Number:", pp, true, "trailing colon"},
+		{"Member ID", ins, true, "two-word label"},
+		{"MEMBER ID", ins, true, "upper case"},
+		{"  Member ID  ", ins, true, "surrounding whitespace"},
+		{"Insurance Member Identification", ins, true, "long-form label"},
+		{"Member ID (primary)", ins, true, "parenthesised qualifier"},
+		{"ID Number (2 of 3)", ins, false, "no keyword of this validator's own"},
+
+		// Prose that mentions the keyword. These are the false positives a naive
+		// previous-line keyword check admits.
+		{"Please renew your driver's license soon.", dl, false, "terminal period, and non-label words"},
+		{"Please renew your driver's license soon", dl, false, "non-label words even without the period"},
+		{"Your passport will expire next year.", pp, false, "prose"},
+		{"Did you bring your passport?", pp, false, "question mark"},
+		{"Send the member the insurance packet today", ins, false, "prose with two keywords"},
+
+		// Not labels at all.
+		{"", dl, false, "empty"},
+		{"   ", dl, false, "whitespace only"},
+		{"D12345678901234", dl, false, "a value, no keyword"},
+		{"Marcus Whitfield,W9998887776,ok", ins, false, "a data row"},
+		{"This line is far too long to be a bare form field label for anything", dl, false, "over the length bound"},
+	}
+
+	for _, tc := range cases {
+		if got := LooksLikeFieldLabel(tc.line, tc.kws); got != tc.want {
+			t.Errorf("LooksLikeFieldLabel(%q) = %v, want %v (%s)", tc.line, got, tc.want, tc.why)
+		}
+	}
+}
+
+// A data row must never qualify, or a label window would let one row vouch for the next.
+func TestFieldLabelRejectsDataRows(t *testing.T) {
+	ins := []string{"member", "insurance"}
+	for _, row := range []string{
+		"member_id,policy_id,group_id",       // a CSV HEADER is handled by tabular, not here
+		"W9998887776,P1234567890,G987654321", // a data row
+		"member 449871234567",                // label plus a value on the same line
+	} {
+		if LooksLikeFieldLabel(row, ins) && hasDigit(row) {
+			t.Errorf("LooksLikeFieldLabel(%q) = true; a line carrying values must not open a "+
+				"label window for the NEXT line", row)
+		}
+	}
+}

--- a/internal/validators/medicalid/column_header_test.go
+++ b/internal/validators/medicalid/column_header_test.go
@@ -78,9 +78,9 @@ func TestNonTabularBehaviourIsUnchanged(t *testing.T) {
 			"member ID is one, so this must stay silent", got)
 	}
 	// A header-shaped first line that is NOT a table (too few fields) must not admit.
-	if got := detect(t, "member_id\nW9998887776\n"); len(got) != 0 {
-		t.Errorf("a two-line non-table was treated as tabular: %v. tabular.Analyze requires "+
-			">=3 fields and a consistent delimiter precisely so prose is not reinterpreted", got)
+	if got := detect(t, "col_a\nW9998887776\n"); len(got) != 0 {
+		t.Errorf("a two-line file with a NON-label first line was admitted: %v. neither mechanism should fire: tabular.Analyze needs >=3 fields, and "+
+			"the label window needs a bare field LABEL, which \"col_a\" is not", got)
 	}
 }
 

--- a/internal/validators/medicalid/column_header_test.go
+++ b/internal/validators/medicalid/column_header_test.go
@@ -1,0 +1,95 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package medicalid
+
+import (
+	"strings"
+	"testing"
+)
+
+// MEDICAL_ID is label-gated: a member ID has no checksum, so context is the only
+// evidence it is one. The keyword search stops at the newline, and in a CSV export the
+// label IS the header row — so a member_id column produced NO finding while the
+// identical value written inline as "Member ID: W9998887776" is reported.
+//
+// An unreported value is never handed to the redactor. Measured on a
+// name,member_id,drivers_license,routing_number export before this: the redacted copy
+// still held every member ID and licence in cleartext, at exit 0, in a file the tool
+// reported as successfully redacted.
+//
+// PASSPORT and SSN already consume tabular.HeaderAt; this is the same mechanism for the
+// remaining label-gated types. Checksum-bearing types do not need it — CREDIT_CARD
+// reports VISA 100 from a CSV column with no inline label at all, because Luhn stands on
+// the value.
+
+func detect(t *testing.T, content string) map[string]float64 {
+	t.Helper()
+	v := NewValidator()
+	ms, err := v.ValidateContent(content, "t.csv")
+	if err != nil {
+		t.Fatalf("ValidateContent: %v", err)
+	}
+	out := make(map[string]float64, len(ms))
+	for _, m := range ms {
+		if c, seen := out[m.Text]; !seen || m.Confidence > c {
+			out[m.Text] = m.Confidence
+		}
+	}
+	return out
+}
+
+func TestColumnHeaderAdmitsMemberIDs(t *testing.T) {
+	got := detect(t, "name,member_id,notes\nMarcus Whitfield,W9998887776,ok\nElena Papadopoulos,W1112223334,ok\n")
+	for _, want := range []string{"W9998887776", "W1112223334"} {
+		if _, ok := got[want]; !ok {
+			t.Errorf("member ID %q in a member_id column was not reported; the label is the "+
+				"header row, and an unreported value is never redacted (got %v)", want, got)
+		}
+	}
+}
+
+// The header must vouch for its OWN column only. Row-level admission is deliberately
+// permissive so candidates can be found at all, so without a per-column check an
+// unlabelled column's values ride in on a sibling's header.
+func TestColumnHeaderDoesNotVouchAcrossColumns(t *testing.T) {
+	got := detect(t, "name,member_id,internal_notes,order_ref\n"+
+		"Marcus Whitfield,W9998887776,ABCD12345678,XY9876543210\n")
+
+	if _, ok := got["W9998887776"]; !ok {
+		t.Fatal("the member_id column value was not reported, so this test cannot detect bleed")
+	}
+	for _, leak := range []string{"ABCD12345678", "XY9876543210"} {
+		if c, ok := got[leak]; ok {
+			t.Errorf("%q from an unlabelled column was reported at %.0f — the member_id header "+
+				"must not lend insurance context to another column", leak, c)
+		}
+	}
+}
+
+// Non-tabular documents must be untouched: tabular.Analyze is conservative, and an
+// inline label is still the ordinary path.
+func TestNonTabularBehaviourIsUnchanged(t *testing.T) {
+	if got := detect(t, "Member ID: W9998887776 on file\n"); len(got) == 0 {
+		t.Error("an inline-labelled member ID stopped being reported")
+	}
+	if got := detect(t, "W9998887776\n"); len(got) != 0 {
+		t.Errorf("a bare unlabelled value was reported %v; context is the only evidence a "+
+			"member ID is one, so this must stay silent", got)
+	}
+	// A header-shaped first line that is NOT a table (too few fields) must not admit.
+	if got := detect(t, "member_id\nW9998887776\n"); len(got) != 0 {
+		t.Errorf("a two-line non-table was treated as tabular: %v. tabular.Analyze requires "+
+			">=3 fields and a consistent delimiter precisely so prose is not reinterpreted", got)
+	}
+}
+
+// The header row itself is not a value-bearing line.
+func TestHeaderRowIsNotScannedAsData(t *testing.T) {
+	got := detect(t, "member_id,policy_id,group_id\nW9998887776,P1234567890,G9876543210\n")
+	for text := range got {
+		if strings.Contains(text, "_id") {
+			t.Errorf("a header cell %q was reported as a value", text)
+		}
+	}
+}

--- a/internal/validators/medicalid/validator.go
+++ b/internal/validators/medicalid/validator.go
@@ -127,7 +127,11 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 			return matches, ctx.Err()
 		}
 
-		lineMatches := v.scanLine(ctx, line, lineNum, originalPath, table)
+		prevLine := ""
+		if lineNum > 0 {
+			prevLine = lines[lineNum-1]
+		}
+		lineMatches := v.scanLine(ctx, line, lineNum, originalPath, table, prevLine)
 		matches = append(matches, lineMatches...)
 	}
 
@@ -174,10 +178,30 @@ type medicalLineContext struct {
 }
 
 // scanLine scans a single line for all medical ID types.
-func (v *Validator) scanLine(ctx stdctx.Context, line string, lineNum int, originalPath string, table *tabular.Table) []detector.Match {
+func (v *Validator) scanLine(ctx stdctx.Context, line string, lineNum int, originalPath string, table *tabular.Table, prevLine string) []detector.Match {
 	var matches []detector.Match
 
 	lowerLine := strings.ToLower(line)
+
+	// ctxLine is lowerLine plus a bare field LABEL from the line above, used ONLY for
+	// the keyword predicates below. lowerLine itself is left alone because match offsets
+	// are computed against it.
+	//
+	// Same defect as the column header in a different layout: MEDICAL_ID is label-gated
+	// and the keyword search stops at the newline, so
+	//
+	//	Member ID
+	//	W9998887776
+	//
+	// reported nothing and the value was left in cleartext. Gated on
+	// kwmatch.LooksLikeFieldLabel rather than on a keyword being present, because a
+	// keyword alone admits prose — "Send the member the insurance packet today" carries
+	// two keywords and vouches for nothing. Bounded to exactly one line back, mirroring
+	// the +/-1 window the secrets validator already uses for AWS keys.
+	ctxLine := lowerLine
+	if kwmatch.LooksLikeFieldLabel(prevLine, v.positiveKeywords) {
+		ctxLine = lowerLine + " " + strings.ToLower(strings.TrimSpace(prevLine))
+	}
 
 	// Column bounds for this row, resolved once. Only for a DATA row: the header
 	// row itself is not a value-bearing line.
@@ -192,8 +216,8 @@ func (v *Validator) scanLine(ctx stdctx.Context, line string, lineNum int, origi
 	// Computing them ONCE per line instead of once per match is what keeps
 	// scanning O(line length) rather than O(matches × line length) — the latter
 	// is a single-long-line CPU-exhaustion DoS. See the timing regression test.
-	lineImpact := v.analyzeContext("", lowerLine)
-	linePositiveKeywords := v.keywordsPresent(lowerLine, v.positiveKeywords)
+	lineImpact := v.analyzeContext("", ctxLine)
+	linePositiveKeywords := v.keywordsPresent(ctxLine, v.positiveKeywords)
 	lineNegativeKeywords := v.keywordsPresent(lowerLine, v.negativeKeywords)
 
 	// Per-line context predicates, hoisted out of the per-match evaluators.
@@ -204,18 +228,24 @@ func (v *Validator) scanLine(ctx stdctx.Context, line string, lineNum int, origi
 	// medicalid O(n^2) the expanded complexity guard caught. Computed once
 	// here and passed down via lc.
 	lc := medicalLineContext{
-		table:        table,
-		bounds:       lineBounds,
-		lineImpact:   lineImpact,
-		posKW:        linePositiveKeywords,
-		negKW:        lineNegativeKeywords,
-		phone:        v.hasPhoneContext(lowerLine),
-		provider:     v.hasProviderContext(lowerLine),
-		dea:          v.hasDEAContext(lowerLine),
-		medicare:     v.hasMedicareContext(lowerLine),
-		medical:      v.hasMedicalContext(lowerLine),
-		mrnKeyword:   v.hasMRNKeyword(lowerLine),
-		insKeyword:   v.hasInsuranceKeyword(lowerLine),
+		table:      table,
+		bounds:     lineBounds,
+		lineImpact: lineImpact,
+		posKW:      linePositiveKeywords,
+		negKW:      lineNegativeKeywords,
+		phone:      v.hasPhoneContext(ctxLine),
+		provider:   v.hasProviderContext(ctxLine),
+		dea:        v.hasDEAContext(ctxLine),
+		medicare:   v.hasMedicareContext(ctxLine),
+		medical:    v.hasMedicalContext(ctxLine),
+		// POSITIVE context reads ctxLine, so a bare label on the line above counts.
+		mrnKeyword: v.hasMRNKeyword(ctxLine),
+		insKeyword: v.hasInsuranceKeyword(ctxLine),
+		// The SUPPRESSORS below deliberately keep reading lowerLine only. A label above
+		// should be able to vouch FOR the value beneath it, but must not be able to
+		// suppress it: "Invoice number" above an unrelated line would otherwise silence a
+		// real member ID sitting on that line. Asymmetric on purpose — the sink rule makes
+		// a wrong suppression costlier than a wrong admission.
 		nonMedHardKW: v.nonMedicalHardKeywordPresent(lowerLine),
 		nonMedSoftKW: v.nonMedicalSoftKeywordPresent(lowerLine),
 		nonInsKW:     v.nonInsuranceKeywordPresent(lowerLine),
@@ -272,7 +302,7 @@ func (v *Validator) scanLine(ctx stdctx.Context, line string, lineNum int, origi
 	// data row and this scan never ran. Admission is per ROW; whether a given
 	// candidate actually has insurance context is decided per COLUMN in
 	// evaluateInsuranceID via insuranceContextFor.
-	if v.hasInsuranceContext(lowerLine) || v.headerRowHasInsuranceContext(lc) {
+	if v.hasInsuranceContext(ctxLine) || v.headerRowHasInsuranceContext(lc) {
 		if !scanMatches(reInsuranceID, v.evaluateInsuranceID) {
 			return matches
 		}

--- a/internal/validators/medicalid/validator.go
+++ b/internal/validators/medicalid/validator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/awslabs/ferret-scan/v2/internal/detector"
 	"github.com/awslabs/ferret-scan/v2/internal/execguard"
 	"github.com/awslabs/ferret-scan/v2/internal/observability"
+	"github.com/awslabs/ferret-scan/v2/internal/tabular"
 	"github.com/awslabs/ferret-scan/v2/internal/validators/kwmatch"
 )
 
@@ -109,12 +110,24 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 
 	lines := strings.Split(content, "\n")
 
+	// In a CSV export the LABEL is the header row, one or more lines above the
+	// value, and the keyword search stops at the newline — so a member_id column
+	// produced no finding at all while the identical value written inline as
+	// "Member ID: W9998887776" is reported. An unreported value is never handed to
+	// the redactor: measured on a 3-column export, the redacted copy still held
+	// every member ID and driver's licence in cleartext.
+	//
+	// tabular.Analyze is conservative by construction (>=3 fields, a consistent
+	// delimiter, a header row of words), so a non-table document produces a nil
+	// table and behaviour is unchanged. Analyzed ONCE per document, not per line.
+	table := tabular.Analyze(content)
+
 	for lineNum, line := range lines {
 		if execguard.LineLoopCancelled(ctx, lineNum) {
 			return matches, ctx.Err()
 		}
 
-		lineMatches := v.scanLine(ctx, line, lineNum, originalPath)
+		lineMatches := v.scanLine(ctx, line, lineNum, originalPath, table)
 		matches = append(matches, lineMatches...)
 	}
 
@@ -127,6 +140,15 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 // per match (as the evaluators used to) was the source of the O(n^2) blowup
 // on a dense line.
 type medicalLineContext struct {
+	// table and bounds resolve the header cell naming a match's own column. Held
+	// rather than pre-flattened because the header varies ALONG the row: folding
+	// every column's header into one per-line string would let a member_id column
+	// lend insurance context to a notes column, which is a false positive the
+	// per-match lookup avoids. HeaderAt is a binary search over the row's field
+	// bounds, so the per-match cost is logarithmic rather than a rescan.
+	table  *tabular.Table
+	bounds *tabular.LineBounds
+
 	lineImpact float64
 	posKW      []string
 	negKW      []string
@@ -152,10 +174,17 @@ type medicalLineContext struct {
 }
 
 // scanLine scans a single line for all medical ID types.
-func (v *Validator) scanLine(ctx stdctx.Context, line string, lineNum int, originalPath string) []detector.Match {
+func (v *Validator) scanLine(ctx stdctx.Context, line string, lineNum int, originalPath string, table *tabular.Table) []detector.Match {
 	var matches []detector.Match
 
 	lowerLine := strings.ToLower(line)
+
+	// Column bounds for this row, resolved once. Only for a DATA row: the header
+	// row itself is not a value-bearing line.
+	var lineBounds *tabular.LineBounds
+	if table.IsTable() && lineNum != table.HeaderLine() {
+		lineBounds = table.Bounds(line)
+	}
 
 	// Per-line invariants, hoisted out of the per-match loop. analyzeContext and
 	// the keyword-collection in buildContext scan only lowerLine (they ignore the
@@ -175,6 +204,8 @@ func (v *Validator) scanLine(ctx stdctx.Context, line string, lineNum int, origi
 	// medicalid O(n^2) the expanded complexity guard caught. Computed once
 	// here and passed down via lc.
 	lc := medicalLineContext{
+		table:        table,
+		bounds:       lineBounds,
 		lineImpact:   lineImpact,
 		posKW:        linePositiveKeywords,
 		negKW:        lineNegativeKeywords,
@@ -234,14 +265,63 @@ func (v *Validator) scanLine(ctx stdctx.Context, line string, lineNum int, origi
 		}
 	}
 
-	// Check for Insurance Member IDs (only if insurance context is present)
-	if v.hasInsuranceContext(lowerLine) {
+	// Check for Insurance Member IDs (only if insurance context is present).
+	//
+	// The header-row arm is what admits a CSV export: the keyword sits one or more
+	// lines above the value, so hasInsuranceContext(lowerLine) is false for every
+	// data row and this scan never ran. Admission is per ROW; whether a given
+	// candidate actually has insurance context is decided per COLUMN in
+	// evaluateInsuranceID via insuranceContextFor.
+	if v.hasInsuranceContext(lowerLine) || v.headerRowHasInsuranceContext(lc) {
 		if !scanMatches(reInsuranceID, v.evaluateInsuranceID) {
 			return matches
 		}
 	}
 
 	return matches
+}
+
+// columnHeaderAt returns the lowercased header cell naming the column that the byte
+// offset off falls in, or "" when the document is not tabular or this is the header
+// row itself.
+func (lc medicalLineContext) columnHeaderAt(off int) string {
+	if lc.table == nil || lc.bounds == nil {
+		return ""
+	}
+	return lc.table.HeaderAt(lc.bounds, off)
+}
+
+// headerRowHasInsuranceContext reports whether ANY column header on this table
+// carries an insurance keyword.
+//
+// Used only for ADMISSION — deciding whether the member-ID scan runs on this row at
+// all. It is deliberately permissive at that level and narrowed per match by
+// insuranceContextFor, because a row cannot be scanned column-by-column before its
+// candidates are found.
+func (v *Validator) headerRowHasInsuranceContext(lc medicalLineContext) bool {
+	if lc.table == nil || lc.bounds == nil {
+		return false
+	}
+	for _, h := range lc.table.Headers() {
+		if v.hasInsuranceContext(strings.ToLower(h)) {
+			return true
+		}
+	}
+	return false
+}
+
+// insuranceContextFor reports whether this match has insurance context: on its own
+// line, or in the header of its OWN column. The column check is what makes a CSV
+// export behave like the equivalent inline label without letting one column's header
+// vouch for another's values.
+func (v *Validator) insuranceContextFor(lc medicalLineContext, off int) bool {
+	if lc.insKeyword {
+		return true
+	}
+	if h := lc.columnHeaderAt(off); h != "" {
+		return v.hasInsuranceContext(h)
+	}
+	return false
 }
 
 // evaluateNPI checks an NPI candidate and returns a match if valid.
@@ -480,14 +560,29 @@ func (v *Validator) evaluateInsuranceID(match, line, lowerLine string, lc medica
 		return detector.Match{}, false
 	}
 
+	// Insurance context for THIS candidate: on its own line, or in the header of its
+	// OWN column. Resolved per match rather than per line because the header varies
+	// along a table row — folding the whole header row into one predicate would let a
+	// member_id column lend context to a notes column.
+	insContext := v.insuranceContextFor(lc, matchStart)
+
 	// Skip if it looks like a common non-insurance pattern
 	// Two tiers, mirroring evaluateMRN: a different number type always
 	// suppresses; an identifier LABEL suppresses only when no insurance keyword
 	// is present, so a labelled member ID beside "patient account 88213" survives.
-	if lc.nonInsKW || (lc.nonInsSoftKW && !lc.insKeyword) ||
-		v.looksLikeNonInsuranceIDShape(match, lc.insKeyword) {
+	if lc.nonInsKW || (lc.nonInsSoftKW && !insContext) ||
+		v.looksLikeNonInsuranceIDShape(match, insContext) {
 		return detector.Match{}, false
 	}
+
+	// No extra per-column gate is needed here, and one was removed rather than shipped:
+	// threading insContext into the two checks above IS the gate. With a hard
+	// `if !insContext { return }` added and then removed, both a
+	// name,member_id,internal_notes,order_ref fixture and a neutral
+	// name,member_id,col_c fixture reported IDENTICALLY — the unlabelled column's value
+	// is already rejected by looksLikeNonInsuranceIDShape, which now receives the
+	// per-column answer. An unreachable guard is worse than none: it reads as the thing
+	// preventing the leak while the substitution above is what actually does.
 
 	// A value that already passes a checksum belonging to a MORE SPECIFIC
 	// subtype is reported by that subtype's evaluator, not here. evaluateMRN
@@ -510,8 +605,9 @@ func (v *Validator) evaluateInsuranceID(match, line, lowerLine string, lc medica
 
 	confidence := 50.0 // Moderate base — alphanumeric with insurance context
 
-	// Boost if strong insurance keywords present
-	if lc.insKeyword {
+	// Boost if strong insurance keywords present. A column header naming this value's
+	// column counts, exactly as a same-line label does.
+	if insContext {
 		confidence += 20 // -> 70
 	}
 

--- a/internal/validators/otp/column_header_test.go
+++ b/internal/validators/otp/column_header_test.go
@@ -1,0 +1,72 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package otp
+
+import "testing"
+
+// OTP is label-gated — a bare base32 run is far too ambiguous to report without context — and the keyword search stops at the newline. In a
+// CSV export the label IS the header row, so a totp_secret column produced NO finding while
+// the identical value written inline is reported. An unreported value is never handed to
+// the redactor, so the redacted copy of such an export still held the value in cleartext.
+//
+// PASSPORT and SSN already consume tabular.HeaderAt; this is the same mechanism for the
+// remaining label-gated types. Checksum-bearing types do not need it: CREDIT_CARD reports
+// VISA 100 from a CSV column with no inline label, because Luhn stands on the value.
+
+func hdrDetect(t *testing.T, content string) map[string]float64 {
+	t.Helper()
+	v := NewValidator()
+	ms, err := v.ValidateContent(content, "t.csv")
+	if err != nil {
+		t.Fatalf("ValidateContent: %v", err)
+	}
+	out := make(map[string]float64, len(ms))
+	for _, m := range ms {
+		if c, seen := out[m.Text]; !seen || m.Confidence > c {
+			out[m.Text] = m.Confidence
+		}
+	}
+	return out
+}
+
+func TestColumnHeaderAdmitsValues(t *testing.T) {
+	got := hdrDetect(t, "name,totp_secret,notes\nMarcus Whitfield,K5CUWY3ZNRXW4Z3T,ok\nElena Papadopoulos,MFYGC4TLLBQXA5DP,ok\n")
+	for _, want := range []string{"K5CUWY3ZNRXW4Z3T", "MFYGC4TLLBQXA5DP"} {
+		if _, ok := got[want]; !ok {
+			t.Errorf("%q in a totp_secret column was not reported; the label is the header row, "+
+				"and an unreported value is never redacted (got %v)", want, got)
+		}
+	}
+}
+
+// The header must vouch for its OWN column only. Row-level admission is deliberately
+// permissive so candidates can be found at all, so without a per-column check an
+// unlabelled column's values ride in on a sibling's header. Measured: the equivalent leak was measured in driverslicense, where two routing_number values were reported as licences at 40.
+func TestColumnHeaderDoesNotVouchAcrossColumns(t *testing.T) {
+	got := hdrDetect(t, "user,totp_secret,internal_notes\nmarcus,K5CUWY3ZNRXW4Z3T,MFYGC4TLLBQXA5DP\n")
+	if _, ok := got["K5CUWY3ZNRXW4Z3T"]; !ok {
+		t.Fatal("the labelled column value was not reported, so this test cannot detect bleed")
+	}
+	for _, leak := range []string{"MFYGC4TLLBQXA5DP"} {
+		if c, ok := got[leak]; ok {
+			t.Errorf("%q from an unlabelled column was reported at %.0f — a header must not "+
+				"lend its standing to another column", leak, c)
+		}
+	}
+}
+
+// Non-tabular documents must be untouched.
+func TestNonTabularBehaviourIsUnchanged(t *testing.T) {
+	if got := hdrDetect(t, "totp secret K5CUWY3ZNRXW4Z3T here\n"); len(got) == 0 {
+		t.Error("an inline-labelled value stopped being reported")
+	}
+	if got := hdrDetect(t, "K5CUWY3ZNRXW4Z3T"+"\n"); len(got) != 0 {
+		t.Errorf("a bare unlabelled value was reported %v; context is the only evidence here, "+
+			"so this must stay silent", got)
+	}
+	if got := hdrDetect(t, "totp_secret\n"+"K5CUWY3ZNRXW4Z3T"+"\n"); len(got) != 0 {
+		t.Errorf("a two-line non-table was treated as tabular: %v. tabular.Analyze requires "+
+			">=3 fields and a consistent delimiter precisely so prose is not reinterpreted", got)
+	}
+}

--- a/internal/validators/otp/validator.go
+++ b/internal/validators/otp/validator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/awslabs/ferret-scan/v2/internal/detector"
 	"github.com/awslabs/ferret-scan/v2/internal/execguard"
 	"github.com/awslabs/ferret-scan/v2/internal/observability"
+	"github.com/awslabs/ferret-scan/v2/internal/tabular"
 	"github.com/awslabs/ferret-scan/v2/internal/validators/kwmatch"
 )
 
@@ -243,6 +244,20 @@ func (v *Validator) ValidateContent(content string, originalPath string) ([]dete
 // length × keywords) — the single-long-line CPU-exhaustion DoS the other
 // validators were already hardened against. See the timing regression test.
 type otpLineContext struct {
+	// table and bounds resolve the header cell naming a match's own column.
+	//
+	// A base32 secret is admitted only with positive OTP context on the line, and in a
+	// CSV export that context is the HEADER ROW, one or more lines above the value. So
+	// a totp_secret column produced nothing while the identical value written inline as
+	// "totp secret K5CUWY3ZNRXW4Z3T" scores 85 — and an unreported secret is never
+	// redacted. Resolved per MATCH because the header varies along the row: folding the
+	// row's headers together would let a totp_secret column vouch for a notes column.
+	table  *tabular.Table
+	bounds *tabular.LineBounds
+	// headerPos is true when ANY column header carries OTP context, used for row
+	// ADMISSION only; per-column standing is decided by columnHasPositiveContext.
+	headerPos bool
+
 	impact  float64
 	posKW   []string
 	negKW   []string
@@ -283,6 +298,20 @@ func (v *Validator) contextInfoAt(line string, start, length int, lc otpLineCont
 	return ci
 }
 
+// columnHasPositiveContext reports whether the header naming the column at byte offset
+// off carries OTP context. Empty header (non-tabular, or the header row itself) is
+// false, so a non-table document is unaffected.
+func (v *Validator) columnHasPositiveContext(lc otpLineContext, off int) bool {
+	if lc.table == nil || lc.bounds == nil {
+		return false
+	}
+	h := lc.table.HeaderAt(lc.bounds, off)
+	if h == "" {
+		return false
+	}
+	return v.hasPositiveContext(h)
+}
+
 // insideAnySpan reports whether [start,end) falls inside any span in locs
 // (sorted by start, as FindAllStringIndex returns them).
 func insideAnySpan(locs [][]int, start, end int) bool {
@@ -304,18 +333,43 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 
 	lines := strings.Split(content, "\n")
 
+	// Conservative by construction (>=3 fields, consistent delimiter, word-like header
+	// row), so a non-table document yields a nil table and behaviour is unchanged.
+	// Analyzed ONCE per document.
+	table := tabular.Analyze(content)
+
 	for lineNum, line := range lines {
 		if execguard.LineLoopCancelled(ctx, lineNum) {
 			return matches, ctx.Err()
 		}
 
 		lc := v.buildOTPLineContext(line)
+		if table.IsTable() && lineNum != table.HeaderLine() {
+			lc.table = table
+			lc.bounds = table.Bounds(line)
+			for _, h := range table.Headers() {
+				if v.hasPositiveContext(strings.ToLower(h)) {
+					lc.headerPos = true
+					break
+				}
+			}
+		}
 
 		// emit scores one candidate at a known offset and appends it if it
 		// survives clamping. Confidence math is identical to the original
 		// per-match path; only the redundant per-match line scans are gone.
 		emit := func(start, length int, matchType string, applyNegative bool) {
 			text := line[start : start+length]
+
+			// A row admitted ONLY by its header row must carry the label in the
+			// candidate's OWN column. Row-level admission is deliberately permissive so
+			// candidates can be found at all; without this per-column requirement a
+			// notes column's base32-shaped value would ride in on the totp_secret
+			// column's header. The equivalent leak was measured in driverslicense,
+			// where two routing_number values were reported as licences at 40.
+			if !lc.hasPos && lc.headerPos && !v.columnHasPositiveContext(lc, start) {
+				return
+			}
 
 			confidence, checks := v.CalculateConfidence(text)
 			confidence += lc.impact
@@ -378,7 +432,7 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 
 		// Check for base32 secrets (only with context keywords — a bare
 		// base32 string is far too ambiguous on its own).
-		if lc.hasPos {
+		if lc.hasPos || lc.headerPos {
 			for i, loc := range reBase32Secret.FindAllStringIndex(line, -1) {
 				if execguard.LineLoopCancelled(ctx, i) {
 					return matches, ctx.Err()

--- a/internal/validators/passport/validator.go
+++ b/internal/validators/passport/validator.go
@@ -14,6 +14,7 @@ import (
 	"github.com/awslabs/ferret-scan/v2/internal/execguard"
 	"github.com/awslabs/ferret-scan/v2/internal/observability"
 	"github.com/awslabs/ferret-scan/v2/internal/tabular"
+	"github.com/awslabs/ferret-scan/v2/internal/validators/kwmatch"
 )
 
 // Package-level pre-compiled regexps for static patterns
@@ -642,6 +643,14 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 		lineIsTabular := v.isTabularDataLine(line)
 		lineIsForm := v.isInFormContextLine(lineLower)
 
+		// A bare field label on the previous line is context for this line's value.
+		// Bounded to exactly one line back, mirroring the +/-1 window the secrets
+		// validator already uses for AWS keys (awsSecretContextOpen), so the cost is one
+		// short-string test per line and cannot grow with document size.
+		if lineNum > 0 && kwmatch.LooksLikeFieldLabel(lines[lineNum-1], v.positiveKeywords) {
+			lc.labelAbove = strings.ToLower(strings.TrimSpace(lines[lineNum-1]))
+		}
+
 		// Field offsets for this line, computed once and reused for every match on
 		// it, so mapping a match to its column stays a binary search rather than a
 		// per-match rescan. Nil when the document is not tabular, or on the header
@@ -885,6 +894,25 @@ type lineContext struct {
 	// resolved by binary search over per-line bounds, so the per-match cost is
 	// logarithmic rather than a rescan.
 	columnHeader string
+
+	// labelAbove is the lowercased previous line when that line is a bare form-field
+	// LABEL rather than prose.
+	//
+	// Same defect as columnHeader in a different layout. PASSPORT is label-gated and the
+	// keyword search stops at the newline, so a two-line form
+	//
+	//	Field: Passport Number
+	//	Value: 512345678
+	//
+	// produced no passport finding. Worse than a plain miss: the number was reported as
+	// an SSN at 50 instead, so redaction applied SSN's partial mask and left four digits
+	// readable in a file the tool called redacted.
+	//
+	// Gated on kwmatch.LooksLikeFieldLabel rather than on a keyword being present,
+	// because a keyword alone admits prose: "Please renew your driver's license soon."
+	// is the same length, carries the keyword and has no digits. The shape test is what
+	// separates them.
+	labelAbove string
 }
 
 func newLineContext(lineLower string) *lineContext {
@@ -921,6 +949,11 @@ func (c *lineContext) contains(kw, beforeLower, afterLower string) bool {
 	// FOR this value in exactly the way a same-line label is. Checked first
 	// because it is a short string and the common case is a miss.
 	if c.columnHeader != "" && strings.Contains(c.columnHeader, kw) {
+		return true
+	}
+	// A bare field label on the line above is context for this line's value, for the
+	// same reason. Also a short string, so the miss is cheap.
+	if c.labelAbove != "" && strings.Contains(c.labelAbove, kw) {
 		return true
 	}
 	if len(c.lineLower) <= 256 {


### PR DESCRIPTION
Closes #369
Closes #370

Two commits, one gate: **where may a label live?** Same validators, so one PR — separate PRs would collide on these files.

## The defect

These validators are label-GATED — a member ID, a driver's licence, a passport number and a base32 TOTP secret carry no checksum, so a label is the only evidence — and the keyword search stops at the newline. Two layouts starve them:

```
name,member_id,drivers_license,routing_number      Field: Passport Number
Marcus Whitfield,W9998887776,D12345678901234,...   Value: 512345678
      ^ #370: the label is the header ROW               ^ #369: the label is the line ABOVE
```

An unreported value is never handed to the redactor. Measured with `--enable-redaction`, exit 0, in files the tool reported as successfully redacted:

```
****************,W9998887776,D12345678901234,121000248
Elena Papadopoulos,W1112223334,S98765432109876,*****0015
```

**5 of 6 identifiers survived in cleartext**, and `011000015` was masked only because a PHONE false positive happened to claim it.

The passport case was worse than a miss — SSN also matches that shape, so the number was reported as an **SSN at 50** and redaction applied SSN's *partial* mask:

| | |
|---|---|
| before | `Value: *****5678` — four digits still readable |
| after | `Value: *********` — PASSPORT 80, fully masked |

## Results

| fixture | before | after |
|---|---|---|
| `member_id` column | 0 | **90, 90** |
| `drivers_license` column | 0 | **80, 80** |
| `totp_secret` column | 0 | **75, 75** |
| `Field: Passport Number` / `Value:` | SSN 50 | **PASSPORT 80** |
| `Member ID` / value below | 0 | **80** |
| `Driver's License Number` / value below | 0 | **70** |
| inline labels, bare unlabelled values | — | **unchanged** |

## #370 is not new machinery

`tabular.HeaderAt` already had two consumers: PASSPORT (support) and SSN (both directions, including a contradicting cap). This completes the pattern for the remaining label-gated types.

Checksum-bearing types are deliberately untouched, and that's the scoping rule rather than an omission: **CREDIT_CARD reports `VISA 100` from a CSV column with no inline label at all**, because Luhn stands on the value and it already carries an `intrinsicValueFloor`. IBAN, NPI, DEA and VIN are the same shape. Only checksum-less types can be starved of a label.

### Two levels, because one leaks

Row admission must be permissive — driverslicense refuses to scan a line with no keyword at all, so per-column logic sat behind a gate that never opened. But permissive admission alone **leaked across columns**, measured while building this:

- driverslicense: `121000248` and `011000015` from the `routing_number` column reported as **licences at 40**
- otp: a base32 value in `internal_notes` reported at **55**

Both fixed by a per-column requirement. Tests assert the labelled column IS reported and its unlabelled sibling is NOT, in the same fixture, so a fix can't pass by admitting everything.

## #369 needed a real discriminator

Nothing to reuse here, and a naive previous-line keyword check admits prose. These are indistinguishable on length, keyword presence and digit absence:

```
Please renew your driver's license soon.   <- next line is NOT a licence
Driver's License Number                    <- next line IS one
```

So `kwmatch.LooksLikeFieldLabel` tests the **shape**: short, not a sentence, and every alphabetic word is either one of the caller's keywords or generic label vocabulary. Callers pass their own keywords, so it doesn't become a divergent copy of any vocabulary. Bounded to exactly one line back, mirroring secrets' existing `awsSecretContextOpen` window.

**Asymmetric on purpose:** in medicalid the positive predicates read the extended context while the suppressors keep reading the value's own line. A label above may vouch *for* a value but must not silence it — "Invoice number" above an unrelated line would otherwise suppress a real member ID. Under the sink rule a wrong suppression costs more than a wrong admission.

## An existing contract test changed, deliberately

driverslicense asserted *"keywords only matter on the SAME line"* using this fixture:

```
driver's license information:
12345678
```

That is exactly the layout this fixes. The case now asserts the value **is** matched — and it did not simply flip: a sibling case was added asserting the same value under **prose** is still not matched, so the test keeps its adversarial value.

Two of my own #370 tests had their premise rebased for the same reason: a two-line `member_id` + value file is now legitimately admitted by the label window, so those fixtures use a non-label first line to test what they meant. otp's equivalent case was left alone — otp deliberately did **not** get the label window, so its premise still holds.

## Three bugs found while building this

- **`kwmatch.ContainsAny` is case-sensitive on the text** (`ContainsLower` is its sibling). Every positive case returned false while the individual lowercased words matched. Only printing the values found it.
- **The per-word vocabulary check tested whole keywords against single words**, so `Member ID` was rejected even though `member id` is a keyword — most of these vocabularies are multi-word.
- **A label line carrying its own value** would open a window for the next line (`member 449871234567`). A digit run of 4+ now disqualifies it.

## Things removed rather than shipped

- medicalid gained a hard `if !insContext { return }` that **never fired** — two different fixtures reported identically with it gone. Mutation proved what actually matters: reverting the `insContext` substitution makes both member IDs disappear. Given #383/#384 are open issues *about* unreachable code, shipping a fifth instance would have been poor form.
- The terminal-punctuation check is labelled a **fast path, not a discriminator** — mutation showed the vocabulary rule alone rejects every prose case.

## Verification

- **67 packages ok, 0 failed.** `gofmt -l ./cmd ./internal ./pkg` clean, `go vet` clean.
- Golden delta: 9 files, 22 new PASSPORT findings, all in the case named `passport_label_above_value` — which `corpus.go` describes as *"Snapshotted as the CURRENT (leaking) behavior."* That snapshot now records detection instead of the leak. **Score baseline unchanged.**
- Perf linear in both mechanisms: table rows 1.33×/1.38×/1.91×, label window 1.00×/1.57×. `HeaderAt` is a binary search, so per-match cost is logarithmic — these three validators have all been O(n²) casualties before.
- **Mutation-tested, 7 mutations:** removing medicalid's admission arm (2 assertions); reverting its `insContext` substitution (detection lost outright); dropping driverslicense's per-column guard (routing number → licence at 40); dropping otp's (notes secret at 55); dropping the label shape test (3 assertions); removing the passport window (1 finding → 0); plus the punctuation fast path, which correctly caught nothing and was relabelled.

