### PR TITLE
fix(personname): charge a street suffix once, so a mailing-label name is reported and redacted

### DIFF
--- a/internal/validators/personname/double_charge_test.go
+++ b/internal/validators/personname/double_charge_test.go
@@ -1,0 +1,239 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package personname
+
+import (
+	"strings"
+	"testing"
+)
+
+// mailingLabelLines put the address BEFORE the name, which is what a mailing label, an "attn" line
+// and a shipping row all look like.
+//
+// The pre-existing corpus in geo_proximity_test.go is entirely name-then-address — even
+// "Deborah Callahan, 1200 State Street, Suite 300" passes today — so this ordering was untested,
+// and it is the ordering where the street suffix lands within the 15-byte negative-keyword window
+// of the name.
+var mailingLabelLines = []struct {
+	line string
+	want string
+}{
+	{"1247 Oakmont Street, Marcus Whitfield", "Marcus Whitfield"},
+	{"1247 Oakmont Drive, Marcus Whitfield", "Marcus Whitfield"},
+	{"1247 Oakmont Avenue, Marcus Whitfield", "Marcus Whitfield"},
+	{"88 Ridgeway Road, Marcus Whitfield", "Marcus Whitfield"},
+	{"Ship to 500 Industrial Boulevard, Renee Mueller", "Renee Mueller"},
+	{"Attn: 42 Lakeview Drive, Carlos Ramirez", "Carlos Ramirez"},
+	{"Deliver to 9 Summit Road, Priya Anand", "Priya Anand"},
+}
+
+// A street suffix must be charged once, not once per penalty family.
+//
+// 13 of 19 geographic patterns and 17 business patterns are also negativeKeywords, so a single
+// "Street" within 15 bytes of a name paid -35 as geography AND -15 as a negative keyword, plus -8
+// for product context. Measured before this: 100 - 58 = 42, under the hardcoded 50 emit floor at
+// two call sites — so the finding did not exist at ANY `--confidence` setting, and
+// `--enable-redaction` wrote no output file at all. The name stayed cleartext in a file the run
+// certified clean (#387).
+//
+// The stacking was deliberate — the comment above specificPatternProximity said so — but it was an
+// asserted design choice sitting next to a measured one (#215's proximity gate). Only the assertion
+// is overturned here; the 25-byte window stays exactly as #215 left it.
+func TestStreetSuffixIsChargedOncePerWord(t *testing.T) {
+	for _, tc := range mailingLabelLines {
+		t.Run(tc.line, func(t *testing.T) {
+			v := NewValidator()
+			matches, err := v.ValidateContent(tc.line, "labels.csv")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			var got []string
+			for _, m := range matches {
+				got = append(got, m.Text)
+				if strings.Contains(m.Text, tc.want) {
+					return
+				}
+			}
+			t.Errorf("%q was not reported (findings: %v). One word is being charged under two "+
+				"penalty families, which pushes a list-surname name below the 50 emit floor — and "+
+				"an unreported name is never redacted, so it stays cleartext.\n  line: %q",
+				tc.want, got, tc.line)
+		})
+	}
+}
+
+// The other direction, and the reason the fix needs a span test rather than a simple de-duplication.
+//
+// In "Jordan Lake State Recreation Area" the geographic word IS the second token of the candidate:
+// the "name" is the place. Both charges are then evidence about the same thing and the stack is
+// correct. Measured during development: de-duplicating unconditionally returned this line as a
+// PERSON_NAME at LOW 57 — a false positive on a lake.
+//
+// So the double charge is only dropped for a word OUTSIDE the matched span.
+func TestGeographicWordInsideTheNameStillStacks(t *testing.T) {
+	for _, line := range []string{
+		"Jordan Lake State Recreation Area",
+		"Madison Avenue advertising firm",
+		"Elm Street Elementary School District",
+		"Cedar Creek Road crosses Pine Valley Avenue",
+		"Golden Gate Boulevard runs through the city",
+	} {
+		t.Run(line, func(t *testing.T) {
+			v := NewValidator()
+			matches, err := v.ValidateContent(line, "doc.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) > 0 {
+				var got []string
+				for _, m := range matches {
+					got = append(got, m.Text)
+				}
+				t.Errorf("reported %v as person name(s) on a line that names no person. Dropping "+
+					"the second charge for a word INSIDE the candidate span turns place names into "+
+					"people.\n  line: %q", got, line)
+			}
+		})
+	}
+}
+
+// specificPatternPenalties must report offsets that are directly comparable with
+// negativeKeywordIndices, because that comparison is the whole mechanism. Both are
+// first-occurrence byte offsets into the same lowered line.
+func TestSpecificPatternPenaltiesReportsComparableOffsets(t *testing.T) {
+	v := NewValidator()
+	v.ensureNamesLoaded()
+
+	const line = "1247 oakmont street, marcus whitfield"
+	cache := v.newLineContextCache(line)
+	nameIndex := strings.Index(line, "marcus")
+	if nameIndex < 0 {
+		t.Fatal("premise broken: name not found")
+	}
+
+	penalty, charged := v.specificPatternPenalties(cache, nameIndex)
+	if penalty == 0 {
+		t.Fatal("no specific-pattern penalty on a line with a street suffix, so this test is vacuous")
+	}
+	if len(charged) == 0 {
+		t.Fatal("no charged offsets returned, so the caller cannot tell which words were paid for")
+	}
+
+	// The street suffix must appear at the SAME offset in both families, or the de-duplication can
+	// never fire and the fix is inert.
+	streetOffset := strings.Index(line, "street")
+	if _, ok := charged[streetOffset]; !ok {
+		t.Errorf("charged offsets %v do not include the street suffix at %d; specificPatternIndices "+
+			"and negativeKeywordIndices must agree on offsets or one word cannot be recognised as "+
+			"one word", charged, streetOffset)
+	}
+	var inNegative bool
+	for _, idx := range cache.negativeKeywordIndices {
+		if idx == streetOffset {
+			inNegative = true
+		}
+	}
+	if !inNegative {
+		t.Errorf("negativeKeywordIndices %v does not include %d: the premise of this fix is that "+
+			"the two lists record the same offset for the same word", cache.negativeKeywordIndices,
+			streetOffset)
+	}
+}
+
+// A word far from the name must still be charged nothing, and a word that is only a negative
+// keyword must still be charged the full negative-keyword penalty. This pins that the change did
+// not widen or narrow either family's own reach.
+func TestUnrelatedPenaltiesAreUnchanged(t *testing.T) {
+	v := NewValidator()
+	v.ensureNamesLoaded()
+
+	t.Run("distant geographic word charges nothing", func(t *testing.T) {
+		line := "marcus whitfield" + strings.Repeat(" x", specificPatternProximity) + " oak drive"
+		cache := v.newLineContextCache(line)
+		penalty, _ := v.specificPatternPenalties(cache, strings.Index(line, "marcus"))
+		if penalty != 0 {
+			t.Errorf("penalty = %.1f for a geographic word past specificPatternProximity, want 0: "+
+				"the proximity gate from #215 must be untouched", penalty)
+		}
+	})
+
+	t.Run("negative keyword that is not a specific pattern still charges", func(t *testing.T) {
+		// A negative keyword with no geographic/business/product twin: nothing to de-duplicate
+		// against, so it must pay in full.
+		lower := strings.ToLower("Marcus Whitfield invoice")
+		cache := v.newLineContextCache(lower)
+		if !cache.hasNegativeKeyword {
+			t.Skip("premise: this line carries no negative keyword in this build")
+		}
+		_, charged := v.specificPatternPenalties(cache, strings.Index(lower, "marcus"))
+		for _, idx := range cache.negativeKeywordIndices {
+			if _, ok := charged[idx]; ok {
+				t.Errorf("offset %d was charged by a specific family too; pick a keyword with no "+
+					"twin so this test isolates the untwinned path", idx)
+			}
+		}
+	})
+}
+
+// The two defensive details in this fix — recording the MAXIMUM penalty per offset, and only
+// skipping when that maximum is at least the negative-keyword penalty — are not reachable through
+// any real line with today's pattern lists. Measured:
+//
+//	product ∩ negativeKeywords   0 of 15
+//	product ∩ geo                0 of 15
+//	product ∩ business           0 of 15
+//	business ∩ geo               0 of 49
+//	geo ∩ negativeKeywords      12 of 13
+//	business ∩ negativeKeywords 17 of 49
+//
+// So only geo (-35) and business (-20) ever twin with a negative keyword, both already above the
+// -15 they would displace, and no offset is ever charged by two specific families at once. Mutating
+// either detail therefore changes nothing observable — they exist so that ADDING a word to a list
+// cannot silently turn the de-duplication into a penalty reduction.
+//
+// Both are asserted directly instead, against a hand-built cache, and the list invariant that makes
+// them dormant is asserted too: if someone adds a product word to negativeKeywords, that assertion
+// fires and points here.
+func TestPenaltyPerOffsetIsTheMaximumNotTheFirstOrSmallest(t *testing.T) {
+	v := NewValidator()
+
+	// One offset claimed by two families at once, which no real line produces today.
+	const shared = 4
+	cache := &lineContextCache{
+		lowerLine:      "0123456789 marcus whitfield",
+		productIndices: []int{shared}, // -8
+		geoIndices:     []int{shared}, // -35
+	}
+
+	total, charged := v.specificPatternPenalties(cache, 11)
+	if total != 43 {
+		t.Errorf("total = %.1f, want 43 (both families charge; only the per-offset RECORD is "+
+			"de-duplicated, not the family total)", total)
+	}
+	if got := charged[shared]; got != 35 {
+		t.Errorf("charged[%d] = %.1f, want 35: the record must be the LARGEST penalty at that "+
+			"offset. Recording the smallest would let a -8 product word displace a -15 "+
+			"negative-keyword charge and REDUCE the total penalty for that word", shared, got)
+	}
+}
+
+// The premise that makes the threshold dormant. If this fails, the `charged >= negativeKeywordPenalty`
+// test in analyzeLineContextForMatch has become load-bearing and needs its own behavioural coverage.
+func TestNoProductPatternIsAlsoANegativeKeyword(t *testing.T) {
+	v := NewValidator()
+	negative := make(map[string]bool, len(v.negativeKeywords))
+	for _, k := range v.negativeKeywords {
+		negative[k] = true
+	}
+
+	for _, p := range v.getSortedProductPatterns() {
+		if negative[p] {
+			t.Errorf("%q is both a product pattern (-8) and a negative keyword (-15). The "+
+				"de-duplication in analyzeLineContextForMatch only skips the negative-keyword "+
+				"charge when the specific-family charge is at least as large, so this word now "+
+				"exercises that threshold — add a behavioural test for it rather than relying on "+
+				"this invariant", p)
+		}
+	}
+}

