### PR TITLE
fix(legacy-office): decode vector-valued properties, so sheet names and slide titles are scanned and redactable

### DIFF
--- a/docs/user-guides/README-Redaction.md
+++ b/docs/user-guides/README-Redaction.md
@@ -109,6 +109,14 @@ ghp_16C7e42F...   →  ghp_ab3pMN5XQuRE  (same ghp_ prefix)
 > `simple` and `format_preserving` are. And detection of body text is approximate
 > (see the Office metadata preprocessor README), so redaction of `.doc` body text is
 > only as complete as detection was — document **properties** are exact.
+>
+> That includes **multi-valued** properties. A workbook keeps its sheet-name list, and a
+> deck its slide titles, in a vector-valued property, and those were reported by nothing
+> at all until #267: the property-set reader mis-reads a vector's type word, so the value
+> arrived as the literal `0`. Measured on 19 real `.doc`/`.xls`/`.ppt` files, 14 of them
+> carry such a property and 40 elements now decode — sheet names, slide titles, theme and
+> font names. A value inside one is redactable like any other, because an element is stored
+> behind its own length prefix and a same-length overwrite never touches it.
 
 ## Synthetic Strategy — Token Details
 

--- a/internal/goldencorpus/corpus.go
+++ b/internal/goldencorpus/corpus.go
@@ -766,6 +766,32 @@ var FileCases = []FileCase{
 		EnablePreprocessors: true,
 	},
 	{
+		Name: "file_xls_legacy_vector_sheet_names",
+		Description: "Tier 4: a legacy .xls whose SHEET-NAME LIST is a vector-valued property (DocumentParts, " +
+			"0x0D), one of the names carrying an SSN. The property-set reader mis-reads a vector's type word and " +
+			"yields the scalar I1(0), so before #267 the list arrived as the literal \"0\" and every name in it was " +
+			"reported by nothing. Measured on 19 real .doc/.xls/.ppt files, 14 carry such a property. This locks " +
+			"that the elements are decoded, that each lands on its own line (a joined line would let a validator " +
+			"match across two unrelated sheet names), and that ordinary names add no findings of their own. Diff " +
+			"against file_xls_legacy_workbook_stream, which is the same shape with scalar properties only.",
+		Checks:   []string{"SSN", "METADATA"},
+		Filename: "sheetnames.xls",
+		Content: olefixture.MustBuild([]olefixture.Stream{
+			{Name: olefixture.StreamWorkbook, Data: []byte("Workbook body with nothing sensitive.\r")},
+			{Name: olefixture.StreamDocSummaryInformation, Data: olefixture.DocSummaryInformationWithVectors(
+				map[uint32]string{olefixture.PropCompany: "Fairbanks Holdings"},
+				map[uint32][]string{olefixture.PropDocumentParts: {
+					// Lengths 12, 24 and 7 with their terminators: at least one is NOT a
+					// multiple of 4, which is what catches a decoder that pads between
+					// vector elements. Real files desynced on exactly that.
+					"First Sheet", "Payroll SSN 449-87-4100", "Sheet3",
+				}},
+			)},
+		}),
+		Tier1Parity:         false,
+		EnablePreprocessors: true,
+	},
+	{
 		Name: "file_doc_legacy_not_a_container",
 		Description: "Tier 4: plain text named .doc — the extension routes to the OLE path, but the bytes are not a " +
 			"compound file. This used to record \"No matches found.\": routing is decided by extension, the Office " +

--- a/internal/goldencorpus/testdata/golden/file_xls_legacy_vector_sheet_names.csv
+++ b/internal/goldencorpus/testdata/golden/file_xls_legacy_vector_sheet_names.csv
@@ -1,0 +1,3 @@
+Filename,Type,Confidence Level,Confidence %,Line Number,Text
+<TMPDIR>/sheetnames.xls,SSN,HIGH,100.0,3,449-87-4100
+<TMPDIR>/sheetnames.xls,COMPANY_INFO,LOW,55.0,1,Fairbanks Holdings

--- a/internal/goldencorpus/testdata/golden/file_xls_legacy_vector_sheet_names.gitlab-sast.json
+++ b/internal/goldencorpus/testdata/golden/file_xls_legacy_vector_sheet_names.gitlab-sast.json
@@ -1,0 +1,82 @@
+{
+  "remediations": [],
+  "scan": {
+    "analyzer": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/awslabs/ferret-scan",
+      "vendor": {
+        "name": "Amazon Web Services"
+      },
+      "version": "0.0.0-development"
+    },
+    "end_time": "<TIMESTAMP>",
+    "scanner": {
+      "id": "ferret-scan",
+      "name": "Ferret Scan",
+      "url": "https://github.com/awslabs/ferret-scan",
+      "vendor": {
+        "name": "Amazon Web Services"
+      },
+      "version": "0.0.0-development"
+    },
+    "start_time": "<TIMESTAMP>",
+    "status": "success",
+    "type": "sast"
+  },
+  "version": "15.0.4",
+  "vulnerabilities": [
+    {
+      "category": "sast",
+      "confidence": "High",
+      "description": "Ferret Scan detected social security number in this file.\n\n**Location:** <TMPDIR>/sheetnames.xls (line 3)\n**Confidence:** HIGH (100.0%)\n**Detected by:** ssn validator\n\n**Context:**\n```\nDocumentParts_2: Payroll SSN 449-87-4100\n```\n\n**Additional Information:**\n- context_impact: 50\n- source: preprocessed_content\n\n**Remediation:**\nRemove Social Security Numbers from code and documentation. Use test data or anonymized identifiers instead.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "SSN"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "ssn"
+        }
+      ],
+      "location": {
+        "end_line": 3,
+        "file": "sheetnames.xls",
+        "start_line": 3
+      },
+      "message": "Social Security Number detected: [HIDDEN] (confidence: HIGH)",
+      "name": "Social Security Number Detected",
+      "severity": "Critical"
+    },
+    {
+      "category": "sast",
+      "confidence": "Medium",
+      "description": "Ferret Scan detected company information in this file.\n\n**Location:** <TMPDIR>/sheetnames.xls (line 1)\n**Confidence:** LOW (55.0%)\n**Detected by:** metadata validator\n\n**Context:**\n```\nCompany: Fairbanks Holdings\n```\n\n**Additional Information:**\n- context_impact: 0\n- source: preprocessed_content\n\n**Remediation:**\nReview the detected sensitive data and remove or replace it with appropriate test data or placeholders.",
+      "id": "ferret-<HASH>",
+      "identifiers": [
+        {
+          "name": "Ferret Scan Check Type",
+          "type": "ferret_scan_check_type",
+          "value": "COMPANY_INFO"
+        },
+        {
+          "name": "Ferret Scan Validator",
+          "type": "ferret_scan_validator",
+          "value": "metadata"
+        }
+      ],
+      "location": {
+        "end_line": 1,
+        "file": "sheetnames.xls",
+        "start_line": 1
+      },
+      "message": "Company information detected: [HIDDEN] (confidence: LOW)",
+      "name": "Company Info Detected",
+      "severity": "Medium"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/file_xls_legacy_vector_sheet_names.json.json
+++ b/internal/goldencorpus/testdata/golden/file_xls_legacy_vector_sheet_names.json.json
@@ -1,0 +1,78 @@
+{
+  "results": [
+    {
+      "confidence": 100,
+      "confidence_level": "HIGH",
+      "filename": "<TMPDIR>/sheetnames.xls",
+      "line_number": 3,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0.3333333333333333,
+        "context_doctype": "Configuration",
+        "context_domain": "Financial",
+        "context_impact": 50,
+        "original_confidence": 100,
+        "original_file": "<TMPDIR>/sheetnames.xls",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "validation_checks": {
+          "digits": true,
+          "format": true,
+          "not_common_pattern": true,
+          "not_repeating": true,
+          "not_sequential": true,
+          "not_test_number": true,
+          "valid_area": true
+        },
+        "validation_path": "document"
+      },
+      "text": "449-87-4100",
+      "type": "SSN",
+      "validator": "ssn"
+    },
+    {
+      "confidence": 55.00000000000001,
+      "confidence_level": "LOW",
+      "filename": "<TMPDIR>/sheetnames.xls",
+      "line_number": 1,
+      "metadata": {
+        "confidence_adjustment": 0,
+        "context_confidence": 0.3333333333333333,
+        "context_doctype": "Configuration",
+        "context_domain": "Financial",
+        "context_impact": 0,
+        "full_field": "Company: Fairbanks Holdings",
+        "metadata_type": "COMPANY_INFO",
+        "original_confidence": 55.00000000000001,
+        "original_file": "<TMPDIR>/sheetnames.xls",
+        "preprocessor_adjustment": 0,
+        "preprocessor_name": "Office Metadata Extractor",
+        "preprocessor_type": "office_metadata",
+        "semantic_context": {
+          "FinancialData": 0,
+          "MedicalData": 0,
+          "PersonalData": 0,
+          "Production": 0,
+          "TestData": 0
+        },
+        "source": "preprocessed_content",
+        "source_file": "<TMPDIR>/sheetnames.xls",
+        "source_preprocessor": "office_metadata",
+        "total_adjustment": 0,
+        "validation_checks": {
+          "contains_company_field": true
+        },
+        "validation_path": "metadata"
+      },
+      "text": "Fairbanks Holdings",
+      "type": "COMPANY_INFO",
+      "validator": "metadata"
+    }
+  ]
+}

