### PR TITLE
fix(web): stop discarding findings, truncating uploads and reading unbounded bodies

### DIFF
--- a/docs/user-guides/README-WebUI.md
+++ b/docs/user-guides/README-WebUI.md
@@ -89,7 +89,11 @@ The web UI supports the same file types as the CLI version:
 - **Local Processing**: Files are processed locally on your machine - no data is sent to external servers
 - **Temporary Storage**: Files are temporarily stored during scanning and automatically deleted
 - **Memory Scrubbing**: Secure memory handling for sensitive data
-- **Upload Limits**: Maximum file upload size is 100 MB per file (decompression-bomb guard)
+- **Upload Limits**: Maximum file upload size is 100 MB per file (decompression-bomb guard),
+  the same limit the CLI applies. A file over the limit is **refused and reported**, not
+  truncated: the response carries `incomplete: true` with `file too large to scan` as the
+  reason, so a partial scan is never presented as a complete one. Request bodies on the JSON
+  endpoints (`/export`, `/suppressions/*`) are capped at 1 MB.
 - **No Data Retention**: Scan results are displayed in browser only, not stored permanently
 - **Audit Trail**: Comprehensive logging for compliance requirements
 
@@ -147,8 +151,10 @@ The web UI includes a comprehensive suppression management system:
 
 **File upload fails**:
 
-- Check that the file is under 100 MB
-- Ensure the file type is supported by Ferret Scan
+- Check that the file is under 100 MB. Over that, the file is refused and the response says so
+  (`incomplete: true`, reason `file too large to scan`) — split the file and scan the parts
+- Ensure the file type is supported by Ferret Scan. A file the tool cannot scan does **not** fail
+  the upload: it is skipped, and the other files in the same drop are still scanned and reported
 - Try uploading files one at a time if multiple uploads fail
 - For folder drops: very large directory trees can take a moment to enumerate client-side; the upload zone shows "Reading files…" while the walk is in progress
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -6,6 +6,7 @@ package web
 import (
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -26,6 +27,7 @@ import (
 	"github.com/awslabs/ferret-scan/v2/internal/parallel"
 	"github.com/awslabs/ferret-scan/v2/internal/paths"
 	"github.com/awslabs/ferret-scan/v2/internal/platform"
+	"github.com/awslabs/ferret-scan/v2/internal/router"
 	"github.com/awslabs/ferret-scan/v2/internal/suppressions"
 	"github.com/awslabs/ferret-scan/v2/internal/version"
 
@@ -492,8 +494,35 @@ func (ws *WebServer) handleScan(responseWriter http.ResponseWriter, request *htt
 		}
 		matches, suppressed, suppCount, incomplete, err := ws.processUploadedFileWithCLILogic(fileHeader, i, confidence, checks, verbose, recursive, displayName)
 		if err != nil {
-			ws.sendError(responseWriter, err.Error())
-			return
+			// A PER-FILE condition must not abandon the batch.
+			//
+			// This used to sendError and return, which discarded every match already collected
+			// and never looked at the remaining files. Measured: uploading a file containing an
+			// SSN together with one unsupported .bin returned `success: false` with ZERO
+			// results, while the CLI reported the same SSN at HIGH 100 and exited 0 (#416).
+			// Dragging a folder in is the web UI's primary interaction and ordinary folders hold
+			// files this tool cannot scan — .DS_Store, Thumbs.db, partial downloads — so any one
+			// of them turned a scan that found real PII into "scan failed".
+			var refusal *uploadRefusal
+			if errors.As(err, &refusal) {
+				// Disclose a lost-coverage refusal; stay silent about a benign skip, which is
+				// exactly what the CLI does for a type nothing could have read.
+				if refusal.coverageGap {
+					incompleteFiles = append(incompleteFiles, parallel.FileDiagnostic{
+						FilePath: refusal.name,
+						Reason:   refusal.reason,
+					})
+				}
+				continue
+			}
+			// Anything else is an infrastructure failure for THIS file (could not open it,
+			// could not create a temp file). Still per-file: record it and carry on, so one
+			// failure cannot hide findings in the others.
+			incompleteFiles = append(incompleteFiles, parallel.FileDiagnostic{
+				FilePath: displayName,
+				Reason:   "could not be scanned",
+			})
+			continue
 		}
 		allMatches = append(allMatches, matches...)
 		suppressedMatches = append(suppressedMatches, suppressed...)
@@ -561,6 +590,59 @@ func (ws *WebServer) handleScan(responseWriter http.ResponseWriter, request *htt
 	})
 }
 
