### PR TITLE
fix(socialmedia): refuse a platform's own system pages, so citing one is not reported or redacted

### DIFF
--- a/docs/social-media-configuration.md
+++ b/docs/social-media-configuration.md
@@ -203,11 +203,46 @@ validators:
   `isFalsePositiveHandle`: a handle immediately followed by `.`, `-` or `@` is a
   domain or a federated (Mastodon-style) address rather than a bare handle.
 
+### Platform system pages are not profiles
+
+Eight of the shipped platforms have no path prefix in their profile pattern — `facebook.com/…`,
+`instagram.com/…`, `pinterest.com/…`, `skype.com/…`, `t.me/…`, `twitch.tv/…`,
+`(twitter|x).com/…` and `discord.gg/…` — so for those, **any** single path segment reads as a
+handle. `instagram.com/explore` and `instagram.com/reneemueller` are the same shape.
+
+The validator therefore refuses a match whose first path segment is one of the platform's own
+system pages: `about`, `help`, `legal`, `privacy`, `terms`, `settings`, `login`, `explore`,
+`search` and similar, plus per-platform additions such as Instagram's `reels` and `tv`,
+Pinterest's `today` and `categories`, Twitter's `home` and `i`, and Telegram's `joinchat`. The
+tables live in `internal/validators/socialmedia/reserved_paths.go`.
+
+Three properties are worth knowing:
+
+- **It is a refusal, not a score reduction.** Confidence is capped at 100 while the raw score for
+  these URLs reaches 134, so a penalty is absorbed by the cap and the finding still reports at
+  HIGH. It also cannot be a threshold: `instagram.com/explore` scores *higher* than a real
+  profile, because nothing distinguishes them but the vocabulary.
+- **Only the first path segment is judged.** Platforms whose pattern carries a prefix
+  (`linkedin.com/in/`, `reddit.com/u/`, `bsky.app/profile/`, and the `/@handle` forms) put the
+  handle in the second segment, so `linkedin.com/in/about` is detected normally.
+- **The whole segment must match.** `instagram.com/exploration` and `twitter.com/homer` are real
+  handles and are detected.
+
+This matters most for redaction: a reported system URL is overwritten in the redacted copy, which
+corrupts a document that was only citing the platform's own help page.
+
+The tables cover the system pages that turn up cited in documents rather than every path a
+platform serves, so an uncovered one remains a false positive. Prefer that direction: an entry
+that is wrong the other way would suppress a real profile, and a suppressed finding is never
+redacted.
+
 ### Pattern Guidelines
 - Use case-insensitive patterns: `(?i)`
 - Include both full URLs and domain-only patterns
 - Test patterns to avoid false positives
 - Consider platform-specific username rules
+- Prefer a pattern with a path prefix where the platform has one (`linkedin.com/in/…` rather than
+  `linkedin.com/…`); a prefix-less pattern makes every system page on that host a candidate handle
 
 ### Security Considerations
 - Social media detection is disabled by default
@@ -248,8 +283,15 @@ ferret-scan --file document.pdf --checks SOCIAL_MEDIA --debug
 ### False positives
 1. Add negative keywords
 2. Use whitelist patterns
-3. Refine regex patterns
+3. Refine regex patterns — give the pattern the platform's path prefix if it has one
 4. Check for email/social media conflicts
