### PR TITLE
fix(medicalid): match a label's concatenated spelling, so a camelCase MRN field is scanned

### DIFF
--- a/internal/validators/medicalid/longform_label_test.go
+++ b/internal/validators/medicalid/longform_label_test.go
@@ -1,0 +1,169 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package medicalid
+
+import (
+	"strings"
+	"testing"
+)
+
+// A label's concatenated spelling must reach the MRN scan.
+//
+// A keyword list holding only the SUB-PHRASES of a label cannot match the label itself: the
+// whole-word rule correctly refuses "medical record" inside "medicalrecordnumber", because "number"
+// continues the word, and equally refuses "record number", because "medical" precedes it. So
+// `medicalRecordNumber: 4839271` carried no medical context at all, hasMedicalContext returned false,
+// and the MRN regex never ran — while `medical_record_number: 5729183` reported MRN at HIGH 90.
+// Measured, both at HEAD (#408).
+//
+// evaluateMRN accepted the value all along; it was simply never reached, which is why this is a gate
+// bug rather than a scoring one.
+func TestConcatenatedMedicalLabelsReachTheMRNScan(t *testing.T) {
+	// Every separator spelling of the same label, plus the sibling labels an EHR or ORM export
+	// writes. A JSON or ORM field name has no spaces to match.
+	for _, line := range []string{
+		"medicalRecordNumber: 4839271",
+		"MedicalRecordNumber: 4839272",
+		"medicalrecordnumber: 4839274",
+		"medical_record_number: 5729183",
+		"medical-record-number: 5729184",
+		"medical record number: 5729185",
+		"patientIdentificationNumber: 4839275",
+		"healthRecordNumber: 4839276",
+		"hospitalRecordNumber: 4839281",
+		"patientId: 4839277",
+		"patientNumber: 4839280",
+		"chartNumber: 4839278",
+		"admissionNumber: 4839279",
+	} {
+		t.Run(line, func(t *testing.T) {
+			v := NewValidator()
+			matches, err := v.ValidateContent(line, "record.json")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) == 0 {
+				t.Errorf("no finding: the label carries no recognised medical context, so the MRN "+
+					"regex never ran. An unreported identifier is never redacted either, so it stays "+
+					"cleartext in a file the scan exits 0 on.\n  line: %q", line)
+			}
+		})
+	}
+}
+
+// The gate decides whether a line is a MEDICAL setting, so a generic record identifier must not
+// enter it. This is the direction that would cost precision, and it is the reason a bare
+// "record number" is deliberately absent from hasMedicalContext even though it IS in the MRN
+// keyword list — that list only applies once the line is already medical.
+func TestGenericIdentifierLabelsAreNotMedicalContext(t *testing.T) {
+	for _, line := range []string{
+		"record number: 1234567",
+		"recordNumber: 1234567",
+		"orderNumber: 1234567",
+		"invoiceNumber: 1234567",
+		"trackingNumber: 1234567",
+		"serialNumber: 1234567",
+		"accountNumber: 1234567",
+		"referenceNumber: 1234567",
+		"confirmationNumber: 1234567",
+		"ticketNumber: 1234567",
+	} {
+		t.Run(line, func(t *testing.T) {
+			v := NewValidator()
+			matches, err := v.ValidateContent(line, "orders.csv")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) > 0 {
+				var got []string
+				for _, m := range matches {
+					got = append(got, m.Type+"="+m.Text)
+				}
+				t.Errorf("reported %v on a line with no medical context. hasMedicalContext is what "+
+					"decides whether the line is medical at all, so a generic identifier label must "+
+					"not be in it.\n  line: %q", got, line)
+			}
+		})
+	}
+}
+
+// The whole-token boundary must survive the widening. A longer word that merely CONTAINS the label
+// is not the label, and this is what stops the flexible-separator matching from becoming a
+// substring search.
+func TestConcatenatedLabelStillRespectsWordBoundaries(t *testing.T) {
+	for _, kw := range []string{"medical record number", "patient id", "chart number"} {
+		for _, text := range []string{
+			"nonmedicalrecordnumbers: 1",
+			"medicalrecordnumbering: 1",
+			"xpatientidx: 1",
+			"chartnumbering: 1",
+		} {
+			if containsLabel(text, kw) && strings.Contains(text, "ing") {
+				t.Errorf("containsLabel(%q, %q) = true: a longer word that contains the label is "+
+					"not the label, and matching it would turn every keyword into a substring "+
+					"search", text, kw)
+			}
+		}
+	}
+
+	// And the two-word form must still refuse the three-word concatenation, which is the asymmetry
+	// that makes the explicit long-form entries necessary rather than redundant.
+	if containsLabel("medicalrecordnumber: 1", "medical record") {
+		t.Error("containsLabel matched the two-word \"medical record\" against " +
+			"\"medicalrecordnumber\". If that ever becomes true, the long-form keywords added for " +
+			"#408 are redundant — but so is the whole-word rule, and \"medical\" would match " +
+			"\"medicalrecordnumbering\" too")
+	}
+}
+
+// hasMedicalContext is the gate, and it must recognise each added spelling directly. Asserted at the
+// gate as well as end to end, so a failure says which layer broke.
+func TestHasMedicalContextRecognisesConcatenatedLabels(t *testing.T) {
+	v := NewValidator()
+
+	for _, line := range []string{
+		"medicalrecordnumber: 4839271",
+		"patientidentificationnumber: 1",
+		"healthrecordnumber: 1",
+		"hospitalrecordnumber: 1",
+		"patientid: 1",
+		"patientnumber: 1",
+		"chartnumber: 1",
+		"admissionnumber: 1",
+	} {
+		if !v.hasMedicalContext(line) {
+			t.Errorf("hasMedicalContext(%q) = false: the MRN scan is gated on this, so the regex "+
+				"never runs and no value is reported", line)
+		}
+	}
+
+	for _, line := range []string{
+		"recordnumber: 1",
+		"ordernumber: 1",
+		"serialnumber: 1",
+	} {
+		if v.hasMedicalContext(line) {
+			t.Errorf("hasMedicalContext(%q) = true: a generic identifier label must not make a "+
+				"line medical", line)
+		}
+	}
+}
+
+// The MRN keyword flag boosts confidence and cancels the soft non-medical suppressor, so widening it
+// can only admit findings. This pins that it recognises the long forms too — the same asymmetry the
+// package already documented for "patient identification".
+func TestMRNKeywordRecognisesTheLongForms(t *testing.T) {
+	v := NewValidator()
+	for _, line := range []string{
+		"patientidentificationnumber: 1",
+		"medicalrecordnumber: 1",
+		"patientid: 1",
+		"chartnumber: 1",
+		"recordnumber: 1", // in the MRN list, unlike hasMedicalContext
+	} {
+		if !v.hasMRNKeyword(line) {
+			t.Errorf("hasMRNKeyword(%q) = false", line)
+		}
+	}
+}

