### PR TITLE
fix(position): short-circuit findBestFuzzyMatch on an exact occurrence

### DIFF
--- a/internal/goldencorpus/complexity_guard_redaction_test.go
+++ b/internal/goldencorpus/complexity_guard_redaction_test.go
@@ -106,6 +106,82 @@ func buildRedactionFixture(n int, fillerLines int) (string, []detector.Match) {
 // unexported text-level helper: the public entry point is what the CLI uses, and
 // a timing guard should measure the path that ships. File I/O adds a constant
 // that cancels in the ratio.
+// buildRedactionFixtureRepeated returns text with n distinct SSNs each emitted TWICE, plus the
+// matches a scan would report for all 2n occurrences.
+//
+// This is the shape buildRedactionFixture deliberately excludes, and excluding it is what let a
+// quadratic hide from the guard for so long. Its comment explains the omission — repeated values
+// "would let a redactor replace every occurrence in one pass and defeat the measurement" — which is
+// true of the plaintext REPLACEMENT step and false of the POSITION CORRELATION that runs first.
+//
+// Correlation scores an exact match 0.95 for a unique value but 0.95*(0.5+0.5/n) for n occurrences,
+// which is 0.7125 at n=2 — below the 0.8 confidenceThreshold. So every duplicated value fell
+// through to the fuzzy matcher, which slid over the whole document per match. Measured at HEAD
+// before the fix, at equal file size and equal finding count:
+//
+//	fixture   bytes   duplicated   distinct
+//	n=75      3.9KB      0.89s      0.07s
+//	n=150     7.9KB     19.92s      0.11s
+//	n=300    16.0KB    128.49s      0.10s
+//
+// Quadratic against a flat control, and 16x past this file's 8s ceiling at 16KB. A log or CSV that
+// repeats any value is the ordinary case, not a hostile one (#376).
+func buildRedactionFixtureRepeated(n int) (string, []detector.Match) {
+	var b strings.Builder
+	matches := make([]detector.Match, 0, 2*n)
+	line := 0
+	for i := 0; i < n; i++ {
+		// Distinct across i, and none are real: area group 900+ is unassigned.
+		ssn := fmt.Sprintf("9%02d-%02d-%04d", i%100, (i/100)%100, i%10000)
+		for _, tag := range [2]string{"record", "repeat"} {
+			line++
+			text := fmt.Sprintf("%s %d ssn %s", tag, i, ssn)
+			b.WriteString(text)
+			b.WriteByte('\n')
+			matches = append(matches, detector.Match{
+				Text:       ssn,
+				Type:       "SSN",
+				Confidence: 100,
+				LineNumber: line,
+				Context:    detector.ContextInfo{FullLine: text},
+			})
+		}
+	}
+	return b.String(), matches
+}
+
+// A value repeated in the document must not cost more than a distinct one.
+//
+// Asserted against the same redactionAbsoluteCeiling the rest of this file uses, and paired with a
+// DISTINCT control of the same size and match count so the assertion cannot pass by the whole
+// redactor being slow or the machine being fast. timeRedact's leak floor applies to every sample,
+// so an "optimisation" that skips matches fails instead of looking quick.
+func TestRedactionComplexity_RepeatedValues(t *testing.T) {
+	const n = 300 // 600 matches, ~16KB — 128s at HEAD before the fix
+
+	repeatedText, repeatedMatches := buildRedactionFixtureRepeated(n)
+	distinctText, distinctMatches := buildRedactionFixture(2*n, 0)
+
+	repeated, _ := timeRedact(t, repeatedText, repeatedMatches)
+	distinct, _ := timeRedact(t, distinctText, distinctMatches)
+
+	if repeated > redactionAbsoluteCeiling {
+		t.Errorf("redacting %d repeated-value matches over %d bytes took %v, ceiling %v — a "+
+			"document that repeats a value routes every match through the whole-document fuzzy "+
+			"slide (#376). The distinct control of the same shape took %v",
+			len(repeatedMatches), len(repeatedText), repeated, redactionAbsoluteCeiling, distinct)
+	}
+
+	// The comparison is the real signal: the two fixtures are the same size and carry the same
+	// number of matches, so any large gap is the duplicate-value path costing extra rather than
+	// redaction being slow in general.
+	if distinct > 0 && repeated > 20*distinct && repeated > 500*time.Millisecond {
+		t.Errorf("repeated values took %v against %v for the same size and match count (%.0fx) — "+
+			"the duplicate path is doing work the distinct path is not", repeated, distinct,
+			float64(repeated)/float64(distinct))
+	}
+}
+
 func timeRedact(t *testing.T, text string, matches []detector.Match) (time.Duration, int) {
 	t.Helper()
 

--- a/internal/redactors/position/fuzzy.go
+++ b/internal/redactors/position/fuzzy.go
@@ -17,6 +17,43 @@ func (dpc *DefaultPositionCorrelator) findBestFuzzyMatch(targetText, originalTex
 		return nil
 	}
 
+	// An EXACT occurrence needs no fuzzy search, and skipping to it is what keeps this
+	// function linear instead of quadratic.
+	//
+	// Callers reach here whenever exactMatchConfidence falls below confidenceThreshold, and it
+	// does that for any value occurring more than once: 0.95*(0.5+0.5/n) is 0.7125 at n=2 against
+	// a 0.8 threshold. So a document that repeats ANY value — a log, a CSV, an export — routed
+	// every one of its findings through the slide below, which walks the whole document running
+	// ~7 lengths x ~7 starts of a freshly allocated Levenshtein matrix per position. Measured on
+	// fixtures of equal size and equal finding count, duplicated against distinct:
+	//
+	//	3.9KB   0.89s  vs 0.07s
+	//	7.9KB  19.92s  vs 0.11s
+	//	16KB  128.49s  vs 0.10s      <- distinct is flat; duplicated is quadratic
+	//
+	// Extrapolated against the 100MB MaxFileSize that is days. Availability only — the output was
+	// always correct — but the streaming redaction path hangs on ordinary input (#376).
+	//
+	// This is OUTPUT-IDENTICAL to the loop, not an approximation:
+	//   - an exact match requires editDistance == 0, which requires substring == targetText, so it
+	//     can only occur at length == targetLen;
+	//   - findBestMatchInCandidate RETURNS the moment editDistance == 0, and the slide below
+	//     BREAKS the moment bestMatch.EditDistance == 0;
+	//   - the earliest window that can contain the first occurrence at offset p is
+	//     max(0, p-2*maxEditDistance), and within it the ascending `start` scan reaches p before
+	//     any later occurrence.
+	// So the loop's own result for a document containing targetText is exactly
+	// {targetText, firstIndex, 0, 1.0} — which is what this returns. calculateStringSimilarity
+	// returns 1.0 for identical strings, so even the Similarity field agrees.
+	if idx := strings.Index(originalText, targetText); idx >= 0 {
+		return &FuzzyMatch{
+			Text:         targetText,
+			Index:        idx,
+			EditDistance: 0,
+			Similarity:   1.0,
+		}
+	}
+
 	bestMatch := &FuzzyMatch{
 		EditDistance: math.MaxInt32,
 		Similarity:   0.0,

--- a/internal/redactors/position/fuzzy_exact_test.go
+++ b/internal/redactors/position/fuzzy_exact_test.go
@@ -1,0 +1,136 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package position
+
+import (
+	"strings"
+	"testing"
+)
+
+// findBestFuzzyMatch short-circuits on an exact occurrence, and the whole justification for doing
+// so is that the result is IDENTICAL to what the slide would have returned — not merely good
+// enough. This pins every field of that result, because "identical" is a claim about all of them.
+//
+// Without this, three mutations survived: returning strings.LastIndex instead of strings.Index,
+// returning idx+1, and returning Similarity 0.5. Each violates the stated contract while leaving
+// the end-to-end plaintext redaction output unchanged, because that path replaces every occurrence
+// regardless of which one was reported. A consumer that uses the reported Index — format-preserving
+// redaction, position mapping — would get a wrong offset with no test to catch it (#376).
+func TestFindBestFuzzyMatch_ExactOccurrence(t *testing.T) {
+	dpc := NewDefaultPositionCorrelator()
+
+	t.Run("returns the FIRST occurrence, not any later one", func(t *testing.T) {
+		target := "449-87-4100"
+		// Three occurrences. The slide starts at offset 0 and breaks on the first exact hit, so
+		// the first is the answer; LastIndex would give the third.
+		original := "alpha " + target + " beta " + target + " gamma " + target + " end"
+		want := strings.Index(original, target)
+
+		got := dpc.findBestFuzzyMatch(target, original)
+		if got == nil {
+			t.Fatal("no match for a value that occurs three times verbatim")
+		}
+		if got.Index != want {
+			t.Errorf("Index = %d, want %d (the FIRST occurrence). The slide breaks on the first "+
+				"exact hit, so any other offset is not what it would have returned — and a "+
+				"consumer that trusts this offset redacts the wrong bytes", got.Index, want)
+		}
+		if got.Text != target {
+			t.Errorf("Text = %q, want %q", got.Text, target)
+		}
+		if got.EditDistance != 0 {
+			t.Errorf("EditDistance = %d, want 0 for an exact occurrence", got.EditDistance)
+		}
+		if got.Similarity != 1.0 {
+			t.Errorf("Similarity = %v, want 1.0 — calculateStringSimilarity returns exactly 1.0 "+
+				"for identical strings, so this is what the slide would have produced",
+				got.Similarity)
+		}
+	})
+
+	t.Run("the reported Index actually locates the value", func(t *testing.T) {
+		// Independent of the arithmetic above: slice the original at the reported offset and
+		// require the value to be there. An off-by-one fails this even if it looks plausible.
+		target := "449-87-4100"
+		original := "padding padding " + target + " trailing"
+
+		got := dpc.findBestFuzzyMatch(target, original)
+		if got == nil {
+			t.Fatal("no match")
+		}
+		if got.Index < 0 || got.Index+len(target) > len(original) {
+			t.Fatalf("Index %d is out of range for a %d-byte document", got.Index, len(original))
+		}
+		if at := original[got.Index : got.Index+len(target)]; at != target {
+			t.Errorf("the document at the reported Index %d holds %q, not %q — the offset does "+
+				"not point at the value it claims to have found", got.Index, at, target)
+		}
+	})
+
+	t.Run("at the very start and the very end", func(t *testing.T) {
+		target := "449-87-4100"
+		for name, original := range map[string]string{
+			"at offset 0":  target + " trailing text",
+			"at the end":   "leading text " + target,
+			"whole string": target,
+		} {
+			t.Run(name, func(t *testing.T) {
+				got := dpc.findBestFuzzyMatch(target, original)
+				if got == nil {
+					t.Fatal("no match")
+				}
+				if want := strings.Index(original, target); got.Index != want {
+					t.Errorf("Index = %d, want %d", got.Index, want)
+				}
+				if got.EditDistance != 0 || got.Similarity != 1.0 {
+					t.Errorf("EditDistance = %d, Similarity = %v; want 0 and 1.0",
+						got.EditDistance, got.Similarity)
+				}
+			})
+		}
+	})
+}
+
+// The genuinely-fuzzy path must still work. The short-circuit only fires on a verbatim occurrence,
+// so a value that differs by an edit still goes through the slide — and if it did not, this change
+// would have replaced fuzzy matching rather than accelerated it.
+func TestFindBestFuzzyMatch_StillMatchesInexactly(t *testing.T) {
+	dpc := NewDefaultPositionCorrelator()
+
+	// One digit differs, so strings.Index finds nothing and the slide runs.
+	target := "449-87-4100"
+	original := "the record shows 449-87-4109 on file"
+	if strings.Contains(original, target) {
+		t.Fatal("test setup: the target is present verbatim, so the slide is not being exercised")
+	}
+
+	got := dpc.findBestFuzzyMatch(target, original)
+	if got == nil {
+		t.Fatal("no fuzzy match for a value differing by one digit: the slide is no longer " +
+			"reachable, which would mean the short-circuit replaced fuzzy matching instead of " +
+			"accelerating it")
+	}
+	if got.EditDistance == 0 {
+		t.Errorf("EditDistance = 0 for a value that is NOT present verbatim (%q vs %q)",
+			got.Text, target)
+	}
+	if got.EditDistance > dpc.maxEditDistance {
+		t.Errorf("EditDistance %d exceeds maxEditDistance %d, so this should have been nil",
+			got.EditDistance, dpc.maxEditDistance)
+	}
+}
+
+// A value that is absent and not close to anything must still return nil.
+func TestFindBestFuzzyMatch_NoMatch(t *testing.T) {
+	dpc := NewDefaultPositionCorrelator()
+	if got := dpc.findBestFuzzyMatch("449-87-4100", "nothing resembling that value here at all"); got != nil {
+		t.Errorf("got %+v, want nil for an absent value", got)
+	}
+	if got := dpc.findBestFuzzyMatch("", "some text"); got != nil {
+		t.Errorf("got %+v, want nil for an empty target", got)
+	}
+	if got := dpc.findBestFuzzyMatch("target", ""); got != nil {
+		t.Errorf("got %+v, want nil for empty original text", got)
+	}
+}


### PR DESCRIPTION
## The bug

`exactMatchConfidence` returns 0.95 for a unique value but `0.95*(0.5+0.5/n)` for n occurrences —
**0.7125 at n=2**, below the 0.8 `confidenceThreshold`. So `CorrelatePosition` falls through to
`findBestFuzzyMatch`, which slides over the **whole document**, running ~7 lengths × ~7 starts of a
freshly allocated Levenshtein matrix per position.

Any document that repeats a value — a log, a CSV, an export — routed **every** finding through that.

## Measured, best of 3 runs so startup noise cannot dominate

| fixture | bytes | before | after | speedup |
|---|---|---|---|---|
| dup75 | 3.9 KB | 0.06s | 0.06s | 1× |
| dup150 | 7.9 KB | **20.04s** | 0.07s | **286×** |
| dup300 | 16.0 KB | **126.35s** | 0.09s | **1404×** |
| uniq300 (distinct control) | 16.1 KB | 0.09s | 0.10s | — flat both sides |

**Correcting my own first figures**: at n=75 there is *no* measurable difference on this machine —
the 0.89s I initially recorded there was startup noise. The effect appears from n=150. The issue's
table showed 3.25s at n=75 on different hardware; either way the quadratic is unambiguous at 150 and
300, against a flat distinct control of identical size and match count.

## The fix

Short-circuit on an exact occurrence, per the issue's sketch. It is **output-identical to the loop,
not an approximation**, and the reasoning is in the code:

- an exact match needs `editDistance == 0`, which needs `substring == targetText`, so it can only
  occur at `length == targetLen`
- `findBestMatchInCandidate` **returns** the moment `editDistance == 0`; the slide **breaks** the
  moment `bestMatch.EditDistance == 0`
- the earliest window that can contain the first occurrence at offset `p` is
  `max(0, p-2*maxEditDistance)`, and within it the ascending `start` scan reaches `p` before any
  later occurrence

So the loop's own answer is exactly `{targetText, firstIndex, 0, 1.0}` — and `calculateStringSimilarity`
returns exactly 1.0 for identical strings, so even that field agrees.

## Output identity, checked at the sink rather than argued

- 4 plaintext fixtures (duplicated and distinct): redacted bytes **identical**
- **123 redacted real documents** out of 189 scanned (`.docx`/`.pptx`/`.xlsx`/`.doc`/`.xls`/`.ppt`/
  `.json`, all checks): **every file byte-identical**, none added, none dropped. This exercises the
  genuinely-fuzzy path too, where `extractedText` differs from `originalText` and the slide still runs.

## Tests — and a gap they exposed

**The complexity guard the existing one deliberately excluded.** `buildRedactionFixture` uses
distinct values and says why: repeated values "would let a redactor replace every occurrence in one
pass and defeat the measurement." That is true of the plaintext *replacement* step and false of the
*position correlation* that runs first — which is exactly how a quadratic hid from a guard built to
catch quadratics. The new `buildRedactionFixtureRepeated` family fixes that, asserted against the
same 8s ceiling and paired with a distinct control.

Verified non-vacuous by removing the fix: **2m17s against the 8s ceiling, and 8125× the distinct
control** — both assertions fire.

**`internal/redactors/position` had no test file at all**, and that showed: three correctness
mutations survived a first pass — `strings.LastIndex` instead of `strings.Index`, `idx+1`, and
`Similarity 0.5`. Each violates the stated contract while leaving end-to-end plaintext redaction
output unchanged, because that path replaces every occurrence regardless of which one was reported.
A consumer that uses the reported `Index` — format-preserving redaction, position mapping — would get
a wrong offset with nothing to catch it.

The new tests pin every returned field, including a case with **three** occurrences so "first" is
distinguishable from "last", and an independent check that slices the document at the reported offset
and requires the value to be there. All three are now caught, plus "the short-circuit always fires".

"Short-circuit removed entirely" still survives *in that package* — correctly, since it changes speed
not values. That case belongs to the complexity guard, where it fails emphatically.

## Verification

- suite **70/0**, `gofmt` and `vet` clean, `-race` clean on both touched packages
- union with #425 and #426: merges clean, builds, `gofmt` clean, Go pins consistent, **70/0**; neither
  touches these files

## Sequencing note

The issue flags that #383 proposes deleting the *contextual* correlation branch in this same package
as unreachable, and that the two should be sequenced deliberately. This change touches only the
**fuzzy** path and leaves the contextual branch alone.

---

Closes #376
