### PR TITLE
fix(cloudresources): disclose the oversize refusal instead of returning an empty result

### DIFF
--- a/internal/core/scanner.go
+++ b/internal/core/scanner.go
@@ -379,6 +379,13 @@ func ScanContent(content string, cfg ContentScanConfig) (*ScanResult, error) {
 		// partial in the same load-bearing way as a timeout.
 		incomplete = true
 		incompleteReason = "validator match budget exceeded: " + validationErr.Error()
+	} else if validationErr != nil && errors.Is(validationErr, execguard.ErrContentTooLarge) {
+		// A validator declined its input for size: that content went unscanned by it, so the
+		// result is partial. The file path reaches this through ValidationError -> a
+		// FileDiagnostic; this arm is what gives library callers of ScanContent the same signal
+		// instead of a silently narrower scan (#414).
+		incomplete = true
+		incompleteReason = "validator declined oversize content: " + validationErr.Error()
 	}
 
 	// Stamp every match as virtual and ensure the filename is the synthetic

--- a/internal/execguard/execguard.go
+++ b/internal/execguard/execguard.go
@@ -42,6 +42,41 @@ import (
 // hit is not a deadline/cancellation.
 var ErrMatchBudgetExceeded = errors.New("validator match budget exceeded")
 
+// ErrContentTooLarge is returned by a validator that DECLINED to scan its input because the
+// content exceeded a size the validator will not process. It belongs to the same family as
+// ErrMatchBudgetExceeded: a guard fired, so the result is partial and must be disclosed, while
+// whatever the validator did find is genuine.
+//
+// Returning an error rather than an empty slice is the whole point. `return nil, nil` is
+// indistinguishable from "scanned it, found nothing", so a caller cannot tell coverage was lost:
+// cloudresources refused anything over 5MB that way, and a real AWS ARN on line 1 of a 6MB file
+// was reported as a clean, complete scan — files_processed=1, no files_not_examined, exit 0 (#414).
+// 5MB is small for the file types that carry infrastructure identifiers: Terraform plans,
+// CloudTrail exports, build logs, support bundles.
+//
+// The cap itself is legitimate — this validator has a measured DoS history — so the fix is to
+// DISCLOSE the refusal, not to remove the bound.
+var ErrContentTooLarge = errors.New("validator declined oversize content")
+
+// IsCoverageCutShort reports whether err means a validator GUARD fired rather than a validator
+// failing: the scan completed, the result is partial, and whatever was found is genuine.
+//
+// This exists because the same family was enumerated in FOUR places — parallel.partialMatchesSurvive,
+// validators.firstBudgetError, the dual-path bridge's match-preservation branch, and core.ScanContent
+// — and adding a member meant finding all four. Missing one is silent: ErrContentTooLarge was
+// returned correctly by cloudresources, recorded by the bridge, and then dropped by
+// firstBudgetError, so the refusal was logged and never disclosed (#414). One predicate cannot
+// drift out of step with itself.
+//
+// Callers that need to distinguish WHICH guard fired (to word a message) still switch on the
+// specific sentinel; this answers only "was coverage cut short".
+func IsCoverageCutShort(err error) bool {
+	return errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, context.Canceled) ||
+		errors.Is(err, ErrMatchBudgetExceeded) ||
+		errors.Is(err, ErrContentTooLarge)
+}
+
 // ContextAwareValidator is an OPTIONAL extension of detector.Validator. A
 // validator that implements it receives the active context and is expected to
 // poll ctx.Err() at loop/match boundaries so it can abort promptly on deadline

