### PR TITLE
fix(preprocessors): disclose an embedded Office part refused for size, and report it as the right kind of coverage loss

### DIFF
--- a/cmd/extraction_warning_cause_test.go
+++ b/cmd/extraction_warning_cause_test.go
@@ -1,0 +1,141 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/parallel"
+)
+
+// The ExtractionWarning channel carries two different statements, and this side used to file
+// every one of them under "no body text (metadata still scanned)":
+//
+//	"no text extracted from .docx: no document body part was found"      <- the body WAS empty
+//	"embedded part %q was not examined: declares N bytes, over the cap"  <- the body was fine
+//
+// The second is a container whose own text was read and scanned normally, with one part
+// unexamined — coverage cut short, not an empty body. Reporting it as "no body text" asserts a
+// failure that did not happen, which is precisely what the cause taxonomy exists to prevent.
+//
+// Every string below is the real wording of a real producer, copied from the code that builds
+// it. That is the point of the table: a new producer whose phrasing lands in the wrong bucket
+// fails HERE rather than in an operator's report, where nobody can tell.
+func TestEveryExtractionWarningProducerLandsInTheRightBucket(t *testing.T) {
+	cases := []struct {
+		producer string
+		reason   string
+		want     unscannedCause
+	}{
+		{
+			producer: "office text extractor, body part missing (text-extract-officetextlib)",
+			reason:   "no text extracted from .docx: no document body part was found in the archive, so document content was NOT scanned",
+			want:     causeNoText,
+		},
+		{
+			producer: "office text extractor, body parts held no text",
+			reason:   "no text extracted from .pptx: 3 body part(s) were read but held no text",
+			want:     causeNoText,
+		},
+		{
+			producer: "PDF extractor failed (text_preprocessor.pdfExtractionWarning)",
+			reason:   "no text extracted from .pdf: malformed PDF: xref not found, so document content was NOT scanned",
+			want:     causeNoText,
+		},
+		{
+			producer: "PDF parsed but held no text layer",
+			reason:   "no text extracted from .pdf: the file parsed but held no document text, so page content was NOT scanned",
+			want:     causeNoText,
+		},
+		{
+			producer: "router-prefixed no-text warning",
+			reason:   "Text Extractor: no text extracted from .docx: no document body part was found in the archive, so document content was NOT scanned",
+			want:     causeNoText,
+		},
+		{
+			producer: "embedded part refused for size (#374, this change)",
+			reason:   `office_metadata: embedded part "attachment.docx" was not examined: declares 52433928 bytes, over the 52428800-byte embedded cap (possible decompression bomb)`,
+			want:     causeCutShort,
+		},
+		{
+			producer: "embedded part unreadable (#374, this change)",
+			reason:   `office_metadata: embedded part "broken.jpg" was not examined: flate: corrupt input before offset 1`,
+			want:     causeCutShort,
+		},
+		{
+			producer: "embedded container past the nesting bound (base_metadata_preprocessor)",
+			reason:   `office_metadata: embedded item "attachment.docx" was not examined: embedded container nesting limit reached`,
+			want:     causeCutShort,
+		},
+		{
+			producer: "WAV chunk walk stopped early (meta-extract-audiolib)",
+			reason:   "audio_metadata: audio metadata may be incomplete: the WAV chunk layout could not be walked to the end",
+			want:     causeCutShort,
+		},
+		{
+			producer: "WAV missing pad byte (padByteNote)",
+			reason:   "audio_metadata: the WAV chunk layout omits a required pad byte after an odd-length chunk; metadata was recovered by realigning, but the file is malformed and may be truncated",
+			want:     causeCutShort,
+		},
+		{
+			producer: "both at once: an empty body AND an unexamined part",
+			reason:   `Text Extractor: no text extracted from .docx: no document body part was found in the archive, so document content was NOT scanned; office_metadata: embedded part "attachment.docx" was not examined: declares 52433928 bytes, over the 52428800-byte embedded cap`,
+			want:     causeCutShort,
+		},
+	}
+
+	for _, c := range cases {
+		if got := classifyExtractionWarning(c.reason); got != c.want {
+			t.Errorf("%s\n  reason: %q\n  cause = %q, want %q",
+				c.producer, c.reason, got.String(), c.want.String())
+		}
+	}
+}
+
+// The joined case deserves its own statement, because it is the one a substring test gets
+// wrong: a leading no-text warning would hide an unexamined embedded document behind it, and
+// the file would be filed under the milder cause.
+func TestANoTextWarningCannotHideAnUnexaminedPart(t *testing.T) {
+	noText := "no text extracted from .docx: no document body part was found in the archive"
+	unexamined := `embedded part "attachment.docx" was not examined: over the embedded cap`
+
+	if got := classifyExtractionWarning(noText); got != causeNoText {
+		t.Fatalf("the no-text half alone = %q, want %q", got.String(), causeNoText.String())
+	}
+	for _, joined := range []string{noText + "; " + unexamined, unexamined + "; " + noText} {
+		if got := classifyExtractionWarning(joined); got != causeCutShort {
+			t.Errorf("joined warning classified as %q, want %q — one unexamined part means "+
+				"coverage really was cut short, whichever order the segments arrive in\n  %q",
+				got.String(), causeCutShort.String(), joined)
+		}
+	}
+}
+
+// The cause must survive the whole collectUnscanned path, not just the classifier: an entry
+// that is classified correctly and then reported under a different cause is no better.
+func TestUnexaminedEmbeddedPartReachesTheReportAsCutShort(t *testing.T) {
+	entries := collectUnscanned(
+		nil,
+		[]parallel.FileDiagnostic{{
+			FilePath: "/scan/outer_big.docx",
+			Reason:   `office_metadata: embedded part "attachment.docx" was not examined: declares 52433928 bytes, over the 52428800-byte embedded cap (possible decompression bomb)`,
+		}},
+		nil,
+		nil,
+		nil,
+	)
+
+	if len(entries) != 1 {
+		t.Fatalf("collectUnscanned produced %d entries, want 1: %+v", len(entries), entries)
+	}
+	if entries[0].Cause != causeCutShort {
+		t.Errorf("cause = %q, want %q: this container's own body text was read and scanned, so "+
+			"claiming it had no body text describes a failure that did not happen",
+			entries[0].Cause.String(), causeCutShort.String())
+	}
+	if !strings.Contains(entries[0].Detail, "attachment.docx") {
+		t.Errorf("detail = %q, want it to name the part that was not examined", entries[0].Detail)
+	}
+}

--- a/cmd/unscanned_report.go
+++ b/cmd/unscanned_report.go
@@ -232,6 +232,58 @@ func describeUnparseable(path string) string {
 	}
 }
 
