### PR TITLE
fix(kwmatch): treat a concatenated label as a field label, so a camelCase line opens a cross-line window

### DIFF
--- a/internal/validators/kwmatch/concatenated_label_test.go
+++ b/internal/validators/kwmatch/concatenated_label_test.go
@@ -1,0 +1,175 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package kwmatch
+
+import "testing"
+
+// labelKeywords is the insurance vocabulary the cross-line window is opened with, so these assertions
+// are about the list that actually reaches this code.
+var labelKeywords = []string{
+	"member id", "member number", "subscriber id", "policy number",
+	"insurance id", "group number", "enrollee id",
+	"member identification", "subscriber identification",
+}
+
+// A label written without separators is still that label.
+//
+// #396 opens a cross-line window when the previous line looks like a field label; #407 taught the
+// matcher that "member id" also finds "memberId". The two did not compose: a camelCase label alone on
+// its own line still opened no window, so the value on the next line was never reported and therefore
+// never redacted.
+//
+// TWO independent gates rejected it, and the ORDER matters for anyone fixing this again. Measured at
+// HEAD: for "memberId:" the vocabulary gate (ContainsAny, now ContainsAnyLabel) returned false and
+// returned early, so the per-word loop below never ran. Teaching only keywordWord — which is what the
+// issue proposed — would have been a measured no-op.
+func TestConcatenatedLabelIsAFieldLabel(t *testing.T) {
+	for _, line := range []string{
+		"member id:", // already worked
+		"member_id:", // already worked
+		"memberId:",  // camelCase, the JSON/ORM default
+		"MemberId:",  // PascalCase
+		"memberID:",  // initialism
+		"memberid:",  // fully concatenated
+		"Member ID (primary)",
+		"policyNumber:",
+		"groupNumber:",
+		"memberIdentification:",
+	} {
+		if !LooksLikeFieldLabel(line, labelKeywords) {
+			t.Errorf("LooksLikeFieldLabel(%q) = false: no cross-line window opens, so a value on the "+
+				"next line is never reported and never redacted", line)
+		}
+	}
+}
+
+// The per-word loop is the false-positive gate that keeps a non-label line from vouching for whatever
+// follows it, and widening the vocabulary must not weaken it. Every line here names no field.
+func TestNonLabelLinesStillOpenNoWindow(t *testing.T) {
+	for _, line := range []string{
+		"itemCount:",
+		"orderNumber:",
+		"lineTotal:",
+		"rowCount:",
+		"batchSize:",
+		"requestId:",
+		"sessionId:",
+		"buildNumber:",
+		"errorCode:",
+		"invoiceTotal:",
+		"Please renew your membership soon.",
+		"the member said the policy was fine",
+		// A line that already carries its own value must not vouch for the next one.
+		"member 449871234567",
+		"memberId 449871234567",
+	} {
+		if LooksLikeFieldLabel(line, labelKeywords) {
+			t.Errorf("LooksLikeFieldLabel(%q) = true: a line that names no field must not open a "+
+				"cross-line window, or it vouches for whatever number follows it", line)
+		}
+	}
+}
+
+// Only the FULL concatenation of a keyword counts. Accepting an arbitrary run of its words would admit
+// "licensenumber" from "driver's license number" and turn the vocabulary check into a substring
+// search.
+func TestOnlyTheWholeKeywordConcatenationCounts(t *testing.T) {
+	licence := []string{"driver's license", "driver's license number", "license number", "dl number"}
+
+	if !keywordWord("licensenumber", licence) {
+		t.Error("\"licensenumber\" is the full concatenation of the keyword \"license number\", " +
+			"which is in this list, so it must be accepted")
+	}
+	if !keywordWord("dlnumber", licence) {
+		t.Error("\"dlnumber\" is the full concatenation of \"dl number\"")
+	}
+	if keywordWord("licensenumberextra", licence) {
+		t.Error("a token longer than any keyword concatenation was accepted")
+	}
+	if keywordWord("driversnumber", licence) {
+		t.Error("\"driversnumber\" skips a word of the keyword; accepting a non-contiguous run would " +
+			"make the check a loose substring match")
+	}
+
+	// A PREFIX of the keyword's words is not the keyword. This is the case that distinguishes "the
+	// whole concatenation" from "as many words as happen to line up", and it is the one a mutation
+	// removing the alignment guard survives on every other input: for
+	// "patient identification number", the guard is what rejects "patientidentification" after
+	// "number" fails to fit.
+	threeWord := []string{"patient identification number"}
+	if !keywordWord("patientidentificationnumber", threeWord) {
+		t.Error("the full three-word concatenation was rejected")
+	}
+	for _, partial := range []string{"patientidentification", "identificationnumber", "patientnumber"} {
+		if keywordWord(partial, threeWord) {
+			t.Errorf("%q is only part of \"patient identification number\" and must not count as that "+
+				"keyword's word. Accepting a prefix or a skipped word widens the false-positive gate "+
+				"that keeps a non-label line from opening a cross-line window", partial)
+		}
+	}
+}
+
+// A keyword containing an APOSTROPHE is a known, separate gap, and it is pinned here so the boundary
+// of this change is explicit rather than accidental.
+//
+// "driver's license number" concatenates to "driver'slicensenumber", keeping the apostrophe, so the
+// camelCase field name a JSON export actually writes — "driversLicenseNumber" — matches neither this
+// per-word check nor the vocabulary gate before it. Measured: ContainsAnyLabel is false for
+// "driverslicensenumber" and true for "driver'slicensenumber".
+//
+// That is a different mechanism from the one this change fixes — a LITERAL character requirement in
+// the keyword, not a separator one — and closing it means changing what an apostrophe means to the
+// shared matcher, for every caller. Filed on its own rather than folded in here.
+func TestApostropheInAKeywordIsAKnownGap(t *testing.T) {
+	licence := []string{"driver's license number"}
+
+	if keywordWord("driverslicensenumber", licence) {
+		t.Log("the apostrophe gap now closes; fold this case into " +
+			"TestOnlyTheWholeKeywordConcatenationCounts and drop this test")
+	}
+	// The apostrophe-preserving spelling is what matches today. If this stops holding, the matcher's
+	// treatment of an apostrophe changed and every caller is affected.
+	if !keywordWord("driver'slicensenumber", licence) {
+		t.Error("the apostrophe-preserving concatenation no longer matches, so the shared matcher's " +
+			"handling of a literal apostrophe has changed — check every caller, not just this one")
+	}
+}
+
+// The whole-word boundary must survive, or the widening becomes a substring search.
+func TestConcatenatedLabelRespectsWordBoundaries(t *testing.T) {
+	for _, line := range []string{
+		"teammemberid:",
+		"xmemberidx:",
+		"memberidentifiers:",
+		"remembering:",
+	} {
+		if LooksLikeFieldLabel(line, labelKeywords) {
+			t.Errorf("LooksLikeFieldLabel(%q) = true: a longer word that merely CONTAINS the label "+
+				"is not the label", line)
+		}
+	}
+}
+
+// ContainsAnyLabel is the vocabulary gate's new matcher; assert it directly so a failure says which
+// layer broke rather than only that the composite verdict changed.
+func TestContainsAnyLabel(t *testing.T) {
+	for _, text := range []string{"memberid:", "memberid: w999", "the memberid field"} {
+		if !ContainsAnyLabel(text, labelKeywords) {
+			t.Errorf("ContainsAnyLabel(%q) = false", text)
+		}
+	}
+	for _, text := range []string{"itemcount:", "teammemberid:", "remembering", ""} {
+		if ContainsAnyLabel(text, labelKeywords) {
+			t.Errorf("ContainsAnyLabel(%q) = true", text)
+		}
+	}
+	// It must agree with ContainsAny wherever ContainsAny already matched: this is a widening, and a
+	// widening that loses a previously-matching case is a regression.
+	for _, text := range []string{"member id:", "member_id:", "policy number: 1"} {
+		if ContainsAny(text, labelKeywords) && !ContainsAnyLabel(text, labelKeywords) {
+			t.Errorf("ContainsAnyLabel(%q) = false while ContainsAny = true: the label form must be "+
+				"a superset, never a replacement", text)
+		}
+	}
+}

