### PR TITLE
fix(video): find moov wherever it sits, and read a position atom by its shape

### DIFF
--- a/cmd/extraction_warning_cause_test.go
+++ b/cmd/extraction_warning_cause_test.go
@@ -84,6 +84,40 @@ func TestEveryExtractionWarningProducerLandsInTheRightBucket(t *testing.T) {
 			reason:   `Text Extractor: no text extracted from .docx: no document body part was found in the archive, so document content was NOT scanned; office_metadata: embedded part "attachment.docx" was not examined: declares 52433928 bytes, over the 52428800-byte embedded cap`,
 			want:     causeCutShort,
 		},
+		// The video walk's six wordings (#398). Each is a case where SOME of the file was read and
+		// the rest was not, so all six are cut-short rather than no-text. A phrasing that happened
+		// to contain "no text extracted from" would be filed under the milder cause and reported to
+		// the operator under a heading that asserts something untrue.
+		{
+			producer: "video walk, box budget exhausted",
+			reason:   "video_metadata: video metadata may be incomplete: the box walk stopped after 1048576 top-level boxes",
+			want:     causeCutShort,
+		},
+		{
+			producer: "video walk, box declares more than the file holds",
+			reason:   `video_metadata: video metadata may be incomplete: the "mdat" box at offset 28 declares more bytes than the file holds, so it was read only to the file's real end`,
+			want:     causeCutShort,
+		},
+		{
+			producer: "video walk, structure not followable",
+			reason:   `video_metadata: video metadata may be incomplete: the box structure could not be followed past offset 20 (box "junk" declares 4 bytes, smaller than its 8-byte header)`,
+			want:     causeCutShort,
+		},
+		{
+			producer: "video walk, moov past the parse limit",
+			reason:   "video_metadata: video metadata may be incomplete: the moov box is 41943040 bytes and only the first 33554432 were parsed",
+			want:     causeCutShort,
+		},
+		{
+			producer: "video walk, moov unreadable",
+			reason:   "video_metadata: video metadata may be incomplete: the moov box at offset 27296158 could not be read in full (unexpected EOF)",
+			want:     causeCutShort,
+		},
+		{
+			producer: "video walk, no moov found",
+			reason:   "video_metadata: video metadata may be incomplete: no moov box was found in the file",
+			want:     causeCutShort,
+		},
 	}
 
 	for _, c := range cases {

--- a/docs/COVERAGE_DISCLOSURE.md
+++ b/docs/COVERAGE_DISCLOSURE.md
@@ -71,6 +71,34 @@ An embedded part of a type nothing can read stays silent on purpose. A line on s
 every decorative `.emf` in every slide deck trains operators to ignore the warnings that
 matter.
 
+### What `coverage cut short` covers in a video container
+
+Video metadata sits in the `moov` box, which the standards permit anywhere in the file and which
+ffmpeg and typical cameras write **last**. The box walk reads only headers and metadata boxes, so a
+`moov` at the end of a 99 MB recording is read like one at the start. Six cases stop it early, and
+each says so:
+
+| case | what the operator sees |
+|---|---|
+| no `moov` box in the file | `video metadata may be incomplete: no moov box was found in the file` |
+| a box declaring more bytes than the file holds | `video metadata may be incomplete: the "mdat" box at offset N declares more bytes than the file holds, so it was read only to the file's real end` |
+| a box smaller than its own header, or an unfollowable structure | `video metadata may be incomplete: the box structure could not be followed past offset N (...)` |
+| a `moov` past the 32 MB parse limit | `video metadata may be incomplete: the moov box is N bytes and only the first 33554432 were parsed` |
+| a `moov` that could not be read or parsed in full | `video metadata may be incomplete: the moov box at offset N could not be read in full (...)` |
+| more than 1,048,576 top-level boxes | `video metadata may be incomplete: the box walk stopped after 1048576 top-level boxes` |
+
+All six were **silent** before #398, and so was the much larger case they sit alongside: the walk
+used to stop once it had passed a 10 MB *file offset*, counting the media bytes it skipped without
+reading. A camera-default recording over roughly 10 MB therefore reported no metadata at all, at
+exit 0, with nothing under `files_not_examined` — and `--fail-on-incomplete` exited 0 too. The same
+file with its `moov` moved to the front reported an SSN at HIGH 100.
+
+These are `coverage cut short` rather than `no body text` for the same reason as the container cases
+above: some of the file genuinely was read. An over-declared `moov` is clamped to the file's real end
+and still yields whatever values are present, so a disclosure here does not mean nothing was found.
+
+A well-formed video never produces any of these lines.
+
 ## Per-format details
 
 ### gitlab-sast — `scan.messages[]`

--- a/docs/reference/quotas-and-limits.md
+++ b/docs/reference/quotas-and-limits.md
@@ -25,6 +25,31 @@ A file over the limit is **not** silently dropped: if it is a type the tool coul
 processed, it is reported under `files_not_examined`, listed in the `NOT FULLY EXAMINED`
 block, and `--fail-on-incomplete` exits 3. See [Coverage Disclosure](../COVERAGE_DISCLOSURE.md).
 
+### Video metadata bounds
+
+Video metadata lives in the `moov` box, which the standards allow anywhere in the file — ISO/IEC
+14496-12 cl. 8.2.1.1 says it is "normally ... close to the beginning or end of the file, though this
+is not required", and Apple's QuickTime format reference states outright that "QuickTime does not
+impose any rules about the order of these atoms". ffmpeg and typical cameras write it **last**;
+`-movflags faststart` is a second pass that moves it to the front.
+
+The extractor therefore has **no positional limit** — it walks the top-level boxes by header and
+reads only the metadata ones, so a `moov` at the end of a 99MB file is read exactly like one at the
+start, and the media payload is never read at all. Two work bounds remain:
+
+| Bound | Value | Configurable | Disclosed when it bites |
+|---|---|---|---|
+| `MaxMoovParse` | 32MB of `moov` payload parsed | No | Yes |
+| `MaxTopLevelBoxes` | 1,048,576 top-level boxes walked | No | Yes |
+
+Both are far above any real file: a real `moov` measures a fraction of a percent of its file, and a
+well-formed movie has a handful of top-level boxes. When either bound is reached the result is a
+`coverage cut short` disclosure, not a silent truncation.
+
+Before this, the extractor stopped once the walk passed a 10MB **file offset** — counting the media
+bytes it skipped without reading — so a camera-default recording over about 10MB reported no metadata
+at all, at exit 0, with nothing under `files_not_examined`.
+
 ## Processing and Performance Limits
 
 | Component | Limit | Type | Configurable | Notes |

--- a/docs/testing/TEST_PLAN.md
+++ b/docs/testing/TEST_PLAN.md
@@ -107,6 +107,22 @@ can be megabytes and a file can be tens of thousands of near-identical rows. A h
 - A measured regression is a blocker unless it is the unavoidable cost of correct
   behavior (e.g. emitting findings that were previously dropped) — and then it is
   stated in the PR with the reason.
+- **A size read out of the file is not a size.** Every allocation taken from a DECLARED
+  length needs the declared value bounded by the bytes that are really there, checked
+  against `Stat`. This repo has produced 8.62GB of RSS from a 4KB `.docx` and 631MB from
+  sixteen 80-byte `.mp4` files, both by trusting a number an attacker supplied. Assert it
+  by **allocation**, not by timing: a bomb often parses fast, so a wall-clock assertion
+  passes on the broken build and flakes on slow CI.
+  Write the bound as `declared > remaining`, never as `offset + declared > size` — a
+  64-bit size near 2^63 makes the addition overflow to a negative number that every
+  later check accepts.
+- **Where metadata sits in a file is not a bound.** A container format that permits its
+  metadata anywhere (ISO base media `moov`, which ffmpeg and cameras write LAST) must be
+  tested in both layouts, and the two must produce identical output. A fixture generator
+  that always writes the easy layout hides this completely — every MP4 fixture in this
+  repo was implicitly faststart, which is why a 10MB positional cap went unnoticed.
+  Build the large-but-cheap case with `Truncate` so the media payload is a hole: it is
+  never read, so it need not exist.
 
 ### 5. Redaction — all types
 

--- a/docs/user-guides/README-Enhanced-Metadata.md
+++ b/docs/user-guides/README-Enhanced-Metadata.md
@@ -123,6 +123,13 @@ Contact: manager@johnmusician.com
 ### Video Files
 **Supported Formats**: MP4, MOV, M4V
 
+Video metadata lives in the `moov` box, and the file formats allow it **anywhere** — ffmpeg and
+typical cameras write it at the END of the file, while `-movflags faststart` moves it to the front.
+Both layouts are read identically, and where the box sits does not change what is reported. The
+media payload itself is never read, so a long recording costs no more memory than a short one. If a
+file's box structure cannot be followed to the end, the scan says so rather than reporting the file
+as fully examined — see [Coverage Disclosure](../COVERAGE_DISCLOSURE.md).
+
 **Metadata Extracted**:
 - **Location Data**: GPS coordinates, recording location
 - **Device Information**: Camera make/model, recording device

--- a/internal/preprocessors/meta-extractors/meta-extract-videolib/position_test.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-videolib/position_test.go
@@ -108,6 +108,19 @@ func buildISOFile(t *testing.T, path string, mdatBytes int64, moovFirst bool, ud
 	return path
 }
 
+// itunesAtom builds one of the iTunes/QuickTime metadata atom types, whose first byte is 0xA9.
+//
+// NOT []byte("©cmt"). The Go literal "©" is its two-byte UTF-8 encoding, so that spelling is a FIVE
+// byte type which copies into a four-byte field truncated — the box then has a nonsense type and is
+// silently ignored. The extractor's own canonicalBoxType comment records this same trap, and writing
+// the fixtures the wrong way is what made the first run of these tests fail.
+func itunesAtom(threeCC string) []byte {
+	if len(threeCC) != 3 {
+		panic("an iTunes atom type is 0xA9 plus exactly three characters, got " + threeCC)
+	}
+	return []byte{0xA9, threeCC[0], threeCC[1], threeCC[2]}
+}
+
 // textAtom encodes a QuickTime string atom the way parseStringBox reads one: a 2-byte text length,
 // a 2-byte language code, then the text.
 func textAtom(boxType []byte, text string) []byte {

--- a/internal/preprocessors/meta-extractors/meta-extract-videolib/position_test.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-videolib/position_test.go
@@ -1,0 +1,349 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package metaextractvideolib
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// closeTo compares positions with a tolerance that admits 16.16 fixed-point quantisation. A loci
+// atom stores 36.3506 as 0x002459C0, which reads back as 36.350586 — the file genuinely holds that
+// value, so an exact comparison would be asserting against the wrong thing.
+func closeTo(got, want float64) bool { return math.Abs(got-want) < 0.0005 }
+
+// fixed encodes a degree value the way an ISO base media file stores one: 16.16 signed fixed-point,
+// big-endian. Written through a variable because a constant expression like int32(37.7749*65536)
+// does not compile — the untyped constant is not an exact integer.
+func fixed(deg float64) uint32 {
+	v := deg * 65536.0
+	return uint32(int32(v))
+}
+
+// realXyzTextPayload is the ©xyz payload ffmpeg 9.0.1 writes into a .mov, captured byte for byte
+// from `ffmpeg -metadata location="+36.3506-082.6985/" out.mov`:
+// a 2-byte text length (0x0012 = 18), a 2-byte language code (0x55C4), then the ISO 6709 string.
+var realXyzTextPayload = append([]byte{0x00, 0x12, 0x55, 0xC4}, []byte("+36.3506-082.6985/")...)
+
+// realLociPayload is the loci payload ffmpeg 9.0.1 writes into a .mp4 for the SAME -metadata
+// location, also captured byte for byte: version+flags, language, an empty NUL-terminated name, a
+// role byte, then LONGITUDE, LATITUDE, altitude as 16.16, then the astronomical body.
+var realLociPayload = []byte{
+	0x00, 0x00, 0x00, 0x00, // version + flags
+	0x00, 0x00, // language
+	0x00,                   // name: empty, NUL-terminated
+	0x00,                   // role
+	0xFF, 0xAD, 0x4D, 0x30, // longitude -82.6985
+	0x00, 0x24, 0x59, 0xC0, // latitude   36.3506
+	0x00, 0x00, 0x00, 0x00, // altitude
+	'e', 'a', 'r', 't', 'h', 0x00,
+}
+
+// buildISOFile writes a minimal conformant ISO base media file and returns its path.
+//
+// mdatBytes is the SIZE the mdat declares and the file really has, created as a hole with Truncate
+// rather than written out, so a fixture with a 200 MB mdat costs no test memory and (on a sparse
+// filesystem) no disk. That matters because the whole point of these fixtures is that the media
+// payload is never read — a builder that allocated it would make the assertion about allocation
+// impossible to state.
+//
+// moovFirst chooses the layout: false puts moov AFTER mdat, which is what ffmpeg and every camera
+// measured on this machine write by default, and which every pre-existing fixture in this package
+// got wrong by always writing moov first.
+func buildISOFile(t *testing.T, path string, mdatBytes int64, moovFirst bool, udtaChildren ...[]byte) string {
+	t.Helper()
+
+	moov := box(atom("moov"), box(atom("udta"), bytes.Join(udtaChildren, nil)))
+	ftyp := box(atom("ftyp"), []byte("isom\x00\x00\x02\x00isomiso2mp41"))
+
+	if mdatBytes < 0 || mdatBytes+8 > math.MaxUint32 {
+		t.Fatalf("mdat size %d does not fit a 32-bit box size", mdatBytes)
+	}
+	mdatHeader := make([]byte, 8)
+	binary.BigEndian.PutUint32(mdatHeader[0:4], uint32(8+mdatBytes))
+	copy(mdatHeader[4:8], "mdat")
+
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create %s: %v", path, err)
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			t.Fatalf("close %s: %v", path, err)
+		}
+	}()
+
+	write := func(b []byte) {
+		if _, err := f.Write(b); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+
+	write(ftyp)
+	if moovFirst {
+		write(moov)
+	}
+	write(mdatHeader)
+	// The hole: extend the file past the mdat payload without writing it.
+	end, err := f.Seek(0, io.SeekCurrent)
+	if err != nil {
+		t.Fatalf("seek %s: %v", path, err)
+	}
+	if err := f.Truncate(end + mdatBytes); err != nil {
+		t.Fatalf("truncate %s: %v", path, err)
+	}
+	if _, err := f.Seek(end+mdatBytes, io.SeekStart); err != nil {
+		t.Fatalf("seek past mdat in %s: %v", path, err)
+	}
+	if !moovFirst {
+		write(moov)
+	}
+	return path
+}
+
+// textAtom encodes a QuickTime string atom the way parseStringBox reads one: a 2-byte text length,
+// a 2-byte language code, then the text.
+func textAtom(boxType []byte, text string) []byte {
+	payload := make([]byte, 4+len(text))
+	binary.BigEndian.PutUint16(payload[0:2], uint16(len(text)))
+	binary.BigEndian.PutUint16(payload[2:4], 0x15C7)
+	copy(payload[4:], text)
+	return box(boxType, payload)
+}
+
+// The udta switch must actually route each atom to its parser.
+//
+// The direct unit tests above all pass with `case "loci":` deleted from the switch — a correct parser
+// that nothing calls. This drives the real container so the wiring is what is under test, which is
+// the same gap that let a disabled call site survive mutation elsewhere in this repo.
+func TestPositionAtomsAreReachedThroughTheContainer(t *testing.T) {
+	dir := t.TempDir()
+
+	cases := map[string]struct {
+		child    []byte
+		wantLat  float64
+		wantLon  float64
+		wantName string
+	}{
+		"loci in .mp4 (ffmpeg default)": {
+			child: box(atom("loci"), realLociPayload), wantLat: 36.3506, wantLon: -82.6985,
+		},
+		"xyz text in .mov (ffmpeg default)": {
+			child: box(xyzAtom, realXyzTextPayload), wantLat: 36.3506, wantLon: -82.6985,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			path := buildISOFile(t, filepath.Join(dir, "pos.mp4"), 4096, false, c.child)
+
+			meta, err := ExtractVideoMetadataWithContext(context.Background(), path)
+			if err != nil {
+				t.Fatalf("ExtractVideoMetadataWithContext: %v", err)
+			}
+			if !closeTo(meta.GPSLatitude, c.wantLat) || !closeTo(meta.GPSLongitude, c.wantLon) {
+				t.Errorf("got lat=%v lon=%v, want %v/%v: the parser is correct in isolation but the "+
+					"udta switch does not route this atom to it, so the position is never reported "+
+					"and never redacted", meta.GPSLatitude, meta.GPSLongitude, c.wantLat, c.wantLon)
+			}
+		})
+	}
+}
+
+// A ©xyz payload carries a position in either of two encodings and the atom name does not say
+// which, so the payload's shape has to decide.
+//
+// Reading the text form as fixed-point turns the length and language bytes into a latitude: the real
+// ffmpeg payload below was reported as "18.335022, 11059.211639" at HIGH confidence — an impossible
+// longitude — while the true position sat unreported in the same bytes (#399).
+//
+// Both encodings are asserted together on purpose. A fix that only adds a text branch and drops the
+// fixed-point one trades a false positive for a leak, and either half alone looks correct.
+func TestPositionAtomShapeDecidesTextVersusFixedPoint(t *testing.T) {
+	t.Run("ffmpeg .mov text form", func(t *testing.T) {
+		m := &VideoMetadata{Properties: map[string]string{}}
+		parsePositionAtom(realXyzTextPayload, m)
+
+		if !closeTo(m.GPSLatitude, 36.3506) || !closeTo(m.GPSLongitude, -82.6985) {
+			t.Errorf("got lat=%v lon=%v, want 36.3506/-82.6985. The text payload is being read as "+
+				"fixed-point, which reports the length and language bytes as a coordinate and "+
+				"buries the real position that is present in the same payload",
+				m.GPSLatitude, m.GPSLongitude)
+		}
+		// Pin the specific garbage value, so a regression is recognisable rather than merely wrong.
+		if closeTo(m.GPSLatitude, 18.335022) {
+			t.Error("latitude is 18.335022 — that is 0x001255C4/65536, i.e. the text length and " +
+				"language code decoded as a fixed-point number")
+		}
+	})
+
+	t.Run("fixed-point form still works", func(t *testing.T) {
+		payload := make([]byte, 12)
+		binary.BigEndian.PutUint32(payload[0:4], fixed(37.7749))
+		binary.BigEndian.PutUint32(payload[4:8], fixed(-122.4194))
+
+		m := &VideoMetadata{Properties: map[string]string{}}
+		parsePositionAtom(payload, m)
+
+		if !closeTo(m.GPSLatitude, 37.7749) || !closeTo(m.GPSLongitude, -122.4194) {
+			t.Errorf("got lat=%v lon=%v, want 37.7749/-122.4194: the shape test is sending a "+
+				"binary payload down the text branch, so cameras that write fixed-point lose "+
+				"their position entirely", m.GPSLatitude, m.GPSLongitude)
+		}
+	})
+}
+
+// A zero-filled payload must yield no position.
+//
+// This is the property that makes video redaction verifiable: the redactor zeroes a whole ©xyz
+// payload and then the output is rescanned to prove nothing survived. '*' would not do — 0x2A2A2A2A
+// is a valid fixed-point 10794.66° — so zero is the one fill no reader turns back into a location.
+// A shape test that read zeroes as anything reportable would make every redacted file look like it
+// still carried a coordinate.
+func TestZeroFilledPositionAtomYieldsNoPosition(t *testing.T) {
+	for _, n := range []int{12, len(realXyzTextPayload), 64} {
+		m := &VideoMetadata{Properties: map[string]string{}}
+		parsePositionAtom(make([]byte, n), m)
+		if m.GPSLatitude != 0 || m.GPSLongitude != 0 {
+			t.Errorf("a %d-byte zero-filled payload produced lat=%v lon=%v; a redacted file would "+
+				"still report a position and the residue check would fail", n,
+				m.GPSLatitude, m.GPSLongitude)
+		}
+	}
+}
+
+// loci is the form ffmpeg writes into .mp4 BY DEFAULT, and it had no case at all: the position was
+// never reported, so it was never redacted either.
+//
+// The word order is the trap. loci stores LONGITUDE before LATITUDE, the reverse of ©xyz. A reader
+// that assumes lat/lon swaps the coordinates, and the fixture is deliberately far from the equator
+// and from the 45° diagonal so a swap cannot pass.
+func TestLociPositionIsReportedWithLongitudeFirst(t *testing.T) {
+	m := &VideoMetadata{Properties: map[string]string{}}
+	parseLociBox(realLociPayload, m)
+
+	if !closeTo(m.GPSLatitude, 36.3506) || !closeTo(m.GPSLongitude, -82.6985) {
+		t.Errorf("got lat=%v lon=%v, want 36.3506/-82.6985", m.GPSLatitude, m.GPSLongitude)
+	}
+	if closeTo(m.GPSLatitude, -82.6985) {
+		t.Error("latitude is -82.6985, the LONGITUDE value: loci stores longitude first and the " +
+			"words are being read in ©xyz order")
+	}
+}
+
+// The place name inside a loci atom is location data in its own right, and it sits before the
+// coordinates as a variable-length NUL-terminated string — so getting it wrong also misaligns every
+// coordinate that follows.
+func TestLociPlaceNameIsKeptAndDoesNotMisalignTheCoordinates(t *testing.T) {
+	name := "Renee's home address"
+	payload := []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+	payload = append(payload, name...)
+	payload = append(payload, 0x00) // name terminator
+	payload = append(payload, 0x00) // role
+	coords := make([]byte, 12)
+	binary.BigEndian.PutUint32(coords[0:4], fixed(-82.6985)) // longitude first
+	binary.BigEndian.PutUint32(coords[4:8], fixed(36.3506))
+	payload = append(payload, coords...)
+	payload = append(payload, []byte("earth\x00")...)
+
+	m := &VideoMetadata{Properties: map[string]string{}}
+	parseLociBox(payload, m)
+
+	if m.Location != name {
+		t.Errorf("Location = %q, want %q: the place name is location data and must be reported so "+
+			"it can be redacted", m.Location, name)
+	}
+	if !closeTo(m.GPSLatitude, 36.3506) || !closeTo(m.GPSLongitude, -82.6985) {
+		t.Errorf("got lat=%v lon=%v after a %d-byte name: the coordinates are read at a fixed "+
+			"offset instead of after the NUL terminator, so any named loci atom decodes to "+
+			"nonsense", m.GPSLatitude, m.GPSLongitude, len(name))
+	}
+}
+
+// A malformed loci atom must not be read past its end, and must not report a partial position.
+func TestLociRefusesMalformedPayloads(t *testing.T) {
+	cases := map[string][]byte{
+		"too short for the coordinates": {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+		"unterminated name":             append([]byte{0, 0, 0, 0, 0, 0}, []byte("no terminator here at all")...),
+		"empty":                         {},
+	}
+	for name, payload := range cases {
+		t.Run(name, func(t *testing.T) {
+			m := &VideoMetadata{Properties: map[string]string{}}
+			parseLociBox(payload, m) // must not panic
+			if m.GPSLatitude != 0 || m.GPSLongitude != 0 {
+				t.Errorf("a malformed payload produced lat=%v lon=%v", m.GPSLatitude, m.GPSLongitude)
+			}
+		})
+	}
+}
+
+// ISO 6709 Annex H has THREE integer widths, and they differ only in digit count. A plain
+// ParseFloat is right for the first and silently wrong for the other two.
+//
+// Measured before this change: "+4012.22-07500.25/" reported latitude 4012.22 and
+// "+401230.5-0750015.3/" reported 401230.5 — impossible coordinates at HIGH confidence. No local
+// producer writes the sexagesimal forms (every real file measured on this machine uses decimal
+// degrees), so this comes from the standard rather than from a sample, which is precisely why it
+// needs a test to hold it in place.
+func TestISO6709AcceptsAllThreeIntegerForms(t *testing.T) {
+	cases := []struct {
+		in       string
+		lat, lon float64
+		alt      float64
+	}{
+		{"+36.3506-082.6985/", 36.3506, -82.6985, 0},                        // ±DD.D±DDD.D
+		{"+36.3506-082.6985+447.403/", 36.3506, -82.6985, 447.403},          // with height
+		{"+4012.22-07500.25/", 40.203667, -75.004167, 0},                    // ±DDMM.M±DDDMM.M
+		{"+401230.5-0750015.3/", 40.208472, -75.004250, 0},                  // ±DDMMSS.S±DDDMMSS.S
+		{"-33.8688+151.2093/", -33.8688, 151.2093, 0},                       // southern and eastern
+		{"+36.3506-082.6985+447.403CRSWGS_84/", 36.3506, -82.6985, 447.403}, // CRS suffix
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			m := &VideoMetadata{Properties: map[string]string{}}
+			parseISO6709Location(c.in, m)
+			if !closeTo(m.GPSLatitude, c.lat) || !closeTo(m.GPSLongitude, c.lon) {
+				t.Errorf("got lat=%v lon=%v, want %v/%v — the integer width is being ignored, so "+
+					"minutes and seconds are read as degrees", m.GPSLatitude, m.GPSLongitude,
+					c.lat, c.lon)
+			}
+			if !closeTo(m.GPSAltitude, c.alt) {
+				t.Errorf("got alt=%v, want %v", m.GPSAltitude, c.alt)
+			}
+		})
+	}
+}
+
+// A value that cannot be a position on Earth must be dropped, not reported. This is what keeps a
+// misread payload from becoming a finding — the caller relies on it when the shape is uncertain.
+func TestISO6709RejectsValuesThatCannotBeAPosition(t *testing.T) {
+	for _, in := range []string{
+		"+91.0000-082.6985/", // latitude past the pole
+		"-90.0001+010.0000/", // just past it the other way
+		"+36.3506-181.0000/", // longitude past the antimeridian
+		"+3699.99-07500.25/", // 99 minutes
+		"+36.3506/",          // longitude missing
+		"+36.35060-82.6985/", // 5 integer digits: not a legal width
+		"+aa.bbbb-0cc.dddd/", // not digits
+		"+36.-082.6985/",     // trailing dot with no fraction
+		"",
+	} {
+		t.Run(in, func(t *testing.T) {
+			m := &VideoMetadata{Properties: map[string]string{}}
+			parseISO6709Location(in, m)
+			if m.GPSLatitude != 0 || m.GPSLongitude != 0 {
+				t.Errorf("%q was reported as lat=%v lon=%v; an impossible coordinate at HIGH "+
+					"confidence is a false positive that also buries any real position",
+					in, m.GPSLatitude, m.GPSLongitude)
+			}
+		})
+	}
+}