--- a/internal/validators/personname/validator.go
+++ b/internal/validators/personname/validator.go
@@ -1210,8 +1210,17 @@ func (v *Validator) analyzeContextCached(match string, matchStart int, cache *li
 //
 // Note this is wider than the negative-keyword penalty's 15, even though many
 // words appear in both lists (13 of 19 geographic patterns and 17 business
-// patterns are also negativeKeywords). That is intentional: the two penalties
-// stack, so the keyword path still contributes at its own tighter distance.
+// patterns are also negativeKeywords).
+//
+// This comment used to end "That is intentional: the two penalties stack, so the
+// keyword path still contributes at its own tighter distance." The window being
+// wider is still intentional and unchanged. The STACKING was not measured, and it
+// cost real names: one "Street" beside a name paid -35 here and -15 there, and
+// 100 - 58 landed at 42, under the 50 emit floor — so five of eight mailing-label
+// forms reported nothing at all and were never redacted (#387). A word outside the
+// name is now charged once, at the higher of the two rates; a word INSIDE the
+// candidate span still stacks, because there the geography and the "name" are the
+// same evidence. See analyzeLineContextForMatch.
 const specificPatternProximity = 25
 
 // matchIndex resolves the byte offset of the match within lowerLine, preferring
@@ -1220,6 +1229,66 @@ const specificPatternProximity = 25
 // lookup finds it (the directly-tested public AnalyzeContext path). Returns -1 if
 // the match cannot be located, in which case no proximity penalty is applied —
 // failing OPEN, because a name is reported rather than silently dropped.
+// negativeKeywordProximity and negativeKeywordPenalty are the window and cost of the
+// negative-keyword penalty, named because specificPatternPenalties has to compare against the cost
+// to decide whether a word has already been charged more heavily elsewhere.
+const (
+	negativeKeywordProximity = 15
+	negativeKeywordPenalty   = 15.0
+)
+
+// specificPatternPenalties returns the total business/product/geographic penalty for a name at
+// nameIndex, and the byte offset of every pattern that contributed, mapped to the largest penalty
+// charged at that offset.
+//
+// The offsets are what let the caller avoid charging one word under two penalty families. They are
+// directly comparable with cache.negativeKeywordIndices: both are first-occurrence byte offsets
+// into the same lowered line.
+//
+// A family charges once even when several of its patterns are in range — that is the pre-existing
+// behaviour of the bool-returning check this replaces, and widening it would be a separate
+// (precision-reducing) decision.
+func (v *Validator) specificPatternPenalties(cache *lineContextCache, nameIndex int) (float64, map[int]float64) {
+	if nameIndex < 0 {
+		return 0, nil
+	}
+
+	var total float64
+	var charged map[int]float64
+
+	families := []struct {
+		indices []int
+		penalty float64
+	}{
+		{cache.businessIndices, 20.0}, // business/technical context
+		{cache.productIndices, 8.0},   // product context
+		{cache.geoIndices, 35.0},      // geographic context
+	}
+
+	for _, f := range families {
+		if !nearestWithin(f.indices, nameIndex, specificPatternProximity) {
+			continue
+		}
+		total += f.penalty
+		for _, idx := range f.indices {
+			distance := idx - nameIndex
+			if distance < 0 {
+				distance = -distance
+			}
+			if distance >= specificPatternProximity {
+				continue
+			}
+			if charged == nil {
+				charged = make(map[int]float64, len(families))
+			}
+			if charged[idx] < f.penalty {
+				charged[idx] = f.penalty
+			}
+		}
+	}
+	return total, charged
+}
+
 func matchIndex(matchStart int, lowerLine, match string) int {
 	if matchStart >= 0 {
 		return matchStart
@@ -1253,6 +1322,16 @@ func (v *Validator) analyzeLineContextForMatch(match string, matchStart int, cac
 	lowerLine := cache.lowerLine
 	adjustment := cache.positiveAdjustment
 
+	// Work out which specific-pattern families penalise THIS name, and at which byte offsets,
+	// before the negative-keyword count below — because the two lists overlap and a word must not
+	// be charged twice for being one word.
+	//
+	// 13 of 19 geographic patterns and 17 business patterns are also negativeKeywords, so a single
+	// "Street" used to pay -35 as geography AND -15 as a negative keyword. The penalties are
+	// applied in the original order further down; only the COUNT below changes.
+	nameIdx := matchIndex(matchStart, lowerLine, match)
+	specificPenalty, chargedOffsets := v.specificPatternPenalties(cache, nameIdx)
+
 	if cache.hasNegativeKeyword {
 		// Apply the business-context penalty only when guard-passing negative
 		// keywords sit close (<15 chars) to the name. The keyword positions and
@@ -1260,10 +1339,7 @@ func (v *Validator) analyzeLineContextForMatch(match string, matchStart int, cac
 		// here we just compare each against the name's offset. nameIndex uses the
 		// known matchStart (or a single fallback lookup) instead of re-scanning the
 		// whole line per match.
-		nameIndex := matchStart
-		if nameIndex < 0 {
-			nameIndex = strings.Index(lowerLine, strings.ToLower(match))
-		}
+		nameIndex := nameIdx
 
 		closeNegativeMatches := 0
 		if nameIndex >= 0 {
@@ -1272,14 +1348,38 @@ func (v *Validator) analyzeLineContextForMatch(match string, matchStart int, cac
 				if distance < 0 {
 					distance = -distance
 				}
-				if distance < 15 {
-					closeNegativeMatches++
+				if distance >= negativeKeywordProximity {
+					continue
 				}
+				// One word OUTSIDE the name, one charge. If a specific-pattern family already
+				// penalised the word at this offset by at least as much, charging it again here
+				// is charging the same evidence twice.
+				//
+				// Measured: "1247 Oakmont Street, Marcus Whitfield" paid -35 (geographic) -15
+				// (negative keyword) -8 (product) = -58, taking a list-surname name from 100 to
+				// 42 — under the hardcoded 50 emit floor, so the finding did not exist at any
+				// --confidence setting and no redacted file was written at all. Five of eight
+				// realistic mailing-label forms behaved that way (#387).
+				//
+				// The span test is what keeps this from re-admitting place names, and it is the
+				// real distinction between the two classes. In "Jordan Lake State Recreation
+				// Area" the geographic word IS the second token of the candidate — the "name" is
+				// the place — so both charges are evidence about the same thing and the stack is
+				// correct. In a mailing label the street suffix sits outside the name entirely and
+				// says nothing more about it than the geographic penalty already did. Measured:
+				// without this test, that line returned as a LOW 57 false positive.
+				insideName := nameIndex >= 0 && keywordIndex >= nameIndex && keywordIndex < nameIndex+len(match)
+				if !insideName {
+					if charged, ok := chargedOffsets[keywordIndex]; ok && charged >= negativeKeywordPenalty {
+						continue
+					}
+				}
+				closeNegativeMatches++
 			}
 		}
 
 		if closeNegativeMatches > 0 {
-			adjustment -= float64(closeNegativeMatches) * 15.0
+			adjustment -= float64(closeNegativeMatches) * negativeKeywordPenalty
 			if closeNegativeMatches > 1 {
 				adjustment = -25.0 // Moderate penalty for multiple close negative keywords
 			}
@@ -1298,17 +1398,9 @@ func (v *Validator) analyzeLineContextForMatch(match string, matchStart int, cac
 	// Same window as the negative-keyword penalty: a pattern has to sit within
 	// specificPatternProximity of the name to say anything about THAT name. A
 	// street address at the other end of a CSV row does not.
-	if nameIndex := matchIndex(matchStart, lowerLine, match); nameIndex >= 0 {
-		if nearestWithin(cache.businessIndices, nameIndex, specificPatternProximity) {
-			adjustment -= 20.0 // business/technical context
-		}
-		if nearestWithin(cache.productIndices, nameIndex, specificPatternProximity) {
-			adjustment -= 8.0 // product context
-		}
-		if nearestWithin(cache.geoIndices, nameIndex, specificPatternProximity) {
-			adjustment -= 35.0 // geographic context
-		}
-	}
+	// Computed above, before the negative-keyword count, so that count can tell which words have
+	// already been charged. The arithmetic and its position here are unchanged.
+	adjustment -= specificPenalty
 
 	trimmedLine := strings.TrimSpace(lowerLine)
 	trimmedMatch := strings.TrimSpace(match)


### PR DESCRIPTION
Closes #387

## The bug

13 of 19 geographic patterns and 17 business patterns are **also** `negativeKeywords`, so one word
beside a name was charged under two penalty families at once. `Street` next to a name paid −35 as
geography **and** −15 as a negative keyword, plus −8 for product context: 100 − 58 = **42**, under the
hardcoded 50 emit floor at two call sites.

`--confidence all` cannot lower that floor, so the finding did not exist at any verbosity — and
`--enable-redaction` wrote **no output file at all**. The name stayed cleartext in a file the run
exited 0 on.

## Measured

The failing shape is the address BEFORE the name — a shipping row, an attn line, a mailing label:

| corpus | before | after |
|---|---:|---:|
| mailing labels (address then name) | **1/8** | **7/8** |
| #215 must-find (name then address) | 10/10 | 10/10 |
| #215 must-stay-suppressed | 0/16 | 0/16 |

The pre-existing corpus is entirely *name-then-address* — even
`"Deborah Callahan, 1200 State Street, Suite 300"` passes today — which is why this went unnoticed.
That ordering keeps the street suffix outside the 15-byte negative-keyword window; the label ordering
puts it inside.

## Why this is allowed to change

The stacking was deliberate. The comment above `specificPatternProximity` read: *"That is intentional:
the two penalties stack, so the keyword path still contributes at its own tighter distance."*

But that was an **asserted** design choice sitting next to a **measured** one — #215's proximity gate,
which replaced a line-global penalty precisely because it was deleting real names. Only the assertion
is overturned. The 25-byte window is untouched and all of #215's guard tests still pass, including
`TestSpecificPatternPenaltyIsProximityGated` and `TestDistantPatternCannotMaskAnAdjacentOne`.

## The span test is the fix, not a detail

A word **outside** the name is charged once, at the higher of the two rates. A word **inside** the
candidate span still stacks — because there the geography and the "name" are the same evidence.

Measured during development: de-duplicating unconditionally returned
`"Jordan Lake State Recreation Area"` as a PERSON_NAME at LOW 57. A false positive on a lake. The span
test is what distinguishes `Jordan Lake` (geo word *is* the second token) from
`1247 Oakmont Street, Marcus Whitfield` (geo word is 8 bytes before a real name).

## Real-corpus effect — 268 documents, 8 types

docx, pdf, txt, pptx, md, csv, html, xlsx:

- **4475 → 4476 findings.** +1, none removed.
- **74 findings promoted MEDIUM → HIGH**, 76 → 91, and every one of them is the **same value** — one
  real person's name, un-penalised by exactly the 15 points that were double-charged. That is the
  intended effect, at the band that drives the pre-commit exit code.

The single new finding is `Silver Spring, MD` at **LOW 52**, and it is **pre-existing rather than
new**: main reports it at MEDIUM 65 when the line stands alone, with no negative keyword and no
geographic pattern involved at all. The double charge was incidentally masking one instance of it.

That is the class #215's own comment already excluded from its corpus — *"those place words are
themselves entries in the first-name database, so they score on their own merits and the geographic
penalty only masked them incidentally — at the cost of deleting real names"* — and its stated fix is
curating the name database, not widening a window. Trading one masked LOW instance of a known FP class
for seven real names recovered from total silence is the direction the sink rule asks for.

## Two defensive details, honestly labelled

The per-offset record keeps the **maximum** penalty, and the skip applies only when that maximum is at
least the negative-keyword penalty. Measured, **neither is reachable through any real line today**:

| intersection | count |
|---|---:|
| `product ∩ negativeKeywords` | 0 of 15 |
| `product ∩ geo` / `product ∩ business` / `business ∩ geo` | 0 each |
| `geo ∩ negativeKeywords` | 12 of 13 |
| `business ∩ negativeKeywords` | 17 of 49 |

Only geo (−35) and business (−20) ever twin with a negative keyword, both already above the −15 they
displace. So both details exist so that **adding** a word to a list cannot silently turn the
de-duplication into a penalty *reduction*. Both are asserted directly against a hand-built cache, and
the list invariant that keeps them dormant is asserted too — if someone adds a product word to
`negativeKeywords`, that test fires and points here.

## Testing

- New corpus for the untested ordering, plus the both-directions pair (labels reported **and** place
  names still suppressed) on one fixture set, since a fix for either half alone looks correct.
- **Mutation-verified: 7 mutants, 6 killed behaviourally.** The seventh — dropping the
  at-least-as-large condition — is an **equivalent mutant** for exactly the reason in the table above,
  and is reported as such rather than papered over with a contorted fixture. Two others (min-instead-
  of-max, first-family-wins) survived a first pass and are now killed by the synthetic-cache test.
- `go build ./...`, `go vet ./...`, `gofmt -l ./cmd ./internal ./pkg` clean; full suite green.
- `make score`: **PASS, unchanged** — `recall_all=1.0000 recall_hm=0.9948 prec_hm=0.9320
  whole_leak=0`, PERSON_NAME still 17/17 at precision 1.0000, baseline untouched.
- Union-tested with the other open PRs: no file overlap, union builds and passes.

## Docs

No doc change: PERSON_NAME's penalty values and windows are code-only. `docs/validators-new.md`'s
negative-keyword table describes DRIVERS_LICENSE, and `docs/development/creating_validators.md`'s −15
is an authoring example — neither describes this validator. The stale claim was the code comment, and
it is corrected in place.

## Filed separately

**#434** — an unpunctuated leading word is absorbed into the name span: `Attn Marcus Whitfield`
reports nothing, while `Attention Marcus Whitfield` reports the routing word *as part of the name*.
That is the eighth mailing-label line, and its line-context adjustment is measured at exactly `0.0`,
so it is a different defect. Worth noting for anyone reading #387: its text lists `Suite` as a
geographic pattern, and it is not one.