--- a/internal/parallel/validator_runner.go
+++ b/internal/parallel/validator_runner.go
@@ -5,7 +5,6 @@ package parallel
 
 import (
 	"context"
-	"errors"
 	"sync"
 	"time"
 
@@ -23,9 +22,7 @@ import (
 // incomplete). A hard error keeps the historical behavior of discarding its
 // partial slice.
 func partialMatchesSurvive(err error) bool {
-	return errors.Is(err, context.DeadlineExceeded) ||
-		errors.Is(err, context.Canceled) ||
-		errors.Is(err, execguard.ErrMatchBudgetExceeded)
+	return execguard.IsCoverageCutShort(err)
 }
 
 // ValidatorStrategy controls how a single validator invocation is executed.

--- a/internal/validators/cloudresources/cloudresources.go
+++ b/internal/validators/cloudresources/cloudresources.go
@@ -127,13 +127,27 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 		finishTiming = v.observer.StartTiming("cloud_resources", "validate_content", originalPath)
 	}
 
-	// Guard against pathological inputs.
+	// Guard against pathological inputs — and SAY SO.
+	//
+	// This used to `return nil, nil`, which a caller cannot distinguish from "scanned it, found
+	// nothing", and the accompanying logDetail is debug-only. So an AWS ARN on line 1 of a 6MB
+	// file was reported as a clean, complete scan: the same ARN in a 1MB file scored a finding,
+	// files_processed was 1 either way, files_not_examined was absent, and the exit code was 0
+	// (#414). 5MB is small for the file types that carry infrastructure identifiers — Terraform
+	// plans, CloudTrail exports, build logs, support bundles routinely exceed it.
+	//
+	// The error is the disclosure channel: the scanner turns any validator error into a
+	// FileDiagnostic that reaches files_not_examined and --fail-on-incomplete, while every other
+	// validator's matches for the file are preserved. The cap stays — it guards a measured DoS —
+	// but a refusal is now visible instead of silent.
 	if len(content) > maxContentBytes {
 		v.logDetail(fmt.Sprintf("Content %d bytes exceeds %d-byte cap; skipping cloud-resource scan for %q", len(content), maxContentBytes, originalPath))
 		if finishTiming != nil {
 			finishTiming(true, map[string]interface{}{"match_count": 0, "skipped_oversize": true})
 		}
-		return nil, nil
+		// Payload-free: sizes and the cap only, never the path or any content.
+		return nil, fmt.Errorf("%w: cloud-resource scan skipped, content is %d bytes against a "+
+			"%d-byte cap", execguard.ErrContentTooLarge, len(content), maxContentBytes)
 	}
 
 	// Entry-level cancellation check (v2 Phase 3): the whole-content regex pass and

--- a/internal/validators/cloudresources/cloudresources_test.go
+++ b/internal/validators/cloudresources/cloudresources_test.go
@@ -4,11 +4,14 @@
 package cloudresources
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/awslabs/ferret-scan/v2/internal/config"
 	"github.com/awslabs/ferret-scan/v2/internal/detector"
+
+	"github.com/awslabs/ferret-scan/v2/internal/execguard"
 )
 
 // scan is a test helper that runs the validator over content and returns the matches.
@@ -390,9 +393,19 @@ func TestOversizeContentSkipped(t *testing.T) {
 	if len(big) <= maxContentBytes {
 		t.Fatalf("test setup: content not over cap (%d <= %d)", len(big), maxContentBytes)
 	}
-	ms := scan(t, big)
+
+	// Skipping is still the behaviour; it is now SAID as well. The refusal returns
+	// execguard.ErrContentTooLarge so the scan is flagged incomplete rather than reported clean
+	// — previously `nil, nil` made a skipped 6MB file indistinguishable from a scanned one
+	// (#414). This test therefore calls ValidateContent directly rather than through scan(),
+	// whose helper fails on any error.
+	ms, err := NewValidator().ValidateContent(big, "oversize.txt")
 	if len(ms) != 0 {
 		t.Errorf("oversize content should be skipped, got %d matches", len(ms))
+	}
+	if !errors.Is(err, execguard.ErrContentTooLarge) {
+		t.Errorf("err = %v, want execguard.ErrContentTooLarge: skipping silently is what made a "+
+			"real ARN in a 6MB file report as a clean scan at exit 0", err)
 	}
 }
 