--- a/internal/preprocessors/meta-extractors/meta-extract-videolib/tail_moov_test.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-videolib/tail_moov_test.go
@@ -1,0 +1,453 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package metaextractvideolib
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// countingReaderAt wraps a file and records every byte the walk actually reads.
+//
+// This is the only way to state the property that matters: a movie's media payload must never be
+// read. A timing assertion could not distinguish "skipped by arithmetic" from "read quickly from
+// page cache", and it would flake on CI besides.
+type countingReaderAt struct {
+	r     io.ReaderAt
+	bytes int64
+	reads int64
+}
+
+func (c *countingReaderAt) ReadAt(p []byte, off int64) (int, error) {
+	n, err := c.r.ReadAt(p, off)
+	atomic.AddInt64(&c.bytes, int64(n))
+	atomic.AddInt64(&c.reads, 1)
+	return n, err
+}
+
+// ssnFixture is a value the SSN validator recognises, so a recovered moov is provable by a finding
+// rather than only by a populated struct.
+const ssnFixture = "452-11-9384"
+
+// A moov after the mdat must be found, and must produce exactly what the same moov produces when it
+// is written first.
+//
+// This is #398. ffmpeg and every camera measured write moov LAST by default; faststart is a second
+// pass. The previous walk charged a 10MB budget for every box it STEPPED OVER — including the mdat
+// it skipped with a bare seek and never read — so a 12MB movie exhausted a "metadata" allowance
+// while costing no memory, then stopped with a bare break and returned nil. The file was reported as
+// a complete, clean scan.
+//
+// The two layouts are compared against each other rather than against a hardcoded string, so the
+// test also fails if some future change makes one layout's extracted text differ from the other's.
+func TestTailMoovIsScannedLikeAFrontMoov(t *testing.T) {
+	dir := t.TempDir()
+
+	// 12MB of declared mdat: past the old 10MB budget, and created as a hole so the fixture costs
+	// no memory and no disk.
+	const mdatBytes = 12 << 20
+	udta := []byte{}
+	udta = append(udta, textAtom(itunesAtom("cmt"), "Employee SSN "+ssnFixture)...)
+	udta = append(udta, textAtom(itunesAtom("ART"), "Marcus Whitfield")...)
+
+	tail := buildISOFile(t, filepath.Join(dir, "tail.mp4"), mdatBytes, false, udta)
+	front := buildISOFile(t, filepath.Join(dir, "front.mp4"), mdatBytes, true, udta)
+
+	tailMeta, err := ExtractVideoMetadataWithContext(context.Background(), tail)
+	if err != nil {
+		t.Fatalf("tail-moov extraction: %v", err)
+	}
+	frontMeta, err := ExtractVideoMetadataWithContext(context.Background(), front)
+	if err != nil {
+		t.Fatalf("front-moov extraction: %v", err)
+	}
+
+	if !strings.Contains(tailMeta.Description, ssnFixture) {
+		t.Errorf("Description = %q, want it to contain the SSN: the moov sits past the old 10MB "+
+			"budget, so its metadata was never read and the file scanned clean", tailMeta.Description)
+	}
+	if tailMeta.Author == "" {
+		t.Error("Author is empty for the tail-moov file")
+	}
+
+	// A healthy file must not warn, or the disclosure becomes noise operators learn to ignore.
+	if tailMeta.ExtractionWarning != "" {
+		t.Errorf("a well-formed tail-moov file produced a warning (%q); only genuine coverage loss "+
+			"may disclose", tailMeta.ExtractionWarning)
+	}
+
+	if tailMeta.ToProcessedContent() != frontMeta.ToProcessedContent() {
+		t.Errorf("the two layouts produced different text.\n tail: %q\nfront: %q\nA file's box order "+
+			"must not change what is reported", tailMeta.ToProcessedContent(), frontMeta.ToProcessedContent())
+	}
+}
+
+// The media payload must never be read, and the walk's reads must be bounded by the metadata it
+// parses rather than by the file's size.
+//
+// Asserted by counting bytes, not by timing. A 200MB declared mdat is stepped over with arithmetic:
+// no read, no allocation, not even a seek.
+func TestSkippedBoxesAreNeverRead(t *testing.T) {
+	dir := t.TempDir()
+	const mdatBytes = 200 << 20
+
+	udta := textAtom(itunesAtom("cmt"), "Employee SSN "+ssnFixture)
+	path := buildISOFile(t, filepath.Join(dir, "big.mp4"), mdatBytes, false, udta)
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+
+	counter := &countingReaderAt{r: f}
+	// Walk the top level exactly as the extractor does, through the instrumented reader.
+	var cur int64
+	var boxes int
+	for cur+BoxHeaderSize <= info.Size() {
+		boxType, total, hdrLen, err := readTopLevelHeaderAt(counter, cur, info.Size())
+		if err != nil {
+			t.Fatalf("header at %d: %v", cur, err)
+		}
+		boxes++
+		if boxType == "moov" {
+			data := make([]byte, total-hdrLen)
+			if _, err := io.ReadFull(io.NewSectionReader(counter, cur+hdrLen, total-hdrLen), data); err != nil {
+				t.Fatalf("read moov: %v", err)
+			}
+		}
+		cur += total
+	}
+
+	// Headers plus the moov payload only. Nothing near the 200MB of declared media.
+	const generousCeiling = 64 << 10
+	if counter.bytes > generousCeiling {
+		t.Errorf("the walk read %d bytes from a file with %d bytes of declared media (%d boxes): a "+
+			"skipped box is being READ instead of stepped over, which is the 100MB-per-8-byte-header "+
+			"allocation this fix removed", counter.bytes, int64(mdatBytes), boxes)
+	}
+	if counter.bytes == 0 {
+		t.Fatal("the walk read nothing at all, so the bound above is vacuous")
+	}
+}
+
+// Allocation must be bounded by the moov, not by the file.
+//
+// This is the shape of the repo's 4KB-file-to-8.62GB-RSS incident: an allocation sized from a
+// DECLARED number. Measured end to end before this fix, 16 files of 80 bytes each whose ftyp declared
+// 100MB drove 631MB of resident memory at exit 0 with no disclosure.
+func TestWalkAllocationIsBoundedByMoovNotFileSize(t *testing.T) {
+	dir := t.TempDir()
+	const mdatBytes = 64 << 20
+
+	udta := textAtom(itunesAtom("cmt"), "Employee SSN "+ssnFixture)
+	path := buildISOFile(t, filepath.Join(dir, "alloc.mp4"), mdatBytes, false, udta)
+
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+
+	meta, err := ExtractVideoMetadataWithContext(context.Background(), path)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	runtime.ReadMemStats(&after)
+	allocated := after.TotalAlloc - before.TotalAlloc
+
+	const ceiling = 8 << 20 // the moov here is a few hundred bytes; 8MB is enormous headroom
+	if allocated > ceiling {
+		t.Errorf("extracting a file with %d bytes of DECLARED media allocated %d bytes (> %d): the "+
+			"allocation is sized from a declared number rather than from what the file really holds",
+			int64(mdatBytes), allocated, ceiling)
+	}
+	if !strings.Contains(meta.Description, ssnFixture) {
+		t.Error("the SSN was not recovered, so the allocation bound above is vacuous — it would " +
+			"hold on an extractor that parses nothing")
+	}
+}
+
+// Every declared size must be checked against the real end of the file, and a truncation must be
+// disclosed rather than silently swallowed.
+//
+// Case (b) is the one that matters most: an over-declared MOOV must still yield its findings AND
+// warn. A fix that only disclosed would lose values a clamp would have kept.
+func TestDeclaredSizeIsCheckedAgainstTheRealFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// writeRaw assembles a file from literal bytes, so a header can lie about its size.
+	writeRaw := func(name string, parts ...[]byte) string {
+		p := filepath.Join(dir, name)
+		var all []byte
+		for _, b := range parts {
+			all = append(all, b...)
+		}
+		if err := os.WriteFile(p, all, 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		return p
+	}
+	header := func(size uint32, kind string) []byte {
+		h := make([]byte, 8)
+		binary.BigEndian.PutUint32(h[0:4], size)
+		copy(h[4:8], kind)
+		return h
+	}
+	ftyp := box(atom("ftyp"), []byte("isom\x00\x00\x02\x00isomiso2mp41"))
+	udtaPayload := box(atom("udta"), textAtom(itunesAtom("cmt"), "Employee SSN "+ssnFixture))
+
+	t.Run("mdat declares more than the file holds", func(t *testing.T) {
+		p := writeRaw("overdeclared.mp4", ftyp, header(50<<20, "mdat"), make([]byte, 1024))
+		meta, err := ExtractVideoMetadataWithContext(context.Background(), p)
+		if err != nil {
+			t.Fatalf("extract: %v", err)
+		}
+		if meta.ExtractionWarning == "" {
+			t.Error("an mdat declaring 50MB inside a 1KB file produced no warning: the walk was cut " +
+				"short and nothing said so")
+		}
+	})
+
+	t.Run("moov declares more than the file holds but its values survive", func(t *testing.T) {
+		// moov claims 90MB; only the real udta bytes follow.
+		p := writeRaw("moovover.mp4", ftyp, header(90<<20, "moov"), udtaPayload)
+		meta, err := ExtractVideoMetadataWithContext(context.Background(), p)
+		if err != nil {
+			t.Fatalf("extract: %v", err)
+		}
+		if !strings.Contains(meta.Description, ssnFixture) {
+			t.Errorf("Description = %q: the over-declared moov was abandoned instead of clamped to "+
+				"the file's real end, so values that are genuinely present were lost",
+				meta.Description)
+		}
+		if meta.ExtractionWarning == "" {
+			t.Error("the truncation was not disclosed, so the operator cannot tell that more " +
+				"metadata may have been missing")
+		}
+	})
+
+	t.Run("declared size smaller than the header", func(t *testing.T) {
+		// Stepping by 4 would walk MISALIGNED through the rest of the file. This is the spin/
+		// misalignment class this file already fixed once, in its inner walkers.
+		//
+		// The warning's CAUSE is asserted, not merely its presence. Without the guard the walk
+		// wanders into the udta bytes, eventually reads a garbage header whose declared size runs
+		// past the end, and warns about THAT instead — a true disclosure under a false heading,
+		// which a presence-only assertion accepts. Removing the guard survived exactly that way.
+		p := writeRaw("undersize.mp4", ftyp, header(4, "junk"), udtaPayload)
+		meta, err := ExtractVideoMetadataWithContext(context.Background(), p)
+		if err != nil {
+			t.Fatalf("extract: %v", err)
+		}
+		if !strings.Contains(meta.ExtractionWarning, "smaller than its") {
+			t.Errorf("warning = %q, want it to name the under-length box: a box cannot be smaller "+
+				"than its own header, and stepping by that size walks the rest of the file "+
+				"misaligned", meta.ExtractionWarning)
+		}
+	})
+
+	t.Run("size 0 mdat is terminal and disclosed", func(t *testing.T) {
+		// Size 0 legally means "extends to the end of the file", so anything after it is
+		// unreachable. Disclose rather than guess.
+		p := writeRaw("size0.mp4", ftyp, header(0, "mdat"), make([]byte, 4096), box(atom("moov"), udtaPayload))
+		meta, err := ExtractVideoMetadataWithContext(context.Background(), p)
+		if err != nil {
+			t.Fatalf("extract: %v", err)
+		}
+		if meta.ExtractionWarning == "" {
+			t.Error("a size-0 mdat swallowing the rest of the file produced no warning")
+		}
+	})
+
+	t.Run("64-bit largesize near the int64 ceiling", func(t *testing.T) {
+		// The EOF bound must be written as subtraction. Phrased as `off+total > fileSize` it
+		// OVERFLOWS to a negative number here, the comparison is false, and the absurd size is
+		// accepted — after which `cur += total` sends the offset negative too.
+		//
+		// The warning's CAUSE is asserted rather than its presence: the overflowing form still
+		// produces a warning, because a read at a negative offset fails and the walk reports that it
+		// could not follow the structure. Presence alone therefore cannot tell the two apart, and
+		// the addition form survived mutation until this assertion named the over-declaration.
+		big := make([]byte, 16)
+		binary.BigEndian.PutUint32(big[0:4], 1) // size == 1: a 64-bit size follows
+		copy(big[4:8], "mdat")
+		binary.BigEndian.PutUint64(big[8:16], 1<<63-5)
+		p := writeRaw("largesize.mp4", ftyp, big, udtaPayload)
+
+		meta, err := ExtractVideoMetadataWithContext(context.Background(), p)
+		if err != nil {
+			t.Fatalf("extract: %v", err)
+		}
+		if !strings.Contains(meta.ExtractionWarning, "declares more bytes than the file holds") {
+			t.Errorf("warning = %q, want it to name the over-declaration. A size of 2^63-5 must be "+
+				"refused by comparing against the bytes REMAINING, not by adding it to the current "+
+				"offset", meta.ExtractionWarning)
+		}
+	})
+
+	t.Run("64-bit largesize beyond int64 entirely", func(t *testing.T) {
+		big := make([]byte, 16)
+		binary.BigEndian.PutUint32(big[0:4], 1)
+		copy(big[4:8], "mdat")
+		binary.BigEndian.PutUint64(big[8:16], ^uint64(0)) // 2^64-1: not representable as int64
+		p := writeRaw("hugesize.mp4", ftyp, big, udtaPayload)
+
+		meta, err := ExtractVideoMetadataWithContext(context.Background(), p)
+		if err != nil {
+			t.Fatalf("extract: %v", err)
+		}
+		if !strings.Contains(meta.ExtractionWarning, "unrepresentable") {
+			t.Errorf("warning = %q, want it to name the unrepresentable size: converting 2^64-1 to "+
+				"int64 yields -1, which every subsequent bound check would treat as harmless",
+				meta.ExtractionWarning)
+		}
+	})
+}
+
+// Walking must be bounded by work, and hitting that bound must be disclosed rather than truncating
+// silently.
+//
+// Progress-based, with no wall-clock assertion, so it is valid on slow or loaded CI. The budget is
+// deliberately large enough that a legitimately fragmented file passes: a tighter 100k ceiling was
+// tried and rejected because it LOST a finding the previous code found.
+func TestBoxCountBudgetDisclosesRatherThanTruncatingSilently(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "manyboxes.mp4")
+
+	f, err := os.Create(p)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	ftyp := box(atom("ftyp"), []byte("isom\x00\x00\x02\x00isomiso2mp41"))
+	if _, err := f.Write(ftyp); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	free := make([]byte, 8)
+	binary.BigEndian.PutUint32(free[0:4], 8)
+	copy(free[4:8], "free")
+	// One past the budget, so the moov after them is unreachable.
+	for i := 0; i <= MaxTopLevelBoxes; i++ {
+		if _, err := f.Write(free); err != nil {
+			t.Fatalf("write free box %d: %v", i, err)
+		}
+	}
+	if _, err := f.Write(box(atom("moov"), box(atom("udta"), textAtom(itunesAtom("cmt"), "Employee SSN "+ssnFixture)))); err != nil {
+		t.Fatalf("write moov: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	meta, err := ExtractVideoMetadataWithContext(context.Background(), p)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if meta.ExtractionWarning == "" {
+		t.Error("the box budget was exhausted with no warning: the walk stopped early and the file " +
+			"would be reported as completely scanned")
+	}
+	if !strings.Contains(meta.ExtractionWarning, "top-level boxes") {
+		t.Errorf("warning = %q, want it to name the box budget so an operator can tell this from a "+
+			"malformed file", meta.ExtractionWarning)
+	}
+}
+
+// A file with no moov at all yields no metadata, and that has to be said rather than reported as a
+// clean, complete scan.
+func TestNoMoovIsDisclosed(t *testing.T) {
+	dir := t.TempDir()
+	f, err := os.Create(filepath.Join(dir, "nomoov.mp4"))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := f.Write(box(atom("ftyp"), []byte("isom\x00\x00\x02\x00isomiso2mp41"))); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	mdat := make([]byte, 8)
+	binary.BigEndian.PutUint32(mdat[0:4], 8+4096)
+	copy(mdat[4:8], "mdat")
+	if _, err := f.Write(mdat); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := f.Truncate(int64(len(box(atom("ftyp"), []byte("isom\x00\x00\x02\x00isomiso2mp41")))) + 8 + 4096); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	name := f.Name()
+	if err := f.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	meta, err := ExtractVideoMetadataWithContext(context.Background(), name)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if meta.ExtractionWarning == "" {
+		t.Error("a file with no moov produced no warning: an empty-but-successful result is " +
+			"indistinguishable from a video that genuinely carries no metadata")
+	}
+	if !strings.Contains(meta.ExtractionWarning, "moov") {
+		t.Errorf("warning = %q, want it to name the missing moov", meta.ExtractionWarning)
+	}
+}
+
+// Every warning reaches stderr and every machine format with no --show-match to gate it, so none of
+// them may carry a metadata value.
+func TestExtractionWarningsCarryNoPayload(t *testing.T) {
+	dir := t.TempDir()
+	secret := "Employee SSN " + ssnFixture
+	udtaPayload := box(atom("udta"), textAtom(itunesAtom("cmt"), secret))
+
+	header := func(size uint32, kind string) []byte {
+		h := make([]byte, 8)
+		binary.BigEndian.PutUint32(h[0:4], size)
+		copy(h[4:8], kind)
+		return h
+	}
+	ftyp := box(atom("ftyp"), []byte("isom\x00\x00\x02\x00isomiso2mp41"))
+
+	fixtures := map[string][][]byte{
+		"over-declared moov": {ftyp, header(90<<20, "moov"), udtaPayload},
+		"under-length box":   {ftyp, header(4, "junk"), udtaPayload},
+		"size-0 mdat":        {ftyp, header(0, "mdat"), make([]byte, 512), box(atom("moov"), udtaPayload)},
+		"no moov":            {ftyp, header(8+512, "mdat"), make([]byte, 512)},
+	}
+
+	for name, parts := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			var all []byte
+			for _, b := range parts {
+				all = append(all, b...)
+			}
+			p := filepath.Join(dir, strings.ReplaceAll(name, " ", "_")+".mp4")
+			if err := os.WriteFile(p, all, 0o600); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+
+			meta, err := ExtractVideoMetadataWithContext(context.Background(), p)
+			if err != nil {
+				t.Fatalf("extract: %v", err)
+			}
+			if meta.ExtractionWarning == "" {
+				t.Skip("no warning produced for this fixture")
+			}
+			for _, forbidden := range []string{ssnFixture, secret, "Marcus"} {
+				if strings.Contains(meta.ExtractionWarning, forbidden) {
+					t.Errorf("warning contains %q: %q. This string reaches stderr and every machine "+
+						"format with no --show-match to gate it", forbidden, meta.ExtractionWarning)
+				}
+			}
+		})
+	}
+}