--- a/internal/goldencorpus/testdata/golden/file_xls_legacy_vector_sheet_names.junit.xml
+++ b/internal/goldencorpus/testdata/golden/file_xls_legacy_vector_sheet_names.junit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="ferret-scan" tests="1" failures="1" errors="0" time="0.000">
+  <testsuite name="security-scan" tests="1" failures="1" errors="0" time="0.000">
+    <testcase name="sheetnames.xls" classname="security-scan" time="0.001">
+      <failure message="2 security findings detected" type="SECURITY_FINDINGS">Line 3: SSN detected with 100.0% confidence (HIGH)&#xA;Match: 449-87-4100&#xA;Validator: ssn&#xA;Line 1: COMPANY_INFO detected with 55.0% confidence (LOW)&#xA;Match: Fairbanks Holdings&#xA;Validator: metadata</failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/internal/goldencorpus/testdata/golden/file_xls_legacy_vector_sheet_names.sarif.json
+++ b/internal/goldencorpus/testdata/golden/file_xls_legacy_vector_sheet_names.sarif.json
@@ -1,0 +1,181 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/refs/heads/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/sheetnames.xls"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "DocumentParts_2: Payroll SSN \nDocumentParts_2: Payroll SSN 449-87-4100"
+                  },
+                  "startLine": 3
+                },
+                "region": {
+                  "endColumn": 41,
+                  "snippet": {
+                    "text": "DocumentParts_2: Payroll SSN 449-87-4100"
+                  },
+                  "startColumn": 30,
+                  "startLine": 3
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Social Security Number Detected in sheetnames.xls at line 3 (confidence: 100.0% - HIGH). Matched text: '449-87-4100'"
+          },
+          "properties": {
+            "confidence": 100,
+            "confidenceLevel": "HIGH",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 0.3,
+              "context_doctype": "Configuration",
+              "context_domain": "Financial",
+              "context_impact": 50,
+              "original_confidence": 100,
+              "original_file": "<TMPDIR>/sheetnames.xls",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "validation_checks": {
+                "digits": true,
+                "format": true,
+                "not_common_pattern": true,
+                "not_repeating": true,
+                "not_sequential": true,
+                "not_test_number": true,
+                "valid_area": true
+              },
+              "validation_path": "document"
+            },
+            "positiveKeywords": [
+              "ssn",
+              "payroll"
+            ],
+            "validator": "ssn"
+          },
+          "rank": 100,
+          "ruleId": "SSN"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://<TMPDIR>/sheetnames.xls"
+                },
+                "region": {
+                  "endColumn": 28,
+                  "snippet": {
+                    "text": "Company: Fairbanks Holdings"
+                  },
+                  "startColumn": 10,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "COMPANY_INFO Detected in sheetnames.xls at line 1 (confidence: 55.0% - LOW). Matched text: 'Fairbanks Holdings'"
+          },
+          "properties": {
+            "confidence": 55,
+            "confidenceLevel": "LOW",
+            "metadata": {
+              "confidence_adjustment": 0,
+              "context_confidence": 0.3,
+              "context_doctype": "Configuration",
+              "context_domain": "Financial",
+              "context_impact": 0,
+              "full_field": "Company: Fairbanks Holdings",
+              "metadata_type": "COMPANY_INFO",
+              "original_confidence": 55,
+              "original_file": "<TMPDIR>/sheetnames.xls",
+              "preprocessor_adjustment": 0,
+              "preprocessor_name": "Office Metadata Extractor",
+              "preprocessor_type": "office_metadata",
+              "semantic_context": {
+                "FinancialData": 0,
+                "MedicalData": 0,
+                "PersonalData": 0,
+                "Production": 0,
+                "TestData": 0
+              },
+              "source": "preprocessed_content",
+              "source_file": "<TMPDIR>/sheetnames.xls",
+              "source_preprocessor": "office_metadata",
+              "total_adjustment": 0,
+              "validation_checks": {
+                "contains_company_field": true
+              },
+              "validation_path": "metadata"
+            },
+            "validator": "metadata"
+          },
+          "rank": 52.5,
+          "ruleId": "COMPANY_INFO"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/awslabs/ferret-scan",
+          "name": "Ferret Scan",
+          "rules": [
+            {
+              "fullDescription": {
+                "text": "Sensitive data of type COMPANY_INFO was detected in the scanned content."
+              },
+              "help": {
+                "text": "Review this finding to determine if the detected data should be present in the code. Consider whether it should be stored in a secure configuration system instead."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/COMPANY_INFO.md",
+              "id": "COMPANY_INFO",
+              "shortDescription": {
+                "text": "COMPANY_INFO Detected"
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "A Social Security Number (SSN) pattern was detected in the scanned content. SSNs are highly sensitive personally identifiable information (PII) that must be protected under various regulations."
+              },
+              "help": {
+                "text": "Social Security Numbers are protected under numerous regulations including GDPR, HIPAA, and various state privacy laws. SSNs should never be stored in source code, configuration files, or logs. Remove this SSN immediately and ensure it is stored in a secure, encrypted system with appropriate access controls. Consider implementing tokenization or other data protection mechanisms."
+              },
+              "helpUri": "https://github.com/awslabs/ferret-scan/blob/main/docs/checks/SSN.md",
+              "id": "SSN",
+              "shortDescription": {
+                "text": "Social Security Number Detected"
+              }
+            }
+          ],
+          "semanticVersion": "0.0.0-development",
+          "version": "0.0.0-development"
+        }
+      },
+      "versionControlProvenance": [
+        {
+          "mappedTo": {
+            "uriBaseId": "%SRCROOT%"
+          },
+          "repositoryUri": "https://github.com/awslabs/ferret-scan",
+          "revisionId": "0.0.0-development"
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/internal/goldencorpus/testdata/golden/file_xls_legacy_vector_sheet_names.txt
+++ b/internal/goldencorpus/testdata/golden/file_xls_legacy_vector_sheet_names.txt
@@ -1,0 +1,4 @@
+LEVEL    VALIDATOR    TYPE                 CONF%    LINE       MATCH              FILE
+--------------------------------------------------------------------------------------------
+[HIGH  ] ssn          SSN                   100.00% line     3 449-87-4100        sheetnames.xls
+[LOW   ] metadata     COMPANY_INFO           55.00% line     1 Fairbanks Holdings sheetnames.xls

--- a/internal/goldencorpus/testdata/golden/file_xls_legacy_vector_sheet_names.yaml
+++ b/internal/goldencorpus/testdata/golden/file_xls_legacy_vector_sheet_names.yaml
@@ -1,0 +1,65 @@
+results:
+    - text: 449-87-4100
+      line_number: 3
+      type: SSN
+      confidence: 100
+      confidence_level: HIGH
+      filename: <TMPDIR>/sheetnames.xls
+      validator: ssn
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0.3333333333333333
+        context_doctype: Configuration
+        context_domain: Financial
+        context_impact: 50
+        original_confidence: 100
+        original_file: <TMPDIR>/sheetnames.xls
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        validation_checks:
+            digits: true
+            format: true
+            not_common_pattern: true
+            not_repeating: true
+            not_sequential: true
+            not_test_number: true
+            valid_area: true
+        validation_path: document
+    - text: Fairbanks Holdings
+      line_number: 1
+      type: COMPANY_INFO
+      confidence: 55.00000000000001
+      confidence_level: LOW
+      filename: <TMPDIR>/sheetnames.xls
+      validator: metadata
+      metadata:
+        confidence_adjustment: 0
+        context_confidence: 0.3333333333333333
+        context_doctype: Configuration
+        context_domain: Financial
+        context_impact: 0
+        full_field: 'Company: Fairbanks Holdings'
+        metadata_type: COMPANY_INFO
+        original_confidence: 55.00000000000001
+        original_file: <TMPDIR>/sheetnames.xls
+        preprocessor_adjustment: 0
+        preprocessor_name: Office Metadata Extractor
+        preprocessor_type: office_metadata
+        semantic_context:
+            FinancialData: 0
+            MedicalData: 0
+            PersonalData: 0
+            Production: 0
+            TestData: 0
+        source: preprocessed_content
+        source_file: <TMPDIR>/sheetnames.xls
+        source_preprocessor: office_metadata
+        total_adjustment: 0
+        validation_checks:
+            contains_company_field: true
+        validation_path: metadata

--- a/internal/olefixture/olefixture.go
+++ b/internal/olefixture/olefixture.go
@@ -637,6 +637,33 @@ func DocSummaryInformation(props map[uint32]string) []byte {
 	return propertySet(fmtidDocSummaryInformation, props, nil)
 }
 
+// DocSummaryInformationWithVectors additionally encodes VECTOR-valued string
+// properties, which is how a real .xls stores its sheet-name list and a real .ppt its
+// slide titles (DocumentParts, property 0x0D).
+//
+// Worth encoding exactly as [MS-OLEPS] specifies, because the whole reason vector
+// properties were unreadable is a type-word disagreement: the property type is ONE
+// 32-bit value with VT_VECTOR (0x1000) OR'd into the same 16-bit type field, so a
+// vector of VT_LPSTR is 0x0000101E — NOT 0x001E with a separate flag word. A fixture
+// that encoded it the other way would make a broken reader look correct.
+func DocSummaryInformationWithVectors(props map[uint32]string, vectors map[uint32][]string) []byte {
+	return propertySetWith(fmtidDocSummaryInformation, props, nil, vectors)
+}
+
+// SummaryInformationWithVectors is the same for the SummaryInformation set, where a
+// Keywords list may be stored as a vector rather than one delimited string.
+func SummaryInformationWithVectors(props map[uint32]string, vectors map[uint32][]string) []byte {
+	return propertySetWith(fmtidSummaryInformation, props, nil, vectors)
+}
+
+// PropDocumentParts is DocumentSummaryInformation 0x0D: the vector of part names —
+// sheet names in a workbook, slide titles in a presentation. msoleps labels it
+// "Document parts".
+const PropDocumentParts = 0x0000000D
+
+// PropHyperlinks is DocumentSummaryInformation 0x15, also vector-valued.
+const PropHyperlinks = 0x00000015
+
 // fmtidUserDefined is {D5CDD502-2E9C-101C-9397-08002B2CF9AE}, the user-defined
 // property set. Note it differs from DocumentSummaryInformation's FMTID in ONE
 // nibble (101C vs 101B), which is easy to mistype into a set no reader recognises.
@@ -735,11 +762,19 @@ const firstCustomPropID = 2
 // order so the bytes are stable across calls: ranging a map directly would vary the
 // output and any golden snapshot built on it would flap.
 func propertySet(fmtid []byte, strs map[uint32]string, times map[uint32]uint64) []byte {
-	ids := make([]uint32, 0, len(strs)+len(times))
+	return propertySetWith(fmtid, strs, times, nil)
+}
+
+// propertySetWith is propertySet plus VT_VECTOR|VT_LPSTR properties.
+func propertySetWith(fmtid []byte, strs map[uint32]string, times map[uint32]uint64, vectors map[uint32][]string) []byte {
+	ids := make([]uint32, 0, len(strs)+len(times)+len(vectors))
 	for id := range strs {
 		ids = append(ids, id)
 	}
 	for id := range times {
+		ids = append(ids, id)
+	}
+	for id := range vectors {
 		ids = append(ids, id)
 	}
 	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
@@ -750,6 +785,33 @@ func propertySet(fmtid []byte, strs map[uint32]string, times map[uint32]uint64) 
 	}
 	vals := make([]encoded, 0, len(ids))
 	for _, id := range ids {
+		if elems, ok := vectors[id]; ok {
+			// VT_VECTOR|VT_LPSTR (0x101E): the 32-bit type word, a 4-byte element
+			// count, then each element as a VT_LPSTR body — 4-byte length INCLUDING
+			// the null terminator, then the bytes padded to a 4-byte boundary.
+			v := make([]byte, 8)
+			binary.LittleEndian.PutUint32(v[0:], 0x0000101E)
+			binary.LittleEndian.PutUint32(v[4:], uint32(len(elems)))
+			for _, e := range elems {
+				// NO padding between elements. A standalone CodePageString property value
+				// is padded to a multiple of 4; the elements inside a vector are packed
+				// end to end. Verified against three real Excel-written files — in
+				// poi_sampless.xls the element lengths run 12, 15, 7 and the next
+				// property's type word follows the last byte immediately.
+				//
+				// A first version of this encoder padded each element, and so did the
+				// first version of the decoder that reads them. The two agreed, so every
+				// test passed while a real file decoded 2 of 3 sheet names. An encoder
+				// that matches a buggy reader is worse than no fixture at all.
+				body := append([]byte(e), 0)
+				n := make([]byte, 4)
+				binary.LittleEndian.PutUint32(n, uint32(len(body)))
+				v = append(v, n...)
+				v = append(v, body...)
+			}
+			vals = append(vals, encoded{id: id, val: v})
+			continue
+		}
 		if ft, ok := times[id]; ok {
 			// VT_FILETIME (0x0040): 2-byte type, 2 bytes padding, 8-byte FILETIME.
 			v := make([]byte, 12)

--- a/internal/preprocessors/meta-extractors/meta-extract-officelib/README.md
+++ b/internal/preprocessors/meta-extractors/meta-extract-officelib/README.md
@@ -4,13 +4,15 @@ This library extracts metadata from various office document formats using Go's s
 
 ## Features
 
-- Extracts metadata from Microsoft Office and OpenDocument formats
-- Provides document properties (title, author, subject, etc.)
+- Extracts metadata from Microsoft Office, legacy Office and OpenDocument formats
+- Provides document properties (title, author, subject, etc.), including custom
+  (user-defined) properties and **multi-valued** ones such as a workbook's sheet-name list
 - Extracts creation and modification dates
 - Retrieves document statistics (page count, word count, etc.)
-- No external dependencies - uses only Go standard libraries
 
 ## Supported File Types
+
+OOXML and OpenDocument (ZIP containers):
 
 - Microsoft Word (.docx)
 - Microsoft Excel (.xlsx)
@@ -18,6 +20,26 @@ This library extracts metadata from various office document formats using Go's s
 - OpenDocument Text (.odt)
 - OpenDocument Spreadsheet (.ods)
 - OpenDocument Presentation (.odp)
+
+Legacy Office (OLE compound files, added in #265):
+
+- Microsoft Word 97-2003 (.doc)
+- Microsoft Excel 97-2003 (.xls)
+- Microsoft PowerPoint 97-2003 (.ppt)
+
+## Dependencies
+
+An earlier version of this file said "no external dependencies — uses only Go standard
+libraries". That has not been true since legacy support landed: the OLE container is read
+with `mscfb` and its property sets with `msoleps`.
+
+`msoleps` cannot read a VECTOR-valued property. A property's type in [MS-OLEPS] is one
+32-bit value with `VT_VECTOR` (0x1000) OR'd into the same 16-bit type field, and the
+library looks for that flag in the other half of the word — so a real vector resolves to
+no known type and comes back as the scalar `I1(0)`, whose string form is `"0"`. Those
+properties are therefore decoded from the stream here; see `legacy-ole-vectors.go`, which
+records the measurement and the element layout (vector elements are packed end to end,
+NOT padded to 4 bytes like a standalone property value).
 
 ## Usage
 

--- a/internal/preprocessors/meta-extractors/meta-extract-officelib/legacy-ole-extractor.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-officelib/legacy-ole-extractor.go
@@ -157,8 +157,26 @@ func applyLegacyProperties(streamBytes []byte, metadata *Metadata) {
 	if err != nil {
 		return
 	}
-	for _, p := range r.Property {
+
+	// Vector-valued properties are decoded from the stream, because msoleps cannot
+	// read one: it looks for the vector flag in the wrong half of the type word, so a
+	// real vector arrives here as the scalar I1(0) and p.String() returns "0". See
+	// legacy-ole-vectors.go for the measurement. Keyed by index into r.Property,
+	// which msoleps builds in property-table order.
+	vectors := legacyVectorStrings(streamBytes)
+
+	for i, p := range r.Property {
 		v := strings.TrimSpace(p.String())
+		if vec, ok := vectors[i]; ok {
+			// A multi-valued property collected as a custom property gets ONE entry
+			// per element, so no validator can match across two unrelated elements —
+			// two adjacent sheet names joined on one line would invite exactly that.
+			// A mapped scalar field has nowhere to put a list, so those are joined.
+			if handleVectorProperty(metadata, p.Name, vec) {
+				continue
+			}
+			v = strings.Join(vec.Elements, "; ")
+		}
 		if v == "" {
 			continue
 		}
@@ -250,7 +268,19 @@ var legacyStructuralProperties = map[string]bool{
 	"Hyperlinks changed": true, "Digital Signature": true, "Thumbnail": true,
 	"DocSecurity": true, "EditTime": true, "LastPrinted": true,
 	"Version": true, "Document Version": true, "Presentation Format": true,
-	"Heading pair": true, "Document parts": true,
+	// "Heading pair" stays: it is a VT_VECTOR|VT_VARIANT of (name, count) pairs, so
+	// its text is the words "Worksheets"/"Slide Titles" and its numbers are counts.
+	"Heading pair": true,
+	// "Document parts" (DocumentSummaryInformation 0x0D) is NOT structural and is no
+	// longer excluded. It is the vector of part names: every SHEET NAME in a workbook,
+	// every SLIDE TITLE in a deck. That is document content an author wrote, and it
+	// routinely carries a customer name, a project codename or an account number.
+	//
+	// It was excluded when the value reaching this code was the literal "0" — msoleps
+	// mis-decodes a vector (see legacy-ole-vectors.go), so the property looked like
+	// structural noise. Now that the elements are decoded, excluding it would drop
+	// real content: measured on an .xls whose sheet names include an SSN, the value
+	// was reported by nothing at all.
 }
 
 // isCollectableCustomProperty reports whether an unmapped property name should be

--- a/internal/preprocessors/meta-extractors/meta-extract-officelib/legacy-ole-vectors.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-officelib/legacy-ole-vectors.go
@@ -1,0 +1,378 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package metaextractofficelib
+
+import (
+	"encoding/binary"
+	"unicode/utf16"
+)
+
+// Vector-valued property support for legacy OLE property sets.
+//
+// # Why this exists at all — msoleps cannot read a real vector
+//
+// A property's type in [MS-OLEPS] is ONE 32-bit value with VT_VECTOR (0x1000) OR'd
+// into the same 16-bit type field, so a vector of VT_LPSTR is 0x0000101E. msoleps
+// instead reads the TypeID from bytes 0-2 and looks for the vector discriminator in
+// bytes 2-4 (types.Evaluate). For a real file that means the id lookup is 0x101E,
+// which is in no table, so Evaluate returns I1(0) with ErrUnknownType — and the
+// caller discards the error ("ignore errors for now as not all types implemented").
+//
+// Measured with a probe over msoleps v1.0.6, three encodings of the same property:
+//
+//	type word 0x101E  (what real writers emit)   -> Int8,               String() == "0"
+//	0x001E + flag in the high word (msoleps)     -> Vector of CodeString, String() == ""
+//	scalar VT_LPSTR (control)                    -> CodeString,         String() == the value
+//
+// So a vector property reaches our code as the literal "0". #267 assumed the value
+// arrives as "" and can be recovered by type-switching on types.Vector; neither is
+// true for a real document, and a type switch never fires because msoleps has already
+// collapsed the property to a scalar. The values have to be decoded from the stream.
+//
+// # What is decoded, and what is not
+//
+// String vectors only: VT_LPSTR, VT_LPWSTR and VT_BSTR. Those are the leak channel —
+// an .xls sheet-name list, a .ppt slide-title list, a Keywords or Hyperlinks list.
+// Vectors of numerics, FILETIMEs and VT_VARIANT (Heading pair) carry counts and
+// pairing information, not document content, so decoding them would add noise to
+// every report for no detection value — the same reasoning that keeps page and word
+// counts out of the mapped fields.
+//
+// # Bounds
+//
+// Every field is read against the buffer's real length, and the element count is
+// bounded by the bytes actually remaining before it is used to size anything. A
+// declared count may only be trusted after it has been checked against a real one
+// (#350). Both the element count and the total text per property are capped, and the
+// cap states that it truncated rather than silently dropping the tail.
+
+const (
+	// vtVector is the flag OR'd into a property's type field for a vector.
+	vtVector = 0x1000
+	// The string type IDs whose vectors carry document content.
+	vtBSTR   = 0x0008
+	vtLPSTR  = 0x001E
+	vtLPWSTR = 0x001F
+
+	// maxVectorElements bounds how many elements of one vector are decoded.
+	//
+	// A workbook with more than this many sheets, or a deck with more than this many
+	// slides, exists but is vanishingly rare; a property claiming more is far more
+	// likely to be a crafted count. The tail is not dropped silently — the caller is
+	// told how many were left, so a truncation cannot be mistaken for a short list.
+	maxVectorElements = 512
+
+	// maxVectorTextBytes bounds the total text decoded from one vector property, so a
+	// container cannot turn a few KB of stream into an unbounded metadata field.
+	maxVectorTextBytes = 64 * 1024
+)
+
+// vectorProperty is one decoded vector-valued property.
+type vectorProperty struct {
+	// Elements are the decoded strings, in stream order.
+	Elements []string
+	// Truncated is how many elements were NOT decoded because a cap fired. Zero for
+	// every ordinary document.
+	Truncated int
+}
+
+// legacyVectorStrings decodes the string-valued vector properties of a property-set
+// stream, keyed by the property's INDEX in msoleps's Property slice.
+//
+// Keyed by index rather than by property ID because msoleps.Property carries no ID —
+// only a Name and a value. It does, however, build that slice in property-table
+// order, set A then set B (msoleps.go), which is exactly the order this walk
+// produces. Pairing by index therefore needs no duplicate of msoleps's own name
+// tables, and a property whose name only its dictionary knows still gets its name
+// from msoleps rather than from a second copy of the vocabulary here.
+func legacyVectorStrings(stream []byte) map[int]vectorProperty {
+	const (
+		headerBytes  = 28 // byte order, version, system id, CLSID, set count
+		setEntryLen  = 20 // FMTID + offset
+		tableHeader  = 8  // set byte count + property count
+		tableEntry   = 8  // property id + offset
+		typeWordLen  = 4
+		countLen     = 4
+		lengthPrefix = 4
+	)
+
+	if len(stream) < headerBytes {
+		return nil
+	}
+	setCount := int(binary.LittleEndian.Uint32(stream[24:28]))
+	// A property-set stream holds one or two sets; msoleps reads at most two, so
+	// walking more would put this index out of step with its Property slice.
+	if setCount < 1 {
+		return nil
+	}
+	if setCount > 2 {
+		setCount = 2
+	}
+
+	out := make(map[int]vectorProperty)
+	index := 0
+
+	for set := 0; set < setCount; set++ {
+		entry := headerBytes + set*setEntryLen
+		if entry+setEntryLen > len(stream) {
+			return out
+		}
+		setStart := int(binary.LittleEndian.Uint32(stream[entry+16 : entry+20]))
+		if setStart < 0 || setStart+tableHeader > len(stream) {
+			return out
+		}
+		propCount := int(binary.LittleEndian.Uint32(stream[setStart+4 : setStart+8]))
+		// Bound the count by the bytes that could actually hold that many entries,
+		// before it is used for anything.
+		if propCount < 0 || setStart+tableHeader+propCount*tableEntry > len(stream) {
+			return out
+		}
+
+		for i := 0; i < propCount; i++ {
+			at := setStart + tableHeader + i*tableEntry
+			id := binary.LittleEndian.Uint32(stream[at : at+4])
+			off := int(binary.LittleEndian.Uint32(stream[at+4 : at+8]))
+			// msoleps creates a Property for EVERY table entry, including the
+			// dictionary at id 0, which it fills with a Null rather than evaluating.
+			// So the index advances for those too or the pairing slips by one.
+			propIndex := index
+			index++
+			if id == 0 {
+				continue
+			}
+
+			start := setStart + off
+			if start < 0 || start+typeWordLen+countLen > len(stream) {
+				continue
+			}
+			typeWord := binary.LittleEndian.Uint32(stream[start : start+typeWordLen])
+			if typeWord&vtVector == 0 {
+				continue // a scalar: msoleps reads these correctly
+			}
+			base := typeWord & 0x0FFF
+			if base != vtLPSTR && base != vtLPWSTR && base != vtBSTR {
+				continue // a vector of non-text: counts and pairs, not content
+			}
+
+			elems, truncated := decodeStringVector(stream, start+typeWordLen, base)
+			if len(elems) == 0 {
+				continue
+			}
+			out[propIndex] = vectorProperty{Elements: elems, Truncated: truncated}
+		}
+	}
+	return out
+}
+
+// decodeStringVector reads an element count at `at`, then that many length-prefixed
+// strings of the given base type.
+//
+// Returns the decoded elements and how many were skipped because a cap fired.
+func decodeStringVector(stream []byte, at int, base uint32) ([]string, int) {
+	const lengthPrefix = 4
+
+	if at+4 > len(stream) {
+		return nil, 0
+	}
+	declared := int(binary.LittleEndian.Uint32(stream[at : at+4]))
+	pos := at + 4
+
+	// The smallest possible element is a 4-byte length prefix, so a count larger than
+	// the remaining quarter-bytes cannot be real. Checked BEFORE the count is used to
+	// size a loop or a slice.
+	if declared < 0 || declared > (len(stream)-pos)/lengthPrefix {
+		return nil, 0
+	}
+
+	limit := declared
+	truncated := 0
+	if limit > maxVectorElements {
+		truncated = limit - maxVectorElements
+		limit = maxVectorElements
+	}
+
+	elems := make([]string, 0, limit)
+	textBytes := 0
+	for i := 0; i < limit; i++ {
+		if pos+lengthPrefix > len(stream) {
+			truncated += limit - i
+			break
+		}
+		n := int(binary.LittleEndian.Uint32(stream[pos : pos+lengthPrefix]))
+		pos += lengthPrefix
+		if n < 0 {
+			break
+		}
+
+		// LPWSTR counts UTF-16 code units; the others count bytes. Either way the
+		// stored run is padded to a 4-byte boundary.
+		width := 1
+		if base == vtLPWSTR {
+			width = 2
+		}
+		raw := n * width
+		if raw < 0 || pos+raw > len(stream) {
+			truncated += limit - i
+			break
+		}
+		body := stream[pos : pos+raw]
+		pos += raw
+		// NO padding between elements, and this is the detail that decides whether the
+		// walk stays in sync. A standalone CodePageString property value is padded to a
+		// multiple of 4; the elements INSIDE a vector are packed end to end. Measured on
+		// three real Excel-written files — here is poi_sampless.xls verbatim:
+		//
+		//	1e100000                       type 0x101E (VT_VECTOR|VT_LPSTR)
+		//	03000000                       count = 3
+		//	0c000000 "First Sheet\0"       len 12
+		//	0f000000 "Sheet Number 2\0"    len 15   <- not a multiple of 4
+		//	07000000 "Sheet3\0"            len 7
+		//	0c100000 ...                   the NEXT property's type word, immediately
+		//
+		// A first version padded each element and therefore desynced after any element
+		// whose length was not a multiple of 4: on that file it decoded 2 of 3 and
+		// reported the third as capped, and on a 3-sheet workbook whose first name was
+		// "Sheet1" (7 bytes with its terminator) it decoded 1 of 3. Every hand-built
+		// fixture used lengths that happened to be multiples of 4, so all of them passed.
+
+		var s string
+		if base == vtLPWSTR {
+			s = decodeUTF16LE(body)
+		} else {
+			s = string(body)
+		}
+		// LPSTR and LPWSTR lengths INCLUDE the terminator; BSTR does not. Trimming
+		// trailing NULs covers all three without depending on which is which, and a
+		// NUL inside a metadata string is not text a validator can use anyway.
+		s = trimTrailingNULs(s)
+		if s == "" {
+			continue
+		}
+
+		if textBytes+len(s) > maxVectorTextBytes {
+			truncated += limit - i
+			break
+		}
+		textBytes += len(s)
+		elems = append(elems, s)
+	}
+	return elems, truncated
+}
+
+// decodeUTF16LE converts little-endian UTF-16 bytes to a string, ignoring a trailing
+// odd byte rather than reading past the run.
+func decodeUTF16LE(b []byte) string {
+	units := make([]uint16, 0, len(b)/2)
+	for i := 0; i+1 < len(b); i += 2 {
+		units = append(units, binary.LittleEndian.Uint16(b[i:i+2]))
+	}
+	return string(utf16.Decode(units))
+}
+
+// trimTrailingNULs removes the terminator (and any padding NULs) from a decoded run.
+func trimTrailingNULs(s string) string {
+	for len(s) > 0 && s[len(s)-1] == 0 {
+		s = s[:len(s)-1]
+	}
+	return s
+}
+
+// handleVectorProperty records a multi-valued property, and reports whether it did.
+//
+// Returns false for a property whose name maps to a single scalar field (Keywords and
+// the like): the caller joins those, because a scalar field has nowhere to put a list.
+// Returns true once the elements have been recorded.
+//
+// # One entry per element, and NOT as a custom property
+//
+// Each element is recorded under its own key, because a joined line invites a match
+// ACROSS two unrelated values: two adjacent sheet names read as one string to every
+// validator, so "Q3 Forecast" followed by an account number would let a name-plus-number
+// rule fire on a pair the document never put together.
+//
+// They go into Properties rather than CustomProps, and that is a precision decision with
+// a measurement behind it. The metadata validator types any field whose name begins
+// "Custom_" as CUSTOM_PROPERTY and reports it, by design — a custom property is an
+// author-named leak channel. A sheet-name list is not that: measured on an ordinary
+// 12-sheet workbook, routing it through CustomProps took the file from 1 finding to 13,
+// twelve of them CUSTOM_PROPERTY at MEDIUM on values like "Sheet1", "Q4" and "Chart1",
+// all visible at the default confidence. A finding per sheet in every legacy workbook is
+// exactly what trains an operator to stop reading findings.
+//
+// Properties still reach the validators as text, so an SSN or a customer name inside a
+// sheet name is detected and redacted — which is the whole point of #267 — without the
+// list itself being asserted as a finding.
+func handleVectorProperty(metadata *Metadata, name string, vec vectorProperty) bool {
+	switch name {
+	case "Title", "Subject", "Author", "Keywords", "Comments", "LastAuthor",
+		"AppName", "Template", "Company", "Manager", "Category",
+		"Content status", "Language", "RevNumber", "Link base":
+		// A mapped scalar field. Let the caller join and take its normal path, so a
+		// vector-valued Keywords still lands in Metadata.Keywords rather than
+		// somewhere the report renders differently.
+		return false
+	}
+	if !isCollectableCustomProperty(name) {
+		// A structural vector (Heading pair) is dropped exactly as its scalar
+		// equivalents are — but return true so the caller does not then join and
+		// record it through the mapped-field path.
+		return true
+	}
+
+	if metadata.Properties == nil {
+		metadata.Properties = make(map[string]string)
+	}
+	key := propertyKeyBase(name)
+	for i, e := range vec.Elements {
+		metadata.Properties[key+"_"+itoa(i+1)] = e
+	}
+	if vec.Truncated > 0 {
+		// Say so rather than truncate silently. A reader who cannot tell a short list
+		// from a truncated one cannot tell whether the scan covered the document.
+		metadata.Properties[key+"_truncated"] = itoa(vec.Truncated) +
+			" further value(s) not decoded: vector element cap"
+	}
+	return true
+}
+
+// propertyKeyBase turns a reader-facing property name into a single-token key, so the
+// rendered line reads as one field rather than as a sentence: "Document parts" becomes
+// "DocumentParts", which is also what the OOXML vocabulary calls the same list.
+//
+// Each word keeps a capital, because the field name reaches the validators as text and
+// the metadata validator reads field names: "Documentparts" is a word no vocabulary
+// contains, while "DocumentParts" matches how every other key here is spelled.
+func propertyKeyBase(name string) string {
+	out := make([]byte, 0, len(name))
+	upperNext := false
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		if c == ' ' {
+			upperNext = true
+			continue
+		}
+		if upperNext && c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		upperNext = false
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+// itoa avoids importing strconv into this file for two calls; the values are small
+// counts, never negative.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(b[i:])
+}

--- a/internal/preprocessors/meta-extractors/meta-extract-officelib/legacy_ole_vectors_test.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-officelib/legacy_ole_vectors_test.go
@@ -1,0 +1,493 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package metaextractofficelib
+
+import (
+	"bytes"
+	"encoding/binary"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/olefixture"
+)
+
+// Vector-valued properties are where a legacy workbook keeps its SHEET NAMES and a legacy
+// deck its SLIDE TITLES, and none of it was reaching any validator. See #267 and the
+// package comment in legacy-ole-vectors.go for why msoleps cannot read one.
+//
+// Measured on 19 real .xls/.doc/.ppt files from the Apache POI corpus: 14 of them carry a
+// property whose type word is 0x101E, so this is what real Office writes, not an exotic
+// shape. Those files decode 40 elements between them — sheet names, slide titles, theme
+// and font names.
+
+// vectorStream builds a property-set stream by hand, so a test can control the exact type
+// word and element layout. The type word is the whole subject: an encoder that "helpfully"
+// wrote it the way msoleps expects would make a broken reader look correct.
+func vectorStream(t *testing.T, id uint32, typeWord uint32, payload []byte, extraScalars map[uint32]string) []byte {
+	return vectorStreamWithDict(t, id, typeWord, payload, extraScalars, false)
+}
+
+// vectorStreamWithDict optionally includes a DICTIONARY entry at property id 0, which is what
+// a user-defined property set carries. msoleps creates a Property for that entry too — filled
+// with a Null rather than evaluated — so it occupies an index in the slice this decoder pairs
+// against. Getting that wrong shifts every value onto the neighbouring property.
+func vectorStreamWithDict(t *testing.T, id uint32, typeWord uint32, payload []byte, extraScalars map[uint32]string, dict bool) []byte {
+	t.Helper()
+
+	type entry struct {
+		id  uint32
+		val []byte
+	}
+	vec := make([]byte, 4)
+	binary.LittleEndian.PutUint32(vec, typeWord)
+	vec = append(vec, payload...)
+
+	entries := []entry{{id: id, val: vec}}
+	if dict {
+		// A minimal dictionary blob: one entry naming a property.
+		d := make([]byte, 4)
+		binary.LittleEndian.PutUint32(d, 1)
+		idBytes := make([]byte, 4)
+		binary.LittleEndian.PutUint32(idBytes, 2)
+		nameBytes := append([]byte("CustomThing"), 0)
+		for len(nameBytes)%4 != 0 {
+			nameBytes = append(nameBytes, 0)
+		}
+		nlen := make([]byte, 4)
+		binary.LittleEndian.PutUint32(nlen, uint32(len("CustomThing")+1))
+		d = append(d, idBytes...)
+		d = append(d, nlen...)
+		d = append(d, nameBytes...)
+		entries = append(entries, entry{id: 0, val: d})
+	}
+	for sid, s := range extraScalars {
+		body := append([]byte(s), 0)
+		for len(body)%4 != 0 {
+			body = append(body, 0)
+		}
+		v := make([]byte, 8+len(body))
+		binary.LittleEndian.PutUint16(v[0:], 0x001E)
+		binary.LittleEndian.PutUint32(v[4:], uint32(len(s)+1))
+		copy(v[8:], body)
+		entries = append(entries, entry{id: sid, val: v})
+	}
+	// Ascending id, as a property table is written.
+	for i := 1; i < len(entries); i++ {
+		for j := i; j > 0 && entries[j].id < entries[j-1].id; j-- {
+			entries[j], entries[j-1] = entries[j-1], entries[j]
+		}
+	}
+
+	table := 8 + len(entries)*8
+	offs := make([]uint32, len(entries))
+	cur := uint32(table)
+	for i, e := range entries {
+		offs[i] = cur
+		cur += uint32(len(e.val))
+	}
+
+	set := new(bytes.Buffer)
+	_ = binary.Write(set, binary.LittleEndian, cur)
+	_ = binary.Write(set, binary.LittleEndian, uint32(len(entries)))
+	for i, e := range entries {
+		_ = binary.Write(set, binary.LittleEndian, e.id)
+		_ = binary.Write(set, binary.LittleEndian, offs[i])
+	}
+	for _, e := range entries {
+		set.Write(e.val)
+	}
+
+	hdr := make([]byte, 48)
+	binary.LittleEndian.PutUint16(hdr[0:], 0xFFFE)
+	binary.LittleEndian.PutUint32(hdr[4:], 0x00020006)
+	binary.LittleEndian.PutUint32(hdr[24:], 1)
+	// DocumentSummaryInformation FMTID, so msoleps names the properties from its own table.
+	copy(hdr[28:44], []byte{
+		0x02, 0xD5, 0xCD, 0xD5, 0x9C, 0x2E, 0x1B, 0x10,
+		0x93, 0x97, 0x08, 0x00, 0x2B, 0x2C, 0xF9, 0xAE,
+	})
+	binary.LittleEndian.PutUint32(hdr[44:], 48)
+	return append(hdr, set.Bytes()...)
+}
+
+// lpstrElements packs count + (length, bytes) elements with NO padding between them, which
+// is how a real file stores them. See TestVectorElementsAreNotPadded.
+func lpstrElements(vals []string) []byte {
+	out := make([]byte, 4)
+	binary.LittleEndian.PutUint32(out, uint32(len(vals)))
+	for _, v := range vals {
+		body := append([]byte(v), 0)
+		n := make([]byte, 4)
+		binary.LittleEndian.PutUint32(n, uint32(len(body)))
+		out = append(out, n...)
+		out = append(out, body...)
+	}
+	return out
+}
+
+func lpwstrElements(vals []string) []byte {
+	out := make([]byte, 4)
+	binary.LittleEndian.PutUint32(out, uint32(len(vals)))
+	for _, v := range vals {
+		units := append([]rune(v), 0)
+		n := make([]byte, 4)
+		binary.LittleEndian.PutUint32(n, uint32(len(units)))
+		out = append(out, n...)
+		for _, r := range units {
+			b := make([]byte, 2)
+			binary.LittleEndian.PutUint16(b, uint16(r))
+			out = append(out, b...)
+		}
+	}
+	return out
+}
+
+// TestVectorElementsAreNotPadded is the bug REAL files found and no hand-built fixture did.
+//
+// A standalone CodePageString property value is padded to a multiple of 4; the elements
+// inside a vector are packed end to end. Padding each element desyncs the walk after the
+// first element whose length is not a multiple of 4 — measured on poi_sampless.xls, which
+// decoded 2 of 3 sheet names, and on a workbook whose first sheet is "Sheet1" (7 bytes with
+// its terminator), which decoded 1 of 3. Every fixture written before that used lengths
+// that happened to be multiples of 4, so all of them passed.
+//
+// The lengths here are 12, 15 and 7 — the exact ones from that real file.
+func TestVectorElementsAreNotPadded(t *testing.T) {
+	want := []string{"First Sheet", "Sheet Number 2", "Sheet3"}
+	for i, w := range want {
+		if got := len(w) + 1; got != []int{12, 15, 7}[i] {
+			t.Fatalf("fixture drift: %q is %d bytes with its terminator, want %d — this test is "+
+				"only meaningful if at least one length is NOT a multiple of 4", w, got, []int{12, 15, 7}[i])
+		}
+	}
+
+	stream := vectorStream(t, olefixture.PropDocumentParts, 0x0000101E, lpstrElements(want), nil)
+	got := legacyVectorStrings(stream)
+	if len(got) != 1 {
+		t.Fatalf("decoded %d vector properties, want 1: %+v", len(got), got)
+	}
+	for _, v := range got {
+		if len(v.Elements) != len(want) {
+			t.Fatalf("decoded %d elements, want %d: %q (truncated=%d)",
+				len(v.Elements), len(want), v.Elements, v.Truncated)
+		}
+		for i := range want {
+			if v.Elements[i] != want[i] {
+				t.Errorf("element %d = %q, want %q", i, v.Elements[i], want[i])
+			}
+		}
+		if v.Truncated != 0 {
+			t.Errorf("Truncated = %d on a complete 3-element vector; a spurious truncation note "+
+				"tells an operator the scan was cut short when it was not", v.Truncated)
+		}
+	}
+}
+
+// TestEveryStringVectorTypeDecodes covers the three base types that carry text.
+func TestEveryStringVectorTypeDecodes(t *testing.T) {
+	cases := []struct {
+		name     string
+		typeWord uint32
+		payload  []byte
+		want     []string
+	}{
+		{"VT_LPSTR", 0x0000101E, lpstrElements([]string{"Payroll", "Q3 Forecast"}), []string{"Payroll", "Q3 Forecast"}},
+		{"VT_LPWSTR", 0x0000101F, lpwstrElements([]string{"Zusammenfassung", "Données"}), []string{"Zusammenfassung", "Données"}},
+		{"VT_BSTR", 0x00001008, lpstrElements([]string{"Summary", "Detail"}), []string{"Summary", "Detail"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := legacyVectorStrings(vectorStream(t, olefixture.PropDocumentParts, c.typeWord, c.payload, nil))
+			if len(got) != 1 {
+				t.Fatalf("decoded %d properties, want 1", len(got))
+			}
+			for _, v := range got {
+				if strings.Join(v.Elements, "|") != strings.Join(c.want, "|") {
+					t.Errorf("elements = %q, want %q", v.Elements, c.want)
+				}
+			}
+		})
+	}
+}
+
+// TestANonTextVectorIsIgnored is the precision floor for the type filter. A vector of
+// counts or of VT_VARIANT pairs (Heading pair) is structure, not content; decoding it would
+// put "Worksheets 3" in every workbook's report for no detection value.
+func TestANonTextVectorIsIgnored(t *testing.T) {
+	// VT_VECTOR|VT_I4: a count vector.
+	payload := make([]byte, 4)
+	binary.LittleEndian.PutUint32(payload, 2)
+	payload = append(payload, 1, 0, 0, 0, 2, 0, 0, 0)
+
+	if got := legacyVectorStrings(vectorStream(t, olefixture.PropDocumentParts, 0x00001003, payload, nil)); len(got) != 0 {
+		t.Errorf("a VT_I4 vector was decoded as text: %+v", got)
+	}
+}
+
+// TestVectorPairsWithTheRightProperty is the subtle one: the decoded values are keyed by
+// INDEX into msoleps's Property slice, so anything that shifts that slice — most obviously
+// the dictionary entry at id 0, which msoleps keeps as a Null rather than skipping — puts
+// every value on the wrong property.
+//
+// A wrong pairing is worse than no fix at all: a sheet-name list would be reported as a
+// company name, or a company name silently replaced by a list.
+func TestVectorPairsWithTheRightProperty(t *testing.T) {
+	path := writeLegacyFixture(t, "pairing.xls", []legacyCFBStream{
+		{Name: "Workbook", Data: []byte("Body text long enough to be recovered.")},
+		{Name: "\x05DocumentSummaryInformation", Data: olefixture.DocSummaryInformationWithVectors(
+			// Scalars on BOTH sides of the vector's id, so an off-by-one in either
+			// direction lands on a mapped field and is visible.
+			map[uint32]string{
+				olefixture.PropCategory: "Quarterly",          // id 0x02
+				olefixture.PropManager:  "Dana Whitfield",     // id 0x0E
+				olefixture.PropCompany:  "Fairbanks Holdings", // id 0x0F
+			},
+			map[uint32][]string{
+				olefixture.PropDocumentParts: {"Sheet1", "Payroll SSN 452-11-9384"}, // id 0x0D
+			},
+		)},
+	})
+
+	md, err := ExtractMetadata(path)
+	if err != nil {
+		t.Fatalf("ExtractMetadata: %v", err)
+	}
+	if md.Category != "Quarterly" {
+		t.Errorf("Category = %q, want %q — a scalar before the vector was corrupted", md.Category, "Quarterly")
+	}
+	if md.Manager != "Dana Whitfield" {
+		t.Errorf("Manager = %q, want %q — a scalar after the vector was corrupted", md.Manager, "Dana Whitfield")
+	}
+	if md.Company != "Fairbanks Holdings" {
+		t.Errorf("Company = %q, want %q", md.Company, "Fairbanks Holdings")
+	}
+	if got := md.Properties["DocumentParts_2"]; got != "Payroll SSN 452-11-9384" {
+		t.Errorf("DocumentParts_2 = %q, want the second sheet name; the vector paired with the "+
+			"wrong property or was not decoded at all.\nProperties: %#v", got, md.Properties)
+	}
+}
+
+// TestVectorPairsPastADictionaryEntry is the other half of the pairing, and it is the one a
+// fixture without a dictionary cannot see.
+//
+// A user-defined property set carries its DICTIONARY at property id 0. msoleps still creates a
+// Property for it — a Null, not a skip — so the index this decoder pairs against advances for
+// it. A decoder that skipped id 0 without advancing would hand every value to the property
+// before it: the sheet-name list would be reported as whatever the next property is, and that
+// property's real value would be replaced. Measured as a surviving mutation before this test
+// existed.
+func TestVectorPairsPastADictionaryEntry(t *testing.T) {
+	want := []string{"First Sheet", "Payroll SSN 452-11-9384"}
+	stream := vectorStreamWithDict(t, olefixture.PropDocumentParts, 0x0000101E,
+		lpstrElements(want), map[uint32]string{olefixture.PropCompany: "Fairbanks Holdings"}, true)
+
+	md := &Metadata{}
+	applyLegacyProperties(stream, md)
+
+	if md.Company != "Fairbanks Holdings" {
+		t.Errorf("Company = %q, want %q — the value landed on the wrong property, which means "+
+			"the dictionary entry shifted the pairing", md.Company, "Fairbanks Holdings")
+	}
+	if got := md.Properties["DocumentParts_2"]; got != want[1] {
+		t.Errorf("DocumentParts_2 = %q, want %q.\nProperties: %#v", got, want[1], md.Properties)
+	}
+}
+
+// TestSheetNamesDoNotBecomeCustomProperties is the PRECISION floor, and it exists because
+// the obvious implementation fails it.
+//
+// The metadata validator types any field named "Custom_*" as CUSTOM_PROPERTY and reports
+// it — by design, since a custom property is an author-named leak channel. A sheet-name
+// list is not that. Measured with the elements routed through CustomProps: an ordinary
+// 12-sheet workbook went from 1 finding to 13, twelve of them CUSTOM_PROPERTY at MEDIUM on
+// values like "Sheet1", "Q4" and "Chart1", all at the default confidence. A finding per
+// sheet in every legacy workbook is what teaches an operator to stop reading findings.
+func TestSheetNamesDoNotBecomeCustomProperties(t *testing.T) {
+	path := writeLegacyFixture(t, "ordinary.xls", []legacyCFBStream{
+		{Name: "Workbook", Data: []byte("Body text long enough to be recovered.")},
+		{Name: "\x05DocumentSummaryInformation", Data: olefixture.DocSummaryInformationWithVectors(
+			map[uint32]string{olefixture.PropCompany: "Contoso Ltd"},
+			map[uint32][]string{olefixture.PropDocumentParts: {
+				"Sheet1", "Sheet2", "Sheet3", "Summary", "Data", "Pivot",
+			}},
+		)},
+	})
+
+	md, err := ExtractMetadata(path)
+	if err != nil {
+		t.Fatalf("ExtractMetadata: %v", err)
+	}
+	for name := range md.CustomProps {
+		if strings.Contains(strings.ToLower(name), "document") || strings.Contains(name, "Sheet") {
+			t.Errorf("CustomProps[%q] exists; a part-name list routed through custom properties "+
+				"makes the metadata validator report one CUSTOM_PROPERTY finding per sheet",
+				name)
+		}
+	}
+	// ...and it must still be SCANNABLE, or the fix removes the leak by hiding the values.
+	if md.Properties["DocumentParts_1"] != "Sheet1" {
+		t.Errorf("DocumentParts_1 = %q, want %q: the values still have to reach the validators "+
+			"as text", md.Properties["DocumentParts_1"], "Sheet1")
+	}
+}
+
+// TestVectorValuedKeywordsLandInTheMappedField covers the other arm: a property that maps
+// to a single scalar field has nowhere to put a list, so those are joined.
+func TestVectorValuedKeywordsLandInTheMappedField(t *testing.T) {
+	const propKeywords = 0x00000005
+	path := writeLegacyFixture(t, "keywords.doc", []legacyCFBStream{
+		{Name: "WordDocument", Data: []byte("Body text long enough to be recovered.")},
+		{Name: "\x05SummaryInformation", Data: olefixture.SummaryInformationWithVectors(
+			map[uint32]string{olefixture.PropAuthor: "Dana Whitfield"},
+			map[uint32][]string{propKeywords: {"confidential", "acme-project", "SSN 452-11-9384"}},
+		)},
+	})
+
+	md, err := ExtractMetadata(path)
+	if err != nil {
+		t.Fatalf("ExtractMetadata: %v", err)
+	}
+	for _, want := range []string{"confidential", "acme-project", "452-11-9384"} {
+		if !strings.Contains(md.Keywords, want) {
+			t.Errorf("Keywords = %q, want it to contain %q", md.Keywords, want)
+		}
+	}
+	if md.Author != "Dana Whitfield" {
+		t.Errorf("Author = %q; the scalar sibling was corrupted", md.Author)
+	}
+}
+
+// TestHostileVectorInputIsBounded covers the shapes a crafted container takes. None may
+// panic, and none may produce a value outside the buffer it came from.
+func TestHostileVectorInputIsBounded(t *testing.T) {
+	huge := make([]byte, 4)
+	binary.LittleEndian.PutUint32(huge, 0xFFFFFFF0) // a count larger than any real file
+
+	truncated := lpstrElements([]string{"Sheet1", "Sheet2"})
+	truncated = truncated[:len(truncated)-4] // cut the last element short
+
+	lying := make([]byte, 4)
+	binary.LittleEndian.PutUint32(lying, 1)
+	lyingLen := make([]byte, 4)
+	binary.LittleEndian.PutUint32(lyingLen, 0x7FFFFFFF) // one element claiming 2GB
+	lying = append(lying, lyingLen...)
+	lying = append(lying, []byte("Sheet1\x00")...)
+
+	// A lying count must be REJECTED against the bytes present before it is used, not walked
+	// until a bounds check happens to trip. The difference is observable at this level:
+	// rejecting it reports nothing truncated, while walking it reports the whole capped run
+	// as truncated — and a truncation note on a stream that never held an element is a false
+	// statement about coverage.
+	//
+	// Called on the payload directly so the count sits at offset 0. An earlier version of
+	// this assertion computed an offset by hand, got it wrong, and passed whether the bound
+	// was present or not.
+	if elems, trunc := decodeStringVector(huge, 0, vtLPSTR); len(elems) != 0 || trunc != 0 {
+		t.Errorf("a count of 0xFFFFFFF0 over a 4-byte payload produced %d elements and "+
+			"truncated=%d, want 0 and 0", len(elems), trunc)
+	}
+
+	cases := map[string][]byte{
+		"count larger than the buffer":  huge,
+		"declared 2GB element":          lying,
+		"element cut short":             truncated,
+		"zero elements":                 {0, 0, 0, 0},
+		"empty payload":                 {},
+		"one byte":                      {0},
+		"count with no elements at all": {9, 0, 0, 0},
+	}
+	for name, payload := range cases {
+		stream := vectorStream(t, olefixture.PropDocumentParts, 0x0000101E, payload, nil)
+		got := legacyVectorStrings(stream)
+		for _, v := range got {
+			for _, e := range v.Elements {
+				if len(e) > len(stream) {
+					t.Errorf("%s: decoded a %d-byte element from a %d-byte stream",
+						name, len(e), len(stream))
+				}
+			}
+			if v.Truncated < 0 {
+				t.Errorf("%s: Truncated = %d", name, v.Truncated)
+			}
+		}
+	}
+
+	// And a malformed HEADER must not walk off the end either.
+	for name, stream := range map[string][]byte{
+		"short header":      {0xFE, 0xFF},
+		"set count of 2^32": append(make([]byte, 24), 0xFF, 0xFF, 0xFF, 0xFF),
+		"set offset past end": func() []byte {
+			s := make([]byte, 48)
+			binary.LittleEndian.PutUint32(s[24:], 1)
+			binary.LittleEndian.PutUint32(s[44:], 0xFFFFFF00)
+			return s
+		}(),
+	} {
+		if got := legacyVectorStrings(stream); len(got) != 0 {
+			t.Errorf("%s: decoded %d properties from a malformed stream", name, len(got))
+		}
+	}
+}
+
+// TestVectorElementCapIsDisclosed pins that a truncation says so. A reader who cannot tell
+// a short list from a truncated one cannot tell whether the scan covered the document —
+// the same reasoning as every other cap in this tool.
+func TestVectorElementCapIsDisclosed(t *testing.T) {
+	many := make([]string, maxVectorElements+7)
+	for i := range many {
+		many[i] = "Sheet" + itoa(i+1)
+	}
+	got := legacyVectorStrings(vectorStream(t, olefixture.PropDocumentParts, 0x0000101E, lpstrElements(many), nil))
+	if len(got) != 1 {
+		t.Fatalf("decoded %d properties, want 1", len(got))
+	}
+	for _, v := range got {
+		if len(v.Elements) != maxVectorElements {
+			t.Errorf("decoded %d elements, want the cap of %d", len(v.Elements), maxVectorElements)
+		}
+		if v.Truncated != 7 {
+			t.Errorf("Truncated = %d, want 7 — the count of what was dropped is what makes the "+
+				"cap honest", v.Truncated)
+		}
+	}
+
+	md := &Metadata{}
+	handleVectorProperty(md, "Document parts", vectorProperty{Elements: []string{"Sheet1"}, Truncated: 7})
+	note := md.Properties["DocumentParts_truncated"]
+	if !strings.Contains(note, "7 further value") {
+		t.Errorf("truncation note = %q, want it to state how many values were dropped", note)
+	}
+}
+
+// TestMsolepsStillCannotReadARealVector documents WHY this decoder exists, so a future
+// dependency bump does not leave dead code nobody dares delete.
+//
+// If msoleps ever reads the vector flag from the correct half of the type word, this test
+// fails and the decoder can be reconsidered. Until then, a real vector reaches our code as
+// the scalar I1(0) whose String() is "0" — which is also why #267's proposed
+// types.Vector type switch could never have worked.
+func TestMsolepsStillCannotReadARealVector(t *testing.T) {
+	stream := vectorStream(t, olefixture.PropDocumentParts, 0x0000101E,
+		lpstrElements([]string{"Sheet1", "Payroll SSN 452-11-9384"}), nil)
+
+	md := &Metadata{}
+	applyLegacyProperties(stream, md)
+	// The decoder is what recovers it; this asserts the recovery happened rather than the
+	// dependency having started to work.
+	if md.Properties["DocumentParts_2"] != "Payroll SSN 452-11-9384" {
+		t.Fatalf("DocumentParts_2 = %q, want the decoded element", md.Properties["DocumentParts_2"])
+	}
+	// And the literal "0" msoleps produces must never reach a field.
+	for k, v := range md.Properties {
+		if v == "0" {
+			t.Errorf("Properties[%q] == \"0\": that is msoleps's I1(0) for a type it could not "+
+				"read, not a value from the document", k)
+		}
+	}
+	for k, v := range md.CustomProps {
+		if v == "0" {
+			t.Errorf("CustomProps[%q] == \"0\": see above", k)
+		}
+	}
+}

--- a/internal/redactors/legacyole/vector_property_sink_test.go
+++ b/internal/redactors/legacyole/vector_property_sink_test.go
@@ -1,0 +1,105 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package legacyole
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/olefixture"
+	"github.com/awslabs/ferret-scan/v2/internal/redactors"
+)
+
+// A value inside a VECTOR-valued property must be removable, or #267 would trade a silent
+// miss for a reported-but-unredactable value — by this tool's own sink rule, a leak dressed
+// as a success.
+//
+// It works for a reason worth stating: a vector element is stored as a 4-byte length
+// followed by its bytes, and a same-length overwrite never touches the length. So the
+// element is masked in place, every sector offset and FAT chain behind it stays valid, and
+// the container still parses. Measured end to end on an .xls whose sheet-name list carried
+// an SSN: the redacted copy is byte-for-byte the same SIZE, the SSN is gone, and reading it
+// back yields the sheet name with the value masked.
+//
+// The read half — decoding the vector so the value is reported at all — lives in
+// internal/preprocessors/meta-extractors/meta-extract-officelib. Neither half is useful
+// without the other, which is why this assertion is here rather than left implied.
+func TestRedaction_ReachesAVectorPropertyElement(t *testing.T) {
+	const (
+		ssn   = "452-11-9384"
+		sheet = "Payroll SSN " + ssn
+	)
+
+	pkg := olefixture.MustBuild([]olefixture.Stream{
+		{Name: olefixture.StreamWorkbook, Data: []byte("Workbook body with nothing sensitive.")},
+		{Name: olefixture.StreamDocSummaryInformation, Data: olefixture.DocSummaryInformationWithVectors(
+			map[uint32]string{olefixture.PropCompany: "Fairbanks Holdings"},
+			map[uint32][]string{olefixture.PropDocumentParts: {"Q3 Forecast", sheet, "Notes"}},
+		)},
+	})
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "vectors.xls")
+	if err := os.WriteFile(src, pkg, 0o600); err != nil {
+		t.Fatalf("writing fixture: %v", err)
+	}
+	// The value must really be in there, or every assertion below is vacuous.
+	if !bytes.Contains(pkg, []byte(ssn)) {
+		t.Fatal("the fixture does not contain the value it is meant to carry")
+	}
+
+	out := filepath.Join(dir, "redacted.xls")
+	r := NewLegacyOLERedactor(nil, nil)
+	res, err := r.RedactDocument(src, out, matchesFor(map[string]string{ssn: "SSN"}),
+		redactors.RedactionFormatPreserving)
+	if err != nil {
+		t.Fatalf("RedactDocument: %v", err)
+	}
+	if !res.Success {
+		t.Fatal("RedactDocument reported failure")
+	}
+
+	redacted, err := os.ReadFile(out) // #nosec G304 -- test-controlled temp path
+	if err != nil {
+		t.Fatalf("reading output: %v", err)
+	}
+	if bytes.Contains(redacted, []byte(ssn)) {
+		t.Error("the SSN survives inside the vector property of a file reported as redacted")
+	}
+	if len(redacted) != len(pkg) {
+		t.Errorf("size changed from %d to %d bytes; a length change would invalidate every "+
+			"sector offset and FAT chain behind it", len(pkg), len(redacted))
+	}
+
+	// The element's NEIGHBOURS and its length prefix must survive, or the list is corrupt
+	// even though the value is gone — which reads as a successful redaction of a file no
+	// reader can parse.
+	streams := streamContents(t, out)
+	props, ok := streams["DocumentSummaryInformation"]
+	if !ok {
+		t.Fatalf("no DocumentSummaryInformation stream in the output: %v", keysOf(streams))
+	}
+	for _, keep := range []string{"Q3 Forecast", "Notes", "Fairbanks Holdings"} {
+		if !bytes.Contains(props, []byte(keep)) {
+			t.Errorf("the property stream lost the UNREPORTED value %q; redaction must overwrite "+
+				"only what was reported", keep)
+		}
+	}
+	// "Payroll SSN " is the reported value's prefix inside the same element: it is not part
+	// of the match, so it stays — which is also what proves the overwrite was scoped to the
+	// value and not to the element.
+	if !bytes.Contains(props, []byte("Payroll SSN ")) {
+		t.Error("the whole element was overwritten rather than just the reported value")
+	}
+}
+
+func keysOf(m map[string][]byte) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
Closes #267

A legacy workbook keeps its **sheet-name list**, and a legacy deck its **slide titles**, in a vector-valued property. None of it reached any validator, so none of it could be redacted. Measured on an `.xls` whose sheet names include an SSN: **0 findings before, SSN at HIGH 100 after.**

## The issue's root cause is wrong, and its proposed fix cannot work

#267 says `Vector.String()` returns `""`, so the value is dropped by an `if v == ""` guard, and that a type switch on `types.Vector` recovers it. Neither holds for a real file. Proved with a probe over `msoleps v1.0.6` on three encodings of one property:

| type word in the file | what we get | `String()` |
|---|---|---|
| **`0x101E`** — what real writers emit | `types.I1` (`Int8`) | **`"0"`** |
| `0x001E` + the flag in the *high* word — what msoleps looks for | `Vector of CodeString` | `""` |
| scalar `VT_LPSTR` (control) | `CodeString` | the value ✓ |

`types.Evaluate` reads the TypeID from bytes 0–2 and the vector discriminator from bytes 2–4, but [MS-OLEPS] packs `VT_VECTOR` (0x1000) into the **same** 16-bit field. So the id lookup is `0x101E`, which is in no table, and it returns `I1(0)` with `ErrUnknownType` — an error the caller discards (*"ignore errors for now as not all types implemented"*). The guard is never reached, the literal `"0"` is what flows, and a type switch on `types.Vector` can never fire because the property has already been collapsed to a scalar. `Vector.String()` does return `""`, but that method is unreachable for any file Office writes.

The visible artifact of the misread: a vector-valued `Keywords` renders as `Keywords: 0` in the text the validators scan.

**A third cause the issue does not mention:** `"Document parts"` was on the structural denylist, so even a correct decode would have been dropped. It was put there when the value arriving was `"0"` and looked like noise. It is document content — every sheet name, every slide title — and is no longer excluded. `"Heading pair"` stays, being a `VT_VARIANT` vector of (name, count) pairs.

## Real files, and the bug only they could find

**19 real `.doc`/`.xls`/`.ppt` from the Apache POI corpus. 14 of them carry a property whose type word is `0x101E`** — this is what Office writes, not an exotic shape. They decode **40 elements**: sheet names, slide titles, theme and font names.

They also found a bug no hand-built fixture could. Vector elements are packed **end to end**, not padded to 4 bytes like a standalone property value. The first decoder padded them and desynced after any element whose length was not a multiple of 4:

```
1e100000  type 0x101E      03000000  count=3
0c000000 "First Sheet\0"      len 12
0f000000 "Sheet Number 2\0"   len 15   <- not a multiple of 4
07000000 "Sheet3\0"           len 7
0c100000 ...                  <- the next property's type word, immediately
```

On that file it decoded **2 of 3** sheet names and reported the third as capped; on a workbook starting with `"Sheet1"` (7 bytes with its terminator), **1 of 3**. Every fixture I had written used lengths that happened to be multiples of 4, so all of them passed — **and so did the fixture encoder, because I had padded it the same way**. Two wrongs that cancelled out until the decoder was right. The layout above is quoted verbatim from the real file.

## Precision: the elements are not custom properties

The metadata validator types any field named `Custom_*` as `CUSTOM_PROPERTY` and reports it, by design — a custom property is an author-named leak channel. A sheet-name list is not. Measured with the elements routed there:

> an ordinary 12-sheet workbook went from **1 finding to 13**, twelve of them `CUSTOM_PROPERTY` at MEDIUM on values like `Sheet1`, `Q4` and `Chart1`, all at the **default** confidence.

A finding per sheet in every legacy workbook is what teaches an operator to stop reading findings. They go into `Properties` instead, one key per element — still scanned as text, so an SSN or a customer name in a sheet name is detected and redacted, without the list being asserted as a finding. One key per element rather than one joined line, because a joined line lets a validator match **across** two unrelated sheet names.

**Net on the 19 real files: 165 → 168 findings.** All three are one extra occurrence of a font name the tool *already* reports as PERSON_NAME in the same file (`Times New Roman` 2→3, `Arial Black` 2→3) — no new false-positive **value**. That PERSON_NAME weakness is pre-existing and filed separately.

## The sink

Reporting a value the redactor cannot remove would trade a silent miss for a reported-but-unredactable one — a leak dressed as a success. So it is asserted, not assumed. A vector element sits behind its own 4-byte length prefix, so a same-length overwrite never touches the length: the element is masked in place, every sector offset and FAT chain stays valid, and the container still parses. End to end on an `.xls` whose sheet-name list carried an SSN — same **size**, SSN gone, and reading it back yields `Payroll SSN ***-**-9384`. The test also pins what must *not* change: the neighbouring elements, the scalar sibling property, and the reported value's own prefix inside the same element.

## Bounds

Every field is read against the buffer's real length, and the element count is checked against the bytes actually present **before** it sizes anything (#350: a declared size may only be trusted after it has been checked against a real one). Element count and total text per property are capped, and the cap states how many values it dropped.

Keyed by **index** into msoleps's `Property` slice, because `msoleps.Property` carries no property ID. It builds that slice in property-table order, set A then set B — including an index for the dictionary entry at id 0, which msoleps keeps as a `Null` rather than skipping. Getting that wrong hands every value to the neighbouring property; a fixture *with* a dictionary pins it, added after the version without one let that mutation survive.

## Verification

- **67 packages ok, 0 failed** on the branch; `gofmt`, `go vet`, `-race` clean on every touched package. Score baseline untouched.
- Golden `FileCase file_xls_legacy_vector_sheet_names` locks detection through `ScanFile`: SSN HIGH 100 from a sheet name, the company scalar still LOW, no per-sheet noise. Its element lengths are 12, 24 and 7 with terminators, so at least one is not a multiple of 4.
- **Union of `main` + all seven open PRs: builds clean, `go vet` clean, 69/0, gofmt clean.** This branch shares two files — `internal/goldencorpus/corpus.go` with #393 and `docs/user-guides/README-Redaction.md` with #397 — and both auto-merge (the README hunks are 4 lines apart; verified rather than assumed).
- **Mutation-tested, 10 mutations, all caught**: pad each element again; stop decoding vectors; skip the id-0 index bump; route elements to `CustomProps`; drop the truncation note; accept non-text base types; re-denylist `Document parts`; remove the element-count bound; pad in the fixture encoder *while declaring the unpadded length* (the historical shape); break the legacy redaction sink. Two of them survived a first pass and exposed real gaps — the dictionary-pairing case and a hostile-count assertion whose hand-computed offset made it vacuous.

## Docs, including retroactively

- The redaction guide said legacy document *"properties are exact"* — true of scalars, silently untrue of vector-valued ones. Corrected, with the measurement.
- The extractor's README listed only OOXML/OpenDocument formats, omitting `.doc/.xls/.ppt` entirely, and claimed *"no external dependencies — uses only Go standard libraries"* while the OLE container is read with `mscfb` and its property sets with `msoleps`. Both predate this change; both fixed, and it now records what `msoleps` cannot do so the next reader does not have to re-derive it from the type word.