--- a/internal/validators/cloudresources/oversize_disclosure_test.go
+++ b/internal/validators/cloudresources/oversize_disclosure_test.go
@@ -1,0 +1,158 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudresources
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/execguard"
+)
+
+// oversizeContent builds content past maxContentBytes whose FIRST line is a real ARN, so a
+// validator that actually scanned it would find something.
+func oversizeContent() string {
+	var b strings.Builder
+	b.WriteString("arn:aws:iam::123456789012:role/ProdAdminRole\n")
+	pad := strings.Repeat("the quick brown fox jumps over the lazy dog. ", 100) + "\n"
+	for b.Len() <= maxContentBytes {
+		b.WriteString(pad)
+	}
+	return b.String()
+}
+
+// Declining oversize content must be an ERROR, not an empty result.
+//
+// `return nil, nil` is indistinguishable from "scanned it, found nothing", so nothing downstream
+// could tell that coverage was lost. Measured before this: the same ARN on line 1 scored a finding
+// in a 1MB file and NOTHING in a 6MB one, with files_processed=1, no files_not_examined and exit 0
+// in both — the tool reported a clean, complete scan of content it never examined. 5MB is small for
+// the file types that carry infrastructure identifiers: Terraform plans, CloudTrail exports, build
+// logs, support bundles (#414).
+//
+// The cap itself stays. It guards a measured DoS; the defect was the silence.
+func TestOversizeContentIsRefusedWithAnError(t *testing.T) {
+	v := NewValidator()
+
+	// Control first: under the cap, the ARN is found. Without this the assertion below could
+	// pass on a validator that finds nothing at any size.
+	under, err := v.ValidateContent("arn:aws:iam::123456789012:role/ProdAdminRole\n", "small.tf")
+	if err != nil {
+		t.Fatalf("under the cap: unexpected error %v", err)
+	}
+	if len(under) == 0 {
+		t.Fatal("the control ARN produced no finding, so this test cannot detect a silent skip")
+	}
+
+	matches, err := v.ValidateContent(oversizeContent(), "big.tf")
+
+	if err == nil {
+		t.Fatal("oversize content was declined with a nil error: a caller cannot distinguish that " +
+			"from a completed scan that found nothing, so the lost coverage is invisible and the " +
+			"scan exits 0 reporting clean")
+	}
+	if !errors.Is(err, execguard.ErrContentTooLarge) {
+		t.Errorf("error = %v, want it to wrap execguard.ErrContentTooLarge: the scanner recognises "+
+			"that sentinel to mark the scan incomplete, and an unrecognised error is logged and "+
+			"dropped", err)
+	}
+	if len(matches) != 0 {
+		t.Errorf("declined content returned %d matches, want 0", len(matches))
+	}
+}
+
+// The refusal message must name sizes only — never the path, never any content. It reaches stderr
+// and every machine format with no --show-match to gate it.
+func TestOversizeRefusalMessageIsPayloadFree(t *testing.T) {
+	v := NewValidator()
+	_, err := v.ValidateContent(oversizeContent(), "/home/someone/secret-project/main.tf")
+	if err == nil {
+		t.Fatal("no error, so there is no message to check")
+	}
+
+	msg := err.Error()
+	for _, forbidden := range []string{
+		"ProdAdminRole",   // content
+		"123456789012",    // content
+		"secret-project",  // path
+		"/home/someone",   // path
+		"quick brown fox", // content
+	} {
+		if strings.Contains(msg, forbidden) {
+			t.Errorf("refusal message contains %q: %q. This string reaches stderr and every "+
+				"machine format with no --show-match to gate it", forbidden, msg)
+		}
+	}
+	// It must still say enough to act on.
+	if !strings.Contains(msg, "cap") {
+		t.Errorf("message %q does not mention the cap, so an operator cannot tell why the "+
+			"validator declined", msg)
+	}
+}
+
+// The cap must not fire below it, or the disclosure would appear on ordinary files and train
+// operators to ignore it.
+func TestContentUnderTheCapIsScannedSilently(t *testing.T) {
+	v := NewValidator()
+
+	var b strings.Builder
+	b.WriteString("arn:aws:iam::123456789012:role/ProdAdminRole\n")
+	pad := strings.Repeat("ordinary infrastructure notes. ", 100) + "\n"
+	for b.Len() < maxContentBytes-len(pad)-1 {
+		b.WriteString(pad)
+	}
+
+	matches, err := v.ValidateContent(b.String(), "just-under.tf")
+	if err != nil {
+		t.Errorf("content just under the cap (%d bytes vs cap %d) returned %v: the guard is "+
+			"firing early, which would report lost coverage on ordinary files", b.Len(),
+			maxContentBytes, err)
+	}
+	if len(matches) == 0 {
+		t.Error("content just under the cap produced no finding, so the boundary check above is " +
+			"vacuous")
+	}
+}
+
+// The whole family of "a guard fired, coverage is partial" sentinels must be recognised by one
+// predicate.
+//
+// This family was enumerated in FOUR places — parallel.partialMatchesSurvive,
+// validators.firstBudgetError, the dual-path bridge's match-preservation branch, and
+// core.ScanContent. Adding a member meant finding all four, and missing one was silent: the
+// sentinel was returned correctly, recorded by the bridge, then DROPPED by firstBudgetError, so
+// the refusal was logged and never disclosed. This pins the predicate's membership.
+func TestCoverageCutShortRecognisesTheWholeFamily(t *testing.T) {
+	if !execguard.IsCoverageCutShort(execguard.ErrContentTooLarge) {
+		t.Error("ErrContentTooLarge is not recognised as cutting coverage short, so a validator " +
+			"declining its input is logged and dropped instead of disclosed")
+	}
+	if !execguard.IsCoverageCutShort(execguard.ErrMatchBudgetExceeded) {
+		t.Error("ErrMatchBudgetExceeded is no longer recognised — a pre-existing member was lost")
+	}
+	// A wrapped sentinel must still be recognised: every producer wraps with %w to add detail.
+	wrapped := errors.New("outer: " + execguard.ErrContentTooLarge.Error())
+	if execguard.IsCoverageCutShort(wrapped) {
+		t.Error("a look-alike error with no wrapped sentinel was accepted; matching must be on " +
+			"errors.Is, not on message text")
+	}
+	if !execguard.IsCoverageCutShort(errWrap(execguard.ErrContentTooLarge)) {
+		t.Error("a properly wrapped sentinel was not recognised, so the %w producers below it " +
+			"would be dropped")
+	}
+	// An ordinary validator failure must NOT be in the family: it does not by itself make the
+	// scan partial, which is the historical behaviour this must not change.
+	if execguard.IsCoverageCutShort(errors.New("some validator blew up")) {
+		t.Error("an ordinary error was treated as cut-short coverage; that would flag every " +
+			"transient validator failure as lost coverage")
+	}
+}
+
+func errWrap(err error) error { return &wrapped{err} }
+
+type wrapped struct{ err error }
+
+func (w *wrapped) Error() string { return "context: " + w.err.Error() }
+func (w *wrapped) Unwrap() error { return w.err }