+// noBodyTextPrefix is the wording every producer of a "the body held no text" warning uses,
+// and it is the CONTRACT that lets this side tell the two meanings of an extraction warning
+// apart. See classifyExtractionWarning.
+const noBodyTextPrefix = "no text extracted from"
+
+// classifyExtractionWarning maps an ExtractionWarning to a user-facing cause.
+//
+// The ExtractionWarning channel carries two different statements, and this side used to file
+// every one of them under causeNoText:
+//
+//	"no text extracted from .docx: no document body part was found"      <- the body was empty
+//	"embedded part %q was not examined: declares N bytes, over the cap"  <- the body was fine
+//
+// Reporting the second as "no body text (metadata still scanned)" asserts something untrue
+// about a document whose body text was read and scanned normally, and it is exactly the
+// mislabelling the cause taxonomy warns about: an operator cannot act on a reason that
+// describes a different failure. A container with an oversize embedded part is PARTLY
+// scanned, which is what causeCutShort means.
+//
+// The discriminator is the prefix rather than a keyword grab-bag, because every no-text
+// producer builds its message from one helper and shares that prefix — the office text
+// extractor, both PDF paths. Anything else on this channel is a coverage note: a WAV whose
+// chunk layout could not be walked to the end, an embedded part refused for size, an embedded
+// container past the nesting bound. Those are all partial coverage.
+//
+// A structured cause travelling with the diagnostic would be better than matching on prose,
+// and would mean threading a field from every preprocessor through worker_pool and
+// parallel_processor into FileDiagnostic. That is worth doing and is not this change; the
+// prefix is asserted by a test that enumerates every producer, so a new wording that lands in
+// the wrong bucket fails there rather than in a report.
+// A file can carry BOTH statements at once, joined with "; " by the router or by the Office
+// preprocessor. It is then only a no-text case if EVERY segment says so: one segment about an
+// unexamined part means coverage really was cut short, and that is the fact the operator has to
+// act on. Segment-wise rather than a whole-string match, because a substring test would let a
+// leading no-text warning hide an unexamined embedded document behind it.
+func classifyExtractionWarning(reason string) unscannedCause {
+	segments := strings.Split(reason, "; ")
+	for _, seg := range segments {
+		seg = strings.ToLower(strings.TrimSpace(seg))
+		if seg == "" {
+			continue
+		}
+		// The router and the Office preprocessor prefix a segment with the producing
+		// preprocessor's name ("office_metadata: no text extracted from ..."), so the
+		// marker can sit after a prefix rather than at the start of the segment.
+		if !strings.Contains(seg, noBodyTextPrefix) {
+			return causeCutShort
+		}
+	}
+	return causeNoText
+}
+
 // classifyReason maps a diagnostic to a user-facing cause.
 func classifyReason(reason string) unscannedCause {
 	l := strings.ToLower(reason)
@@ -296,7 +348,7 @@ func collectUnscanned(
 		if d == "" {
 			d = "no readable text found"
 		}
-		out = append(out, unscannedEntry{fd.FilePath, causeNoText, d})
+		out = append(out, unscannedEntry{fd.FilePath, classifyExtractionWarning(fd.Reason), d})
 	}
 	for _, fd := range failed {
 		cause := classifyReason(fd.Reason)

--- a/docs/COVERAGE_DISCLOSURE.md
+++ b/docs/COVERAGE_DISCLOSURE.md
@@ -26,7 +26,7 @@ one `.docx` whose body could not be extracted, the in-band signal on **stdout** 
 The human-readable report was always produced for the machine formats — it went to
 **stderr**, which pipelines routinely discard.
 
-## The four causes
+## The six causes
 
 | cause | meaning | were findings possible? |
 |---|---|---|
@@ -34,10 +34,42 @@ The human-readable report was always produced for the machine formats — it wen
 | `cannot parse` | bytes do not match the declared type | no text was recovered |
 | `no body text (metadata still scanned)` | opened and parsed, no body text found | **yes** — metadata was scanned and may already have produced findings |
 | `coverage cut short` | a budget, size cap or timeout fired | **yes** — the file is partly scanned |
+| `symlink not followed` | a link that dangles, loops, names a directory or device, or resolves outside the scanned tree | the target was never read; scan it directly |
+| `file too large to scan` | over the size limit, so never opened — and of a type the tool WOULD have processed | no |
 
 The third and fourth never claim the file was unread. A `.docx` with an empty body but
 PII in its author field appears both as findings *and* in this list, and saying its
 contents were never read would contradict the same report.
+
+`symlink not followed` (#326) and `file too large to scan` (#324) were added to the code
+after this table was written and are documented here retroactively; both are deliberately
+distinct from `cannot read`, which would assert a failure that did not happen — for most
+of those files the bytes could have been read and the tool declined.
+
+An **unprocessable** type refused for size is not listed at all. It is a genuine skip: no
+finding was ever possible from it, so reporting lost coverage would be reporting a
+non-event.
+
+### What `coverage cut short` covers inside a container
+
+A container is partly scanned when one of its parts could not be examined, and the
+container's own text was read normally. Three cases reach this cause:
+
+| case | what the operator sees |
+|---|---|
+| an embedded part over the 50 MB embedded cap | `embedded part "attachment.docx" was not examined: declares N bytes, over the 52428800-byte embedded cap` |
+| an embedded part whose bytes could not be extracted | `embedded part "broken.jpg" was not examined: flate: corrupt input before offset 1` |
+| an embedded container past the nesting bound (3) | `embedded item "attachment.docx" was not examined: embedded container nesting limit reached` |
+
+The first two used to be **silent** (#374): the part was skipped, the container reported
+`No matches found` at exit 0, and `--fail-on-incomplete` also exited 0 — while the same
+inner document under the cap reported its SSN at HIGH 100. All three are now `coverage cut
+short` rather than `no body text`, because the container's body text *was* read: claiming
+otherwise describes a failure that did not happen.
+
+An embedded part of a type nothing can read stays silent on purpose. A line on stderr for
+every decorative `.emf` in every slide deck trains operators to ignore the warnings that
+matter.
 
 ## Per-format details
 

--- a/internal/preprocessors/meta-extractors/meta-extract-officelib/embedded_oversize_disclosure_test.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-officelib/embedded_oversize_disclosure_test.go
@@ -1,0 +1,333 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package metaextractofficelib
+
+import (
+	"archive/zip"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// An embedded part refused for size must be REPORTED, not skipped.
+//
+// The loop that extracts embedded parts discarded extractImageToTemp's error with a bare
+// `continue`. When that error was the MaxEmbeddedMediaSize refusal, the part was never scanned
+// and nothing said so: measured on the pair these fixtures reproduce, the over-cap container
+// reported "No matches found" at exit 0 — and exit 0 again under --fail-on-incomplete, with
+// nothing on stderr — while the identical inner document under the cap reported its SSN at
+// HIGH 100. See #374.
+//
+// The fixtures are built here rather than committed, because the interesting one is 50 MB
+// uncompressed and the point of the pair is that ONLY the size differs.
+
+// zeros is an infinite reader of NUL bytes, so padding is streamed rather than buffered. A
+// 50 MB []byte in a test is 50 MB of RSS for no reason, and this package's own subject is
+// bounding what a container can make the tool allocate.
+type zeros struct{}
+
+func (zeros) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}
+
+// innerDocx writes a minimal .docx carrying an SSN in its body, padded with `pad` STORED bytes
+// so the file's own SIZE crosses whatever the caller needs.
+//
+// STORED, not deflated: the cap is compared against the outer entry's UncompressedSize64,
+// which is this file's byte length. Compressed padding would shrink the file itself and the
+// cap would never fire.
+func innerDocx(t *testing.T, path string, pad int64) {
+	t.Helper()
+
+	f, err := os.Create(path) // #nosec G304 -- test-controlled temp path
+	if err != nil {
+		t.Fatalf("create inner: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	zw := zip.NewWriter(f)
+	add := func(name, body string) {
+		w, werr := zw.Create(name)
+		if werr != nil {
+			t.Fatalf("create %s: %v", name, werr)
+		}
+		if _, werr = io.WriteString(w, body); werr != nil {
+			t.Fatalf("write %s: %v", name, werr)
+		}
+	}
+	add("[Content_Types].xml", contentTypes)
+	add("word/document.xml", documentXML("Attached record SSN: 452-11-9384"))
+
+	if pad > 0 {
+		w, werr := zw.CreateHeader(&zip.FileHeader{Name: "word/media/pad.bin", Method: zip.Store})
+		if werr != nil {
+			t.Fatalf("create pad: %v", werr)
+		}
+		if _, werr = io.CopyN(w, zeros{}, pad); werr != nil {
+			t.Fatalf("write pad: %v", werr)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close inner: %v", err)
+	}
+}
+
+// outerDocx wraps innerPath as word/embeddings/attachment.docx, deflated so the padding costs
+// almost nothing on disk while the entry still DECLARES its full uncompressed size.
+func outerDocx(t *testing.T, dir, name, innerPath string) string {
+	t.Helper()
+
+	outPath := filepath.Join(dir, name)
+	f, err := os.Create(outPath) // #nosec G304 -- test-controlled temp path
+	if err != nil {
+		t.Fatalf("create outer: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	zw := zip.NewWriter(f)
+	add := func(entry, body string) {
+		w, werr := zw.Create(entry)
+		if werr != nil {
+			t.Fatalf("create %s: %v", entry, werr)
+		}
+		if _, werr = io.WriteString(w, body); werr != nil {
+			t.Fatalf("write %s: %v", entry, werr)
+		}
+	}
+	add("[Content_Types].xml", contentTypes)
+	add("word/document.xml", documentXML("Cover letter, see attachment"))
+
+	inner, err := os.Open(innerPath) // #nosec G304 -- test-controlled temp path
+	if err != nil {
+		t.Fatalf("open inner: %v", err)
+	}
+	defer func() { _ = inner.Close() }()
+
+	w, err := zw.Create("word/embeddings/attachment.docx")
+	if err != nil {
+		t.Fatalf("create embedded entry: %v", err)
+	}
+	if _, err := io.Copy(w, inner); err != nil {
+		t.Fatalf("copy inner: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close outer: %v", err)
+	}
+	return outPath
+}
+
+const contentTypes = `<?xml version="1.0" encoding="UTF-8"?>` +
+	`<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+	`<Default Extension="xml" ContentType="application/xml"/>` +
+	`<Default Extension="bin" ContentType="application/octet-stream"/>` +
+	`<Default Extension="docx" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document"/>` +
+	`<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>` +
+	`</Types>`
+
+func documentXML(body string) string {
+	return `<?xml version="1.0" encoding="UTF-8"?>` +
+		`<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
+		`<w:body><w:p><w:r><w:t>` + body + `</w:t></w:r></w:p></w:body></w:document>`
+}
+
+// TestOverCapEmbeddedPartIsReportedNotSkipped is the control/test pair. Only the SIZE of the
+// embedded document differs, so any difference in the returned notes is attributable to the cap
+// and to nothing else.
+func TestOverCapEmbeddedPartIsReportedNotSkipped(t *testing.T) {
+	dir := t.TempDir()
+
+	small := filepath.Join(dir, "inner_small.docx")
+	innerDocx(t, small, 0)
+	big := filepath.Join(dir, "inner_big.docx")
+	innerDocx(t, big, MaxEmbeddedMediaSize+4096)
+
+	control := outerDocx(t, dir, "outer_small.docx", small)
+	oversize := outerDocx(t, dir, "outer_big.docx", big)
+
+	media, notExamined, err := ExtractEmbeddedMediaForProcessing(control)
+	if err != nil {
+		t.Fatalf("control: %v", err)
+	}
+	CleanupEmbeddedMedia(media)
+	if len(media) != 1 {
+		t.Errorf("control extracted %d parts, want 1 — the pair is only comparable if the "+
+			"under-cap part really is extracted", len(media))
+	}
+	if len(notExamined) != 0 {
+		t.Errorf("control produced notes %v; an ordinary embedded part must stay silent, or "+
+			"every document with an attachment warns and the warnings stop meaning anything",
+			notExamined)
+	}
+
+	media, notExamined, err = ExtractEmbeddedMediaForProcessing(oversize)
+	if err != nil {
+		t.Fatalf("oversize: %v", err)
+	}
+	CleanupEmbeddedMedia(media)
+	if len(media) != 0 {
+		t.Errorf("the over-cap part was extracted after all (%d parts); the cap is what this "+
+			"test depends on", len(media))
+	}
+	if len(notExamined) != 1 {
+		t.Fatalf("oversize produced %d notes, want 1: %v. A part refused for size and reported "+
+			"nowhere is a container declared clean while sensitive content sits unread inside it",
+			len(notExamined), notExamined)
+	}
+
+	note := notExamined[0]
+	if !strings.Contains(note, "attachment.docx") {
+		t.Errorf("note %q does not name the part; an operator cannot act on 'something was skipped'", note)
+	}
+	if !strings.Contains(note, "not examined") {
+		t.Errorf("note %q does not say the part was not examined", note)
+	}
+	if !strings.Contains(note, "cap") {
+		t.Errorf("note %q does not give the reason, so the remedy is unguessable", note)
+	}
+
+	// Payload-free and path-free: this string reaches stderr and every machine format.
+	if strings.Contains(note, "452-11-9384") {
+		t.Errorf("note %q leaked content from the part it is reporting", note)
+	}
+	if strings.Contains(note, dir) || strings.Contains(note, "word/embeddings") {
+		t.Errorf("note %q carries a path; the base name is deliberately all it names (#367)", note)
+	}
+}
+
+// TestUnreadableEmbeddedPartIsAlsoReported covers the other errors the same call site
+// discards. The size refusals are the measured case, but a part whose bytes cannot be read is
+// equally unexamined, and a fix that only special-cased the cap would leave the rest silent.
+func TestUnreadableEmbeddedPartIsAlsoReported(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "corrupt_part.docx")
+
+	// A zip whose embedded entry declares DEFLATE but stores bytes that are not a valid
+	// deflate stream: the entry opens, and the read fails part way.
+	f, err := os.Create(path) // #nosec G304 -- test-controlled temp path
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	zw := zip.NewWriter(f)
+	w, err := zw.Create("[Content_Types].xml")
+	if err != nil {
+		t.Fatalf("create content types: %v", err)
+	}
+	if _, err = io.WriteString(w, contentTypes); err != nil {
+		t.Fatalf("write content types: %v", err)
+	}
+	w, err = zw.CreateHeader(&zip.FileHeader{Name: "word/media/broken.jpg", Method: zip.Deflate})
+	if err != nil {
+		t.Fatalf("create entry: %v", err)
+	}
+	if _, err = io.WriteString(w, "not a deflate stream at all"); err != nil {
+		t.Fatalf("write entry: %v", err)
+	}
+	if err = zw.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if err = f.Close(); err != nil {
+		t.Fatalf("close file: %v", err)
+	}
+
+	// Corrupt the stored bytes so inflating them fails. The header still says Deflate, so
+	// the entry opens and the failure happens during the read — the shape a truncated
+	// download or a tampered container has.
+	raw, err := os.ReadFile(path) // #nosec G304 -- test-controlled temp path
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if i := strings.Index(string(raw), "word/media/broken.jpg"); i > 0 {
+		for j := i + len("word/media/broken.jpg"); j < i+len("word/media/broken.jpg")+8 && j < len(raw); j++ {
+			raw[j] = 0xFF
+		}
+	}
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+
+	media, notExamined, err := ExtractEmbeddedMediaForProcessing(path)
+	CleanupEmbeddedMedia(media)
+	if err != nil {
+		// The whole archive failed to open, which is a different disclosure path (the file
+		// is reported as unparseable). Nothing to assert here.
+		t.Skipf("the archive itself became unreadable, so this case is covered elsewhere: %v", err)
+	}
+	if len(media) == 0 && len(notExamined) == 0 {
+		t.Error("a part that could not be extracted produced neither media nor a note — that is " +
+			"the silent skip this change exists to remove")
+	}
+}
+
+// A container with more refused parts than the note cap must still say HOW MANY.
+//
+// The part count is attacker-controlled: measured on a 6 MB .docx holding 120 entries that
+// each deflate from 50 MB of zeros, the unbounded form produced a single 16.8 KB stderr line.
+// Truncating that silently would be the same class of defect as the silent skip this
+// disclosure exists to fix, so the note that replaces the dropped names carries their count.
+func TestMoreRefusalsThanTheNoteCapAreCountedNotDropped(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "many_parts.docx")
+
+	f, err := os.Create(path) // #nosec G304 -- test-controlled temp path
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	zw := zip.NewWriter(f)
+	w, err := zw.Create("[Content_Types].xml")
+	if err != nil {
+		t.Fatalf("create content types: %v", err)
+	}
+	if _, err = io.WriteString(w, contentTypes); err != nil {
+		t.Fatalf("write content types: %v", err)
+	}
+
+	// One more part than the cap, each declaring more than the embedded limit. Deflated
+	// zeros, so the fixture stays small on disk while every entry is genuinely over-cap.
+	const parts = maxEmbeddedNotes + 3
+	for i := 0; i < parts; i++ {
+		pw, cerr := zw.CreateHeader(&zip.FileHeader{
+			Name:   filepath.ToSlash(filepath.Join("word", "media", "pad"+string(rune('a'+i))+".bin")),
+			Method: zip.Deflate,
+		})
+		if cerr != nil {
+			t.Fatalf("create pad %d: %v", i, cerr)
+		}
+		if _, cerr = io.CopyN(pw, zeros{}, MaxEmbeddedMediaSize+4096); cerr != nil {
+			t.Fatalf("write pad %d: %v", i, cerr)
+		}
+	}
+	if err = zw.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
+	}
+	if err = f.Close(); err != nil {
+		t.Fatalf("close file: %v", err)
+	}
+
+	media, notExamined, err := ExtractEmbeddedMediaForProcessing(path)
+	CleanupEmbeddedMedia(media)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(media) != 0 {
+		t.Fatalf("%d parts extracted; every one of them is over the cap, so the fixture is wrong",
+			len(media))
+	}
+
+	// Bounded: named refusals plus exactly one summary.
+	if len(notExamined) != maxEmbeddedNotes+1 {
+		t.Fatalf("notes = %d, want %d named refusals plus one summary:\n%v",
+			len(notExamined), maxEmbeddedNotes+1, notExamined)
+	}
+	summary := notExamined[len(notExamined)-1]
+	if !strings.Contains(summary, "3 more embedded part(s) were not examined") {
+		t.Errorf("summary = %q, want it to count the %d refusals whose names were dropped; a cap "+
+			"that truncates silently reproduces the silence it was added to remove",
+			summary, parts-maxEmbeddedNotes)
+	}
+}

--- a/internal/preprocessors/meta-extractors/meta-extract-officelib/office-extractor.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-officelib/office-extractor.go
@@ -30,6 +30,19 @@ const (
 	// exhaust the temp filesystem (security finding MED-3). The XML readers in
 	// this file already cap at MaxXMLSize; media is larger but still bounded.
 	MaxEmbeddedMediaSize = 50 * 1024 * 1024 // 50MB max per embedded media file
+	// maxEmbeddedNotes bounds how many individually-named refusals one container can put
+	// into its disclosure, because that text goes on ONE line of stderr and into every
+	// machine format.
+	//
+	// The part count is attacker-controlled and cheap: a 6 MB .docx holding 120 entries
+	// that each deflate from 50 MB of zeros produced a single 16.8 KB warning line,
+	// measured, and the shape scales linearly with entries a container can declare. A
+	// report an operator cannot read is a report they will not read.
+	//
+	// The count is never lost — what is dropped is the NAMES beyond this many, and the note
+	// that replaces them says how many. A cap that truncates silently would be the same
+	// class of defect as the silent skip this disclosure exists to fix.
+	maxEmbeddedNotes = 8
 )
 
 // Global replacer for efficient error sanitization (initialized once)
@@ -795,6 +808,19 @@ func extractEmbeddedImages(reader *zip.ReadCloser, metadata *Metadata) error {
 		// Extract media to temp file
 		tempFile, err := extractImageToTemp(file)
 		if err != nil {
+			// Silent HERE, deliberately, and not the same omission as the one #374 fixed.
+			//
+			// This loop exists only to count the embedded parts and record their names as
+			// metadata properties; it deletes every temp file it makes (see the defer above).
+			// The loop that decides what actually gets SCANNED is
+			// ExtractEmbeddedMediaForProcessing, which walks the same parts against the same
+			// cap and returns a note for each one it could not extract. Reporting the refusal
+			// here as well would put the same part on the operator's screen twice.
+			//
+			// The visible cost is that EmbeddedMediaCount under-counts by the refused parts.
+			// That count is a report hint, and it is rendered into the text the validators
+			// scan, so changing it changes scanned content — a separate decision from
+			// disclosure.
 			continue
 		}
 		tempFiles = append(tempFiles, tempFile)
@@ -829,8 +855,12 @@ func extractImageToTemp(file *zip.File) (string, error) {
 
 	// Reject before extracting when the entry declares a size over the cap.
 	if file.UncompressedSize64 > MaxEmbeddedMediaSize {
-		return "", fmt.Errorf("embedded media %q declares %d bytes, exceeding the %d cap (possible decompression bomb)",
-			file.Name, file.UncompressedSize64, MaxEmbeddedMediaSize)
+		// The part's NAME is deliberately absent from the message. The only caller that
+		// surfaces this error names the part's base name itself, and a scanned tree's
+		// internal paths should not be repeated into a report twice — see #367, which is
+		// open about exactly that. Sizes only.
+		return "", fmt.Errorf("declares %d bytes, over the %d-byte embedded cap (possible decompression bomb)",
+			file.UncompressedSize64, MaxEmbeddedMediaSize)
 	}
 
 	// Create temp file.
@@ -848,7 +878,7 @@ func extractImageToTemp(file *zip.File) (string, error) {
 	// only so this function has no path that concatenates an unvalidated string.
 	safeExt, ok := embedded.SafeExt(file.Name)
 	if !ok {
-		return "", fmt.Errorf("embedded part %q has no admitted file type", filepath.Base(file.Name))
+		return "", fmt.Errorf("no admitted file type")
 	}
 	tempFile, err := os.CreateTemp("", "office_embedded_*"+safeExt)
 	if err != nil {
@@ -866,23 +896,46 @@ func extractImageToTemp(file *zip.File) (string, error) {
 	}
 	if n > MaxEmbeddedMediaSize {
 		os.Remove(tempFile.Name())
-		return "", fmt.Errorf("embedded media %q exceeds the %d extraction cap (possible decompression bomb)",
-			file.Name, MaxEmbeddedMediaSize)
+		// Name omitted for the same reason as the declared-size refusal above.
+		return "", fmt.Errorf("exceeds the %d-byte embedded extraction cap while being read (possible decompression bomb)",
+			MaxEmbeddedMediaSize)
 	}
 
 	return tempFile.Name(), nil
 }
 
-// ExtractEmbeddedMediaForProcessing extracts embedded media and returns temp file paths for full processing
-func ExtractEmbeddedMediaForProcessing(filePath string) ([]EmbeddedMedia, error) {
+// ExtractEmbeddedMediaForProcessing extracts embedded media and returns temp file paths for
+// full processing, plus one note per part it could NOT extract.
+//
+// # Why the notes exist
+//
+// This loop used to discard extractImageToTemp's error with a bare `continue`. When that error
+// was the MaxEmbeddedMediaSize refusal, the part was never scanned and nothing said so: an
+// outer .docx whose word/embeddings/attachment.docx crossed the cap reported "No matches
+// found" at exit 0, and exit 0 again under --fail-on-incomplete, with nothing on stderr —
+// while the identical inner document under the cap reported its SSN at HIGH 100. A container
+// declared clean while sensitive content sat unread inside it is the cleartext-passthrough
+// shape this tool exists to prevent, and the flag whose entire purpose is to escalate
+// incomplete coverage could not see it. See #374.
+//
+// The notes are returned rather than logged because the caller owns the disclosure channel:
+// OfficeMetadataPreprocessor merges them into ProcessedContent.ExtractionWarning, which
+// survives FileRouter's combine step and reaches both the operator's "NOT FULLY EXAMINED"
+// section and the --fail-on-incomplete exit code.
+//
+// Payload-free by construction: a note names the part's BASE name and the reason, never a
+// path and never any bytes from the part. It reaches stderr and every machine format.
+func ExtractEmbeddedMediaForProcessing(filePath string) ([]EmbeddedMedia, []string, error) {
 	// Open the file as a ZIP archive
 	reader, err := zip.OpenReader(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("error opening file as ZIP: %v", err)
+		return nil, nil, fmt.Errorf("error opening file as ZIP: %v", err)
 	}
 	defer reader.Close()
 
 	var embeddedMedia []EmbeddedMedia
+	var notExamined []string
+	refused := 0
 
 	for _, file := range reader.File {
 		if !isEmbeddedPartPath(file.Name) {
@@ -913,6 +966,22 @@ func ExtractEmbeddedMediaForProcessing(filePath string) ([]EmbeddedMedia, error)
 		// Extract media to temp file
 		tempFile, err := extractImageToTemp(file)
 		if err != nil {
+			// DISCLOSE rather than skip. Every error this can return means a part that the
+			// router was going to be asked about was not made available to it: the size
+			// refusals, a zip entry that will not open, a temp file that cannot be created,
+			// a read that fails part way. In each case content the operator believes was
+			// scanned was not, so the note has to travel — a silent `continue` here is what
+			// #374 is.
+			//
+			// Deliberately NOT the same judgement as the router's own admission check. That
+			// one stays silent on purpose (a part nothing can read is a non-event, and a
+			// line per decorative .emf trains operators to ignore warnings). This is the
+			// opposite case: whether the part was readable is exactly what we no longer know.
+			refused++
+			if len(notExamined) < maxEmbeddedNotes {
+				notExamined = append(notExamined, fmt.Sprintf("embedded part %q was not examined: %v",
+					filepath.Base(file.Name), err))
+			}
 			continue
 		}
 
@@ -923,7 +992,12 @@ func ExtractEmbeddedMediaForProcessing(filePath string) ([]EmbeddedMedia, error)
 		})
 	}
 
-	return embeddedMedia, nil
+	if refused > len(notExamined) {
+		notExamined = append(notExamined, fmt.Sprintf(
+			"and %d more embedded part(s) were not examined", refused-len(notExamined)))
+	}
+
+	return embeddedMedia, notExamined, nil
 }
 
 // CleanupEmbeddedMedia removes temporary files

--- a/internal/preprocessors/office_metadata_preprocessor.go
+++ b/internal/preprocessors/office_metadata_preprocessor.go
@@ -184,9 +184,24 @@ func (omp *OfficeMetadataPreprocessor) formatOfficeMetadata(meta *meta_extract_o
 // returning the text to append and the out-of-band sections describing it.
 func (omp *OfficeMetadataPreprocessor) processEmbeddedMedia(filePath string) (string, []ContentSection, []string) {
 	// Extract embedded media for processing
-	embeddedMedia, err := meta_extract_officelib.ExtractEmbeddedMediaForProcessing(filePath)
-	if err != nil || len(embeddedMedia) == 0 {
+	embeddedMedia, notExamined, err := meta_extract_officelib.ExtractEmbeddedMediaForProcessing(filePath)
+	if err != nil {
+		// The only error here is "this file is not a ZIP", and processOfficeMetadata has
+		// already called ExtractMetadata on the same path, which opens the same archive and
+		// returns an error content for exactly that case. So the file is reported as
+		// unparseable through its own channel and there is nothing left to disclose here.
 		return "", nil, nil
+	}
+	// A part that could not be extracted is disclosed even when NOTHING extracted.
+	//
+	// The early return used to cover len(embeddedMedia) == 0 as well, which threw the
+	// notes away in precisely the case that matters most: a document whose only embedded
+	// part is the one refused for size leaves an empty media slice, so the refusal was
+	// dropped one line after being detected. Measured before this: 0 findings, exit 0,
+	// exit 0 again under --fail-on-incomplete, nothing on stderr, while the same inner
+	// document under the cap reported its SSN at HIGH 100. See #374.
+	if len(embeddedMedia) == 0 {
+		return "", nil, notExamined
 	}
 
 	// Ensure cleanup of temporary files
@@ -203,7 +218,13 @@ func (omp *OfficeMetadataPreprocessor) processEmbeddedMedia(filePath string) (st
 	}
 
 	// Process through base preprocessor's embedded media handler
-	return omp.ProcessEmbeddedMedia(filePath, baseEmbeddedMedia)
+	text, sections, warnings := omp.ProcessEmbeddedMedia(filePath, baseEmbeddedMedia)
+
+	// Extraction refusals first, then the descent's own warnings. Both are the same kind
+	// of statement — "this item's content was not examined" — and they are joined by the
+	// caller into one ExtractionWarning, so ordering them puts the parts that never
+	// reached the router ahead of the ones that reached it and were declined.
+	return text, sections, append(notExamined, warnings...)
 }
 
 // GetSupportedExtensions returns the file extensions this preprocessor supports

--- a/internal/router/empty_extraction_visibility_test.go
+++ b/internal/router/empty_extraction_visibility_test.go
@@ -200,3 +200,63 @@ func docxWithoutBodyPart() []byte {
 	}
 	return out.Bytes()
 }
+
+// A warning that already names its producer must not be prefixed with that name again.
+//
+// An embedded container routes back through this same combine step, and every level used to
+// add its own copy, so a note from four levels down reached the operator as
+//
+//	office_metadata: office_metadata: office_metadata: office_metadata: embedded item …
+//
+// measured on a .docx nested six deep. The name is there to say which reader produced the
+// note; repeating it says nothing more and pushes the part that matters off the line.
+func TestAWarningIsNotPrefixedTwiceWithItsOwnProducer(t *testing.T) {
+	fr := NewFileRouter(false)
+	fr.preprocessors = []preprocessors.Preprocessor{
+		// Exactly what a nested container hands back: the child's combine step already
+		// prefixed the note, and the parent's is about to run over it.
+		&stubPreprocessor{
+			name:    "office_metadata",
+			text:    "Author: Jane Analyst\n",
+			warning: `office_metadata: embedded item "attachment.docx" was not examined: embedded container nesting limit reached`,
+		},
+	}
+
+	got, err := fr.ProcessFileWithContext("outer.docx", &ProcessingContext{FilePath: "outer.docx"})
+	if err != nil {
+		t.Fatalf("routing failed: %v", err)
+	}
+	if n := strings.Count(got.ExtractionWarning, "office_metadata: "); n != 1 {
+		t.Errorf("the producer name appears %d times, want 1:\n  %q", n, got.ExtractionWarning)
+	}
+	// Still prefixed once, because a combined result has several producers and the
+	// operator needs to know which one is talking.
+	if !strings.HasPrefix(got.ExtractionWarning, "office_metadata: ") {
+		t.Errorf("ExtractionWarning = %q, want it to name the producer once", got.ExtractionWarning)
+	}
+	if !strings.Contains(got.ExtractionWarning, "attachment.docx") {
+		t.Errorf("ExtractionWarning = %q, want the part it is about to survive the prefixing",
+			got.ExtractionWarning)
+	}
+}
+
+// The other direction: a note that does NOT already carry its producer's name still gets one.
+// Dropping the prefix entirely would be the obvious wrong way to remove the duplication.
+func TestAnUnprefixedWarningStillGetsItsProducer(t *testing.T) {
+	fr := NewFileRouter(false)
+	fr.preprocessors = []preprocessors.Preprocessor{
+		&stubPreprocessor{
+			name:    "audio_metadata",
+			text:    "Artist: Jane Analyst\n",
+			warning: "audio metadata may be incomplete: the WAV chunk layout could not be walked to the end",
+		},
+	}
+
+	got, err := fr.ProcessFileWithContext("clip.wav", &ProcessingContext{FilePath: "clip.wav"})
+	if err != nil {
+		t.Fatalf("routing failed: %v", err)
+	}
+	if !strings.HasPrefix(got.ExtractionWarning, "audio_metadata: ") {
+		t.Errorf("ExtractionWarning = %q, want the producing preprocessor named", got.ExtractionWarning)
+	}
+}

--- a/internal/router/file_router.go
+++ b/internal/router/file_router.go
@@ -465,8 +465,19 @@ func (fr *FileRouter) processFileInternal(filePath string, config *ProcessingCon
 
 	for _, pResult := range ordered {
 		if pResult.result != nil && pResult.result.ExtractionWarning != "" {
-			extractionWarnings = append(extractionWarnings,
-				pResult.name+": "+pResult.result.ExtractionWarning)
+			// Prefix ONCE. An embedded container routes back through this same function,
+			// and each level used to add its own copy, so a note from four levels down
+			// reached the operator as
+			//
+			//	office_metadata: office_metadata: office_metadata: office_metadata: embedded item …
+			//
+			// The name is here to say which reader produced the note; repeating it says
+			// nothing more and pushes the part that matters off the line.
+			warning := pResult.result.ExtractionWarning
+			if !strings.HasPrefix(warning, pResult.name+": ") {
+				warning = pResult.name + ": " + warning
+			}
+			extractionWarnings = append(extractionWarnings, warning)
 		}
 		if pResult.err == nil && pResult.result != nil && pResult.result.Success && pResult.result.Text != "" {
 			if len(successfulProcessors) == 0 {

--- a/tests/integration/embedded_oversize_disclosure_test.go
+++ b/tests/integration/embedded_oversize_disclosure_test.go
@@ -1,0 +1,328 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// maxEmbeddedMediaSize mirrors metaextractofficelib.MaxEmbeddedMediaSize.
+//
+// Duplicated rather than imported because this test's job is to describe what an OPERATOR sees
+// at the CLI boundary, and importing an internal constant would make the fixture agree with the
+// implementation by construction. If the cap changes and this is not updated, the padded
+// fixture stops being over-cap and the assertions below fail loudly — which is the intended
+// outcome, not a maintenance trap.
+const maxEmbeddedMediaSize = 50 * 1024 * 1024
+
+// The operator-visible half of #374.
+//
+// A .docx whose embedded document is refused for size used to report "No matches found" at exit
+// 0, and exit 0 AGAIN under --fail-on-incomplete — the flag whose entire purpose is to escalate
+// incomplete coverage — with nothing on stderr. The identical inner document under the cap
+// reports its SSN at HIGH 100. A container declared clean while sensitive content sits unread
+// inside it is the cleartext-passthrough shape this tool exists to prevent.
+//
+// This runs the real binary because every hop matters here: the extractor's note, the
+// preprocessor's merge, the router's combine step, the parallel processor's diagnostic channel,
+// the cause classification, the stderr section, the exit code, and the machine formats. A unit
+// test on any one of them would pass while an operator saw nothing.
+func TestOversizeEmbeddedPartIsDisclosedAndExitsThree(t *testing.T) {
+	bin := embeddedDisclosureBinary(t)
+	dir := t.TempDir()
+
+	control := buildOuterDocx(t, dir, "outer_small.docx", 0)
+	oversize := buildOuterDocx(t, dir, "outer_big.docx", maxEmbeddedMediaSize+4096)
+
+	// The control proves the pair is comparable: the SAME inner document, under the cap, is
+	// scanned and its SSN reported. Without this, "0 findings" on the oversize file could
+	// mean the fixture was simply wrong.
+	// Asserted on the TYPE and band, not on the value: csv prints "[HIDDEN]" unless
+	// --show-match is passed, so a test that looked for the digits would pass for the wrong
+	// reason on the control and be vacuous on the oversize case below.
+	stdout, _, code := runFerret(t, bin, "--file", control, "--format", "csv", "--confidence", "high,medium,low")
+	if !strings.Contains(stdout, ",SSN,HIGH,") {
+		t.Fatalf("the under-cap control did not report the embedded SSN, so this pair proves "+
+			"nothing.\nstdout:\n%s", stdout)
+	}
+	if code != 0 {
+		t.Errorf("control exit = %d, want 0", code)
+	}
+
+	// The oversize case: still no findings — the part genuinely was not read — but it must
+	// now SAY so, and --fail-on-incomplete must escalate.
+	stdout, stderr, code := runFerret(t, bin, "--file", oversize, "--fail-on-incomplete",
+		"--format", "csv", "--confidence", "high,medium,low")
+	if strings.Contains(stdout, ",SSN,") {
+		t.Fatalf("the over-cap part was scanned after all; the fixture is not over the cap and "+
+			"the rest of this test is vacuous.\nstdout:\n%s", stdout)
+	}
+	if code != 3 {
+		t.Errorf("exit = %d, want 3.\n--fail-on-incomplete exists to turn incomplete coverage "+
+			"into a build failure. An embedded document refused for size is the clearest case "+
+			"of incomplete coverage there is, and it used to exit 0.\nstderr:\n%s", code, stderr)
+	}
+	if !strings.Contains(stderr, "NOT FULLY EXAMINED") {
+		t.Errorf("stderr has no NOT FULLY EXAMINED section:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "attachment.docx") {
+		t.Errorf("stderr does not name the part that was not examined:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "coverage cut short") {
+		t.Errorf("stderr does not file this under 'coverage cut short':\n%s\n"+
+			"This container's own body text WAS read and scanned; reporting it as having no "+
+			"body text describes a failure that did not happen.", stderr)
+	}
+	// Payload-free: this text reaches stderr and every machine format.
+	if strings.Contains(stderr, "452-11-9384") {
+		t.Errorf("the disclosure leaked content from the part it is reporting:\n%s", stderr)
+	}
+
+	// And the machine formats have to agree with the human one, since an operator compares a
+	// report against an artifact from the same run.
+	stdout, _, _ = runFerret(t, bin, "--file", oversize, "--format", "json")
+	var doc struct {
+		Stats struct {
+			FilesNotExamined int `json:"files_not_examined"`
+		} `json:"stats"`
+		NotExamined []struct {
+			Path   string `json:"path"`
+			Cause  string `json:"cause"`
+			Detail string `json:"detail"`
+		} `json:"files_not_examined_detail"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &doc); err != nil {
+		t.Fatalf("json output did not parse: %v\n%s", err, stdout)
+	}
+	if doc.Stats.FilesNotExamined != 1 {
+		t.Errorf("stats.files_not_examined = %d, want 1 — a scan that reports complete coverage "+
+			"while a part went unread is the defect, whatever stderr says",
+			doc.Stats.FilesNotExamined)
+	}
+}
+
+// embeddedDisclosureBinary builds ferret-scan once for this file's tests.
+func embeddedDisclosureBinary(t *testing.T) string {
+	t.Helper()
+	name := "ferret-scan"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	bin := filepath.Join(t.TempDir(), name)
+	cmd := exec.Command("go", "build", "-o", bin, "../../cmd")
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to build ferret-scan: %v\n%s", err, out)
+	}
+	return bin
+}
+
+// runFerret runs the binary and returns stdout, stderr and the exit code.
+func runFerret(t *testing.T, bin string, args ...string) (string, string, int) {
+	t.Helper()
+	cmd := exec.Command(bin, args...) //nolint:gosec // bin is built by the test
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	code := 0
+	if err != nil {
+		ee, ok := err.(*exec.ExitError)
+		if !ok {
+			t.Fatalf("unexpected exec error: %v\nstderr=%s", err, stderr.String())
+		}
+		code = ee.ExitCode()
+	}
+	return stdout.String(), stderr.String(), code
+}
+
+// buildOuterDocx writes a .docx carrying word/embeddings/attachment.docx, whose own body holds
+// an SSN and which is padded with `pad` STORED bytes.
+//
+// STORED padding inside the inner file, deflated by the outer archive: the cap is compared
+// against the outer entry's declared uncompressed size, which is the inner file's byte length,
+// so the padding has to be incompressible WITHIN the inner file and is then squeezed to almost
+// nothing by the outer one. That keeps the fixture on disk at a few tens of KB.
+//
+// Padding is streamed, never buffered — a 50 MB []byte in a test is 50 MB of RSS for nothing.
+func buildOuterDocx(t *testing.T, dir, name string, pad int64, extra ...embeddedPart) string {
+	t.Helper()
+
+	innerPath := filepath.Join(dir, "inner_"+name)
+	inner, err := os.Create(innerPath) // #nosec G304 -- test-controlled temp path
+	if err != nil {
+		t.Fatalf("create inner: %v", err)
+	}
+	iz := zip.NewWriter(inner)
+	writeEntry(t, iz, "[Content_Types].xml", officeContentTypes)
+	writeEntry(t, iz, "word/document.xml", officeDocumentXML("Attached record SSN: 452-11-9384"))
+	if pad > 0 {
+		w, werr := iz.CreateHeader(&zip.FileHeader{Name: "word/media/pad.bin", Method: zip.Store})
+		if werr != nil {
+			t.Fatalf("create pad: %v", werr)
+		}
+		if _, werr = io.CopyN(w, nulReader{}, pad); werr != nil {
+			t.Fatalf("write pad: %v", werr)
+		}
+	}
+	if err := iz.Close(); err != nil {
+		t.Fatalf("close inner zip: %v", err)
+	}
+	if err := inner.Close(); err != nil {
+		t.Fatalf("close inner file: %v", err)
+	}
+
+	outPath := filepath.Join(dir, name)
+	out, err := os.Create(outPath) // #nosec G304 -- test-controlled temp path
+	if err != nil {
+		t.Fatalf("create outer: %v", err)
+	}
+	oz := zip.NewWriter(out)
+	writeEntry(t, oz, "[Content_Types].xml", officeContentTypes)
+	writeEntry(t, oz, "word/document.xml", officeDocumentXML("Cover letter, see attachment"))
+
+	src, err := os.Open(innerPath) // #nosec G304 -- test-controlled temp path
+	if err != nil {
+		t.Fatalf("open inner: %v", err)
+	}
+	w, err := oz.Create("word/embeddings/attachment.docx")
+	if err != nil {
+		t.Fatalf("create embedded entry: %v", err)
+	}
+	if _, err := io.Copy(w, src); err != nil {
+		t.Fatalf("copy inner: %v", err)
+	}
+	if err := src.Close(); err != nil {
+		t.Fatalf("close inner reader: %v", err)
+	}
+
+	// Additional embedded parts, each a small .docx of its own. A container with BOTH a
+	// refused part and a readable one is the realistic shape, and it is the only one that
+	// exercises the path where the refusal notes have to be MERGED with the descent's own
+	// warnings rather than returned on their own.
+	for _, e := range extra {
+		nested := filepath.Join(dir, "extra_"+e.entry+".tmp")
+		innerExtra, cerr := os.Create(nested) // #nosec G304 -- test-controlled temp path
+		if cerr != nil {
+			t.Fatalf("create extra: %v", cerr)
+		}
+		ez := zip.NewWriter(innerExtra)
+		writeEntry(t, ez, "[Content_Types].xml", officeContentTypes)
+		writeEntry(t, ez, "word/document.xml", officeDocumentXML(e.body))
+		if cerr = ez.Close(); cerr != nil {
+			t.Fatalf("close extra zip: %v", cerr)
+		}
+		if cerr = innerExtra.Close(); cerr != nil {
+			t.Fatalf("close extra file: %v", cerr)
+		}
+
+		rd, cerr := os.Open(nested) // #nosec G304 -- test-controlled temp path
+		if cerr != nil {
+			t.Fatalf("open extra: %v", cerr)
+		}
+		ew, cerr := oz.Create("word/embeddings/" + e.entry)
+		if cerr != nil {
+			t.Fatalf("create extra entry: %v", cerr)
+		}
+		if _, cerr = io.Copy(ew, rd); cerr != nil {
+			t.Fatalf("copy extra: %v", cerr)
+		}
+		if cerr = rd.Close(); cerr != nil {
+			t.Fatalf("close extra reader: %v", cerr)
+		}
+	}
+	if err := oz.Close(); err != nil {
+		t.Fatalf("close outer zip: %v", err)
+	}
+	if err := out.Close(); err != nil {
+		t.Fatalf("close outer file: %v", err)
+	}
+	return outPath
+}
+
+// embeddedPart describes an extra embedded .docx to place alongside the padded one.
+type embeddedPart struct {
+	entry string
+	body  string
+}
+
+func writeEntry(t *testing.T, zw *zip.Writer, name, body string) {
+	t.Helper()
+	w, err := zw.Create(name)
+	if err != nil {
+		t.Fatalf("create %s: %v", name, err)
+	}
+	if _, err := io.WriteString(w, body); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+// nulReader is an endless source of NUL bytes.
+type nulReader struct{}
+
+func (nulReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}
+
+const officeContentTypes = `<?xml version="1.0" encoding="UTF-8"?>` +
+	`<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+	`<Default Extension="xml" ContentType="application/xml"/>` +
+	`<Default Extension="bin" ContentType="application/octet-stream"/>` +
+	`<Default Extension="docx" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document"/>` +
+	`<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>` +
+	`</Types>`
+
+func officeDocumentXML(body string) string {
+	return `<?xml version="1.0" encoding="UTF-8"?>` +
+		`<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
+		`<w:body><w:p><w:r><w:t>` + body + `</w:t></w:r></w:p></w:body></w:document>`
+}
+
+// A container with one refused part AND one readable part must report BOTH facts.
+//
+// This is the merge: the refusal notes come from the extractor before the router is ever
+// consulted, and the descent produces its own warnings afterwards, so a fix that returned only
+// one of the two lists would pass every single-part test. Measured as a survived mutation —
+// dropping the merge left this case silent while the single-part case still passed.
+func TestAContainerReportsBothItsReadablePartAndItsRefusedOne(t *testing.T) {
+	bin := embeddedDisclosureBinary(t)
+	dir := t.TempDir()
+
+	mixed := buildOuterDocx(t, dir, "outer_mixed.docx", maxEmbeddedMediaSize+4096,
+		embeddedPart{entry: "readable.docx", body: "Reachable by phone 415-555-0142"})
+
+	stdout, stderr, code := runFerret(t, bin, "--file", mixed, "--fail-on-incomplete",
+		"--format", "csv", "--confidence", "high,medium,low")
+
+	// The readable part still contributes its findings: a disclosure that suppressed the
+	// scan would be a worse bug than the one being fixed.
+	if !strings.Contains(stdout, ",PHONE,") {
+		t.Errorf("the readable embedded part produced no finding, so the refusal cost the "+
+			"container its working coverage.\nstdout:\n%s", stdout)
+	}
+	// ...and the refused one is still disclosed, in the same run.
+	if !strings.Contains(stderr, "attachment.docx") {
+		t.Errorf("the refused part is not named while another part scanned fine — the notes "+
+			"were dropped in favour of the descent's own warnings.\nstderr:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "coverage cut short") {
+		t.Errorf("stderr does not file this under 'coverage cut short':\n%s", stderr)
+	}
+	if code != 3 {
+		t.Errorf("exit = %d, want 3: a partly examined container is incomplete coverage even "+
+			"when some of its parts scanned fine.\nstderr:\n%s", code, stderr)
+	}
+}


### PR DESCRIPTION
Closes #374

An embedded Office part that could not be extracted was dropped with a bare `continue`, so a container holding sensitive content inside an over-cap part was reported **clean**. Measured on a control/test pair whose inner documents are byte-identical apart from padding:

| fixture | embedded `.docx` | result |
|---|---|---|
| `outer_small.docx` | 962 B | **SSN reported at HIGH 100** |
| `outer_big.docx` | the SAME inner, padded past the 50 MB embedded cap | `No matches found`, **exit 0** — and exit 0 again under `--fail-on-incomplete`, nothing on stderr, nothing in json |

The flag whose entire purpose is to escalate incomplete coverage could not see it. Only reported findings are redacted, so the SSN survives `--enable-redaction` too.

## The disclosure channel already existed; the refusal never reached it

`ExtractionWarning` is the one channel that survives `FileRouter`'s combine step, and the embedded **nesting bound** already uses it — *"DISCLOSE rather than skip"*, as `base_metadata_preprocessor` puts it. This routes extraction refusals into the same slice.

I verified the channel was live **before writing the fix**, by driving the existing nesting-bound producer end to end (a six-level `.docx` → exit 3). Two details are what actually made it work:

- the notes are **returned**, not logged, because the caller owns the channel;
- `processEmbeddedMedia`'s early return covered `len(embeddedMedia) == 0`, which threw the notes away in precisely the case that matters most — a document whose **only** embedded part is the refused one leaves an empty media slice, so the refusal was dropped one line after being detected.

## Every extraction error, not only the cap

The size refusals are the measured case, but a zip entry that will not open, a temp file that cannot be created, and a read that fails part way all mean the same thing: a part the router was about to be asked about was never offered to it. Measured on a container with a corrupt deflate stream:

```
embedded part "broken.jpg" was not examined: flate: corrupt input before offset 1
```

The router's own admission check **stays silent**, deliberately and unchanged: a part nothing can read is a non-event, and a line per decorative `.emf` in every deck trains operators to ignore warnings.

**Measured on 150 real Office documents** (`.docx`/`.xlsx`/`.pptx`/`.doc`/`.xls`/`.ppt`) from this machine: **zero** new not-examined lines, byte-identical to the parent binary. An ordinary `.docx` with three embedded PNGs also produces none.

## Bounded, and the bound says what it dropped

The part count is attacker-controlled and cheap. A 6 MB `.docx` holding 120 entries that each deflate from 50 MB of zeros produced a single **16.8 KB** stderr line, so notes cap at 8 named parts plus `and N more embedded part(s) were not examined` — **16.8 KB → 1.4 KB**. The count is never lost; a cap that truncated silently would reproduce the silence this exists to remove.

Notes are payload-free and path-free: the part's **base name** and the reason, never a path (#367) and never a byte from the part.

## Commit 2 — the cause was also wrong, in a way that mattered

The `ExtractionWarning` channel carries two different statements, and this side filed every one under `no body text (metadata still scanned)`:

```
"no text extracted from .docx: no document body part was found"      <- the body WAS empty
"embedded part X was not examined: declares N bytes, over the cap"   <- the body was fine
```

The second is a container whose own text was read and scanned normally. So the first version of this fix produced a **true** disclosure under a **false** heading:

| | |
|---|---|
| before | `no body text (metadata still scanned) (1)` |
| after | `coverage cut short (1)` — *"a budget, size cap or timeout fired, so the file is PARTLY scanned"* |

The taxonomy's own comment warns about exactly this: *"an unmapped cause silently becomes 'cannot read', asserting a failure that did not happen"*. The embedded nesting bound moves the same way, and for the same reason: `MaxDepth` is a budget.

The discriminator is the shared prefix `no text extracted from`, which every no-text producer builds from one helper. It is applied **per segment**, not to the whole string — a file can carry both statements joined with `"; "`, and a substring test would let a leading no-text warning hide an unexamined embedded document behind it. Asserted in both orders.

A structured cause travelling with the diagnostic would beat matching on prose, and would mean threading a field from every preprocessor through `worker_pool` and `parallel_processor` into `FileDiagnostic`. Worth doing, not this change — so the prefix is a stated contract, asserted by a table enumerating **all eleven** current producer wordings copied from the code that builds them.

## Commit 3 — one prefix per producer, not one per nesting level

A note from four levels down reached the operator as

```
office_metadata: office_metadata: office_metadata: office_metadata: embedded item "attachment.docx" …
```

measured on a `.docx` nested six deep. Both directions are pinned, because dropping the prefix altogether is the obvious wrong way to remove the duplication.

## Commit 4 — docs, including retroactively

`docs/COVERAGE_DISCLOSURE.md` said *"the four causes"* while the code has had **six** since #324 and #326 — `symlink not followed` and `file too large to scan` were added and never documented (`internal/formatters/notexamined.go` still says "The four causes" in its own comment). Now documented, along with what makes a container partly scanned, the exact operator-facing wording for each of the three cases, and the two exclusions the code treats as policy but the doc never stated.

## Verification

- **69 packages ok, 0 failed.** `gofmt -l ./cmd ./internal ./pkg ./tests` clean, `go vet` clean, `-race` clean on `./internal/preprocessors/... ./internal/router/ ./cmd/`.
- Golden corpus and score baseline **unchanged**.
- **Union check**: `main` + all five open PRs (#393–#397) + this one, merged together in a worktree — **builds clean, 69/0, gofmt clean**. Zero file overlap with any of them.
- Determinism: 10 runs of the 120-part fixture → one unique warning digest. Perf and RSS unchanged on an ordinary document (0.09s → 0.06s, 37 MB → 36 MB, identical findings).
- **Mutation-tested, 10 mutations.** Two survived on the first pass and both were real test gaps, now closed: dropping the note/warning **merge** (only reachable when a container has a refused part *and* a readable one) and the prefix collapse (untested). The other eight: restoring the bare `continue`; restoring the early return; classifying everything as `noText`; as `cutShort`; whole-string instead of per-segment; re-prefixing at every level; dropping the prefix entirely; and a silent note cap.

## Related work deliberately NOT in scope

- **#379** — the resource half of the same function family (no aggregate budget, every part materialised to temp twice). Different fix, different severity.
- `extractEmbeddedImages` keeps its bare `continue`: that loop only counts parts and deletes every temp file it makes, so disclosing there too would name the same part twice. Its cost is that `EmbeddedMediaCount` under-counts, and that count is rendered into the text the validators scan — changing it changes scanned content, which is a separate decision. Both facts are now comments at the call site.
- Two further silent skips found while measuring are filed separately rather than fixed blind.