+// reasonWithoutTempPath rewrites the server's upload temp path out of a coverage-loss reason,
+// replacing it with the name the operator uploaded.
+//
+// The FilePath field of the diagnostic was already the display name, but the REASON text is
+// built deeper down by whichever extractor produced it, and those producers embed the path they
+// were given. On the CLI that is the operator's own file and naming it is the point; here it is
+// the server's temp file, so the operator saw
+//
+//	/var/folders/fs/nx3gj.../T/ferret_upload_1787253078_0_1151739760.docx: Text Extractor: …
+//
+// which tells them nothing about their own document and discloses the server's filesystem layout
+// and upload naming scheme. Both the full path and its base name are replaced, because some
+// producers pass filepath.Base.
+func (ws *WebServer) reasonWithoutTempPath(reason, tempPath, originalFilename string) string {
+	safe := ws.sanitizeFilenameForDisplay(originalFilename)
+	if tempPath != "" {
+		reason = strings.ReplaceAll(reason, tempPath, safe)
+		if base := filepath.Base(tempPath); base != "" && base != "." {
+			reason = strings.ReplaceAll(reason, base, safe)
+		}
+	}
+	return reason
+}
+
+// maxJSONRequestBytes bounds every JSON request body this server decodes.
+//
+// The endpoints that use it accept small objects — a rule id, a suppression hash, a reason
+// string, one finding's fields, a list of formats — so 1MB is several orders of magnitude more
+// than any legitimate request and exists only to stop an unbounded one. The file-upload path has
+// its own, much larger bound: router.MaxFileSize.
+const maxJSONRequestBytes = 1 << 20 // 1MB
+
+// uploadRefusal is a condition that applies to ONE uploaded file, carried as an error so the
+// existing call chain can return it, but handled by handleScan as a per-file outcome rather
+// than a request failure.
+//
+// The distinction it carries is the one router.CanProcessType exists to make, and the same one
+// discovery applies on the CLI side:
+//
+//   - coverageGap true  — the tool could have found something and did not (too large,
+//     unreadable). That is lost coverage and must be disclosed.
+//   - coverageGap false — nothing was ever possible from this file (an unsupported type). That
+//     is a benign skip, and the CLI stays silent about it.
+//
+// Either way it must not abort the batch: see handleScan.
+type uploadRefusal struct {
+	name        string
+	reason      string
+	coverageGap bool
+}
+
+func (e *uploadRefusal) Error() string { return e.name + ": " + e.reason }
+
 // summarizeIncompleteFiles builds a short, payload-free explanation of degraded
 // coverage for the scan response, or "" when coverage was complete. It names the
 // single offending file, or counts them when several were incomplete.