--- a/internal/validators/dual_path_bridge.go
+++ b/internal/validators/dual_path_bridge.go
@@ -781,9 +781,7 @@ func validatorName(v detector.Validator) string {
 // ordinary validator errors are deliberately excluded (historical behavior).
 func firstBudgetError(errs []error) error {
 	for _, err := range errs {
-		if errors.Is(err, stdctx.DeadlineExceeded) ||
-			errors.Is(err, stdctx.Canceled) ||
-			errors.Is(err, execguard.ErrMatchBudgetExceeded) {
+		if execguard.IsCoverageCutShort(err) {
 			return err
 		}
 	}
@@ -883,7 +881,7 @@ func (dvb *DocumentValidatorBridge) ProcessDocumentContentCtx(ctx stdctx.Context
 				// matches are genuine findings and must be kept, unlike a real
 				// validator error (which discards its partial slice). The error is
 				// still recorded above so the scan is flagged incomplete.
-				if errors.Is(err, execguard.ErrMatchBudgetExceeded) {
+				if execguard.IsCoverageCutShort(err) {
 					resultsChan <- validatorResult{index: idx, matches: matches, err: err}
 					return
 				}


### PR DESCRIPTION
## The bug

`cloudresources` refuses content over 5MB and returned `nil, nil` — indistinguishable from
"scanned it, found nothing". The accompanying log is debug-only, so in normal operation nothing was
said.

```
the SAME AWS ARN on line 1 of a text file:
  arn_1mb.txt   1 finding    exit 0   files_processed=1   files_not_examined ABSENT
  arn_6mb.txt   0 findings   exit 0   files_processed=1   files_not_examined ABSENT
```

The tool reported a **clean, complete scan of content it never examined**. 5MB is small for the
file types that carry infrastructure identifiers — Terraform plans, CloudTrail exports, build logs,
support bundles routinely exceed it, and those are exactly where ARNs, account IDs and access keys
live.

The cap itself is legitimate: this validator has a measured DoS history, and the comment calling it
a guard against pathological inputs is right. **The defect was the silence**, so this discloses the
refusal rather than removing the bound.

## After

```
arn_6mb.txt   0 findings   exit 3   files_not_examined 1
              coverage cut short — validator declined oversize content:
              cloud-resource scan skipped, content is 6292443 bytes against a 5242880-byte cap

arn_1mb.txt   unchanged: 1 finding, exit 0, no disclosure
```

The message is **payload-free** by design — sizes and the cap only, never the path and never any
content. It reaches stderr and every machine format with no `--show-match` to gate it.

## The sentinel family was enumerated four times, and my first attempt failed silently because of it

Returning an error was not enough. A validator signals "a guard fired, coverage is partial" with an
error the scanner recognises, and that family — `context.DeadlineExceeded`, `context.Canceled`,
`execguard.ErrMatchBudgetExceeded` — was spelled out in **four** places:

```
parallel.partialMatchesSurvive
validators.firstBudgetError                     <-- dropped it
the dual-path bridge's match-preservation branch
core.ScanContent's incomplete arms
```

My first version added the sentinel, the validator returned it correctly, the bridge **recorded**
it — and then `firstBudgetError`, which lists the family to decide what to surface, did not
recognise it and dropped it. The refusal was logged and never disclosed, and the end-to-end
behaviour was **byte-identical to the bug**. I only caught it because the end-to-end check still
showed `exit 0`.

So the family is now one predicate, `execguard.IsCoverageCutShort`, used by the three "is this the
soft family" call sites. Callers that must word a message still switch on the specific sentinel. One
predicate cannot drift out of step with itself; four lists can, and did.

## Verification

| check | result |
|---|---|
| mutations | **5, all caught** |
| boundary | content *just under* the cap is scanned with **no** disclosure, so the guard cannot fire on ordinary files |
| 189 real documents | **byte-identical**, and the new disclosure fires on **none** of them |
| suite | **69/0**, `gofmt` and `vet` clean |
| union with #423 | merges clean, builds, **69/0**; no shared files |

The mutations: restoring the silent `nil, nil`; removing the sentinel from the predicate; making the
predicate accept any error; making `firstBudgetError` drop the family again; and putting the path
into the refusal message. A sixth attempt was **invalid** — it inserted the path inside a `/* */`
comment so it never reached the message; re-run properly, it was caught.

Non-vacuity controls throughout: the control ARN must be found *under* the cap, or the silent-skip
assertion proves nothing.

`TestOversizeContentSkipped` is **rebased, not replaced**: its assertion (zero matches) still holds
and is kept, and it now also asserts the refusal is disclosed. It failed only because its helper
treats any error as a test failure.

---

Closes #414