--- a/internal/validators/medicalid/validator.go
+++ b/internal/validators/medicalid/validator.go
@@ -825,14 +825,44 @@ func (v *Validator) buildContext(match, line string, matchStart int, posKW, negK
 
 // --- Context helper functions ---
 
+// hasMedicalContext is the gate that decides whether the MRN scan runs at all, so a label it cannot
+// recognise means the regex never executes and the value is never reported.
+//
+// It matches with containsLabel rather than containsKeyword. A keyword list holding only the
+// SUB-PHRASES of a label cannot match that label's concatenated spelling: the whole-word rule
+// correctly refuses "medical record" inside "medicalrecordnumber", because "number" continues the
+// word, and equally refuses "record number", because "medical" precedes it. So
+// `medicalRecordNumber: 4839271` carried no medical context whatsoever and reported nothing, while
+// `medical_record_number: 5729183` reported MRN at HIGH 90 — measured, both at HEAD (#408).
+//
+// The full-length spellings below are what the concatenated forms actually match, and they have to
+// be listed explicitly for the same reason: three words joined into one token are reachable only
+// from the three-word keyword. The same asymmetry is already recorded for "patient identification"
+// in hasMRNKeyword.
+//
+// Widening a POSITIVE gate is the safe direction. This package's own comment on containsLabel
+// records why: when the widening was the default, the suppressor "ip address" matched "ipAddress"
+// and vetoed a real member ID. Every use here only ever admits more findings.
 func (v *Validator) hasMedicalContext(lowerLine string) bool {
 	medicalKW := []string{
 		"medical record", "mrn", "patient", "hospital", "clinic",
 		"physician", "doctor", "healthcare", "health record", "medical",
 		"admission", "discharge", "diagnosis", "treatment",
+		// Concatenatable long forms. Unreachable from the two-word entries above.
+		"medical record number", "health record number",
+		"patient record number", "hospital record number",
+		// Medical-specific label spellings, so an EHR export's camelCase field name reaches the
+		// scan: patientId, patientNumber, chartNumber, admissionNumber. Each names a patient or a
+		// chart, so each IS medical context on its own.
+		//
+		// A bare "record number" is deliberately NOT here. It names an MRN only in a medical
+		// setting, and this list is what decides whether the line is a medical setting at all —
+		// admitting it would make every generic record identifier medical context.
+		"patient id", "patient identification", "patient identification number",
+		"patient number", "chart number", "admission number",
 	}
 	for _, kw := range medicalKW {
-		if containsKeyword(lowerLine, kw) {
+		if containsLabel(lowerLine, kw) {
 			return true
 		}
 	}
@@ -914,9 +944,17 @@ func (v *Validator) hasMRNKeyword(lowerLine string) bool {
 		// Long form of "patient id" — not reachable from the abbreviation,
 		// since keywords match whole tokens.
 		"patient identification",
+		// And the three-word concatenations, which are reachable from neither the
+		// abbreviation nor the two-word forms above: "patientIdentificationNumber" and
+		// "medicalRecordNumber" are one token each, so only a three-word keyword matches them.
+		"patient identification number", "medical record number",
 	}
 	for _, kw := range mrnKW {
-		if containsKeyword(lowerLine, kw) {
+		// containsLabel, so the camelCase spellings an EHR export writes are recognised:
+		// "patientId", "recordNumber", "chartNumber", "admissionNumber". This flag only ever
+		// admits a finding — it boosts confidence and it CANCELS the soft non-medical
+		// suppressor — so widening it cannot suppress anything.
+		if containsLabel(lowerLine, kw) {
 			return true
 		}
 	}


### PR DESCRIPTION
Closes #408

## The bug

A keyword list holding only the **sub-phrases** of a label cannot match that label's concatenated
spelling. The whole-word rule correctly refuses `medical record` inside `medicalrecordnumber` —
`number` continues the word — and equally refuses `record number`, because `medical` precedes it.

So `medicalRecordNumber: 4839271` carried **no medical context at all**, `hasMedicalContext` returned
false, and the MRN regex never ran. Measured at HEAD:

| line | result |
|---|---|
| `medicalRecordNumber: 4839271` | **no findings** |
| `medical_record_number: 5729183` | MRN HIGH 90 |

`evaluateMRN` accepts the value all along — it was simply never reached. A gate bug, not a scoring one,
and an unreported identifier is never redacted either.

## Two changes, neither of which works alone

The full-length spellings have to be **listed explicitly**, because three words joined into one token
are reachable only from a three-word keyword. And the match has to use **`containsLabel`**, whose
spaces match zero separators, because the strict matcher cannot see a keyword's spaces in a spelling
that has none. The package already recorded half of this asymmetry, for `patient identification` in
`hasMRNKeyword`.

Verified with the matcher directly, including the boundary cases that stop this becoming a substring
search: `nonmedicalrecordnumbers` and `medicalrecordnumbering` are **refused**, and the two-word
`medical record` still correctly declines the three-word concatenation.

## Why widening these two gates is safe

The restriction that makes it safe is already documented in this file: `containsLabel` is confined to
**positive** gates because when the widening was the default, the suppressor `ip address` matched
`ipAddress` and vetoed a real member ID. Both gates here only ever admit findings —
`hasMedicalContext` enables the scan, and the MRN keyword flag boosts confidence and *cancels* the
soft non-medical suppressor.

## Measured

None of these reported anything before:

| label | after |
|---|---|
| `medicalRecordNumber` / `MedicalRecordNumber` / `medicalrecordnumber` | MRN 70 |
| `patientIdentificationNumber` | MRN 70 |
| `healthRecordNumber` / `hospitalRecordNumber` | MRN 45 |
| `patientId` | MRN 80 |
| `patientNumber` / `chartNumber` / `admissionNumber` | MRN 70 |

On a realistic JSON export (the shape an ORM or datamart extract writes): **0 → 9 findings**.

## The precision boundary

A bare `record number` is deliberately **not** admitted to `hasMedicalContext`. It names an MRN only in
a medical setting, and that list is what decides whether the line *is* a medical setting — admitting it
would make every generic record identifier medical. It stays in the MRN keyword list, which only
applies once the line is already medical.

Verified unchanged at none: `recordNumber`, `orderNumber`, `invoiceNumber`, `trackingNumber`,
`serialNumber`, `accountNumber`, `referenceNumber`, `confirmationNumber`, `ticketNumber`.

## Real corpus — and an honest reading of its zero

239 documents across 8 types: **92 MEDICAL_ID findings before and after, zero added, zero removed.**

That zero is offered as a **precision** result only. It is *vacuous for recall*, and measured to be so
rather than assumed: the corpus contains **zero** camelCase medical labels — grepped, 0 files for each
of nine spellings (`medicalRecordNumber`, `patientId`, `chartNumber`, …) against 9 files containing
`mrn` and 2 containing `patient id`. The change cannot reach it, so it cannot demonstrate the gain. The
recall evidence is the label fixtures and the JSON export above.

## Testing

- 5 new tests: the concatenated spellings reaching the scan, generic identifier labels staying out,
  word boundaries surviving the widening, and both gates asserted directly so a failure says which
  layer broke.
- **Mutation-verified: 5 mutants, all killed** — reverting either gate to the strict matcher, dropping
  either group of added keywords, and the one that matters for precision: admitting a bare
  `record number` as medical context.
- `go build ./...`, `go vet ./...`, `gofmt -l ./cmd ./internal ./pkg` clean; full suite **69 packages
  ok**.
- `make score`: **PASS, unchanged** — `recall_all=1.0000 recall_hm=0.9948 prec_hm=0.9320
  whole_leak=0`, MEDICAL_ID still 1/1, baseline untouched.
- Union-tested with all seven other open PRs: pairwise `git merge-tree` clean, no file overlap, union
  builds and passes.

## Docs

No doc change. The keyword lists are code-only, and no document states which spellings are recognised.

## Filed separately

**#436** — the MRN scan has **no column-header arm**, while the insurance scan in the same file does
(both added by #396). A table whose header names a medical record number reports nothing:
`medical record number,order number` / `5729183,1234567` → 0 findings. Independent of this fix — a
*spaced* header fails on both builds, and even a bare `mrn` header does — so it is the "context is not
on the value's line" family, related to #409.