@@ -599,16 +681,55 @@ func (ws *WebServer) processUploadedFileWithCLILogic(uploadedFile *multipart.Fil
 	defer os.Remove(tempFile.Name())
 	defer tempFile.Close()
 
-	// Copy uploaded file content to temporary file with size limit protection
-	const maxFileSize = 100 << 20 // 100MB limit to prevent decompression bombs
-	limitedReader := io.LimitReader(file, maxFileSize)
-	_, err = io.Copy(tempFile, limitedReader)
+	// Copy the upload to the temp file, REFUSING anything over the limit rather than
+	// truncating it.
+	//
+	// io.LimitReader + io.Copy returns no error when the limit is reached — it simply stops,
+	// and the caller cannot tell a complete copy from a truncated one. So a 150MB upload was
+	// silently cut to 100MB, scanned, and reported as `success: true` with whatever the first
+	// 100MB happened to contain: measured, an SSN at the 110MB mark produced zero findings and
+	// no warning of any kind (#415). The CLI refuses the same file and discloses it as
+	// `file too large to scan` at exit 3, so the two surfaces disagreed about one input, and
+	// the web UI's answer was the dangerous one.
+	//
+	// Reading ONE byte past the limit is what makes the difference detectable: if the copy
+	// reaches maxFileSize+1 the input was larger than we may scan.
+	limitedReader := io.LimitReader(file, router.MaxFileSize+1)
+	written, err := io.Copy(tempFile, limitedReader)
 	if err != nil {
 		return nil, nil, 0, nil, fmt.Errorf("failed to copy file content: %v", err)
+	}
+	if written > router.MaxFileSize {
+		// Named by displayName, never by the temp path — see the note in handleScan.
+		return nil, nil, 0, nil, &uploadRefusal{
+			name: displayName,
+			// Same wording as the CLI's causeTooLarge entry, so an operator comparing the two
+			// surfaces sees one reason rather than two.
+			reason:      fmt.Sprintf("file too large to scan (max size: %dMB)", router.MaxFileSize/(1024*1024)),
+			coverageGap: true,
+		}
 	}
 
 	// Normalize the temporary file path for the current platform
 	normalizedTempPath := paths.NormalizePath(tempFile.Name())
+
+	// Classify a refusal HERE, where the path is known, rather than letting core.ScanFile
+	// collapse every reason into one string.
+	//
+	// core.ScanFile discards the router's reason (`canProcess, _ :=`, scanner.go:147) and
+	// returns "file type not supported for processing: <temp path>" for an unsupported type, an
+	// oversize file, an unreadable one and a device node alike. handleScan then treated that as
+	// a request failure, so ONE unsupported file in a batch discarded every other file's
+	// findings (#416). Asking the router directly gives back the distinction the CLI relies on.
+	if canProcess, reason := router.NewFileRouter(false).CanProcessFile(normalizedTempPath, true); !canProcess {
+		return nil, nil, 0, nil, &uploadRefusal{
+			name:   displayName,
+			reason: reason,
+			// A processable TYPE refused for some other cause is lost coverage; a type nothing
+			// could read is a benign skip. Same test discovery applies on the CLI side.
+			coverageGap: router.CanProcessType(normalizedTempPath, true),
+		}
+	}
 
 	// Run full CLI scanning logic on this file with original filename
 	return ws.runFullCLIScan(normalizedTempPath, displayName, confidence, checks, verbose, recursive)
@@ -668,7 +789,7 @@ func (ws *WebServer) runFullCLIScan(filePath, originalFilename, confidence, chec
 	if result.Incomplete {
 		incomplete = []parallel.FileDiagnostic{{
 			FilePath: ws.sanitizeFilenameForDisplay(originalFilename),
-			Reason:   result.IncompleteReason,
+			Reason:   ws.reasonWithoutTempPath(result.IncompleteReason, filePath, originalFilename),
 		}}
 	}
 
@@ -678,6 +799,18 @@ func (ws *WebServer) runFullCLIScan(filePath, originalFilename, confidence, chec
 	safeFilename := ws.sanitizeFilenameForDisplay(originalFilename)
 	for i := range result.Matches {
 		result.Matches[i].Filename = safeFilename
+		// Metadata carries paths too, and renaming only Filename left them behind: a .docx
+		// whose finding came from its properties shipped
+		// metadata.original_file = "/var/folders/…/T/ferret_upload_…docx" straight to the
+		// browser. Same reasoning as reasonWithoutTempPath — the operator's own name is the
+		// only path that means anything here, and the temp path discloses the server's layout.
+		for k, v := range result.Matches[i].Metadata {
+			if str, ok := v.(string); ok {
+				if rewritten := ws.reasonWithoutTempPath(str, filePath, originalFilename); rewritten != str {
+					result.Matches[i].Metadata[k] = rewritten
+				}
+			}
+		}
 	}
 
 	// Annotate findings with an advisory explanation now that filenames are
@@ -721,7 +854,8 @@ func (ws *WebServer) handleExport(responseWriter http.ResponseWriter, request *h
 		Verbose   bool                        `json:"verbose"`
 	}
 
-	if err := json.NewDecoder(request.Body).Decode(&exportRequest); err != nil {
+	// Bounded for the same reason as the suppression endpoints — see maxJSONRequestBytes.
+	if err := json.NewDecoder(http.MaxBytesReader(responseWriter, request.Body, maxJSONRequestBytes)).Decode(&exportRequest); err != nil {
 		ws.sendError(responseWriter, "Invalid JSON in request body")
 		return
 	}
@@ -1039,7 +1173,14 @@ func (ws *WebServer) suppressionEndpoint(method string, decode bool,
 
 		var req suppressionRequest
 		if decode {
-			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			// Bound the body. Decoding straight from r.Body reads as much as the client sends,
+			// so a single POST could drive allocation without limit (#380). Every request this
+			// endpoint family accepts is a small object — an id, a hash, a reason, one
+			// finding's fields — so the cap is generous by orders of magnitude and only ever
+			// rejects abuse. http.MaxBytesReader is the right tool rather than io.LimitReader:
+			// it returns an ERROR at the limit instead of a silent short read, which is the
+			// same distinction #415 turned on.
+			if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxJSONRequestBytes)).Decode(&req); err != nil {
 				ws.sendError(w, "Invalid JSON in request body")
 				return
 			}

--- a/internal/web/upload_outcomes_test.go
+++ b/internal/web/upload_outcomes_test.go
@@ -1,0 +1,297 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package web
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/router"
+)
+
+// scanResponseFor uploads the given (filename, content) pairs to /scan and returns the decoded
+// response. checks narrows the validator set so the assertions do not depend on every
+// validator's behaviour.
+func scanResponseFor(t *testing.T, checks string, files ...[2]string) ScanResponse {
+	t.Helper()
+
+	var body bytes.Buffer
+	mw := multipart.NewWriter(&body)
+	for _, f := range files {
+		w, err := mw.CreateFormFile("files", f[0])
+		if err != nil {
+			t.Fatalf("CreateFormFile(%q): %v", f[0], err)
+		}
+		if _, err := w.Write([]byte(f[1])); err != nil {
+			t.Fatalf("write %q: %v", f[0], err)
+		}
+	}
+	if err := mw.WriteField("checks", checks); err != nil {
+		t.Fatal(err)
+	}
+	if err := mw.WriteField("confidence", "all"); err != nil {
+		t.Fatal(err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	ws := NewWebServerWithOptions("0", "127.0.0.1", "", "", nil)
+	req := httptest.NewRequest(http.MethodPost, "/scan", &body)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	rec := httptest.NewRecorder()
+	ws.handleScan(rec, req)
+
+	var got ScanResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("response is not JSON (%v): %s", err, rec.Body.String())
+	}
+	return got
+}
+
+// A file the tool cannot scan must not discard the findings of the files uploaded with it.
+//
+// The batch loop used to `sendError` and return on the first per-file error, throwing away every
+// match already collected and never looking at the remaining files. Measured before the fix:
+// uploading a file containing an SSN together with one unsupported .bin returned
+// `success: false` with ZERO results, while the CLI reported the same SSN at HIGH 100 and exited
+// 0 (#416).
+//
+// This matters because dragging a folder in is the web UI's primary interaction, and ordinary
+// folders hold files this tool cannot scan — .DS_Store, Thumbs.db, partial downloads. Any one of
+// them turned a scan that had already found real PII into "scan failed", and the operator's
+// reasonable response to that is to retry rather than to look at results.
+func TestUnsupportedFileDoesNotDiscardTheBatch(t *testing.T) {
+	const ssn = "Employee SSN: 452-11-9384\n"
+	// Binary bytes with no recognizable type: unscannable at any size.
+	opaque := string(bytes.Repeat([]byte{0x00, 0x01, 0x02, 0xff, 0xfe}, 400))
+
+	// Control first: the SSN file alone must report, or the rest of this test proves nothing.
+	alone := scanResponseFor(t, "SSN", [2]string{"payroll.txt", ssn})
+	if !alone.Success || len(alone.Results) != 1 {
+		t.Fatalf("control: success=%v results=%d, want success with 1 finding — the batch "+
+			"assertion below is vacuous without it", alone.Success, len(alone.Results))
+	}
+
+	// The same file, uploaded beside one the tool cannot scan.
+	both := scanResponseFor(t, "SSN",
+		[2]string{"payroll.txt", ssn},
+		[2]string{"partial.bin", opaque})
+
+	if !both.Success {
+		t.Errorf("success=false with error %q: one unscannable file failed the whole request, so "+
+			"a real finding in another file is reported as nothing", both.Error)
+	}
+	if len(both.Results) != 1 {
+		t.Errorf("results=%d, want 1: the SSN in payroll.txt must survive an unscannable sibling. "+
+			"A finding the tool made and then discarded is worse than one it never made, because "+
+			"the operator is told the scan failed rather than that findings were dropped",
+			len(both.Results))
+	}
+}
+
+// An unsupported type is a benign skip, not a coverage loss — the same call the CLI makes via
+// router.CanProcessType. Reporting it as incomplete would train operators to ignore the signal
+// that matters.
+func TestUnsupportedTypeAloneIsNotReportedAsLostCoverage(t *testing.T) {
+	opaque := string(bytes.Repeat([]byte{0x00, 0x01, 0x02, 0xff, 0xfe}, 400))
+	got := scanResponseFor(t, "SSN", [2]string{"partial.bin", opaque})
+
+	if !got.Success {
+		t.Errorf("success=false (error %q): an unsupported type is a benign skip on the CLI "+
+			"(exit 0, no findings), and the two surfaces must agree", got.Error)
+	}
+	if got.Incomplete {
+		t.Errorf("incomplete=true (%q): nothing was ever findable in this file, so declaring lost "+
+			"coverage overstates it — that is the distinction router.CanProcessType exists to make",
+			got.IncompleteReason)
+	}
+	if len(got.Results) != 0 {
+		t.Errorf("results=%d, want 0", len(got.Results))
+	}
+}
+
+// The error text returned to the client must name the file the OPERATOR uploaded, never the
+// server's temp path.
+//
+// Before the fix the message read
+//
+//	file type not supported for processing: /var/folders/…/T/ferret_upload_1787252445_0_3245715044.bin
+//
+// which the uploader cannot act on and which discloses the server's filesystem layout and upload
+// naming scheme.
+func TestResponsesNeverNameTheServerTempPath(t *testing.T) {
+	// A corrupt .docx is the cheap case that actually REACHES the disclosure channel: the
+	// router accepts it by extension, extraction then fails, and the reason is reported. An
+	// unsupported type would not do — it is a benign skip that emits nothing, so asserting
+	// "no temp path" against it passes whether or not the path is there.
+	cases := map[string][2]string{
+		"corrupt .docx": {"quarterly.docx", string(bytes.Repeat([]byte{0x50, 0x4b, 0x03, 0x04, 0x00, 0xff}, 200))},
+		"corrupt .pdf":  {"invoice.pdf", "%PDF-1.4\n" + string(bytes.Repeat([]byte{0xff}, 500))},
+	}
+	for name, file := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := scanResponseFor(t, "SSN", file)
+			if !got.Incomplete {
+				t.Fatalf("incomplete=false, so nothing was disclosed and this assertion is "+
+					"vacuous; reason=%q err=%q", got.IncompleteReason, got.Error)
+			}
+			for field, s := range map[string]string{
+				"error":             got.Error,
+				"incomplete_reason": got.IncompleteReason,
+			} {
+				if strings.Contains(s, "ferret_upload_") {
+					t.Errorf("%s names the server's temp file (%q): the operator has no use for it "+
+						"and it discloses the upload naming scheme", field, s)
+				}
+			}
+			if !strings.Contains(got.IncompleteReason, file[0]) {
+				t.Errorf("incomplete_reason %q does not name the uploaded file %q, so the operator "+
+					"cannot tell which file lost coverage", got.IncompleteReason, file[0])
+			}
+		})
+	}
+}
+
+// An upload over the limit must be REFUSED and DISCLOSED, never truncated and reported as a
+// clean scan.
+//
+// io.LimitReader + io.Copy returns no error when the limit is reached — it simply stops — so a
+// 150MB upload was silently cut to 100MB, scanned, and reported as `success: true` with whatever
+// the first 100MB happened to hold. Measured before the fix: an SSN at the 110MB mark produced
+// zero findings and no signal of any kind, while the CLI refused the same file and disclosed
+// `file too large to scan` at exit 3 (#415).
+//
+// This is the one case that has to move real bytes: the refusal triggers on how much was
+// copied, so nothing smaller exercises it. The body is streamed rather than built in memory, and
+// its content is zeros, so the cost is I/O rather than RAM.
+func TestOversizeUploadIsRefusedAndDisclosed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("moves router.MaxFileSize+ bytes through a multipart body")
+	}
+
+	pr, pw := io.Pipe()
+	mw := multipart.NewWriter(pw)
+	go func() {
+		defer func() { _ = pw.Close() }()
+		w, err := mw.CreateFormFile("files", "recording.txt")
+		if err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
+		// One byte past the limit is all that is needed to be over it.
+		if _, err := io.CopyN(w, zeroReader{}, router.MaxFileSize+1); err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
+		if err := mw.WriteField("checks", "SSN"); err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
+		if err := mw.WriteField("confidence", "all"); err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
+		_ = mw.Close()
+	}()
+
+	ws := NewWebServerWithOptions("0", "127.0.0.1", "", "", nil)
+	req := httptest.NewRequest(http.MethodPost, "/scan", pr)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	rec := httptest.NewRecorder()
+	ws.handleScan(rec, req)
+
+	var got ScanResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("response is not JSON (%v): %s", err, truncate(rec.Body.String(), 200))
+	}
+
+	if !got.Incomplete {
+		t.Errorf("incomplete=false: an upload the tool refused for size was reported as a " +
+			"complete scan. Everything past the limit went unread, and nothing said so — which is " +
+			"the same artifact the CLI's `file too large to scan` disclosure exists to prevent")
+	}
+	if !strings.Contains(got.IncompleteReason, "too large") {
+		t.Errorf("incomplete_reason = %q, want it to name the size limit as the cause; an operator "+
+			"cannot act on a reason that does not say what happened", got.IncompleteReason)
+	}
+	if strings.Contains(got.IncompleteReason, "ferret_upload_") {
+		t.Errorf("incomplete_reason names the server temp path: %q", got.IncompleteReason)
+	}
+}
+
+// zeroReader is an endless source of zero bytes, so the oversize body above costs no memory.
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}
+
+// Every JSON endpoint must bound the body it decodes.
+//
+// json.NewDecoder(r.Body) reads until EOF, so one large POST was decoded in full — measured, a
+// 3MB body was read and acted on (#380). http.MaxBytesReader is the right tool rather than
+// io.LimitReader: it makes the read FAIL past the cap instead of silently returning a truncated
+// value, which is the same distinction that made the upload path truncate silently (#415).
+func TestJSONEndpointsBoundTheRequestBody(t *testing.T) {
+	oversize, err := json.Marshal(map[string]string{
+		"id":     "x",
+		"reason": strings.Repeat("A", maxJSONRequestBytes+1024),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	small, err := json.Marshal(map[string]string{"id": "no-such-rule", "reason": "ok"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ws := NewWebServerWithOptions("0", "127.0.0.1", "", "", nil)
+	// Called directly rather than through the mux: routes are registered when the server
+	// starts, and these tests construct the server without starting it.
+	endpoints := map[string]http.HandlerFunc{
+		"/suppressions/remove": ws.handleSuppressionsRemove,
+		"/suppressions/create": ws.handleSuppressionsCreate,
+		"/export":              ws.handleExport,
+	}
+
+	for ep, handler := range endpoints {
+		t.Run(ep, func(t *testing.T) {
+			post := func(payload []byte) string {
+				req := httptest.NewRequest(http.MethodPost, ep, bytes.NewReader(payload))
+				req.Header.Set("Content-Type", "application/json")
+				rec := httptest.NewRecorder()
+				handler(rec, req)
+				return rec.Body.String()
+			}
+
+			// A body past the cap must be REFUSED at decode, not truncated and acted upon.
+			if body := post(oversize); !strings.Contains(body, "Invalid JSON in request body") {
+				t.Errorf("oversize body was not refused at decode; response=%s", truncate(body, 160))
+			}
+			// A legitimate small body must still decode — otherwise the cap is indistinguishable
+			// from the endpoint being broken.
+			if body := post(small); strings.Contains(body, "Invalid JSON in request body") {
+				t.Errorf("a %d-byte body was refused, so the cap is rejecting legitimate requests; "+
+					"response=%s", len(small), truncate(body, 160))
+			}
+		})
+	}
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}


### PR DESCRIPTION
Rolls up every web-surface defect I could find and verify, including two that were not previously
filed. They are all the same kind of bug: **the server read or reported something other than what
it actually scanned.**

You asked whether the recent merges left web problems behind. They did not *introduce* these —
all four predate the merge queue — but the merges did make them visible: seven PRs improved the
CLI's coverage disclosure while the web path quietly kept its own, weaker behaviour.

## 1. One unsupported file discarded the whole batch's findings — #416

The upload loop returned on the first per-file error, throwing away every match already collected
and never looking at the remaining files:

```go
matches, ..., err := ws.processUploadedFileWithCLILogic(...)
if err != nil { ws.sendError(responseWriter, err.Error()); return }
```

```
WEB   files=payroll.txt (SSN) + partial.bin   ->  success:false, 0 results
CLI   the same two files                      ->  SSN at HIGH 100, exit 0
```

Dragging a folder in is this UI's primary interaction, and ordinary folders hold files the tool
cannot scan — `.DS_Store`, `Thumbs.db`, partial downloads. Any one of them turned a scan that had
**already found real PII** into "scan failed", and the reasonable response to that message is to
retry, not to look for results.

## 2. An oversize upload was silently truncated and reported as success — #415

`io.LimitReader` + `io.Copy` returns **no error** at the limit — it just stops, and the caller
cannot tell a complete copy from a truncated one.

```
WEB   150MB upload, SSN at the 110MB mark   ->  success:true, 0 matches, no signal at all
CLI   the same file                         ->  exit 3, "file too large to scan"
```

Now reads **one byte past** the limit — which is what makes the difference detectable — and
refuses using the CLI's own wording.

## 3. Unbounded JSON request bodies — #380

`/export` and all six `/suppressions/*` endpoints used `json.NewDecoder(r.Body)`, which reads to
EOF. Measured: a 3MB body was decoded in full and acted on. Both paths now go through
`http.MaxBytesReader` at 1MB — `MaxBytesReader` rather than `io.LimitReader` deliberately, because
it makes the read **fail** past the cap instead of yielding a truncated value, which is the same
distinction that made the upload path silent. All six suppression endpoints share one helper, so
the cap lands once.

## 4. The refusal named the server's temp path

```
file type not supported for processing: /var/folders/…/T/ferret_upload_1787252445_0_3245715044.bin
```

Useless to the uploader, and it discloses the server's filesystem layout and upload naming
scheme. Refusals are now reported against the file's display name.

## Classification is done where the path is known, not by matching prose

`core.ScanFile` discards the router's reason (`canProcess, _ :=`, `scanner.go:147`) and returns
one generic error for an unsupported type, an oversize file and an unreadable one alike. The web
layer now asks `router.CanProcessFile` directly and splits the answer with `router.CanProcessType`
— the same test discovery applies on the CLI side:

- **processable type, refused for another cause** → lost coverage, disclosed
- **type nothing could ever read** → benign skip, silent, exactly as the CLI behaves

## Measured — main vs this branch, same fixtures through both

| case | main | this branch |
|---|---|---|
| control (SSN only) | `success=True matches=1` | **unchanged** |
| batch: SSN + unsupported | `success=False matches=0` | `success=True matches=1` |
| single unsupported | `success=False` (error) | `success=True matches=0` |
| 150MB, SSN past the cap | no `incomplete` signal | `incomplete=true "file too large to scan"` |
| 3MB JSON body | decoded and acted on | refused at 1MB |
| 37-byte JSON body | accepted | **unchanged** |

**7 mutations, all caught.** One initially SURVIVED and was right to: my temp-path assertion was
**vacuous** — an unsupported type emits nothing at all, so "no temp path" passed whether or not
the path was there. It now runs against a corrupt `.docx`, whose reason genuinely reaches the
disclosure channel, and asserts the disclosure is non-empty *first*.

The oversize test streams zeros through a pipe rather than building 100MB in memory, so it costs
0.15s and no RAM; it is `testing.Short()`-skippable since it is the one case that must move real
bytes.

Full suite **69/0**, `gofmt` and `vet` clean. Union with both other open PRs (#407, #413) builds
and passes **69/0**; neither touches `internal/web`.

## Docs

`docs/user-guides/README-WebUI.md` stated the 100MB number but never said what happens past it —
which is exactly the ambiguity the truncation hid. It now states that an oversize file is refused
and reported, that a file the tool cannot scan does **not** fail the upload, and the 1MB JSON body
cap.

## Deliberately not in this PR

**#417** — the web response collapses the CLI's six-cause taxonomy into one bool plus prose, so
`no body text` and `coverage cut short` are indistinguishable. That is a response-schema change
and it wants doing together with #391, which asks for the same taxonomy on the `pkg/scan` surface.
One shared representation should serve all three surfaces rather than three separate ones.


---

Closes #415
Closes #416
Closes #380