--- a/internal/validators/kwmatch/fieldlabel.go
+++ b/internal/validators/kwmatch/fieldlabel.go
@@ -68,7 +68,18 @@ func LooksLikeFieldLabel(line string, keywords []string) bool {
 	// "Driver's License Number" missed every keyword while its individual lowercased
 	// words matched — the bug this ordering fixes.
 	lower := strings.ToLower(t)
-	if !ContainsAny(lower, keywords) {
+	// ContainsAnyLabel, not ContainsAny: a label written without separators is still that label.
+	//
+	// This is the gate that actually rejected a camelCase label, and it fires BEFORE the per-word
+	// loop below — so teaching only that loop about concatenated spellings would have been a no-op.
+	// Measured at HEAD: for "memberId:" this returned false while "member id:" and "member_id:"
+	// returned true, which is why the spaced spellings opened a cross-line window and the camelCase
+	// one did not (#409).
+	//
+	// Widening here is the safe direction: this function only ever ADMITS context that would
+	// otherwise be ignored, so it can add a finding and never remove one. That is the restriction
+	// ContainsLabel documents, and the per-word loop below is what still keeps a non-label line out.
+	if !ContainsAnyLabel(lower, keywords) {
 		return false
 	}
 	for _, w := range strings.FieldsFunc(lower, func(r rune) bool {
@@ -95,20 +106,48 @@ func LooksLikeFieldLabel(line string, keywords []string) bool {
 	return true
 }
 
-// keywordWord reports whether w appears as one of the WORDS of any keyword.
+// keywordWord reports whether w appears as one of the WORDS of any keyword, or is the whole keyword
+// with its separators removed.
 //
 // Per-word rather than ContainsAny(w, keywords), because most of these vocabularies are
 // multi-word: "member id", "driver's license", "medical record". Testing the whole
 // keyword against a single word can never match, so "Member ID" was rejected as
 // non-label vocabulary even though "member id" is a keyword — the bug this fixes.
+//
+// The concatenated spelling counts because it is the same label written the way a JSON key or an ORM
+// field is: "memberid" for "member id", "driverslicensenumber" for "driver's license number". Without
+// it, a line consisting of exactly that one token has no qualifying word at all and is rejected as
+// non-label vocabulary (#409).
+//
+// Only the FULL concatenation, deliberately. Accepting an arbitrary run of a keyword's words would
+// admit "licensenumber" from "driver's license number", and this loop is the false-positive gate that
+// keeps a non-label line from opening a cross-line window, so the narrowest widening that closes the
+// gap is the right one.
+//
+// The concatenation is compared INCREMENTALLY rather than built. A strings.Builder here cost one
+// allocation per keyword — measured at +1 alloc/op and +12% on a label line walked word by word —
+// while consuming w as the keyword's words are visited costs none, and abandons a keyword as soon as
+// its prefix diverges.
 func keywordWord(w string, keywords []string) bool {
 	for _, kw := range keywords {
+		consumed := 0   // bytes of w matched by this keyword's words so far
+		aligned := true // w is still a prefix-match of the concatenation
 		for _, part := range strings.FieldsFunc(strings.ToLower(kw), func(r rune) bool {
 			return !(r >= 'a' && r <= 'z') && !(r >= '0' && r <= '9') && r != '\''
 		}) {
 			if part == w {
 				return true
 			}
+			if aligned {
+				if consumed+len(part) <= len(w) && w[consumed:consumed+len(part)] == part {
+					consumed += len(part)
+				} else {
+					aligned = false
+				}
+			}
+		}
+		if aligned && consumed == len(w) && consumed > 0 {
+			return true
 		}
 	}
 	return false

--- a/internal/validators/kwmatch/fieldlabel_bench_test.go
+++ b/internal/validators/kwmatch/fieldlabel_bench_test.go
@@ -1,0 +1,52 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package kwmatch
+
+import "testing"
+
+// benchKeywords mirrors the real medicalid vocabulary, the largest list LooksLikeFieldLabel is called
+// with, so the per-keyword cost is measured at the size it actually runs at.
+var benchKeywords = []string{
+	"insurance", "member id", "member number", "subscriber", "policy number", "group number",
+	"health plan", "enrollee", "covered", "copay", "deductible", "claims",
+	"member identification", "subscriber identification", "policyholder",
+	"rxbin", "rxpcn", "rxgrp", "rx bin", "rx group", "medical record", "patient id",
+	"patient number", "record number", "chart number", "admission number", "patient account",
+	"patient identification", "patient identification number", "medical record number",
+}
+
+// These exist because LooksLikeFieldLabel runs on EVERY line of every scanned document, so a constant
+// factor here is not a micro-optimization — and because the sub-quadratic complexity guard in
+// internal/goldencorpus is a RATIO test that cannot see one.
+//
+// BenchmarkLooksLikeFieldLabelMiss is the one to watch: ordinary prose is the common case, and it
+// pays the full keyword scan before failing. Measured when the concatenated-label support was added
+// (#409): the miss path went 507ns -> 534ns (+5%) with allocations unchanged, and a first draft that
+// built the concatenation with a strings.Builder cost +1 alloc/op and +12% on ManyWords until it was
+// rewritten to compare incrementally.
+func BenchmarkLooksLikeFieldLabelMiss(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = LooksLikeFieldLabel("The quarterly report was circulated", benchKeywords)
+	}
+}
+
+func BenchmarkLooksLikeFieldLabelHit(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = LooksLikeFieldLabel("Member ID (primary)", benchKeywords)
+	}
+}
+
+// The concatenated spelling, which is what #409 added.
+func BenchmarkLooksLikeFieldLabelConcatenated(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = LooksLikeFieldLabel("memberId:", benchKeywords)
+	}
+}
+
+// A label whose every word must be walked is the worst case for the per-word loop.
+func BenchmarkLooksLikeFieldLabelManyWords(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = LooksLikeFieldLabel("member id number field value primary", benchKeywords)
+	}
+}

--- a/internal/validators/kwmatch/kwmatch.go
+++ b/internal/validators/kwmatch/kwmatch.go
@@ -110,6 +110,21 @@ func ContainsAny(text string, keywords []string) bool {
 	return false
 }
 
+// ContainsAnyLabel is [ContainsAny] with each keyword matched as a LABEL, so a concatenated or
+// camelCase spelling counts: "member id" finds "memberid" and "memberId".
+//
+// Both text and keywords must already be lowercased, matching ContainsAny. Carries the same
+// restriction as [ContainsLabel] and for the same reason: use it only where a keyword identifies the
+// value beside it, never where one suppresses a finding.
+func ContainsAnyLabel(text string, keywords []string) bool {
+	for _, kw := range keywords {
+		if ContainsLabelLower(text, kw) {
+			return true
+		}
+	}
+	return false
+}
+
 // ContainsLabel is [Contains] with the keyword's spaces allowed to match ZERO separator
 // bytes, so "member id" also finds "memberid" and — since text is lowercased before matching
 // — the camelCase "memberId". That spelling is the default key style of JSON, REST payloads


### PR DESCRIPTION
Closes #409

## Gate summary (`make pr-checklist BASE=origin/main`, run before pushing)

```
=== summary: 10 ran, 0 failed, 5 need manual work ===
1 gofmt / go vet / go build   RAN — clean / clean / ok
2 full suite (-count=1)       RAN — 68 packages ok
3 golden regen                RAN — 0 files changed
11 cross-platform vet         RAN — linux darwin windows
12 flake (3 repeats)          RAN — ./internal/validators/kwmatch
13 race (whole module)        RAN — 68 packages ok
-- -short mode                RAN — ok
-- tree clean                 RAN — this run dirtied nothing
8 web / CSP                   N/A — no web/template/asset file touched
```

All five NEEDS-MANUAL dimensions are completed below.

## The bug

#396 opens a cross-line window when the previous line looks like a field label. #407 taught the
matcher that `member id` also finds `memberId`. **The two did not compose**: a camelCase label alone on
its own line still opened no window, so the value on the next line was never reported and therefore
never redacted.

Label on line 1, `W9998887776` on line 2:

| label | main | this PR |
|---|---:|---:|
| `member id:` | 1 | 1 |
| `member_id:` | 1 | 1 |
| `memberId:` | **0** | **1** |
| `MemberId:` | **0** | **1** |
| `memberID:` | **0** | **1** |
| `memberid:` | **0** | **1** |
| `policyNumber:` | **0** | **1** |

## Which gate — the issue's suggested fix would have been a no-op

Two independent gates rejected it, and the order decides the fix. The issue proposed teaching
`keywordWord`; probed directly, the **vocabulary gate above it** (`ContainsAny`, `fieldlabel.go:71`)
returns false first and returns early — for `memberId:` it is false, while for `member id:` and
`member_id:` it is true. Patching only the per-word loop would have changed nothing measurable, the
same trap as #414. **Both gates are fixed here.**

## The precision boundary

Only the **full** concatenation counts. A prefix or a skipped word would admit
`patientidentification` from `patient identification number`, and this loop is the false-positive gate
that stops a non-label line vouching for whatever number follows it. Widening is safe only because
`LooksLikeFieldLabel` exclusively *admits* context it would otherwise ignore — it can add a finding and
never remove one, which is the restriction `ContainsLabel` documents.

Verified in the costly direction — twelve decoys above a bare digit run, **all zero on both builds**:
`itemCount`, `orderNumber`, `lineTotal`, `rowCount`, `batchSize`, `requestId`, `sessionId`,
`buildNumber`, `errorCode`, `invoiceTotal`, a prose sentence, and `member 449871234567` (a line already
carrying its own value). Word boundaries hold too: `teammemberid`, `xmemberidx`, `memberidentifiers`,
`remembering` all rejected.

## 4 — redaction, every strategy (the base-vs-fix leak diff)

| binary | strategy | result |
|---|---|---|
| parent | `simple` | **NO FILE WRITTEN** — nothing reported, so nothing redacted |
| parent | `format_preserving` | **NO FILE WRITTEN** |
| this PR | `simple` | `[INSURANCE_MEMBER_ID-REDACTED]` — value gone |
| this PR | `format_preserving` | `***********` — value gone |

The parent leaves the member ID in cleartext in a file it exits 0 on.

## 5 — suppression, generated by the PARENT and applied with MINE

Generated from the spaced spelling both builds detect, `enabled: true` set, applied with both:

| binary | result |
|---|---|
| parent | `findings=0 suppressed=1` |
| this PR | `findings=0 suppressed=1` |

The parent's hash still silences the finding under this build.

## 6 — timing / O(n²)

This runs on **every line of every scanned document**, and the sub-quadratic guard is a ratio test that
cannot see a constant factor, so it is measured directly.

Scaling at N/2N/4N (15k/30k/60k prose lines, the three label-gated validators):

| lines | main | this PR | main ratio | PR ratio |
|---|---|---|---|---|
| 15,000 | 0.64s | 0.62s | – | – |
| 30,000 | 1.19s | 1.14s | 1.86x | 1.84x |
| 60,000 | 2.33s | 2.22s | 1.95x | 1.95x |

Linear, same slope. End to end on 60k prose lines: main 2.47s vs 2.24s — **no regression**.

Micro-benchmarks, best of three (committed as `fieldlabel_bench_test.go` so the next change to this hot
path is measurable rather than arguable):

| path | main | this PR |
|---|---|---|
| **miss** (ordinary prose — dominates) | 507ns, 1 alloc | 534ns (+5%), **1 alloc** |
| hit | 211ns, 4 allocs | 216ns, **4 allocs** |
| many words | 256ns, 3 allocs | 260ns, **3 allocs** |
| concatenated | 289ns | 163ns (−43%) |

A first draft built the concatenation with a `strings.Builder`: **+1 alloc/op and +12%**. It now
consumes the word incrementally, which allocates nothing and abandons a keyword as soon as its prefix
diverges. **Allocations are back to parity with main on every path.**

## 7 — all seven output formats

text 758B, json 952B, yaml 800B, csv 143B, junit 495B, gitlab-sast 1860B, sarif 2849B — all rc=0.

## 10 — non-vacuity

Mutation-verified: **6 mutants, 5 killed.** The sixth drops a `consumed > 0` guard that is unreachable
because `FieldsFunc` never yields an empty word — an equivalent mutant, reported rather than papered
over. Two survived a first pass and are now killed: reverting the vocabulary gate, and accepting a
partial run of a keyword's words (`patientidentification`).

## Filed separately

**#438** — an apostrophe inside a keyword is a required literal, so `driver's license number` never
matches the camelCase `driversLicenseNumber` a JSON export writes. Different mechanism (a literal
character, not a separator), and closing it changes what an apostrophe means to the shared matcher for
every caller. Pinned here by `TestApostropheInAKeywordIsAKnownGap`, which logs a reminder to delete
itself once #438 lands and fails if the current behaviour silently changes.