+
+### A platform's own help or policy page is reported as a profile
+
+The first path segment is not in the reserved tables for that platform. See
+[Platform system pages are not profiles](#platform-system-pages-are-not-profiles); the tables in
+`internal/validators/socialmedia/reserved_paths.go` are not exhaustive. A `whitelist_patterns`
+entry reduces the confidence of such a match but does not remove it.
 
 ### Email addresses detected as social media
 1. Remove email patterns from social media config

--- a/internal/validators/socialmedia/reserved_paths.go
+++ b/internal/validators/socialmedia/reserved_paths.go
@@ -1,0 +1,296 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package socialmedia
+
+import "strings"
+
+// Reserved first-path segments: a platform's own system pages, which are never anybody's profile.
+//
+// Most platform profile patterns carry a path prefix that disambiguates them — linkedin.com/in/,
+// reddit.com/u/, bsky.app/profile/, and the /@handle forms (clubhouse, medium, threads, tiktok,
+// mastodon). For those the first path segment is the prefix itself, so nothing here can apply to
+// them. Eight platforms have no prefix, and for them any single path segment reads as a handle:
+// facebook, instagram, pinterest, skype, telegram (t.me), twitch (twitch.tv), twitter/x, and
+// discord (discord.gg). Those are the ones these tables exist for.
+//
+// Why a veto rather than a confidence penalty. validateNotFalsePositive is advisory: a failure
+// costs 30 points at validator.go's scoring site. But the raw score for these URLs runs to 134
+// before being capped at 100, so subtracting 30 leaves 104 — still capped to 100, still HIGH,
+// still reported and still redacted. Measured on a fixture of 18 platform system URLs: every one
+// scored 54-134 raw with false_positive_prevention exactly 0, and instagram.com/explore scored
+// HIGHER (134) than the real profile instagram.com/reneemueller (124). No threshold can separate
+// them, because there is no structural difference between the two — only vocabulary. So the
+// discriminator has to be categorical.
+//
+// Why that is safe in the direction that matters. A wrong entry here suppresses a real finding,
+// and a suppressed finding is a cleartext leak (only reported findings reach the redactor), so
+// every entry must be a name the platform genuinely reserves and nobody can register. Matching is
+// against the WHOLE segment, case-folded: instagram.com/exploration is not instagram.com/explore.
+// The generic set below is limited to names reserved on every consumer platform; anything
+// platform-specific, or that could plausibly be somebody's handle elsewhere, lives in the
+// per-platform table instead of the shared one.
+//
+// Grounding. The per-platform entries are taken from each platform's own robots.txt Disallow list
+// where it publishes one — pinterest.com/robots.txt names over 120 system segments, facebook's and
+// twitter's name theirs — plus the platforms' documented feature paths. robots.txt is authoritative
+// but incomplete (twitter publishes four segments, pinterest a hundred), which is why these tables
+// do not attempt to be exhaustive: they cover the system pages that actually turn up cited in
+// documents. An uncovered system path stays a false positive, which is the tolerable direction of
+// error.
+
+// sharedReservedPaths are first-path segments reserved as system pages on every consumer platform.
+// No platform permits registering these as a profile name.
+var sharedReservedPaths = map[string]struct{}{
+	"about":         {},
+	"account":       {},
+	"accounts":      {},
+	"admin":         {},
+	"api":           {},
+	"careers":       {},
+	"contact":       {},
+	"developer":     {},
+	"developers":    {},
+	"explore":       {},
+	"faq":           {},
+	"help":          {},
+	"legal":         {},
+	"login":         {},
+	"logout":        {},
+	"messages":      {},
+	"notifications": {},
+	"policies":      {},
+	"policy":        {},
+	"press":         {},
+	"privacy":       {},
+	"register":      {},
+	"search":        {},
+	"security":      {},
+	"settings":      {},
+	"signin":        {},
+	"signup":        {},
+	"support":       {},
+	"terms":         {},
+	"tos":           {},
+}
+
+// platformReservedPaths holds segments reserved by one platform in particular. Kept separate from
+// the shared set because several — "business", "home", "today", "tv" — are plausible handles on a
+// platform that does not reserve them, and vetoing those would suppress a real profile.
+var platformReservedPaths = map[string]map[string]struct{}{
+	"instagram": {
+		"archive":   {},
+		"business":  {},
+		"challenge": {},
+		"creators":  {},
+		"direct":    {},
+		"directory": {},
+		"emails":    {},
+		"invites":   {},
+		"oauth":     {},
+		"p":         {},
+		"reel":      {},
+		"reels":     {},
+		"session":   {},
+		"stories":   {},
+		"tv":        {},
+		"web":       {},
+	},
+	"pinterest": {
+		"board":        {},
+		"business":     {},
+		"categories":   {},
+		"discover":     {},
+		"homefeed":     {},
+		"ideas":        {},
+		"invite":       {},
+		"join":         {},
+		"news_hub":     {},
+		"oauth":        {},
+		"password":     {},
+		"pin":          {},
+		"place":        {},
+		"prefs":        {},
+		"secure":       {},
+		"shop":         {},
+		"source":       {},
+		"today":        {},
+		"topics":       {},
+		"tv":           {},
+		"videos":       {},
+		"website":      {},
+		"welcome":      {},
+		"your-shop":    {},
+		"live-session": {},
+	},
+	"facebook": {
+		"ads":         {},
+		"adsmanager":  {},
+		"ajax":        {},
+		"bookmarks":   {},
+		"business":    {},
+		"checkpoint":  {},
+		"community":   {},
+		"dialog":      {},
+		"events":      {},
+		"feeds":       {},
+		"friends":     {},
+		"gaming":      {},
+		"groups":      {},
+		"hashtag":     {},
+		"marketplace": {},
+		"memories":    {},
+		"notes":       {},
+		"pages":       {},
+		"permalink":   {},
+		"plugins":     {},
+		"safety":      {},
+		"saved":       {},
+		"share":       {},
+		"sharer":      {},
+		"watch":       {},
+	},
+	"twitter": {
+		"bookmarks":       {},
+		"compose":         {},
+		"download":        {},
+		"followers":       {},
+		"following":       {},
+		"hashtag":         {},
+		"home":            {},
+		"i":               {},
+		"intent":          {},
+		"lists":           {},
+		"moments":         {},
+		"oauth":           {},
+		"personalization": {},
+		"share":           {},
+		"status":          {},
+		"statuses":        {},
+		"topics":          {},
+		"who_to_follow":   {},
+		"widgets":         {},
+	},
+	"telegram": {
+		"addemoji":     {},
+		"addlist":      {},
+		"addstickers":  {},
+		"addtheme":     {},
+		"bg":           {},
+		"c":            {},
+		"confirmphone": {},
+		"iv":           {},
+		"joinchannel":  {},
+		"joinchat":     {},
+		"proxy":        {},
+		"s":            {},
+		"setlanguage":  {},
+		"share":        {},
+		"socks":        {},
+	},
+	"twitch": {
+		"broadcast":     {},
+		"communities":   {},
+		"dashboard":     {},
+		"directory":     {},
+		"downloads":     {},
+		"drops":         {},
+		"friends":       {},
+		"inventory":     {},
+		"jobs":          {},
+		"moderator":     {},
+		"popout":        {},
+		"prime":         {},
+		"products":      {},
+		"subscriptions": {},
+		"team":          {},
+		"teams":         {},
+		"turbo":         {},
+		"videos":        {},
+		"wallet":        {},
+	},
+	// skype.com hosts no user profiles at all — it is a product site, so every segment is a
+	// system page. Only the segments that actually appear in cited URLs are listed; the locale
+	// codes it also serves are open-ended and are left alone.
+	"skype": {
+		"blogs":     {},
+		"business":  {},
+		"community": {},
+		"de":        {},
+		"download":  {},
+		"en":        {},
+		"en-us":     {},
+		"es":        {},
+		"features":  {},
+		"fr":        {},
+		"it":        {},
+		"ja":        {},
+		"plans":     {},
+		"pricing":   {},
+		"rates":     {},
+	},
+}
+
+// firstPathSegment returns the first path segment of a matched URL, and whether there was one.
+//
+// It reports false for a match with no path at all — a bare @handle, a skype: URI, a
+// sub.medium.com host — because there is then no segment to judge and the veto must not apply.
+func firstPathSegment(match string) (string, bool) {
+	s := match
+	if i := strings.Index(s, "://"); i >= 0 {
+		s = s[i+3:]
+	}
+
+	// The host runs to the first slash. Without one, the match carries no path.
+	slash := strings.IndexByte(s, '/')
+	if slash < 0 {
+		return "", false
+	}
+
+	seg := s[slash+1:]
+	if i := strings.IndexAny(seg, "/?#"); i >= 0 {
+		seg = seg[:i]
+	}
+	if seg == "" {
+		return "", false
+	}
+	return seg, true
+}
+
+// isReservedPlatformPath reports whether match addresses one of the platform's own system pages
+// rather than somebody's profile.
+func isReservedPlatformPath(match, platform string) bool {
+	seg, ok := firstPathSegment(match)
+	if !ok {
+		return false
+	}
+	seg = strings.ToLower(seg)
+
+	// Trailing dots and the .php suffix Facebook still serves (permalink.php, sharer.php) are not
+	// part of the reserved name; its robots.txt lists these segments with the suffix attached.
+	//
+	// Note what this means for "profile": facebook.com/profile.php?id=<n> IS a real person's
+	// profile — the shipped config has a pattern dedicated to it — and this trim would turn it
+	// into a lookup for "profile". So "profile" must never be added to the facebook table below;
+	// doing so would suppress a genuine profile reference into cleartext.
+	seg = strings.TrimSuffix(seg, ".php")
+	seg = strings.Trim(seg, ".")
+	if seg == "" {
+		return false
+	}
+
+	if _, reserved := sharedReservedPaths[seg]; reserved {
+		return true
+	}
+
+	// Platform keys reach this package in both the bare and the "<platform>_patterns" form, so
+	// normalise before the lookup rather than spelling both out — every platform switch in
+	// validator.go accepts both spellings and this has to agree with them.
+	key := strings.TrimSuffix(strings.ToLower(platform), "_patterns")
+	if extra, ok := platformReservedPaths[key]; ok {
+		if _, reserved := extra[seg]; reserved {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/validators/socialmedia/reserved_paths_test.go
+++ b/internal/validators/socialmedia/reserved_paths_test.go
@@ -1,0 +1,304 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package socialmedia
+
+import (
+	"strings"
+	"testing"
+)
+
+// systemURLs are platform system pages. None of them is a profile, and citing one in a document
+// is ordinary prose.
+var systemURLs = []string{
+	"instagram.com/explore",
+	"instagram.com/reels",
+	"instagram.com/tv",
+	"instagram.com/legal",
+	"instagram.com/about",
+	"pinterest.com/today",
+	"pinterest.com/business",
+	"pinterest.com/categories",
+	"facebook.com/help",
+	"facebook.com/privacy",
+	"facebook.com/business",
+	"facebook.com/legal",
+	"twitter.com/home",
+	"twitter.com/settings",
+	"twitter.com/tos",
+	"x.com/explore",
+	"t.me/joinchat",
+	"t.me/share",
+	"twitch.tv/directory",
+	"skype.com/features",
+}
+
+// profileURLs are real profiles on the same prefix-less platforms. Every one must stay detected:
+// only reported findings reach the redactor, so suppressing one of these is a cleartext leak.
+var profileURLs = []string{
+	"instagram.com/reneemueller",
+	"pinterest.com/johnsmith",
+	"facebook.com/carlos.ramirez",
+	"twitter.com/kwilson",
+	"t.me/dcheng",
+	"twitch.tv/mgarcia",
+}
+
+// platformOf maps each fixture URL to the platform key the scanner would pass alongside it.
+func platformOf(t *testing.T, url string) string {
+	t.Helper()
+	switch {
+	case strings.Contains(url, "instagram.com"), strings.Contains(url, "instagr.am"):
+		return "instagram"
+	case strings.Contains(url, "pinterest.com"):
+		return "pinterest"
+	case strings.Contains(url, "facebook.com"), strings.Contains(url, "fb.com"):
+		return "facebook"
+	case strings.Contains(url, "twitter.com"), strings.Contains(url, "x.com"):
+		return "twitter"
+	case strings.Contains(url, "t.me"):
+		return "telegram"
+	case strings.Contains(url, "twitch.tv"):
+		return "twitch"
+	case strings.Contains(url, "skype.com"):
+		return "skype"
+	case strings.Contains(url, "linkedin.com"):
+		return "linkedin"
+	case strings.Contains(url, "reddit.com"):
+		return "reddit"
+	case strings.Contains(url, "medium.com"):
+		return "medium"
+	case strings.Contains(url, "tiktok.com"):
+		return "tiktok"
+	case strings.Contains(url, "bsky.app"):
+		return "bluesky"
+	case strings.Contains(url, "snapchat.com"):
+		return "snapchat"
+	}
+	t.Fatalf("fixture %q has no platform mapping; add one rather than letting it fall through to "+
+		"a key with no reserved table, which would make the assertion vacuous", url)
+	return ""
+}
+
+// The two directions are asserted on ONE fixture set, in one test, deliberately.
+//
+// They pull against each other: a suppressor wide enough to kill every system URL also kills real
+// profiles, and a suppressor narrow enough to spare every profile catches nothing. Asserted apart,
+// a fix for either half looks correct on its own — `return false` passes the profile half and
+// `return true` passes the system half. Only together do they pin the discriminator.
+func TestReservedPathsSuppressSystemURLsAndSpareProfiles(t *testing.T) {
+	for _, url := range systemURLs {
+		if !isReservedPlatformPath(url, platformOf(t, url)) {
+			t.Errorf("%q was NOT recognised as a system page, so it is reported as somebody's "+
+				"profile and the redactor overwrites it — a documentation URL is corrupted in the "+
+				"redacted copy", url)
+		}
+	}
+	for _, url := range profileURLs {
+		if isReservedPlatformPath(url, platformOf(t, url)) {
+			t.Errorf("%q was suppressed as a system page, but it is a real profile. A suppressed "+
+				"finding never reaches the redactor, so this is a cleartext leak", url)
+		}
+	}
+}
+
+// A reserved word must match the WHOLE path segment. Substring matching here would suppress real
+// handles that merely contain a reserved word, which is the leak direction.
+func TestReservedPathsMatchWholeSegmentsOnly(t *testing.T) {
+	for _, url := range []string{
+		"instagram.com/exploration", // contains "explore"
+		"instagram.com/helper",      // contains "help"
+		"instagram.com/aboutface",   // contains "about"
+		"pinterest.com/todayshow",   // contains "today"
+		"twitter.com/homer",         // contains "home"
+		"t.me/shared",               // contains "share"
+		"twitch.tv/teamwork",        // contains "team"
+		"facebook.com/sharert",      // contains "share"
+	} {
+		if isReservedPlatformPath(url, platformOf(t, url)) {
+			t.Errorf("%q was suppressed: a reserved word is being matched as a substring rather "+
+				"than as the whole segment, so real handles containing one are leaked", url)
+		}
+	}
+}
+
+// Platforms whose profile pattern carries a path prefix put the handle in the SECOND segment, so a
+// reserved word appearing there is part of somebody's handle and must be left alone. This is what
+// makes it safe to apply the shared table to every platform.
+func TestReservedPathsIgnoreHandlesBehindAPathPrefix(t *testing.T) {
+	for _, url := range []string{
+		"linkedin.com/in/about",
+		"reddit.com/user/privacy",
+		"medium.com/@help",
+		"tiktok.com/@legal",
+		"bsky.app/profile/terms",
+		"snapchat.com/add/settings",
+	} {
+		if isReservedPlatformPath(url, platformOf(t, url)) {
+			t.Errorf("%q was suppressed: only the FIRST path segment may be judged, and here that "+
+				"segment is the platform's own prefix, not a reserved name", url)
+		}
+	}
+}
+
+// Real documents cite these URLs in every shape. Suppression must not depend on the scheme, the
+// www. prefix, letter case, a deeper path, or the short domain.
+func TestReservedPathsNormaliseTheURLShape(t *testing.T) {
+	for _, url := range []string{
+		"https://www.instagram.com/explore",
+		"http://instagram.com/legal",
+		"INSTAGRAM.COM/EXPLORE",
+		"Instagram.com/Reels",
+		"https://instagr.am/about",
+		"instagram.com/explore/tags/summer", // deeper path, same system page
+		"instagram.com/explore?hl=en",       // query string
+	} {
+		if !isReservedPlatformPath(url, "instagram") {
+			t.Errorf("%q was not recognised: the shape of the URL is changing the verdict, so the "+
+				"same system page is suppressed in one document and reported in another", url)
+		}
+	}
+}
+
+// facebook.com/profile.php?id=<n> is a REAL profile and the shipped config has a pattern dedicated
+// to it. The .php trim that lets "sharer.php" match "sharer" turns this into a lookup for
+// "profile", so adding "profile" to the facebook table would suppress a genuine profile into
+// cleartext. This pins that it is absent.
+func TestFacebookProfilePHPIsNotTreatedAsASystemPage(t *testing.T) {
+	if isReservedPlatformPath("facebook.com/profile.php?id=61550000000000", "facebook") {
+		t.Error("facebook.com/profile.php was suppressed as a system page, but it identifies a " +
+			"specific person — the .php trim maps it onto \"profile\", which must never be a " +
+			"reserved segment for facebook")
+	}
+	// The trim must still do its job for the segments that ARE reserved.
+	if !isReservedPlatformPath("facebook.com/sharer.php?u=x", "facebook") {
+		t.Error("facebook.com/sharer.php was not suppressed: the .php trim is not reaching the " +
+			"reserved table, so every one of Facebook's .php system endpoints stays a false positive")
+	}
+}
+
+// A match with no path at all — a bare @handle, a skype: URI, a bare host — carries no segment to
+// judge, and the veto must not fire on it.
+func TestReservedPathsRequireAPathSegment(t *testing.T) {
+	for _, match := range []string{
+		"@explore",
+		"skype:legal",
+		"about.medium.com",
+		"instagram.com",
+		"instagram.com/",
+	} {
+		if isReservedPlatformPath(match, "instagram") {
+			t.Errorf("%q was suppressed although it has no first path segment; the veto is firing "+
+				"on something other than a path", match)
+		}
+	}
+}
+
+// firstPathSegment's contract, asserted directly.
+//
+// Its "no path means no verdict" half is not observable through isReservedPlatformPath today: no
+// shipped pattern can produce a bare token equal to a reserved name (the handle patterns all carry
+// @, skype: carries a colon, the medium subdomain form carries dots), so a version that returned
+// the whole host instead would behave identically. Pinning the helper keeps that from silently
+// becoming a leak if a future pattern does match a bare word.
+func TestFirstPathSegment(t *testing.T) {
+	cases := []struct {
+		in     string
+		want   string
+		wantOK bool
+	}{
+		{"instagram.com/explore", "explore", true},
+		{"https://www.instagram.com/explore", "explore", true},
+		{"http://instagram.com/explore/tags/x", "explore", true},
+		{"instagram.com/explore?hl=en", "explore", true},
+		{"instagram.com/explore#top", "explore", true},
+		{"t.me/s/channel", "s", true},
+		// No path at all: there is nothing to judge, and the veto must not fire.
+		{"instagram.com", "", false},
+		{"@explore", "", false},
+		{"skype:legal", "", false},
+		{"about.medium.com", "", false},
+		{"instagram.com/", "", false},
+	}
+	for _, c := range cases {
+		got, ok := firstPathSegment(c.in)
+		if got != c.want || ok != c.wantOK {
+			t.Errorf("firstPathSegment(%q) = (%q, %v), want (%q, %v)", c.in, got, ok, c.want, c.wantOK)
+		}
+	}
+}
+
+// The platform key reaches this package in both spellings. Every platform switch in validator.go
+// accepts "<platform>" and "<platform>_patterns", and this table has to agree with them or the
+// per-platform entries silently never apply.
+func TestReservedPathsAcceptBothPlatformKeySpellings(t *testing.T) {
+	for _, key := range []string{"instagram", "instagram_patterns", "Instagram"} {
+		if !isReservedPlatformPath("instagram.com/reels", key) {
+			t.Errorf("platform key %q did not resolve to the instagram table, so its "+
+				"platform-specific reserved segments never apply", key)
+		}
+	}
+	// A platform with no table of its own still gets the shared set.
+	if !isReservedPlatformPath("twitch.tv/settings", "twitch") {
+		t.Error("the shared reserved set did not apply to twitch")
+	}
+	// And an unknown platform gets the shared set only, without panicking on the missing table.
+	if !isReservedPlatformPath("example.com/privacy", "someplatform") {
+		t.Error("the shared reserved set did not apply to an unknown platform")
+	}
+	if isReservedPlatformPath("example.com/reels", "someplatform") {
+		t.Error("an unknown platform picked up instagram's platform-specific entries")
+	}
+}
+
+// The end-to-end assertion: the veto has to be reached from the scanning path, not merely be
+// correct in isolation. A helper that no emit path consults would pass every test above.
+//
+// Uses the SHIPPED config via configuredValidator — a bare NewValidator leaves patternsConfigured
+// false and ValidateContent returns nothing at all, which would make both halves vacuous.
+func TestValidatorDoesNotReportSystemURLsButStillReportsProfiles(t *testing.T) {
+	v := configuredValidator(t)
+
+	content := "Docs: instagram.com/explore and pinterest.com/today and twitter.com/settings\n" +
+		"Contact: instagram.com/reneemueller\n"
+
+	matches, err := v.ValidateContent(content, "policy.txt")
+	if err != nil {
+		t.Fatalf("ValidateContent: %v", err)
+	}
+
+	// Matched on the bare segment name, NOT on "/explore".
+	//
+	// Several system URLs on one line are collapsed by the clustering pass into a single
+	// SOCIAL_MEDIA_CLUSTER match whose Text is a synthesised summary — here
+	// "instagram: explore | pinterest: today | twitter: settings" — which contains no slashes and
+	// does not appear in the file at all. An earlier version of this test looked for "/explore"
+	// and so passed with the veto's call site disabled: the three URLs were still reported, just
+	// under a shape the assertion could not see.
+	segments := []string{"explore", "today", "settings"}
+
+	var sawProfile bool
+	for _, m := range matches {
+		lower := strings.ToLower(m.Text)
+
+		var namesSystemPage bool
+		for _, seg := range segments {
+			if strings.Contains(lower, seg) {
+				namesSystemPage = true
+				t.Errorf("a reported %s match still names the system page %q (text %q, confidence "+
+					"%v): the reserved-path veto is not reached from the scanning path, so these "+
+					"URLs are reported and the redactor overwrites them", m.Type, seg, m.Text,
+					m.Confidence)
+			}
+		}
+		if !namesSystemPage && strings.Contains(lower, "reneemueller") {
+			sawProfile = true
+		}
+	}
+
+	if !sawProfile {
+		t.Error("the real profile instagram.com/reneemueller was NOT reported, so it is never " +
+			"redacted — and the system-page assertion above would hold on a validator that " +
+			"reports nothing at all")
+	}
+}

--- a/internal/validators/socialmedia/validator.go
+++ b/internal/validators/socialmedia/validator.go
@@ -2095,8 +2095,14 @@ func (v *Validator) isOverlyBroadMatch(match string, platform string) bool {
 		return true
 	}
 
-	// Platform-specific overly broad pattern checks
-	switch strings.ToLower(platform) {
+	// Platform-specific overly broad pattern checks.
+	//
+	// The key is normalised because every other platform switch in this file spells its cases as
+	// `case "instagram", "instagram_patterns":` while the four below carry the bare form only. No
+	// shipped config uses the "<platform>_patterns" spelling — config.yaml and examples/ferret.yaml
+	// both key platform_patterns bare, so these cases do fire today — but a config using the other
+	// form would silently skip them while every other check still applied.
+	switch strings.TrimSuffix(strings.ToLower(platform), "_patterns") {
 	case "twitter", "x":
 		// Twitter handles should not be just numbers or single characters
 		if matched, _ := regexp.MatchString(`^[0-9]+$`, match); matched {
@@ -2736,6 +2742,15 @@ func (v *Validator) processMatchOptimized(match, platform string, patternIndex i
 
 	// Filter out other common false positive patterns
 	if v.isFalsePositiveHandle(match, line, matchOffset) {
+		return nil
+	}
+
+	// A URL addressing one of the platform's own system pages is refused outright. It has to be a
+	// veto and not a score adjustment: confidence is capped at 100 while the raw total for these
+	// URLs reaches 134, so validateNotFalsePositive's 30-point penalty is absorbed by the cap and
+	// the finding still lands at HIGH 100. See reserved_paths.go for the measurement and for why
+	// suppressing these cannot suppress a real profile.
+	if isReservedPlatformPath(match, platform) {
 		return nil
 	}
 


### PR DESCRIPTION
Closes #349

## The bug

Eight of the shipped platforms have no path prefix in their profile pattern — `facebook.com/…`,
`instagram.com/…`, `pinterest.com/…`, `skype.com/…`, `t.me/…`, `twitch.tv/…`, `(twitter|x).com/…`
and `discord.gg/…` — so for those, **any** single path segment reads as a handle.
`instagram.com/explore` and `instagram.com/reneemueller` are the same shape. #345 removed the
trailing slash that had kept some of these patterns off bare paths.

Measured on a fixture of 18 platform system URLs plus 5 real profiles, with the shipped
`config.yaml`: **all 23 reported**, a 78% false-positive rate, spanning five platforms.

The severity is in the redactor rather than the report. Every one of the 18 documentation URLs was
overwritten in the redacted copy:

```
  Instagram help centre: ********************* and *******************
  Pinterest trends: *******************
  Facebook help: ***************** and ********************
  Twitter home timeline: ****************
  Telegram group invites use *************
```

A document that merely cited a platform's help page comes back corrupted.

## Why this is a veto and not a confidence penalty

The existing suppressor already ran and changed nothing. Three reasons, measured:

- `validateNotFalsePositive` is **advisory** — its failure costs 30 points at the scoring site and
  nothing drops the match.
- The raw score reaches **134** before being capped at 100, so −30 leaves 104 and the cap puts it
  straight back to **100**. On the worst offenders the penalty is not observable at all. This is
  what left the issue's earlier partial attempt with "9 of 14 still at HIGH 100".
- There is **no threshold to find**. `instagram.com/explore` scores 134 where the real profile
  `instagram.com/reneemueller` scores 124 — the false positive scores *higher*. Nothing separates
  them but vocabulary, so the discriminator has to be categorical.

`metadata.confidence_factors` shows both halves; `false_positive_prevention` was exactly `0` on all
18, so the check never fired in the first place.

## The fix

A match whose first path segment is one of the platform's own system pages is refused in
`processMatchOptimized` — the single emit path in the validator.

| fixture | main | this PR |
|---|---:|---:|
| 18 system URLs + 5 real profiles | 23 | **5** |
| near-miss handles + prefixed platforms (must all survive) | 17 | **17** |

All 5 real profiles retained at byte-identical confidence, and the documentation URLs are intact in
the redacted output.

## Built to fail in the safe direction

A wrong entry suppresses a real profile, and a suppressed finding never reaches the redactor — so it
would be a cleartext leak, not just a miss. Hence:

- **Only the first path segment is judged.** That is what makes it safe to apply the shared set to
  every platform: `linkedin.com/in/`, `reddit.com/u/`, `bsky.app/profile/` and the `/@handle` forms
  put the handle in the second segment, so `linkedin.com/in/about` is unaffected.
- **The whole segment must match**, case-folded. `instagram.com/exploration`, `twitter.com/homer`
  and `t.me/shared` are real handles and still detected.
- **The shared set holds only names reserved on every consumer platform.** Anything
  platform-specific or plausibly a handle elsewhere — `business`, `home`, `today`, `tv` — sits in
  the per-platform table.
- **Entries are grounded** in each platform's own `robots.txt` `Disallow` list where it publishes
  one, plus documented feature paths. `robots.txt` is authoritative but uneven (pinterest names 120+
  segments, twitter four), so the tables are deliberately **not exhaustive**: an uncovered system
  path stays a false positive, which is the tolerable direction of error.

One trap is pinned by a test: `facebook.com/profile.php?id=<n>` **is** a real person and the shipped
config has a pattern for it. The `.php` trim that lets `sharer.php` match `sharer` turns it into a
lookup for `profile`, so `profile` must never enter the facebook table.

## Also in this PR

`isOverlyBroadMatch`'s platform switch normalises its key. Its four cases carry the bare form only
while every other platform switch in the file accepts `"<platform>"` and `"<platform>_patterns"`.
The issue reported these cases as unreachable; that is **not** correct — no shipped config uses the
suffixed spelling (`config.yaml` and `examples/ferret.yaml` both key `platform_patterns` bare, and
`instagram_patterns` appears nowhere outside a Go display-name map), so they do fire today. The
change is defensive consistency, not the fix.

## Testing

- 8 new tests, both directions **on one fixture set** as the issue requires — the two pull against
  each other, and asserted apart, `return false` passes the profile half while `return true` passes
  the system half.
- **Mutation-tested, 7 mutants, all killed.** Two survived the first pass and both were real test
  defects, now fixed:
  - Disabling the veto's call site did not fail. Several system URLs on one line are collapsed by
    the clustering pass into a single `SOCIAL_MEDIA_CLUSTER` whose `Text` is a synthesised summary
    (`"instagram: explore | pinterest: today | twitter: settings"`) containing no slashes, so an
    assertion looking for `"/explore"` could not see them. Now matched on the bare segment name.
  - `firstPathSegment` returning the whole host on a path-less match was unobservable through
    behaviour (no shipped pattern yields a bare token equal to a reserved name), so its contract is
    now asserted directly.
- `go build ./...`, `go vet ./...`, `gofmt -l ./cmd ./internal ./pkg` clean; full suite **69
  packages ok**.
- `make score`: **PASS, unchanged** — `recall_all=1.0000 recall_hm=0.9948 prec_hm=0.9320
  whole_leak=0`, baseline file untouched. Worth stating plainly: the score corpus does **not** score
  SOCIAL_MEDIA (`registry.go` records it as "config-gated by design"), and the golden corpus records
  zero social-media findings, so neither gate can move on this change. Both confirm no collateral
  damage to the other validators; the evidence for the change itself is the fixtures and the real
  corpus below.
- **Real corpus: 871 files across 12 types** (txt, pdf, docx, json, md, csv, html, pptx, xlsx, htm,
  doc, rtf), 844 processed.

  Delta: **1525 → 1519 findings, 6 removed, 0 added.** Every removal is a genuine system endpoint,
  and four were at HIGH 100 — so they were being redacted out of real HTML documents:

  | removed | conf | what it is |
  |---|---:|---|
  | `facebook.com/sharer` ×2 | 100 | Facebook's share endpoint |
  | `twitter.com/intent` ×2 | 100 | Twitter's tweet-intent endpoint |
  | `x.com/help` | 50 | help page |
  | `x.com/api` | 3 | API root |

  No real profile lost: LINKEDIN 36→36, TWITCH 5→5, DISCORD 2→2, MEDIUM 3→3, YOUTUBE 1→1,
  SOCIAL_MEDIA_CLUSTER 5→5. `twitch.tv/aws`, `facebook.com/amazonwebservices` and
  `twitter.com/engineering` are all real accounts and all survive.
- **No performance cost.** On a dense 40k-line fixture the fixed build is slightly *faster* (2.35s
  vs 2.96s): a vetoed match returns before the confidence and context pipeline runs. The veto itself
  is a map lookup and a few string operations per match.
- Union-tested with the four other open PRs (#425, #426, #427, #428): pairwise `git merge-tree`
  clean, union worktree builds, vets and passes **70 packages ok**. No file overlap with any of them.

## Docs

`docs/social-media-configuration.md` gains a "Platform system pages are not profiles" section
covering the mechanism, the three safety properties and the non-exhaustiveness, a troubleshooting
entry for an uncovered system path, and a pattern guideline to prefer a platform's path prefix where
it has one.

## Found along the way, filed separately

#429 — `whitelist_patterns` does not exclude a match either. It shares the same advisory −30 path, so
`instagram.com/demo` is still reported at MEDIUM 59 despite `(?i)demo` being whitelisted in the
shipped config. Left out of this PR deliberately: the shipped patterns are unanchored substrings, so
promoting them to a veto would suppress `instagram.com/demolition_dave`, and that needs a semantics
decision rather than a one-line change.