--- a/internal/preprocessors/meta-extractors/meta-extract-videolib/video-extractor.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-videolib/video-extractor.go
@@ -65,25 +65,66 @@ type VideoMetadata struct {
 
 	// Additional properties
 	Properties map[string]string
+
+	// ExtractionWarning is a payload-free note that extraction finished but covered less than the
+	// whole file, so a value may be missing. It carries box types, byte offsets and limit
+	// constants only — never a metadata value, and never matched text.
+	//
+	// Before this existed the walk gave up on a bare `break` and returned a nil error, so a file
+	// whose metadata was never reached was reported as a complete, clean scan. AudioMetadata has
+	// carried the equivalent field for the same reason.
+	ExtractionWarning string
 }
 
-// MP4Box represents an MP4 atom/box structure
-type MP4Box struct {
-	Size   uint32
-	Type   [4]byte
-	Data   []byte
-	Offset int64
+// noteTruncation records the FIRST reason coverage was lost and keeps it.
+//
+// First wins rather than last: the earliest failure is the one that explains the others, and a
+// later note would otherwise overwrite the cause with a symptom.
+func noteTruncation(metadata *VideoMetadata, note string) {
+	if metadata.ExtractionWarning == "" {
+		metadata.ExtractionWarning = note
+	}
 }
 
 // Constants for MP4 parsing
 const (
-	MaxFileSize       = 500 * 1024 * 1024 // 500MB limit
-	MaxBoxSize        = 100 * 1024 * 1024 // 100MB per box limit
-	BoxHeaderSize     = 8                 // 4 bytes size + 4 bytes type
-	ExtendedBoxSize   = 16                // For 64-bit size boxes
-	MaxMetadataRead   = 10 * 1024 * 1024  // Only read first 10MB for metadata
-	ProcessingTimeout = 30 * time.Second  // 30 second timeout
+	// MaxFileSize is the extractor's own ceiling. It sits above the router's 100MB gate, which
+	// refuses the file first, so it is effectively unreachable on the CLI path.
+	MaxFileSize   = 500 * 1024 * 1024 // 500MB limit
+	BoxHeaderSize = 8                 // 4 bytes size + 4 bytes type
+
+	// ExtendedBoxSize is the header length when a box declares a 64-bit size (size == 1).
+	ExtendedBoxSize = 16
+
+	// MaxMoovParse bounds the ONE allocation this extractor makes: the moov payload it parses.
+	// Memory is therefore O(min(|moov|, MaxMoovParse)) and independent of the file's size.
+	//
+	// 32MB is measured headroom rather than a guess. The router refuses anything over 100MB before
+	// extraction runs, and a real moov is a fraction of its file — 0.14%, 0.27% and 0.39% across
+	// the videos on the machine this was written on — so a 100MB file's moov is a few hundred
+	// kilobytes. A moov beyond this is clamped and DISCLOSED, never silently truncated.
+	MaxMoovParse = 32 * 1024 * 1024
+
+	// MaxTopLevelBoxes bounds the walk's work so a file made of millions of tiny boxes cannot turn
+	// a scan into a CPU amplifier. A well-formed movie has a handful; a fragmented one (DASH/CMAF,
+	// a moof+mdat pair per fragment) can legitimately have tens of thousands.
+	//
+	// 1<<20 matches the atom budget the redactor's walk already uses, so the two sides give up at
+	// the same point. Measured cost is ~1.3µs per box — 100k boxes walk in 0.13s — so this ceiling
+	// is ~1.4s in the worst case, well inside ProcessingTimeout. A tighter 100k ceiling was tried
+	// first and rejected: it is reachable in an 800KB file, and it LOST a finding that the previous
+	// code found, which is the wrong direction to trade even for a disclosure.
+	MaxTopLevelBoxes = 1 << 20
+
+	ProcessingTimeout = 30 * time.Second // 30 second timeout
 )
+
+// errDeclaredOverrun marks a box whose declared size runs past the real end of the file.
+//
+// Its own sentinel because it is the one header error worth recovering from: the bytes up to the
+// real end are still worth parsing, which turns a truncated download into a partial result plus a
+// disclosure rather than nothing at all.
+var errDeclaredOverrun = errors.New("box declares more bytes than the file holds")
 
 // ExtractVideoMetadata extracts metadata from video files with resource limits
 func ExtractVideoMetadata(filePath string) (*VideoMetadata, error) {
@@ -313,140 +354,6 @@ func isVideoErrorRecoverable(errorType string) bool {
 	default:
 		return false
 	}
-}
-
-// parseMP4ContainerWithContext parses the MP4/MOV container structure with context
-func parseMP4ContainerWithContext(ctx context.Context, file *os.File, metadata *VideoMetadata) error {
-	bytesRead := int64(0)
-
-	for {
-		// Check context for cancellation
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-
-		// Stop reading if we've read too much metadata
-		if bytesRead > MaxMetadataRead {
-			break
-		}
-
-		box, err := readMP4BoxWithContext(ctx, file)
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return fmt.Errorf("failed to read box: %w", err)
-		}
-
-		bytesRead += int64(box.Size) + BoxHeaderSize
-
-		// Process specific box types
-		switch string(box.Type[:]) {
-		case "moov":
-			err = parseMoovBoxWithContext(ctx, box.Data, metadata)
-			if err != nil {
-				return fmt.Errorf("failed to parse moov box: %w", err)
-			}
-		case "ftyp":
-			err = parseFtypBox(box.Data, metadata)
-			if err != nil {
-				// Non-fatal error for ftyp parsing
-				continue
-			}
-		case "mdat":
-			// Skip media data - we only need metadata
-			continue
-		}
-	}
-
-	return nil
-}
-
-// readMP4BoxWithContext reads an MP4 box from the file with context
-func readMP4BoxWithContext(ctx context.Context, file *os.File) (*MP4Box, error) {
-	// Check context before reading
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	default:
-	}
-
-	var header [BoxHeaderSize]byte
-	n, err := file.Read(header[:])
-	if err != nil {
-		return nil, err
-	}
-	if n != BoxHeaderSize {
-		return nil, io.EOF
-	}
-
-	// Parse box header
-	size := binary.BigEndian.Uint32(header[0:4])
-	var boxType [4]byte
-	copy(boxType[:], header[4:8])
-
-	// Handle extended size (64-bit)
-	if size == 1 {
-		var extSize [8]byte
-		n, err := file.Read(extSize[:])
-		if err != nil {
-			return nil, err
-		}
-		if n != 8 {
-			return nil, io.EOF
-		}
-		size64 := binary.BigEndian.Uint64(extSize[:])
-		if size64 > MaxBoxSize {
-			return nil, fmt.Errorf("box too large: %d bytes", size64)
-		}
-		// Safe conversion with bounds checking
-		if size64 < ExtendedBoxSize {
-			return nil, fmt.Errorf("invalid box size: %d is less than extended box size %d", size64, ExtendedBoxSize)
-		}
-		adjustedSize := size64 - ExtendedBoxSize
-		if adjustedSize > math.MaxUint32 {
-			return nil, fmt.Errorf("box size too large for uint32: %d", adjustedSize)
-		}
-		size = uint32(adjustedSize)
-	} else if size == 0 {
-		// Box extends to end of file - skip for safety
-		return nil, io.EOF
-	} else {
-		size -= BoxHeaderSize
-	}
-
-	// Safety check for box size
-	if size > MaxBoxSize {
-		return nil, fmt.Errorf("box too large: %d bytes", size)
-	}
-
-	// Check context before reading data
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	default:
-	}
-
-	// Read box data efficiently
-	data := make([]byte, size)
-	if size > 0 {
-		n, err := file.Read(data)
-		if err != nil {
-			return nil, err
-		}
-		// Safe comparison with bounds checking
-		if n < 0 || uint64(n) > math.MaxUint32 || uint32(n) != size {
-			return nil, fmt.Errorf("incomplete box read: expected %d, got %d", size, n)
-		}
-	}
-
-	return &MP4Box{
-		Size: size,
-		Type: boxType,
-		Data: data,
-	}, nil
 }
 
 // parseFtypBox parses the file type box
