### PR TITLE
fix(preprocessors): judge a PDF by its magic bytes, so raw PDF source stops reaching validators

### DIFF
--- a/internal/preprocessors/pdf_magic_sniff_test.go
+++ b/internal/preprocessors/pdf_magic_sniff_test.go
@@ -1,0 +1,138 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package preprocessors
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// realPDFHeader is the first 512 bytes of an ordinary PDF as browsers and Office write them:
+// the mandatory "%PDF-1.x" magic followed by a large ASCII metadata dictionary. Every byte of
+// it is printable and there is not a single NUL, which is precisely why a printability sniff
+// cannot judge it.
+const realPDFHeader = "%PDF-1.4\n" +
+	"1 0 obj\n" +
+	"<< /Title (Quarterly Security Awareness Training - Module 3 of 4 - Completion Record)\n" +
+	"/Creator (Mozilla/5.0 \\(Macintosh; Intel Mac OS X 10_15_7\\) AppleWebKit/537.36 " +
+	"\\(KHTML, like Gecko\\) Chrome/129.0.0.0 Safari/537.36)\n" +
+	"/Producer (Skia/PDF m129)\n" +
+	"/CreationDate (D:20240115120000+00'00') >>\nendobj\n"
+
+// A PDF must never sniff as text, however ASCII its header is.
+//
+// The sniff below judges printability, and a PDF header is printable BY SPECIFICATION — so it
+// returned true and the plaintext preprocessor claimed real PDFs, handing raw PDF source to
+// every validator. Measured on one real 957KB PDF: 533,976 characters of "text", 33% of it
+// non-printable, producing 200 TWITTER findings at HIGH 100 on compressed stream bytes and 41
+// PHONE findings on xref table offsets (#419).
+func TestLooksLikeText_RejectsPDFHeaderHoweverPrintable(t *testing.T) {
+	// Proof that the guard is load-bearing rather than incidental: strip the magic and the very
+	// same bytes ARE judged text. So nothing else in the sniff would have caught this.
+	withoutMagic := strings.TrimPrefix(realPDFHeader, "%PDF-")
+	if !LooksLikeText([]byte(withoutMagic)) {
+		t.Fatalf("the PDF header minus its magic does not sniff as text, so this test would " +
+			"pass for the wrong reason — some other rule is rejecting it and the magic check " +
+			"is not what is being exercised")
+	}
+
+	if LooksLikeText([]byte(realPDFHeader)) {
+		t.Error("a real PDF header sniffs as TEXT. The plaintext preprocessor will claim the " +
+			"file and hand raw PDF source — xref tables, dictionary syntax, compressed streams " +
+			"— to every validator, which is what produced 200 TWITTER findings at HIGH 100 on " +
+			"stream bytes (#419)")
+	}
+}
+
+// The mislabelled case #271 exists for must keep working: a genuine text file that merely
+// carries a .pdf name has no magic, so it is still text, still scanned, still redacted.
+func TestLooksLikeText_TextFileNamedPDFIsStillText(t *testing.T) {
+	for name, content := range map[string]string{
+		"prose":                 "Employee SSN: 452-11-9384\nthis is really just text\n",
+		"csv mislabelled":       "name,ssn\nJane Roe,452-11-9384\n",
+		"mentions pdf in prose": "See the attached PDF for the SSN 452-11-9384\n",
+		"percent but not magic": "%PDQ-1.4 is not a PDF header\nSSN: 452-11-9384\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if !LooksLikeText([]byte(content)) {
+				t.Errorf("%q was classified binary; a text file named .pdf must still be "+
+					"scanned, which is the whole point of #271", content[:min(len(content), 48)])
+			}
+		})
+	}
+}
+
+// The end-to-end consequence: the plaintext preprocessor must not CLAIM a real PDF.
+//
+// LooksLikeText is the shared sniff behind three callers — this preprocessor, the router's
+// isTextFile, and the redactor's looksLikeTextFile — so asserting the claim here covers the
+// routing decision that actually leaked.
+func TestPlainTextPreprocessorDoesNotClaimARealPDF(t *testing.T) {
+	dir := t.TempDir()
+	ptp := NewPlainTextPreprocessor()
+
+	realPDF := filepath.Join(dir, "training.pdf")
+	if err := os.WriteFile(realPDF, []byte(realPDFHeader), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if ptp.CanProcess(realPDF) {
+		t.Error("the plaintext preprocessor claims a real PDF, so raw PDF source reaches every " +
+			"validator as if it were text (#419)")
+	}
+
+	// And the converse, so the guard cannot be satisfied by refusing every .pdf: a text file
+	// with a .pdf name is still claimed.
+	textPDF := filepath.Join(dir, "notes.pdf")
+	if err := os.WriteFile(textPDF, []byte("Employee SSN: 452-11-9384\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !ptp.CanProcess(textPDF) {
+		t.Error("a text file named .pdf is no longer claimed; that is the mislabelled-container " +
+			"case #271 added this branch for, and dropping it would leave its contents unscanned")
+	}
+}
+
+// Why PDF is the ONLY container extension needing a magic check — and the honest reason, which
+// is narrower than "their magic is binary".
+//
+// ZIP fails on its magic alone: PK\x03\x04 carries NUL bytes, and a NUL means binary. OLE's
+// 8-byte magic does NOT — \xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1 has no NUL, and the legacy
+// fallback counts every byte >= 0xA0 as printable, so the magic padded with printable bytes
+// sniffs as TEXT. Real .doc/.xls/.ppt files are rejected because the OLE header REGION that
+// follows (the CLSID and reserved fields) is NUL-filled, not because of the magic.
+//
+// That distinction matters: OLE's safety rests on the shape of real files rather than on a
+// signature check, so if a future OLE-ish variant ever arrives with a NUL-free header it needs
+// the same treatment PDF has. Verified empirically at the same time: real .docx/.pptx/.xlsx/
+// .doc/.xls/.ppt files are all correctly refused by the plaintext preprocessor today.
+func TestLooksLikeText_WhyOnlyPDFNeedsAMagicCheck(t *testing.T) {
+	t.Run("zip magic alone is binary (it contains NULs)", func(t *testing.T) {
+		buf := append([]byte{'P', 'K', 0x03, 0x04, 0x14, 0x00, 0x00, 0x00},
+			[]byte(strings.Repeat("A", 200))...)
+		if LooksLikeText(buf) {
+			t.Error("a ZIP magic sniffs as text; .docx/.xlsx/.pptx would need a magic check too")
+		}
+	})
+
+	oleMagic := []byte{0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1}
+
+	t.Run("ole magic ALONE is not enough to look binary", func(t *testing.T) {
+		buf := append(append([]byte{}, oleMagic...), []byte(strings.Repeat("A", 200))...)
+		if !LooksLikeText(buf) {
+			t.Skip("the OLE magic now fails the sniff on its own; the note above is stale and " +
+				"can be simplified")
+		}
+	})
+
+	t.Run("a REAL ole header region is binary (NUL-filled CLSID)", func(t *testing.T) {
+		// Real OLE: magic, then a 16-byte CLSID that is zero in practice, then more.
+		buf := append(append([]byte{}, oleMagic...), make([]byte, 200)...)
+		if LooksLikeText(buf) {
+			t.Error("a real OLE header region sniffs as text, so .doc/.xls/.ppt would reach the " +
+				"plaintext preprocessor the way PDF did (#419)")
+		}
+	})
+}

--- a/internal/preprocessors/plaintext_preprocessor.go
+++ b/internal/preprocessors/plaintext_preprocessor.go
@@ -4,6 +4,7 @@
 package preprocessors
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -169,6 +170,11 @@ func claimedByAnotherPreprocessor(ext string) bool {
 //
 // PDF is included for the same reason as the rest: a text file named .pdf is
 // exactly as unscannable as one named .docx, and the sniff is what decides.
+// pdfMagic is the header every PDF is required to begin with (PDF 1.7 §7.5.2). It is the
+// discriminator LooksLikeText uses, because a PDF's header is ASCII and a printability sniff
+// therefore cannot tell one from a text file.
+var pdfMagic = []byte("%PDF-")
+
 var containerExtensions = map[string]bool{
 	".docx": true, ".xlsx": true, ".pptx": true,
 	".docm": true, ".xlsm": true, ".pptm": true,
@@ -360,6 +366,39 @@ func (ptp *PlainTextPreprocessor) isTextFile(filePath string) bool {
 // which are not valid UTF-8 but are still text someone may want scanned.
 func LooksLikeText(buf []byte) bool {
 	if len(buf) == 0 {
+		return false
+	}
+
+	// A format whose header is ASCII BY SPECIFICATION cannot be judged by a printability
+	// sniff, so it is judged by its magic bytes instead.
+	//
+	// PDF is the only such container in this tree. Every PDF opens "%PDF-1.x", and one written
+	// by a browser or by Office follows that with a large ASCII metadata dictionary (/Title,
+	// /Creator, /Producer), so the first 512 bytes carry no NUL and are ~100% printable — and
+	// the tests below therefore returned TRUE for a file that is mostly compressed streams.
+	//
+	// Measured on one real 957KB PDF: the plaintext preprocessor claimed it and handed 533,976
+	// characters of RAW PDF SOURCE to every validator, 33% of it non-printable. That produced
+	// 200 TWITTER findings at HIGH 100 on stream bytes, 41 PHONE findings on xref table offsets
+	// ("0000956276" is a byte offset, not a number anyone can call), and INTELLECTUAL_PROPERTY
+	// on stray 0xA9/0xAE bytes. Across 10 real PDFs the finding count tracked the non-printable
+	// share of the extracted text almost exactly, and the three whose extraction was clean
+	// produced ZERO (#419).
+	//
+	// The other container extensions are safe and always were, though for two different
+	// reasons. ZIP fails on its magic alone, because PK\x03\x04 carries NUL bytes. OLE's magic
+	// does NOT — \xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1 has no NUL and every byte >= 0xA0
+	// counts as printable in the fallback below — so .doc/.xls/.ppt are rejected by the
+	// NUL-filled header REGION that follows their magic rather than by a signature. Verified
+	// against real files of all six types; see TestLooksLikeText_WhyOnlyPDFNeedsAMagicCheck,
+	// which pins the distinction so a future NUL-free container variant is not assumed safe.
+	//
+	// This does NOT withdraw #271. A text file merely NAMED .pdf does not carry the magic, so
+	// it still sniffs as text and is still scanned and redacted — that mislabelled case is what
+	// #271 exists for, and it keeps working. Nor does it stop PDFs being scanned: the router
+	// accepts them as "Binary document" (isBinaryDocument -> IsPDFFile) before this sniff is
+	// ever consulted, and the PDF text and metadata extractors have their own parsers.
+	if bytes.HasPrefix(buf, pdfMagic) {
 		return false
 	}
 


### PR DESCRIPTION
## The bug

The plaintext preprocessor claimed **real PDFs** and handed raw PDF source — xref tables,
dictionary syntax, compressed stream bytes — to every validator as if it were text.

```
$ ferret-scan --file <a real 957KB PDF> --preprocess-only
Processor: Plain Text Preprocessor+Text Extractor+pdf_metadata
Content: 21436 words, 533976 characters        <-- 33% of it NON-PRINTABLE
%PDF-1.4
1 0 obj
<</Title (…) /Creator (Mozilla/5.0 …)         <-- raw PDF source, as "text"
```

Every finding was a match on binary:

| reported as | what the bytes actually are |
|---|---|
| `PHONE` ×41 (LOW) | xref table offsets — `0000956276`, `0000955916` (each verified as a real `%010d nnnnn n` entry) |
| `TWITTER` ×200 (**HIGH 100**) | stream bytes — `'@z4GM`, `'@e8`, `'@yn`, `'@Sc` |
| `INTELLECTUAL_PROPERTY` ×16 (8 HIGH) | stray `0xA9`/`0xAE` — `©эMv`, `(c)IJ`, `nmE®` |
| `EMAIL` (HIGH) | `F@mZ.mF` |
| `IP_ADDRESS` ×2 | `43::`, and `129.0.0.0` from the Chrome version in `/Creator` |

`TWITTER` at HIGH 100 is the worst of it — the top band survives every `--confidence` filter and
reaches redaction.

## Root cause

`containerExtensions` routes a container away from the plaintext preprocessor **on name alone**,
then re-admits it if the bytes sniff as text. That is right, and #271 added `.pdf` for exactly the
case it protects. But **the sniff cannot judge this one**: the PDF format *mandates* an ASCII
header, and a PDF written by a browser or Office follows `%PDF-1.x` with a large ASCII metadata
dictionary — so the first 512 bytes carry no NUL and are ~100% printable.

It is worse than a coin flip: `LooksLikeText`'s legacy fallback counts every byte `>= 0xA0` as
printable against a 95% bar, so even stream data often passes.

So the decision moves to the **magic bytes** — the one signal an ASCII header cannot fake.

**This does not withdraw #271.** A text file merely *named* `.pdf` carries no magic, still sniffs
as text, and is still scanned and redacted (verified: still reports `SSN HIGH 100`). **Nor does it
stop PDFs being scanned** — the router accepts them as `"Binary document"` via
`isBinaryDocument → IsPDFFile` *before* this sniff is consulted, and the PDF text and metadata
extractors have their own parsers. The fix lands in `LooksLikeText`, so all three callers agree:
this preprocessor, the router's `isTextFile`, and the redactor's `looksLikeTextFile`.

## Measured — 10 real PDFs

| before → after | | before → after |
|---|---|---|
| 61 → **1** | | 19 → **19** |
| 49 → **1** | | 55 → **55** |
| 11 → **3** | | 0 → 0 (×3) |
| 5 → **0** | | 4 → **2** |
| **TOTAL 204 → 81** | | **TWITTER on the worst file 200 → 0** |

**123 false positives gone, and every PDF whose text extraction was already clean is unchanged**
(19→19, 55→55) — real findings preserved, only garbage removed. The correlation that diagnosed the
bug also confirms the fix: beforehand the finding count tracked the non-printable share of the
extracted text almost exactly, and the three PDFs with clean extraction produced zero.

**189 non-PDF real files are byte-identical** before and after (108 `.docx`, 25 `.pptx`,
17 `.xlsx`, 10 `.xls`, 5 `.ppt`, 4 `.doc`, 15 `.json`).

## Scope check — other file types, other surfaces

- **Other container extensions: not affected.** Verified against real files of all six Office
  types — `.docx`/`.pptx`/`.xlsx`/`.doc`/`.xls`/`.ppt` are all correctly refused today. PDF is the
  only entry whose header is ASCII by specification.
- **Other surfaces: all were affected**, because the bug sits in the shared sniff. The web UI
  showed the same false positives on the same PDF (49 findings) — one fix covers CLI, web,
  pre-commit and `pkg/scan`.
- **Redaction: not affected.** No redactor claims a PDF, so nothing was written or corrupted.

One thing the investigation corrected in my own reasoning, now recorded in the code and pinned by
a test: the other containers are safe for **two different reasons**, not one. ZIP fails on its
magic alone (`PK\x03\x04` contains NULs); OLE's magic does **not** — it has no NUL and its high
bytes count as printable — so `.doc`/`.xls`/`.ppt` are rejected by the NUL-filled header *region*
after the magic, not by a signature. I asserted the stronger claim first and the test refuted it,
so the test now says the true thing and warns that a future NUL-free container variant would need
the same treatment PDF has.

**3 mutations, all caught**: removing the guard, inverting it, and widening the magic to `"%"`
(which would reject ordinary text beginning with a percent sign).

Suite **69/0**, `gofmt` and `vet` clean. Union with the three other open PRs (#407, #413, #418)
builds and passes **69/0**; none of them touches this file.

## Why this was not caught earlier

Every whole-tree false-positive check to date has run on **Office and JSON only — zero PDFs**. A
regression check that never scans a PDF cannot see this, so the class was invisible regardless of
how many times it ran. Worth adding a multi-type FP corpus (PDF, HTML, CSV, Markdown, plain text,
source, media) so "no FP regression on N real files" means what it sounds like.

---

Closes #419