@@ -1500,107 +1407,6 @@ func NewOptimizedVideoReader(filePath string) (*OptimizedVideoReader, error) {
 	}, nil
 }
 
-// ReadBoxHeader reads a box header efficiently
-func (ovr *OptimizedVideoReader) ReadBoxHeader() (*MP4Box, error) {
-	var header [BoxHeaderSize]byte
-	n, err := ovr.file.Read(header[:])
-	if err != nil {
-		return nil, err
-	}
-	if n != BoxHeaderSize {
-		return nil, io.EOF
-	}
-
-	ovr.position += BoxHeaderSize
-
-	// Parse box header
-	size := binary.BigEndian.Uint32(header[0:4])
-	var boxType [4]byte
-	copy(boxType[:], header[4:8])
-
-	// Handle extended size (64-bit)
-	if size == 1 {
-		var extSize [8]byte
-		n, err := ovr.file.Read(extSize[:])
-		if err != nil {
-			return nil, err
-		}
-		if n != 8 {
-			return nil, io.EOF
-		}
-		ovr.position += 8
-		size64 := binary.BigEndian.Uint64(extSize[:])
-		if size64 > MaxBoxSize {
-			return nil, fmt.Errorf("box too large: %d bytes", size64)
-		}
-		// Safe conversion with bounds checking
-		if size64 < ExtendedBoxSize {
-			return nil, fmt.Errorf("invalid box size: %d is less than extended box size %d", size64, ExtendedBoxSize)
-		}
-		adjustedSize := size64 - ExtendedBoxSize
-		if adjustedSize > math.MaxUint32 {
-			return nil, fmt.Errorf("box size too large for uint32: %d", adjustedSize)
-		}
-		size = uint32(adjustedSize)
-	} else if size == 0 {
-		// Box extends to end of file - skip for safety
-		return nil, io.EOF
-	} else {
-		size -= BoxHeaderSize
-	}
-
-	// Safety check for box size
-	if size > MaxBoxSize {
-		return nil, fmt.Errorf("box too large: %d bytes", size)
-	}
-
-	return &MP4Box{
-		Size: size,
-		Type: boxType,
-		Data: nil, // Data will be read on demand
-	}, nil
-}
-
-// ReadBoxData reads box data efficiently
-func (ovr *OptimizedVideoReader) ReadBoxData(size uint32) ([]byte, error) {
-	if size == 0 {
-		return nil, nil
-	}
-
-	data := make([]byte, size)
-	n, err := ovr.file.Read(data)
-	if err != nil {
-		return nil, err
-	}
-	// Safe comparison with bounds checking
-	if n < 0 || uint64(n) > math.MaxUint32 || uint32(n) != size {
-		return nil, fmt.Errorf("incomplete box read: expected %d, got %d", size, n)
-	}
-
-	ovr.position += int64(size)
-	return data, nil
-}
-
-// SkipBoxData skips box data without reading it
-func (ovr *OptimizedVideoReader) SkipBoxData(size uint32) error {
-	if size == 0 {
-		return nil
-	}
-
-	_, err := ovr.file.Seek(int64(size), io.SeekCurrent)
-	if err != nil {
-		return err
-	}
-
-	ovr.position += int64(size)
-	return nil
-}
-
-// GetPosition returns the current position
-func (ovr *OptimizedVideoReader) GetPosition() int64 {
-	return ovr.position
-}
-
 // GetFileSize returns the file size
 func (ovr *OptimizedVideoReader) GetFileSize() int64 {
 	return ovr.fileSize
@@ -1611,85 +1417,172 @@ func (ovr *OptimizedVideoReader) Close() error {
 	return ovr.file.Close()
 }
 
-// parseMP4ContainerOptimized parses MP4 container with optimized reading
-func parseMP4ContainerOptimized(ctx context.Context, reader *OptimizedVideoReader, metadata *VideoMetadata) error {
-	bytesRead := int64(0)
+// readTopLevelHeaderAt reads one top-level box header at off and returns its type, its TOTAL size
+// (header included) and the length of that header.
+//
+// Takes an io.ReaderAt rather than the file so a test can wrap it and count exactly how many bytes
+// the walk reads — which is the only way to assert that a media payload is never touched.
+//
+// Every declared size is checked against the real end of the file before it is trusted. That check
+// is written as `total > fileSize-off`, deliberately NOT as `off+total > fileSize`: a 64-bit
+// largesize near 2^63 makes the addition overflow to a negative offset, which a bounds test phrased
+// that way silently accepts. Both operands here are non-negative, so the comparison cannot wrap.
+func readTopLevelHeaderAt(r io.ReaderAt, off, fileSize int64) (boxType string, total, hdrLen int64, err error) {
+	var head [ExtendedBoxSize]byte
+	if _, err = io.ReadFull(io.NewSectionReader(r, off, BoxHeaderSize), head[:BoxHeaderSize]); err != nil {
+		return "", 0, 0, err
+	}
+	size32 := binary.BigEndian.Uint32(head[0:4])
+	boxType = string(head[4:8])
+	hdrLen = BoxHeaderSize
 
-	for {
-		// Check context for cancellation
+	switch size32 {
+	case 1:
+		// The real size is a 64-bit value following the type.
+		if _, err = io.ReadFull(io.NewSectionReader(r, off+BoxHeaderSize, 8), head[BoxHeaderSize:ExtendedBoxSize]); err != nil {
+			return "", 0, 0, err
+		}
+		hdrLen = ExtendedBoxSize
+		size64 := binary.BigEndian.Uint64(head[BoxHeaderSize:ExtendedBoxSize])
+		if size64 > math.MaxInt64 {
+			return boxType, 0, hdrLen, fmt.Errorf("box %q declares an unrepresentable 64-bit size", boxType)
+		}
+		total = int64(size64)
+	case 0:
+		// Size 0 means "extends to the end of the file", permitted for the last box.
+		total = fileSize - off
+	default:
+		total = int64(size32)
+	}
+
+	// A box cannot be smaller than its own header. Stepping by such a size would not advance the
+	// walk, which is the spin this file has already been bitten by once.
+	if total < hdrLen {
+		return boxType, 0, hdrLen, fmt.Errorf("box %q declares %d bytes, smaller than its %d-byte header", boxType, total, hdrLen)
+	}
+	if total > fileSize-off {
+		return boxType, 0, hdrLen, errDeclaredOverrun
+	}
+	return boxType, total, hdrLen, nil
+}
+
+// parseMP4ContainerOptimized walks the top-level boxes and parses the metadata ones.
+//
+// The walk is by ABSOLUTE OFFSET and has no positional budget, because moov is legal anywhere in the
+// file. ISO/IEC 14496-12 cl. 8.2.1.1 says moov is "normally ... close to the beginning or end of the
+// file, though this is not required", and Apple's QTFF is blunter: "QuickTime does not impose any
+// rules about the order of these atoms." ffmpeg and every camera measured on this machine write moov
+// LAST by default; faststart is a second pass nobody runs by accident.
+//
+// What was here before charged a 10MB budget for every box it stepped over, including the mdat it
+// skipped with a bare seek and never read — so the counter measured a file offset, not bytes read,
+// and a 12MB movie exhausted a "metadata" allowance while costing no memory at all. The walk then
+// stopped with a bare `break` and returned nil, so a file whose entire moov was never reached was
+// reported as a complete, clean scan at exit 0 (#398).
+//
+// Cost: TIME is O(number of top-level boxes) — a handful of 8-byte header reads. MEMORY is
+// O(min(|moov|, MaxMoovParse)), independent of the file's size, because no other box is ever read.
+// A media payload is stepped over by arithmetic, not even seeked.
+//
+// Always returns nil once the file is open. Lost coverage is reported through
+// metadata.ExtractionWarning instead, so a file that yielded SOME metadata keeps it — an error here
+// would throw away findings the walk had already collected.
+func parseMP4ContainerOptimized(ctx context.Context, reader *OptimizedVideoReader, metadata *VideoMetadata) error {
+	fileSize := reader.GetFileSize()
+	cur := int64(0)
+	boxes := 0
+	sawMoov := false
+
+	for cur+BoxHeaderSize <= fileSize {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
 		}
 
-		// Stop reading if we've read too much metadata
-		if bytesRead > MaxMetadataRead {
+		if boxes >= MaxTopLevelBoxes {
+			noteTruncation(metadata, fmt.Sprintf(
+				"video metadata may be incomplete: the box walk stopped after %d top-level boxes",
+				MaxTopLevelBoxes))
 			break
 		}
+		boxes++
 
-		// Read box header
-		box, err := reader.ReadBoxHeader()
-		if err == io.EOF {
-			break
+		boxType, total, hdrLen, err := readTopLevelHeaderAt(reader.file, cur, fileSize)
+		switch {
+		case errors.Is(err, io.EOF), errors.Is(err, io.ErrUnexpectedEOF):
+			// A clean end of file, or a few stray bytes after the last box. Nothing was lost.
+			return nil
+		case errors.Is(err, errDeclaredOverrun):
+			// A truncated file. Read to its real end rather than abandoning the box: a partial
+			// moov still yields values, and the operator is told coverage was cut short.
+			noteTruncation(metadata, fmt.Sprintf(
+				"video metadata may be incomplete: the %q box at offset %d declares more bytes than "+
+					"the file holds, so it was read only to the file's real end", boxType, cur))
+			total = fileSize - cur
+			if total < hdrLen {
+				return nil
+			}
+		case err != nil:
+			noteTruncation(metadata, fmt.Sprintf(
+				"video metadata may be incomplete: the box structure could not be followed past "+
+					"offset %d (%v)", cur, err))
+			return nil
 		}
-		if err != nil {
-			return fmt.Errorf("failed to read box header: %w", err)
-		}
 
-		boxType := string(box.Type[:])
-		bytesRead += int64(box.Size) + BoxHeaderSize
+		payloadStart := cur + hdrLen
+		payloadLen := total - hdrLen
 
-		// Process specific box types
 		switch boxType {
 		case "moov":
-			// Read moov box data for metadata
-			data, err := reader.ReadBoxData(box.Size)
-			if err != nil {
-				return fmt.Errorf("failed to read moov box data: %w", err)
+			sawMoov = true
+			readLen := payloadLen
+			if readLen > MaxMoovParse {
+				readLen = MaxMoovParse
+				noteTruncation(metadata, fmt.Sprintf(
+					"video metadata may be incomplete: the moov box is %d bytes and only the first "+
+						"%d were parsed", payloadLen, MaxMoovParse))
 			}
-			box.Data = data
-
-			err = parseMoovBoxWithContext(ctx, box.Data, metadata)
-			if err != nil {
-				return fmt.Errorf("failed to parse moov box: %w", err)
+			data := make([]byte, readLen)
+			if _, err := io.ReadFull(io.NewSectionReader(reader.file, payloadStart, readLen), data); err != nil {
+				noteTruncation(metadata, fmt.Sprintf(
+					"video metadata may be incomplete: the moov box at offset %d could not be read "+
+						"in full (%v)", cur, err))
+			} else if err := parseMoovBoxWithContext(ctx, data, metadata); err != nil {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+				noteTruncation(metadata, fmt.Sprintf(
+					"video metadata may be incomplete: the moov box at offset %d could not be "+
+						"parsed in full (%v)", cur, err))
 			}
 		case "ftyp":
-			// Read ftyp box data for file type info
-			data, err := reader.ReadBoxData(box.Size)
-			if err != nil {
-				// Non-fatal error for ftyp reading
-				reader.SkipBoxData(box.Size)
-				continue
+			// Only the brands are wanted, and they sit at the front of the payload.
+			readLen := payloadLen
+			if readLen > 1024 {
+				readLen = 1024
 			}
-			box.Data = data
-
-			err = parseFtypBox(box.Data, metadata)
-			if err != nil {
-				// Non-fatal error for ftyp parsing
-				continue
-			}
-		case "mdat":
-			// Skip media data - we only need metadata
-			err = reader.SkipBoxData(box.Size)
-			if err != nil {
-				return fmt.Errorf("failed to skip mdat box: %w", err)
-			}
-		case "free", "skip":
-			// Skip free space boxes
-			err = reader.SkipBoxData(box.Size)
-			if err != nil {
-				return fmt.Errorf("failed to skip %s box: %w", boxType, err)
+			data := make([]byte, readLen)
+			if _, err := io.ReadFull(io.NewSectionReader(reader.file, payloadStart, readLen), data); err == nil {
+				_ = parseFtypBox(data, metadata) // brands are advisory; a bad ftyp is not a failure
 			}
 		default:
-			// Skip unknown boxes to save time and memory
-			err = reader.SkipBoxData(box.Size)
-			if err != nil {
-				return fmt.Errorf("failed to skip %s box: %w", boxType, err)
-			}
+			// mdat, free, skip, wide, uuid and anything unrecognised: stepped over by arithmetic.
+			// No read, no allocation, not even a seek — which is what makes a 90MB movie cost the
+			// same as a 90KB one.
 		}
+
+		if metadata.ExtractionWarning != "" && errors.Is(err, errDeclaredOverrun) {
+			// The file ended early; there is nothing after this box to walk.
+			return nil
+		}
+		cur += total // total >= hdrLen >= BoxHeaderSize, so the walk always advances
 	}
 
+	if !sawMoov {
+		noteTruncation(metadata,
+			"video metadata may be incomplete: no moov box was found in the file")
+	}
 	return nil
 }
 

--- a/internal/preprocessors/meta-extractors/meta-extract-videolib/video-extractor.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-videolib/video-extractor.go
@@ -4,6 +4,7 @@
 package metaextractvideolib
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
@@ -17,6 +18,14 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	// isobmff is a pure-standard-library ISO base media container parser — its own package
+	// comment states that nothing about redaction belongs in it — and it owns the spec-derived
+	// definition of an ISO 6709 position string. The extractor shares that definition rather
+	// than keeping a second copy, because the two sides disagreeing about what a position looks
+	// like is exactly the defect being fixed here (#399). Its home under internal/redactors is
+	// historical; moving it somewhere neutral is a separate, purely mechanical change.
+	"github.com/awslabs/ferret-scan/v2/internal/redactors/isobmff"
 )
 
 // VideoMetadata represents extracted video file metadata
@@ -683,7 +692,9 @@ func parseUdtaBoxWithContext(ctx context.Context, data []byte, metadata *VideoMe
 				metadata.CreatedDate = date
 			}
 		case "©xyz":
-			parseGPSBox(boxData, metadata)
+			parsePositionAtom(boxData, metadata)
+		case "loci":
+			parseLociBox(boxData, metadata)
 		case "©cpy":
 			metadata.Copyright = parseStringBox(boxData)
 		case "©des":
@@ -917,6 +928,82 @@ func parseStringBox(data []byte) string {
 	}
 
 	return strings.TrimSpace(string(data))
+}
+
+// parsePositionAtom reads a ©xyz payload, which carries a position in EITHER of two encodings.
+//
+// The atom name does not say which, so the payload's SHAPE decides. ffmpeg writes a .mov ©xyz as a
+// 2-byte text length, a 2-byte language code and then an ISO 6709 string; some cameras write three
+// 16.16 fixed-point words instead. Reading the text form as fixed-point turns the length and
+// language bytes into a latitude: the payload "\x00\x12\x55\xc4+36.3506-082.6985/" was reported as
+// 18.335022, 11059.211639 at HIGH confidence, while the real position sat unreported in the same
+// bytes (#399).
+//
+// The shape test is isobmff.FindISO6709, the same spec-derived pattern the redactor uses to locate a
+// position. Sharing it is the point: the redactor's own notes record that these two readers
+// disagreeing about what a position looks like is what produced the garbage value, and a second copy
+// of the pattern here would let them drift apart again.
+//
+// A zero-filled payload still yields nothing, which is what keeps redaction verifiable by rescanning
+// the output: it holds no ISO 6709 text, so it falls to the fixed-point branch, decodes to 0/0, and
+// parseGPSBox drops that.
+func parsePositionAtom(data []byte, metadata *VideoMetadata) {
+	if match := isobmff.FindISO6709(data); match != nil {
+		parseISO6709Location(string(match), metadata)
+		return
+	}
+	parseGPSBox(data, metadata)
+}
+
+// parseLociBox reads a 3GPP/QuickTime loci atom, the form ffmpeg writes into .mp4 by default.
+//
+// Layout: a version byte and three flag bytes, a 2-byte language code, a NUL-terminated UTF-8 place
+// name, a one-byte role, then LONGITUDE, LATITUDE and altitude as 16.16 fixed-point in that order —
+// longitude first, unlike ©xyz — then a NUL-terminated astronomical body and NUL-terminated notes.
+//
+// The place name is location data in its own right and is kept. The reversed word order is the trap
+// here: reading them as lat/lon swaps the coordinates, which stays plausible near the equator and is
+// wrong everywhere else.
+func parseLociBox(data []byte, metadata *VideoMetadata) {
+	const (
+		versionAndFlags = 4
+		languageBytes   = 2
+		roleBytes       = 1
+		coordinateWords = 3 * 4
+	)
+	if len(data) < versionAndFlags+languageBytes+1+roleBytes+coordinateWords {
+		return
+	}
+
+	offset := versionAndFlags + languageBytes
+	nameEnd := bytes.IndexByte(data[offset:], 0)
+	if nameEnd < 0 {
+		return // unterminated name: the coordinate offsets below cannot be trusted
+	}
+	name := strings.TrimSpace(string(data[offset : offset+nameEnd]))
+	offset += nameEnd + 1 + roleBytes
+
+	if offset+coordinateWords > len(data) {
+		return
+	}
+	// #nosec G115 -- bit-pattern preservation for sign-extension, as in parseGPSBox
+	lon := float64(int32(binary.BigEndian.Uint32(data[offset:offset+4]))) / 65536.0
+	// #nosec G115 -- see lon above
+	lat := float64(int32(binary.BigEndian.Uint32(data[offset+4:offset+8]))) / 65536.0
+	// #nosec G115 -- see lon above
+	alt := float64(int32(binary.BigEndian.Uint32(data[offset+8:offset+12]))) / 65536.0
+
+	if lat < -90 || lat > 90 || lon < -180 || lon > 180 {
+		return // not a position on Earth; see parseISO6709Location on why this is dropped
+	}
+	if lat != 0 || lon != 0 {
+		metadata.GPSLatitude = lat
+		metadata.GPSLongitude = lon
+		metadata.GPSAltitude = alt
+	}
+	if name != "" {
+		metadata.Location = name
+	}
 }
 
 // parseGPSBox parses GPS coordinates from binary data
@@ -1831,65 +1918,136 @@ func extractAppleMetadataValue(searchArea, metadataKey string) string {
 	return ""
 }
 
-// parseISO6709Location parses GPS coordinates in ISO 6709 format
+// parseISO6709Location parses GPS coordinates in ISO 6709 Annex H format.
+//
+// The three forms differ only in how many INTEGER digits the angle carries, and that is the whole
+// difficulty: ±DD, ±DDMM and ±DDMMSS for latitude, ±DDD, ±DDDMM and ±DDDMMSS for longitude, with an
+// optional fraction on the smallest unit present. A plain ParseFloat is correct for the first form
+// and silently wrong for the other two — measured before this change, "+4012.22-07500.25/" (40°12.22′
+// north, 75°00.25′ west) reported latitude 4012.22 and longitude -7500.25, and
+// "+401230.5-0750015.3/" reported 401230.5. An impossible coordinate at HIGH confidence is a false
+// positive that also buries the real position, which is the pair of defects #399 is about.
+//
+// A value that cannot be a position on Earth is DROPPED rather than reported. That is what stops
+// this function turning a misread payload into a finding, and it is why the caller may hand it a
+// candidate it is not certain about.
 func parseISO6709Location(iso6709Str string, metadata *VideoMetadata) {
-	// ISO 6709 format: ±DD.DDDD±DDD.DDDD±AAA.AAA/
-	// Example: +36.3506-082.6985+447.403/
-
 	iso6709Str = strings.TrimSpace(iso6709Str)
-	if len(iso6709Str) == 0 {
+	iso6709Str = strings.TrimSuffix(iso6709Str, "/")
+	if iso6709Str == "" {
 		return
 	}
 
-	// Remove trailing slash if present
-	iso6709Str = strings.TrimSuffix(iso6709Str, "/")
+	// A CRS suffix is permitted after the height and is not part of any angle.
+	if i := strings.Index(iso6709Str, "CRS"); i > 0 {
+		iso6709Str = iso6709Str[:i]
+	}
 
-	// Parse latitude (first coordinate)
-	if len(iso6709Str) > 0 {
-		// Find the second sign (longitude start)
-		lonStart := -1
-		for i := 1; i < len(iso6709Str); i++ {
-			if iso6709Str[i] == '+' || iso6709Str[i] == '-' {
-				lonStart = i
-				break
-			}
-		}
-
-		if lonStart > 0 {
-			latStr := iso6709Str[:lonStart]
-			if lat, err := strconv.ParseFloat(latStr, 64); err == nil {
-				metadata.GPSLatitude = lat
-			}
-
-			// Parse longitude (second coordinate)
-			remaining := iso6709Str[lonStart:]
-			altStart := -1
-			for i := 1; i < len(remaining); i++ {
-				if remaining[i] == '+' || remaining[i] == '-' {
-					altStart = i
-					break
-				}
-			}
-
-			if altStart > 0 {
-				lonStr := remaining[:altStart]
-				if lon, err := strconv.ParseFloat(lonStr, 64); err == nil {
-					metadata.GPSLongitude = lon
-				}
-
-				// Parse altitude (third coordinate)
-				altStr := remaining[altStart:]
-				if alt, err := strconv.ParseFloat(altStr, 64); err == nil {
-					metadata.GPSAltitude = alt
-				}
-			} else {
-				// No altitude, just longitude
-				if lon, err := strconv.ParseFloat(remaining, 64); err == nil {
-					metadata.GPSLongitude = lon
-				}
-			}
+	// Split on the signs that introduce each component; every component keeps its own sign.
+	var fields []string
+	start := 0
+	for i := 1; i < len(iso6709Str); i++ {
+		if iso6709Str[i] == '+' || iso6709Str[i] == '-' {
+			fields = append(fields, iso6709Str[start:i])
+			start = i
 		}
 	}
+	fields = append(fields, iso6709Str[start:])
+	if len(fields) < 2 {
+		return
+	}
+
+	lat, latOK := decodeISO6709Angle(fields[0], 2, 90)
+	lon, lonOK := decodeISO6709Angle(fields[1], 3, 180)
+	if !latOK || !lonOK {
+		// Not a position. Reporting half of one, or a value out of range, is worse than
+		// reporting nothing: it is a finding the operator cannot act on.
+		return
+	}
+	metadata.GPSLatitude = lat
+	metadata.GPSLongitude = lon
+
+	// Height is plain signed decimal metres, not a sexagesimal angle.
+	if len(fields) >= 3 {
+		if alt, err := strconv.ParseFloat(fields[2], 64); err == nil {
+			metadata.GPSAltitude = alt
+		}
+	}
+}
+
+// decodeISO6709Angle converts one signed ISO 6709 angle to decimal degrees.
+//
+// degreeDigits is 2 for a latitude and 3 for a longitude; the digits beyond that are minutes, then
+// seconds, and any fraction belongs to the smallest unit present. limit is the largest magnitude
+// the angle may have. Reports false for anything that is not one of the three legal widths or is
+// out of range, so a caller can use it as the shape test as well as the parse.
+func decodeISO6709Angle(field string, degreeDigits int, limit float64) (float64, bool) {
+	if len(field) < 2 || (field[0] != '+' && field[0] != '-') {
+		return 0, false
+	}
+	sign, body := 1.0, field[1:]
+	if field[0] == '-' {
+		sign = -1.0
+	}
+
+	intPart, frac := body, ""
+	if dot := strings.IndexByte(body, '.'); dot >= 0 {
+		intPart, frac = body[:dot], body[dot:]
+		if len(frac) < 2 {
+			return 0, false // a trailing '.' with no digits
+		}
+	}
+	for i := 0; i < len(intPart); i++ {
+		if intPart[i] < '0' || intPart[i] > '9' {
+			return 0, false
+		}
+	}
+
+	// Only DD / DDMM / DDMMSS widths exist, so the surplus over the degree field is 0, 2 or 4.
+	surplus := len(intPart) - degreeDigits
+	if surplus != 0 && surplus != 2 && surplus != 4 {
+		return 0, false
+	}
+
+	parse := func(s string) (float64, bool) {
+		v, err := strconv.ParseFloat(s, 64)
+		return v, err == nil
+	}
+
+	var deg, minutes, seconds float64
+	var ok bool
+	switch surplus {
+	case 0:
+		if deg, ok = parse(intPart + frac); !ok {
+			return 0, false
+		}
+	case 2:
+		if deg, ok = parse(intPart[:degreeDigits]); !ok {
+			return 0, false
+		}
+		if minutes, ok = parse(intPart[degreeDigits:] + frac); !ok {
+			return 0, false
+		}
+	case 4:
+		if deg, ok = parse(intPart[:degreeDigits]); !ok {
+			return 0, false
+		}
+		if minutes, ok = parse(intPart[degreeDigits : degreeDigits+2]); !ok {
+			return 0, false
+		}
+		if seconds, ok = parse(intPart[degreeDigits+2:] + frac); !ok {
+			return 0, false
+		}
+	}
+	if minutes >= 60 || seconds >= 60 {
+		return 0, false
+	}
+
+	value := sign * (deg + minutes/60 + seconds/3600)
+	if value < -limit || value > limit {
+		return 0, false
+	}
+	return value, true
 }
 
 // parseDMSCoordinates parses GPS coordinates in degrees/minutes/seconds format

--- a/internal/preprocessors/video_metadata_preprocessor.go
+++ b/internal/preprocessors/video_metadata_preprocessor.go
@@ -64,7 +64,20 @@ func (vmp *VideoMetadataPreprocessor) processVideoMetadata(filePath string) (*Pr
 	// Convert video metadata to text format for validation
 	text := meta.ToProcessedContent()
 
-	return vmp.BuildSuccessContent(filePath, text, "video_metadata", 0), nil
+	content := vmp.BuildSuccessContent(filePath, text, "video_metadata", 0)
+
+	// Carry an extraction caveat forward, so a file whose box layout could not be followed to the
+	// end is not reported as clean.
+	//
+	// Deliberately NOT an Error, for the same reason as the audio path above: extraction succeeded
+	// and may have produced findings, and failing the file would discard them. Only
+	// ExtractionWarning survives the router's combine step. Without this, a movie whose moov the
+	// walk never reached printed "No matches found." and exited 0 — output byte-identical to a
+	// genuinely clean file, and unchanged even under --fail-on-incomplete (#398).
+	if content != nil && meta.ExtractionWarning != "" {
+		content.ExtractionWarning = meta.ExtractionWarning
+	}
+	return content, nil
 }
 
 // SetObserver sets the observability component

--- a/internal/redactors/isobmff/isobmff.go
+++ b/internal/redactors/isobmff/isobmff.go
@@ -89,6 +89,18 @@ func (s Span) Len() int64 { return s.End - s.Start }
 // match what writers emit, not what they should emit.
 var iso6709 = regexp.MustCompile(`[+-]\d{2}(?:\d{2}(?:\d{2})?)?(?:\.\d+)?[+-]\d{3}(?:\d{2}(?:\d{2})?)?(?:\.\d+)?(?:[+-]\d+(?:\.\d+)?)?(?:CRS[A-Za-z0-9_:.\-/]*?)?/`)
 
+// FindISO6709 returns the first ISO 6709 Annex H position string in b, or nil if there is none.
+//
+// Exported so the metadata EXTRACTOR can decide "is this payload a position, and in which form?"
+// against the same definition the redactor uses. The two sides disagreeing about that is not
+// hypothetical — it is the bug documented above, where ffmpeg's .mov ©xyz text payload was read as
+// fixed-point and reported as 18.335022, 11059.211639 (#399). A second copy of this pattern in the
+// extractor would let the two drift apart again, and the shape is spec-derived rather than
+// obvious: the integer digit counts are what distinguish the three forms.
+//
+// The returned slice aliases b; callers that keep it past a buffer reuse must copy.
+func FindISO6709(b []byte) []byte { return iso6709.Find(b) }
+
 var (
 	udtaAtom = []byte("udta")
 	metaAtom = []byte("meta")

--- a/internal/redactors/video/redactor.go
+++ b/internal/redactors/video/redactor.go
@@ -59,10 +59,16 @@ import (
 // walk already bounds each span by the file's actual length — this bounds the SUM, which the
 // per-span check does not.
 //
-// 10 MB matches the metadata extractor's own MaxMetadataRead, so a value beyond it could not
-// have been reported in the first place. Exceeding it is a refusal rather than a truncation:
-// #374 is an open issue about exactly the "skip the oversize part and report the container
-// clean" shape.
+// This bounds the SUM of metadata bytes, which is a different quantity from anything on the read
+// side. An earlier version of this note justified the value by saying it "matches the metadata
+// extractor's own MaxMetadataRead, so a value beyond it could not have been reported in the first
+// place". That was wrong twice over: MaxMetadataRead bounded a cumulative FILE OFFSET rather than a
+// volume of metadata, so the two were never the same measure; and a file whose metadata sum exceeds
+// this is perfectly capable of reporting findings first and being refused here second. It no longer
+// exists in any case — #398 replaced it with an offset-free walk.
+//
+// Exceeding this is a refusal rather than a truncation: #374 is an open issue about exactly the
+// "skip the oversize part and report the container clean" shape.
 const maxTagBytes = 10 << 20
 
 // gpsType is the finding type the metadata validator emits for a position.

--- a/internal/redactors/video/tail_moov_test.go
+++ b/internal/redactors/video/tail_moov_test.go
@@ -1,0 +1,126 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package video
+
+import (
+	"bytes"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+)
+
+// tailMoovMP4 writes a file with the moov AFTER a large mdat — the layout ffmpeg and every camera
+// produce by default.
+//
+// Every other fixture in this package writes moov FIRST, which is the faststart layout that a
+// second ffmpeg pass produces and that nothing writes by accident. A write side tested only against
+// the easy layout could grow an assumption about it without anything failing.
+//
+// The mdat is a hole made with Truncate, so a 12MB fixture costs no test memory and, on a sparse
+// filesystem, no disk. Its bytes are never read by the walk, which is what makes that affordable.
+func tailMoovMP4(t *testing.T, dir, filename string, mdatBytes int64, udtaChildren ...[]byte) string {
+	t.Helper()
+
+	ftyp := atom("ftyp", []byte("isomiso2mp41"))
+	moov := atom("moov", atom("mvhd", make([]byte, 100)), atom("udta", udtaChildren...))
+
+	mdatHeader := make([]byte, 8)
+	binary.BigEndian.PutUint32(mdatHeader[0:4], uint32(8+mdatBytes))
+	copy(mdatHeader[4:8], "mdat")
+
+	p := filepath.Join(dir, filename)
+	f, err := os.Create(p)
+	if err != nil {
+		t.Fatalf("create %s: %v", filename, err)
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			t.Fatalf("close %s: %v", filename, err)
+		}
+	}()
+
+	for _, b := range [][]byte{ftyp, mdatHeader} {
+		if _, err := f.Write(b); err != nil {
+			t.Fatalf("write %s: %v", filename, err)
+		}
+	}
+	end := int64(len(ftyp) + len(mdatHeader))
+	if err := f.Truncate(end + mdatBytes); err != nil {
+		t.Fatalf("truncate %s: %v", filename, err)
+	}
+	if _, err := f.WriteAt(moov, end+mdatBytes); err != nil {
+		t.Fatalf("write moov in %s: %v", filename, err)
+	}
+	return p
+}
+
+// A value in a moov that sits past the old 10MB read bound must still be redactable.
+//
+// The detection side stopped walking at a 10MB file offset, so a value beyond it was never reported
+// and this path was never exercised (#398). Now that those findings are reported, the write side has
+// to reach them — a reported finding in a file the redactor cannot touch would be a worse outcome
+// than the original silence, because the run would claim success.
+//
+// The walk here has no positional bound and reads only atom headers, so this holds at any offset; the
+// fixture is 12MB purely because that is just past where detection used to give up.
+func TestTailMoovValueBeyondTenMegabytesIsRedactable(t *testing.T) {
+	dir := t.TempDir()
+	const mdatBytes = 12 << 20
+
+	src := tailMoovMP4(t, dir, "tail.mp4", mdatBytes,
+		atom("meta", []byte{0, 0, 0, 0}, atom("ilst",
+			itunesTag("\xa9cmt", "Employee SSN "+testSSN),
+			itunesTag("\xa9ART", testName))))
+
+	info, err := os.Stat(src)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Size() < mdatBytes {
+		t.Fatalf("fixture is %d bytes, expected at least %d", info.Size(), mdatBytes)
+	}
+
+	out, res, err := redact(t, src, []detector.Match{match("SSN", testSSN), match("PERSON_NAME", testName)})
+	if err != nil {
+		t.Fatalf("RedactDocument on a tail-moov file: %v", err)
+	}
+	if !res.Success {
+		t.Fatalf("result = %+v, want success: the walk did not reach a moov past 10MB", res)
+	}
+
+	before, after := mustRead(t, src), mustRead(t, out)
+	if len(before) != len(after) {
+		t.Fatalf("size changed from %d to %d", len(before), len(after))
+	}
+	for _, v := range []string{testSSN, testName} {
+		if bytes.Contains(after, []byte(v)) {
+			t.Errorf("%q survives in the redacted copy of a tail-moov file, and the run reported "+
+				"success — a reported value that is not removed is the leak this whole path exists "+
+				"to prevent", v)
+		}
+	}
+	if len(res.RedactionMap) != 2 {
+		t.Errorf("RedactionMap has %d entries, want 2", len(res.RedactionMap))
+	}
+
+	// The change must be confined to the metadata at the END of the file. Anything written inside
+	// the mdat region would corrupt the media while the container still parses.
+	firstDiff := -1
+	for i := range before {
+		if before[i] != after[i] {
+			firstDiff = i
+			break
+		}
+	}
+	if firstDiff < 0 {
+		t.Fatal("no bytes changed at all, so the assertions above are vacuous")
+	}
+	if int64(firstDiff) < mdatBytes {
+		t.Errorf("the first changed byte is at offset %d, inside the %d-byte media region: the "+
+			"redactor is writing over the payload, not the trailing metadata", firstDiff, int64(mdatBytes))
+	}
+}


### PR DESCRIPTION
Closes #398
Closes #399

Two commits, in this order deliberately. #399 must land first or with #398, never after — measured
below.

## #398 — a moov past 10MB was never read, silently

Video metadata lives in the `moov` box, and both standards allow it anywhere. ISO/IEC 14496-12:2015
cl. 8.2.1.1: *"Normally this box is close to the beginning or end of the file, though this is not
required."* Apple's QuickTime reference: *"QuickTime does not impose any rules about the order of
these atoms"*, with mdat-first in its own typical-file figure. ffmpeg and typical cameras write it
**last**; `-movflags faststart` is a second pass. All three local videos with a readable moov are
tail-moov, and their moov is 0.14%, 0.27% and 0.39% of the file.

The walk gave up once it passed a **10MB file offset**, and the counter was charged for bytes it
never read — `bytesRead += box.Size + BoxHeaderSize` ran for every box including the `mdat` handed
to a bare seek. A 12MB recording exhausted a "metadata" allowance while costing no memory, stopped
on a bare `break`, and returned nil.

**The miss was silent, which is the sink rule's worst case.** On a real 27MB ffmpeg encode with the
same metadata in both layouts:

| | main | this PR |
|---|---:|---:|
| moov last (ffmpeg default) | **0 findings** | SSN + PERSON_NAME + GPS, all HIGH 100 |
| moov first (`+faststart`) | 3 findings | 3 findings, unchanged |

and the two layouts now produce **byte-identical output**. On the non-faststart file main gave exit
0, no `files_not_examined` key, empty stderr, `--preprocess-only` printing `Status: Success`, and
`--fail-on-incomplete` **also exiting 0** — while `strings` found the SSN in it twice. The affected
band is ~10MB–100MB: above 100MB the router refuses the file loudly (exit 3), which is exactly why
this hid in the gap between two working gates.

The leak diff is the security statement: with `--enable-redaction`, **main writes no redacted file at
all** (nothing was reported to redact), leaving the SSN in place in a file it called clean. This PR
writes a same-length copy with the SSN, the name and the coordinate all absent.

### The new walk

Absolute offsets, no positional budget. Only box headers and metadata boxes are read; `mdat`, `free`,
`skip`, `wide`, `uuid` and anything unrecognised are stepped over by arithmetic — no read, no
allocation, not even a seek. **TIME** is O(top-level boxes), **MEMORY** is O(min(|moov|, 32MB)) and
independent of file size. No measurable cost: best-of-three on the 27MB encode is 0.21s vs main's
0.20s.

### It also closes a memory amplification in the same function

`ReadBoxData` allocated a box's **declared** size with no check against the bytes present. Measured:
sixteen files of **80 bytes each**, whose `ftyp` declares 100MB, drove **631MB RSS at exit 0 with no
disclosure**. Now 31MB, exit 3, all sixteen disclosed. That is the 4KB→8.62GB class this repo has
already been bitten by; every declared size is now bounded by the real one from `Stat`.

### Six silent stops now disclose

No moov found; a box declaring more than the file holds; a box smaller than its own header; a moov
past the 32MB parse limit; a moov that cannot be read or parsed; the box-count budget. All reach the
existing coverage-cut-short channel (verified live — a 200KB unparseable `.mov` already produces exit
3 with `files_not_examined: 1`, so the channel works and the walk simply wasn't using it).

An over-declared moov is **clamped** to the file's real end and still yields its values: measured
`findings 1` **and** `files_not_examined 1` together, so a disclosure does not throw away findings. A
healthy tail-moov file stays at exit 0 with **no** warning — a disclosure operators learn to ignore is
worse than none.

### Details that are easy to get wrong, each pinned by a test

- The EOF bound is `total > fileSize-off`, never `off+total > fileSize`. A 64-bit `largesize` near
  2^63 makes the addition overflow to a negative offset the comparison accepts.
- `size64 > math.MaxInt64` is refused rather than converted.
- `total < hdrLen` is refused, so `cur += total` cannot fail to advance or walk misaligned.
- `size == 0` ("extends to EOF") is terminal; a moov after such a box is unreachable and that is
  disclosed rather than guessed at.
- A `uuid` box's 16-byte usertype counts toward the header length. One of the three real local videos
  has a top-level `uuid` box, so this is not hypothetical.
- `MaxTopLevelBoxes = 1<<20`, matching the redactor's own atom budget. **A tighter 100k ceiling was
  tried and rejected**: it is reachable in an 800KB file and it LOST a finding main found, which is
  the wrong direction to trade even for a disclosure.

### Dead code removed

`parseMP4ContainerWithContext` and `readMP4BoxWithContext` carried an **identical** 10MB cap with
**zero callers**. The issue names that function first, so a patch applied only there would have been a
measured no-op. With the walk rewritten, `ReadBoxHeader`, `ReadBoxData`, `SkipBoxData`, `GetPosition`,
`MP4Box` and `MaxBoxSize` have no callers anywhere and go too — `MaxBoxSize` especially, since its
only remaining effect would be to invite reintroducing the refuse-instead-of-skip behaviour that makes
an oversize `mdat` unskippable.

## #399 — a position atom read the wrong way, and one never read at all

ffmpeg writes the same `-metadata location` into two different atoms depending on container, and both
were wrong. Measured on real ffmpeg 9.0.1 output:

| file | atom | main | this PR |
|---|---|---|---|
| `.mp4` | `loci` | **no finding** — never reported, never redacted | `36.350586, -82.698486` HIGH 100 |
| `.mov` | `©xyz` text | `18.335022, 11059.211639` HIGH 100 | `36.350600, -82.698500` |

The `©xyz` payload is a 2-byte text length, a 2-byte language code, then an ISO 6709 string. Read as
three 16.16 fixed-point words, the length and language bytes **become a latitude** — an impossible
longitude at HIGH confidence, while the true position sat unreported in the same bytes. A wrong
coordinate is not just noise: it buries the real one.

The atom name does not say which encoding is in use, so the payload's **shape** now decides, via
`isobmff.FindISO6709` — the same spec-derived pattern the redactor already uses. Sharing one
definition is the point: the redactor's own comments document this exact extractor bug, and a second
copy of the pattern would let the two drift apart again. (`.mp4`'s value differs in the 5th decimal
because 16.16 quantises it; that is what the file stores.)

**A third defect in the same function.** ISO 6709 Annex H has three integer widths, and `ParseFloat`
is correct only for the first: `+4012.22-07500.25/` reported latitude **4012.22** and
`+401230.5-0750015.3/` reported **401230.5**. No local producer writes the sexagesimal forms, so this
comes from the standard rather than a sample — included because fixing one garbage-coordinate path
and leaving its sibling is half a fix, and the write side already recognises all three widths. A
value that cannot be a position on Earth is now **dropped**, which removes the class rather than the
two instances.

`loci` also carries a place name (location data, now reported) and stores **longitude before
latitude** — the reverse of `©xyz`.

### Why the order matters

Measured: with #398 applied and #399 **not**, a real 19MB non-faststart `.mov` reports the wanted SSN
**plus a brand-new garbage GPS at HIGH 100**, because #398 hands #399's misparse exactly the
camera-default files it was never reaching. #399 is non-vacuous alone (it corrects a value reported
today on faststart files) and adds no new file class, so it goes first.

### Redaction stays verifiable, which the shape test could have broken

The redactor zeroes a whole `©xyz` payload precisely because `*` is a valid fixed-point 10794.66°. A
zero-filled payload holds no ISO 6709 text, so it falls to the fixed-point branch, decodes to 0/0,
and is dropped. Measured on the real `.mov`: redacted copy identical length, rescan reports **0** GPS
findings.

## Testing

- **19 new tests.** Both #399 directions asserted on one fixture set; #398's guards asserted by
  **allocation and byte counts, never wall clock** (Windows CI). Fixtures use `Truncate` holes, so a
  200MB-declared `mdat` costs no memory and no disk — affordable precisely because those bytes are
  never read.
- **Mutation-verified: 16 mutants, all killed.** Four survivors are worth recording:
  - Deleting `case "loci":` from the udta switch left every direct unit test passing — a correct
    parser nothing calls. There is now a container-level test.
  - Disabling the `©xyz` shape decision in the switch, likewise.
  - The addition-form EOF bound **and** deleting the under-length guard both still produce a warning,
    just with the wrong cause, so presence-only assertions accepted them. They now assert the cause —
    a true disclosure under a false heading is half a fix.
  - One of my own mutations was invalid (it assigned the same coordinate word twice rather than
    swapping), so the swap is now asserted with a fixture far from both the equator and the 45°
    diagonal.
- A first test run failed because the fixtures spelled an iTunes atom `atom("©cmt")` — **five** bytes
  in Go. The same trap the extractor's own comments warn about; there is now a helper that cannot be
  written wrongly.
- The video redactor and `isobmff` suites had **only** faststart fixtures (moov first). Added a
  non-faststart one, so a future write-side change cannot quietly assume the easy layout.
- `cmd/extraction_warning_cause_test.go` gains all six new wordings, so a phrasing that accidentally
  contained "no text extracted from" would fail here rather than in an operator's report.
- `go build ./...`, `go vet ./...`, `gofmt -l ./cmd ./internal ./pkg` clean; full suite **69 packages
  ok**.
- `make score`: **PASS, unchanged** — `recall_all=1.0000 recall_hm=0.9948 prec_hm=0.9320
  whole_leak=0`, baseline untouched.
- **Union-tested with all five other open PRs** (#425, #426, #427, #428, #430): pairwise
  `git merge-tree` clean, zero file overlap, union worktree builds and passes **70 packages ok**, and
  a behavioural matrix on real fixtures shows my video results byte-identical with and without them
  while #430's socialmedia veto still works (23 → 5).

## Docs

`docs/reference/quotas-and-limits.md` (the 10MB cap was **undocumented**; now the two work bounds are,
with the moov-anywhere guarantee), `docs/COVERAGE_DISCLOSURE.md` (had zero mentions of video; now all
six cases), `docs/user-guides/README-Enhanced-Metadata.md`, `docs/testing/TEST_PLAN.md` (the
declared-size and both-layouts lessons), and the `maxTagBytes` comment in the video redactor, which
justified itself by citing `MaxMetadataRead` as the same quantity — it never was one, and it no longer
exists.

## Filed separately, not fixed here

- **#431** — Apple `mdta keys/ilst` metadata is never reported, in **either** layout, so #398 does not
  close it. A raw moov text scrape was prototyped and measured a net negative (it injected junk
  properties), which is why this PR does not attempt it.
- **#432** — `pkg/scan` and the web UI label every coverage loss "no document text extracted", including
  losses where the text *was* read. Pre-existing, affects audio and Office too.

## Not addressed

`MaxMoovParse = 32MB` is measured headroom, not a proof: real moov runs ≤0.39% of file and the router
caps files at 100MB, so an expected worst case is ~400KB. A multi-hour 4K recording's `stbl` tables
could in principle exceed 32MB, in which case it clamps **and discloses** — correct under the sink
rule, but a recall loss. I did not have a long-form recording to measure.
