### PR TITLE
fix(detector): index a dense line once instead of rescanning it per distinct value

### DIFF
--- a/internal/detector/line_span.go
+++ b/internal/detector/line_span.go
@@ -74,6 +74,14 @@ func ResolveLineSpans(matches []Match) []LineSpan {
 		lastID     int
 	)
 
+	// Match indices grouped by line, in arrival order.
+	//
+	// Grouping is what lets a DENSE line be resolved with one pass over it instead of one pass per
+	// distinct value (see resolveByIndex). It costs nothing extra: the interning above already has
+	// to visit every match, and the memo means a line is hashed once rather than once per match.
+	perLine := make(map[int][]int, len(lineIDs))
+	lineText := make(map[int]string, len(lineIDs))
+
 	for i := range matches {
 		m := &matches[i]
 		line := m.Context.FullLine
@@ -95,29 +103,166 @@ func ResolveLineSpans(matches []Match) []LineSpan {
 			lastLine, lastNumber, lastID = line, m.LineNumber, lineID
 		}
 
-		byText, ok := cursor[lineID]
-		if !ok {
-			byText = make(map[string]int)
-			cursor[lineID] = byText
-		}
+		perLine[lineID] = append(perLine[lineID], i)
+		lineText[lineID] = line
+	}
 
-		from := byText[m.Text]
-		idx := strings.Index(line[from:], m.Text)
-		if idx < 0 {
-			// Fall back to the first occurrence rather than losing the position.
-			idx = strings.Index(line, m.Text)
-			if idx < 0 {
-				continue
-			}
-			spans[i] = LineSpan{LineID: lineID, Start: idx, End: idx + len(m.Text), OK: true}
+	for lineID, idxs := range perLine {
+		line := lineText[lineID]
+		if useIndex(line, matches, idxs) {
+			resolveByIndex(line, lineID, matches, idxs, spans)
 			continue
 		}
-		start := from + idx
-		spans[i] = LineSpan{LineID: lineID, Start: start, End: start + len(m.Text), OK: true}
-		byText[m.Text] = start + len(m.Text)
+		resolveByRescan(line, lineID, matches, idxs, spans, cursor)
 	}
 
 	return spans
+}
+
+// resolveByRescan is the original strategy: each (line, text) keeps a cursor and every match
+// searches forward from it.
+//
+// Kept, and still the default for ordinary input, because it walks the line only as far as the
+// match and allocates nothing per line. Its weakness is one specific shape — see useIndex.
+func resolveByRescan(line string, lineID int, matches []Match, idxs []int, spans []LineSpan, cursor map[int]map[string]int) {
+	byText, ok := cursor[lineID]
+	if !ok {
+		byText = make(map[string]int)
+		cursor[lineID] = byText
+	}
+
+	for _, i := range idxs {
+		text := matches[i].Text
+		from := byText[text]
+		idx := strings.Index(line[from:], text)
+		if idx < 0 {
+			// Fall back to the first occurrence rather than losing the position.
+			idx = strings.Index(line, text)
+			if idx < 0 {
+				continue
+			}
+			spans[i] = LineSpan{LineID: lineID, Start: idx, End: idx + len(text), OK: true}
+			continue
+		}
+		start := from + idx
+		spans[i] = LineSpan{LineID: lineID, Start: start, End: start + len(text), OK: true}
+		byText[text] = start + len(text)
+	}
+}
+
+// useIndex reports whether indexing the line beats rescanning it, by estimating both.
+//
+// Rescanning costs roughly one traversal of the line per DISTINCT value, because each value's
+// cursor starts at zero and strings.Index walks from the line start to that value — averaging half
+// the line, so about distinct/2 traversals.
+//
+// Indexing costs one traversal per distinct value LENGTH: the single pass tests, at each byte, one
+// candidate substring per length, and hashing a candidate of length L is O(L). So the estimate is
+// the SUM of the distinct lengths.
+//
+// Comparing the two directly is what keeps this from being a regression on ordinary input. A line
+// with a handful of matches has few distinct values but a similar number of distinct lengths, so
+// rescanning wins and is chosen; a line with thousands of distinct values of a few shapes — the
+// machine-generated case — inverts that by orders of magnitude. For 16,000 IP addresses of 9
+// distinct lengths the estimates are ~99 against ~8,000.
+func useIndex(line string, matches []Match, idxs []int) bool {
+	// Below this there is nothing to amortise a line pass against, and the map allocations would
+	// dominate a cost that is already microseconds.
+	const minMatches = 64
+	if len(idxs) < minMatches || len(line) < 1024 {
+		return false
+	}
+
+	distinct := make(map[string]struct{}, len(idxs))
+	lengths := make(map[int]struct{}, 8)
+	for _, i := range idxs {
+		t := matches[i].Text
+		distinct[t] = struct{}{}
+		lengths[len(t)] = struct{}{}
+	}
+
+	sumLengths := 0
+	for l := range lengths {
+		sumLengths += l
+	}
+	return sumLengths < len(distinct)/2
+}
+
+// resolveByIndex locates every occurrence of every match value on this line in ONE pass, then hands
+// them out in arrival order.
+//
+// This is the "multi-pattern single pass" the complexity guard for this function named as the only
+// way to make the many-distinct-values shape linear. The trick that makes one pass enough is to key
+// on LENGTH rather than on value: at each byte, for each distinct value length present, look up that
+// candidate substring in a set. The cost is therefore independent of how MANY values there are,
+// which is the term that made rescanning quadratic.
+//
+// The hand-out rules reproduce resolveByRescan exactly, because consumers depend on them:
+//
+//   - repeated values consume successive occurrences left to right;
+//   - an occurrence that starts before the previous one ended is skipped, matching a cursor that
+//     advances past the whole match (so "aa" in "aaa" yields one occurrence, not two);
+//   - when the occurrences are exhausted the FIRST is reused and nothing advances;
+//   - a value that does not appear at all leaves OK=false rather than a guessed offset.
+func resolveByIndex(line string, lineID int, matches []Match, idxs []int, spans []LineSpan) {
+	distinct := make(map[string]struct{}, len(idxs))
+	lengths := make([]int, 0, 8)
+	seenLen := make(map[int]struct{}, 8)
+	for _, i := range idxs {
+		t := matches[i].Text
+		distinct[t] = struct{}{}
+		if _, ok := seenLen[len(t)]; !ok {
+			seenLen[len(t)] = struct{}{}
+			lengths = append(lengths, len(t))
+		}
+	}
+
+	occurrences := make(map[string][]int, len(distinct))
+	for pos := 0; pos < len(line); pos++ {
+		remaining := len(line) - pos
+		for _, l := range lengths {
+			if l > remaining {
+				continue
+			}
+			candidate := line[pos : pos+l]
+			if _, ok := distinct[candidate]; ok {
+				occurrences[candidate] = append(occurrences[candidate], pos)
+			}
+		}
+	}
+
+	next := make(map[string]int, len(distinct))
+	end := make(map[string]int, len(distinct))
+	for _, i := range idxs {
+		text := matches[i].Text
+		found := occurrences[text]
+		if len(found) == 0 {
+			continue // absent from the line: no position is better than a wrong one
+		}
+
+		p := next[text]
+		for p < len(found) && found[p] < end[text] {
+			p++
+		}
+		if p >= len(found) {
+			// Exhausted. Reuse the first occurrence and do NOT advance, matching the
+			// long-standing behaviour of the redaction overlap pass.
+			//
+			// Not advancing is unobservable HERE — next[text] is already past the end, so every
+			// later match of this value takes this branch too — but it is observable in
+			// resolveByRescan, where leaving the cursor alone is what lets the fallback keep
+			// returning the first occurrence. The two are written the same way on purpose, so
+			// neither can be "simplified" into disagreeing with the other.
+			first := found[0]
+			spans[i] = LineSpan{LineID: lineID, Start: first, End: first + len(text), OK: true}
+			continue
+		}
+
+		start := found[p]
+		spans[i] = LineSpan{LineID: lineID, Start: start, End: start + len(text), OK: true}
+		next[text] = p + 1
+		end[text] = start + len(text)
+	}
 }
 
 // AssignLineColumns records each match's position on its line as 1-based byte

--- a/internal/detector/line_span_complexity_test.go
+++ b/internal/detector/line_span_complexity_test.go
@@ -33,20 +33,33 @@ import (
 // check and a pointer compare. K=8000 went 19.5ms -> 0.69ms, a 28x improvement, and
 // growth 18.5x -> 8.1x at times small enough that noise dominates.
 //
-// What remains, and is a RATCHET rather than a target:
+// Both shapes are now linear:
 //
-//   - MANY OCCURRENCES OF ONE VALUE is now near-linear. The cursor advances past each
-//     occurrence and the memo removes the per-match hash.
-//   - MANY DISTINCT VALUES is still O(K x line length): each value owns a cursor
-//     starting at zero, so each strings.Index scans from the line start to that value.
-//     Measured 16.2x for 4x input, 148ms at K=8000 — which the arithmetic corroborates
-//     (8000 values x ~64KB average scan is ~512MB). Making it linear needs a
-//     multi-pattern single pass over the line, not a tweak, and per-validator execution
-//     budgets already bound pathological single-line input.
+//   - MANY OCCURRENCES OF ONE VALUE. The cursor advances past each occurrence and the
+//     memo removes the per-match hash.
+//   - MANY DISTINCT VALUES. This was O(K x line length) — each value owned a cursor
+//     starting at zero, so every strings.Index scanned from the line start to that value.
+//     ResolveLineSpans now indexes a dense line in ONE pass instead, keyed on value
+//     LENGTH rather than on value, so the cost no longer carries a factor of K (#388).
 //
-// None of this is visible end-to-end, because validator cost dominates a real scan:
-// through the CLI on a dense single-line file the whole change measured +1.7% to +8.9%
-// and the scan stayed linear. That masking is exactly why the shape is measured here.
+// Two claims that used to sit here were wrong, and correcting them is why the ratio below
+// is now ASSERTED rather than logged:
+//
+//   - "Making it linear needs a multi-pattern single pass over the line, not a tweak, and
+//     per-validator execution budgets already bound pathological single-line input." The
+//     first half was right and is what was done. The second half was not: nothing bounded
+//     it.
+//   - "None of this is visible end-to-end, because validator cost dominates a real scan:
+//     through the CLI on a dense single-line file the whole change measured +1.7% to
+//     +8.9%." Measured directly at 64,000 distinct values on a 1.14 MB line,
+//     ResolveLineSpans was 8.14s of a 9.64s scan — 84% of it, not a rounding error. The
+//     +1.7% to +8.9% figure came from a fixture that did not reach this shape. A shape
+//     measured only in isolation can look harmless there and dominate in production;
+//     measure BOTH.
+//
+// After the change the same 64,000-value line resolves in 53ms, and every input size
+// measured is faster than before — 1.14x at 1,000 values through 6.3x at 32,000 end to
+// end, with no size slower.
 
 // columnsAbsoluteCeiling bounds the largest sample.
 //
@@ -166,18 +179,31 @@ func TestAssignLineColumnsComplexityDistinctValues(t *testing.T) {
 	tBase := timeAssign(t, buildDistinctOnOneLine(baseK), true)
 	tBig := timeAssign(t, buildDistinctOnOneLine(bigK), true)
 
-	// LOGGED, not asserted. Each distinct value owns its cursor and therefore scans
-	// from the line start, so 4x input is expected to cost well over 4x here. The
-	// number is recorded so a human can see the shape move.
 	ratio := float64(tBig) / float64(tBase)
-	t.Logf("4x input, K DISTINCT values on one line: %.1fx (base=%v big=%v) — informational. "+
-		"Each value owns a cursor starting at zero, so this is O(K x line length); linear "+
-		"would be 4x.", ratio, tBase, tBig)
+	t.Logf("4x input, K DISTINCT values on one line: %.1fx (base=%v big=%v) — linear is 4x. "+
+		"Was 16.2x when each value owned a cursor starting at zero.", ratio, tBase, tBig)
 
 	if tBig > columnsAbsoluteCeiling {
 		t.Errorf("assigning columns for %d distinct values on one line took %v (> %v) — a "+
 			"regression of this size means the per-value scan got worse than a single pass "+
 			"over the line", bigK, tBig, columnsAbsoluteCeiling)
+	}
+
+	// ASSERTED now, where it used to be logged only.
+	//
+	// The ceiling above cannot catch this shape returning: at K=8000 the old quadratic cost
+	// 148ms, which is comfortably inside a 4s ceiling, so it passed for as long as the
+	// quadratic existed. A growth bound is what actually pins the shape.
+	//
+	// 8x rather than 4x because both the value COUNT and the line LENGTH grow with K here, and
+	// these samples are milliseconds where scheduler noise is a large fraction. A return to
+	// O(K x line) would show 16x.
+	const maxGrowth = 8.0
+	if tBase > 0 && ratio > maxGrowth {
+		t.Errorf("4x input cost %.1fx (base=%v big=%v), over %.0fx: the per-value line rescan is "+
+			"back. Each distinct value scanning from the line start is O(K x line length), which "+
+			"measured 8.14s of a 9.64s scan on a 1.14MB line before #388",
+			ratio, tBase, tBig, maxGrowth)
 	}
 }
 
@@ -214,5 +240,89 @@ func TestAssignLineColumnsComplexityManyLines(t *testing.T) {
 	if tBig > columnsAbsoluteCeiling {
 		t.Errorf("assigning columns across %d lines took %v (> %v) — the ordinary document "+
 			"shape must stay linear in the number of lines", bigN, tBig, columnsAbsoluteCeiling)
+	}
+}
+
+// The INDEX path must stay linear when values are also REPEATED, which needs its own guard.
+//
+// The two existing shapes miss it: many-distinct-values uses the index but never repeats a value, and
+// one-repeated-value stays on the rescan path (correctly — the cursor already makes that linear, so
+// indexing would only add allocations). The shape that exercises both at once is a log with thousands
+// of DISTINCT values each appearing many times, which is ordinary machine-generated input.
+//
+// It guards a specific mechanism: resolveByIndex keeps a per-value pointer into that value's
+// occurrence list so hand-out is amortised O(1). Removing that pointer's advance leaves correctness
+// untouched — the end-offset check still skips consumed occurrences — while making each match rescan
+// the occurrence list from the start, i.e. quadratic in the repeat count. Mutation-verified: deleting
+// the advance passes every other test in this package.
+func TestAssignLineColumnsComplexityDistinctAndRepeated(t *testing.T) {
+	if testing.Short() {
+		t.Skip("column-assignment complexity guard skipped in -short mode")
+	}
+
+	build := func(distinct, repeats int) []Match {
+		var sb strings.Builder
+		vals := make([]string, 0, distinct)
+		for i := 0; i < distinct; i++ {
+			vals = append(vals, fmt.Sprintf("%03d-%02d-%04d", 400+(i/8100)%500, 10+(i/90)%90, 1000+i%9000))
+		}
+		for r := 0; r < repeats; r++ {
+			for _, v := range vals {
+				sb.WriteString("SSN ")
+				sb.WriteString(v)
+				sb.WriteString(" ")
+			}
+		}
+		line := sb.String()
+
+		out := make([]Match, 0, distinct*repeats)
+		for r := 0; r < repeats; r++ {
+			for _, v := range vals {
+				out = append(out, Match{
+					Text: v, Type: "SSN", LineNumber: 1,
+					Context: ContextInfo{FullLine: line},
+				})
+			}
+		}
+		return out
+	}
+
+	// Hold the distinct count fixed and grow the REPEAT count, so what scales is exactly the
+	// occurrence-list walking this pins. The repeat count has to be LARGE for that walk to be
+	// measurable: without the pointer the r-th match of a value walks r entries, so the cost is
+	// O(repeats^2) per value and only separates from linear once repeats is in the hundreds. A
+	// first attempt used 4 and 16 repeats, where the difference is a few hundred thousand steps
+	// and the mutation survived.
+	const distinct = 40
+
+	tBase := timeAssign(t, build(distinct, 500), false)
+	tBig := timeAssign(t, build(distinct, 2000), false) // 4x the repeats
+
+	ratio := float64(tBig) / float64(tBase)
+	t.Logf("4x the repeats of %d distinct values on one line: %.1fx (base=%v big=%v) — linear is 4x",
+		distinct, ratio, tBase, tBig)
+
+	// The ABSOLUTE time of the big case is asserted, not the growth ratio, because it is the far
+	// cleaner signal. Measured over five runs each, with and without the pointer:
+	//
+	//   with:     base 4.7-6.7ms   big 22.7-25.2ms   ratio 3.6-5.1x
+	//   without:  base 34-40ms     big 422-465ms     ratio ~11-12x
+	//
+	// So the big case separates by ~18x while the ratio separates by only ~2.5x — and a ratio of two
+	// millisecond samples is exactly where scheduler noise lives. The ceiling below sits ~10x above
+	// the observed big case, so a runner an order of magnitude slower than this one still passes,
+	// while the quadratic hand-out (440ms) does not.
+	//
+	// The ratio is still asserted, loosely, because it is scale-free and so catches a machine that is
+	// uniformly slow enough to hide the ceiling.
+	const repeatBigCeiling = 250 * time.Millisecond
+	if tBig > repeatBigCeiling {
+		t.Errorf("resolving %d repeats of %d distinct values took %v (> %v): hand-out is walking "+
+			"each value's occurrence list from the start instead of carrying a pointer into it, "+
+			"which is O(repeats^2) per value", 2000, distinct, tBig, repeatBigCeiling)
+	}
+	const maxGrowth = 8.0
+	if tBase > 0 && ratio > maxGrowth {
+		t.Errorf("4x the repeats cost %.1fx (base=%v big=%v), over %.0fx", ratio, tBase, tBig, maxGrowth)
 	}
 }

--- a/internal/detector/line_span_index_test.go
+++ b/internal/detector/line_span_index_test.go
@@ -1,0 +1,226 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package detector
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// The two strategies must produce IDENTICAL spans for the same input.
+//
+// This is the load-bearing test of the change. resolveByIndex exists only to be faster; any
+// disagreement with resolveByRescan is a behaviour change smuggled in as an optimisation, and every
+// consumer of these offsets — SARIF regions, gitlab-sast ids, the redaction overlap pass — depends on
+// the exact hand-out rules rather than merely on "some position".
+//
+// The cases are chosen to cover each rule that took a comment to explain: successive occurrences of a
+// repeated value, an overlapping candidate that a cursor advancing past the whole match must skip,
+// exhaustion (reuse the first, advance nothing), and a value absent from the line.
+func TestIndexAndRescanAgree(t *testing.T) {
+	cases := []struct {
+		name  string
+		line  string
+		texts []string
+	}{
+		{"distinct values in order", "a 10.0.0.1 b 10.0.0.2 c 10.0.0.3", []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"}},
+		{"distinct values out of order", "a 10.0.0.1 b 10.0.0.2 c 10.0.0.3", []string{"10.0.0.3", "10.0.0.1", "10.0.0.2"}},
+		{"one value repeated", "x 4.4.4.4 y 4.4.4.4 z 4.4.4.4", []string{"4.4.4.4", "4.4.4.4", "4.4.4.4"}},
+		{"more matches than occurrences", "only 4.4.4.4 once", []string{"4.4.4.4", "4.4.4.4", "4.4.4.4"}},
+		{"overlapping candidate", "aaa", []string{"aa", "aa"}},
+		{"overlapping longer run", "aaaaa", []string{"aa", "aa", "aa"}},
+		{"absent value", "nothing here", []string{"10.0.0.1"}},
+		{"present and absent mixed", "has 10.0.0.1 only", []string{"10.0.0.1", "10.0.0.2"}},
+		{"different lengths", "a 1.1.1.1 bb 222.222.222.222 c", []string{"1.1.1.1", "222.222.222.222"}},
+		{"value is the whole line", "10.0.0.1", []string{"10.0.0.1"}},
+		{"adjacent occurrences", "1.1.1.11.1.1.1", []string{"1.1.1.1", "1.1.1.1"}},
+		{"repeat interleaved with distinct", "p 5.5.5.5 q 6.6.6.6 r 5.5.5.5", []string{"5.5.5.5", "6.6.6.6", "5.5.5.5"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			build := func() ([]Match, []int) {
+				ms := make([]Match, len(tc.texts))
+				idxs := make([]int, len(tc.texts))
+				for i, txt := range tc.texts {
+					ms[i] = Match{Text: txt, LineNumber: 1, Context: ContextInfo{FullLine: tc.line}}
+					idxs[i] = i
+				}
+				return ms, idxs
+			}
+
+			msA, idxsA := build()
+			byIndex := make([]LineSpan, len(msA))
+			resolveByIndex(tc.line, 1, msA, idxsA, byIndex)
+
+			msB, idxsB := build()
+			byRescan := make([]LineSpan, len(msB))
+			resolveByRescan(tc.line, 1, msB, idxsB, byRescan, map[int]map[string]int{})
+
+			for i := range byIndex {
+				if byIndex[i] != byRescan[i] {
+					t.Errorf("match %d (%q) disagrees:\n  index  = %+v\n  rescan = %+v\n  line   = %q",
+						i, tc.texts[i], byIndex[i], byRescan[i], tc.line)
+				}
+			}
+		})
+	}
+}
+
+// A randomised sweep over the same equivalence, because the hand-picked cases above can only cover
+// the shapes I thought of. Deterministic seed so a failure is reproducible.
+func TestIndexAndRescanAgreeOnGeneratedInput(t *testing.T) {
+	values := []string{"aa", "ab", "aab", "b", "bb", "abab", "ba"}
+	alphabet := "ab"
+
+	// A deterministic pseudo-random walk: no math/rand, so this cannot vary between runs.
+	next := func(state *uint64, n int) int {
+		*state = *state*6364136223846793005 + 1442695040888963407
+		return int((*state >> 33) % uint64(n))
+	}
+
+	state := uint64(42)
+	for trial := 0; trial < 400; trial++ {
+		var sb strings.Builder
+		for i := 0; i < 24; i++ {
+			sb.WriteByte(alphabet[next(&state, len(alphabet))])
+		}
+		line := sb.String()
+
+		texts := make([]string, 0, 6)
+		for i := 0; i < 1+next(&state, 5); i++ {
+			texts = append(texts, values[next(&state, len(values))])
+		}
+
+		build := func() ([]Match, []int) {
+			ms := make([]Match, len(texts))
+			idxs := make([]int, len(texts))
+			for i, txt := range texts {
+				ms[i] = Match{Text: txt, LineNumber: 1, Context: ContextInfo{FullLine: line}}
+				idxs[i] = i
+			}
+			return ms, idxs
+		}
+
+		msA, idxsA := build()
+		byIndex := make([]LineSpan, len(msA))
+		resolveByIndex(line, 1, msA, idxsA, byIndex)
+
+		msB, idxsB := build()
+		byRescan := make([]LineSpan, len(msB))
+		resolveByRescan(line, 1, msB, idxsB, byRescan, map[int]map[string]int{})
+
+		for i := range byIndex {
+			if byIndex[i] != byRescan[i] {
+				t.Fatalf("trial %d, match %d (%q) disagrees on line %q:\n  index  = %+v\n  rescan = %+v",
+					trial, i, texts[i], line, byIndex[i], byRescan[i])
+			}
+		}
+	}
+}
+
+// Lines are grouped into a map, so they are RESOLVED in randomised order. The result must not depend
+// on that order — each line owns its own cursor, and a span is written by match index.
+//
+// Asserted because map-order nondeterminism reaching the output is a defect this repo has shipped
+// before: the same file reported a different number of findings run to run.
+func TestResolveLineSpansIsIndependentOfLineOrder(t *testing.T) {
+	build := func() []Match {
+		var ms []Match
+		for lineNo := 1; lineNo <= 40; lineNo++ {
+			line := fmt.Sprintf("row %d has 10.0.%d.1 and 10.0.%d.1 again", lineNo, lineNo, lineNo)
+			for rep := 0; rep < 2; rep++ {
+				ms = append(ms, Match{
+					Text:       fmt.Sprintf("10.0.%d.1", lineNo),
+					LineNumber: lineNo,
+					Context:    ContextInfo{FullLine: line},
+				})
+			}
+		}
+		return ms
+	}
+
+	first := ResolveLineSpans(build())
+	for run := 0; run < 25; run++ {
+		got := ResolveLineSpans(build())
+		for i := range first {
+			if got[i] != first[i] {
+				t.Fatalf("run %d differs at match %d: %+v vs %+v — line resolution order is "+
+					"reaching the output", run, i, got[i], first[i])
+			}
+		}
+	}
+
+	// Non-vacuity: the two matches per line must land on DIFFERENT offsets, or this test would
+	// hold for a function that assigned everything the same position.
+	if !first[0].OK || !first[1].OK || first[0].Start == first[1].Start {
+		t.Fatalf("the two occurrences on line 1 resolved to %+v and %+v; distinct offsets are the "+
+			"whole point of the cursor", first[0], first[1])
+	}
+}
+
+// useIndex must choose rescanning for ordinary input and indexing for the machine-generated shape.
+// If it ever chose indexing for a handful of matches it would add map allocations to every scan.
+func TestUseIndexPicksTheCheaperStrategy(t *testing.T) {
+	mk := func(line string, texts ...string) ([]Match, []int) {
+		ms := make([]Match, len(texts))
+		idxs := make([]int, len(texts))
+		for i, txt := range texts {
+			ms[i] = Match{Text: txt, LineNumber: 1, Context: ContextInfo{FullLine: line}}
+			idxs[i] = i
+		}
+		return ms, idxs
+	}
+
+	t.Run("a few matches: rescan", func(t *testing.T) {
+		line := "a 10.0.0.1 b 10.0.0.2 c" + strings.Repeat(" pad", 500)
+		ms, idxs := mk(line, "10.0.0.1", "10.0.0.2")
+		if useIndex(line, ms, idxs) {
+			t.Error("indexing chosen for 2 matches: building the maps costs more than two short scans")
+		}
+	})
+
+	t.Run("short line: rescan", func(t *testing.T) {
+		line := "10.0.0.1 10.0.0.2"
+		texts := make([]string, 0, 100)
+		for i := 0; i < 100; i++ {
+			texts = append(texts, "10.0.0.1")
+		}
+		ms, idxs := mk(line, texts...)
+		if useIndex(line, ms, idxs) {
+			t.Error("indexing chosen for a line under the byte floor")
+		}
+	})
+
+	t.Run("many distinct values of few lengths: index", func(t *testing.T) {
+		var sb strings.Builder
+		var texts []string
+		for i := 0; i < 2000; i++ {
+			v := fmt.Sprintf("%d.%d.1.2", (i/254)%200+11, i%254+1)
+			texts = append(texts, v)
+			sb.WriteString("host " + v + " ")
+		}
+		line := sb.String()
+		ms, idxs := mk(line, texts...)
+		if !useIndex(line, ms, idxs) {
+			t.Error("rescanning chosen for 2000 distinct values on one line — this is the shape " +
+				"that costs one full line traversal PER VALUE")
+		}
+	})
+
+	t.Run("many matches but one repeated value: rescan", func(t *testing.T) {
+		// The cursor already makes this linear, so indexing would only add allocations.
+		line := strings.Repeat("host 4.4.4.4 ", 2000)
+		texts := make([]string, 0, 2000)
+		for i := 0; i < 2000; i++ {
+			texts = append(texts, "4.4.4.4")
+		}
+		ms, idxs := mk(line, texts...)
+		if useIndex(line, ms, idxs) {
+			t.Error("indexing chosen for ONE repeated value: rescanning is already linear here " +
+				"because the cursor advances past each occurrence")
+		}
+	})
+}


### PR DESCRIPTION
Closes #388

## Gate summary (`make pr-checklist BASE=origin/main`, run after committing and before pushing)

```
=== summary: 10 ran, 0 failed, 5 need manual work ===
1 gofmt / go vet / go build   RAN — clean / clean / ok
2 full suite (-count=1)       RAN — 68 packages ok
3 golden regen                RAN — 0 files changed
11 cross-platform vet         RAN — linux darwin windows
12 flake (3 repeats)          RAN — ./internal/detector
13 race (whole module)        RAN — 68 packages ok
-- -short mode                RAN — ok
-- tree clean                 RAN — this run dirtied nothing
8 web / CSP                   N/A — no web/template/asset file touched
```

All five NEEDS-MANUAL dimensions are completed at the bottom.

## The bug

`ResolveLineSpans` kept its scan cursor keyed per `(line, match TEXT)`, so for a **distinct** value the
cursor was always zero and every match rescanned the line from the start: **O(matches × line length)**.
`AssignLineColumns` calls it after every validator on every scan, and validators that dedup per line
always hit the worst case.

Measured in isolation, one line, two distinct IP-shaped values per repetition:

| matches | line | before | after | |
|---|---|---:|---:|---:|
| 16,000 | 281 KB | 896 ms | **9.5 ms** | 95x |
| 32,000 | 562 KB | 2.43 s | **20.3 ms** | 120x |
| 64,000 | 1.14 MB | 8.14 s | **53.0 ms** | 154x |

End to end through the CLI, best of three at every size, **faster everywhere** — 1.14x at 1,000
repetitions, 2.9x at 8,000, 6.3x at 32,000 — with **no size slower** and identical findings at every
size (8,000 / 16,000 / 32,000 / 63,364).

## Two claims in the existing guard were wrong

The complexity guard for this function documented the shape as accepted. Correcting it in place is part
of the change:

- *"per-validator execution budgets already bound pathological single-line input"* — nothing bounded it.
- *"None of this is visible end-to-end, because validator cost dominates a real scan: through the CLI on
  a dense single-line file the whole change measured +1.7% to +8.9%."* Measured here,
  `ResolveLineSpans` was **8.14s of a 9.64s scan** at 64,000 values — **84% of it**. That fixture never
  reached this shape.

Its third claim was right and is what this does: *"making it linear needs a multi-pattern single pass
over the line, not a tweak."*

## How one pass is enough

Key on value **LENGTH** rather than on value: at each byte, test one candidate substring per distinct
length against a set. The cost stops carrying a factor of the value **count**, which is the term that
made it quadratic.

**Rescanning is kept and stays the default.** `useIndex` estimates both strategies and picks the
cheaper — rescanning costs about one line traversal per distinct value, indexing one per distinct
length — so a line with a handful of matches takes the old path and allocates nothing. For 16,000 IP
addresses of 9 distinct lengths the estimates are ~99 against ~8,000.

The hand-out rules are reproduced exactly, because consumers depend on them and not merely on "some
position": repeated values consume successive occurrences left to right; an occurrence starting before
the previous one ended is skipped, so `aa` in `aaa` yields one occurrence and not two; when exhausted
the first is reused and nothing advances; an absent value leaves `OK=false` rather than a guessed
offset.

## Testing

- **Strategy equivalence is the load-bearing test**: both paths are driven over the same inputs and
  their spans compared field by field — twelve hand-picked shapes covering each rule above, plus a
  400-trial deterministic sweep, since hand-picked cases only cover the shapes I thought of.
- Lines are now grouped in a map and so resolved in **randomised order**; a test asserts the result is
  independent of that order over 25 runs, with a non-vacuity check that two occurrences on one line
  still land on different offsets. This repo has shipped map-order nondeterminism reaching output
  before, so it is pinned rather than reasoned about.
- **Mutation-verified: 7 mutants, 6 killed.** Two needed work:
  - Reverting to always-rescan is caught **only** by a growth bound — the old quadratic cost 148ms at
    K=8000 and sat comfortably inside the existing 4-second ceiling, so it passed for as long as the
    quadratic existed. The distinct-values ratio is now **asserted** where it was logged: **4.1x for 4x
    input**, against 16.2x before.
  - Dropping the per-value pointer into the occurrence list is correctness-neutral but makes hand-out
    O(repeats²). No existing guard covers the shape that exposes it — many distinct values **each**
    repeated many times — so there is a new one. Sizing it took two attempts: at 16 repeats the
    mutation survived, because the walk is only a few hundred thousand steps there. It asserts the
    **absolute** big-case time, because that separates 18x (24ms vs 440ms) where the ratio separates
    only 2.5x, and a ratio of two millisecond samples is where scheduler noise lives.
  - The seventh is equivalent: setting the end offset on the exhausted branch cannot be observed, since
    the pointer is already past the end. The code still mirrors `resolveByRescan` there, and says why.
- `make score`: **PASS, unchanged** — `recall_all=1.0000 recall_hm=0.9948 prec_hm=0.9320
  whole_leak=0`.
- **Union-tested with all nine other open PRs**: pairwise `git merge-tree` all clean, union of ten
  branches builds and passes **70 packages ok**.

## 4 — redaction, every strategy

Column assignment feeds the redaction overlap pass, so the fixture uses a **repeated** value on one
line — the case whose offsets this function exists to distinguish.

| binary | strategy | raw values surviving | output |
|---|---|---:|---|
| parent | `simple` | 0 of 2 | `contact [SSN-REDACTED] and also [SSN-REDACTED] plus [SSN-REDACTED]` |
| this PR | `simple` | 0 of 2 | identical |
| parent | `format_preserving` | 0 of 2 | `contact ***-**-4100 and also ***-**-4100 plus ***-**-9384` |
| this PR | `format_preserving` | 0 of 2 | identical |

## 5 — suppression, generated by the PARENT and applied with MINE

| binary | result |
|---|---|
| parent | `findings=0 suppressed=3` |
| this PR | `findings=0 suppressed=3` |

Identical, so the change does not perturb the suppression hash inputs — which matters because column
assignment runs before suppression.

## 6 — timing / O(n²)

Above. Non-vacuity satisfied (findings > 0 at every size, and the isolated harness asserts every match
resolved) with distinct values.

## 7 — all seven output formats

text, csv, junit, gitlab-sast and **sarif** are **byte-identical** to the parent. json and yaml differ
in exactly one field, `duration_seconds`; findings compare equal. SARIF is the format that carries the
columns, and its regions are unchanged — the two occurrences of the repeated value still get 9-20 and
30-41, the distinction #321 and #328 exist for.

## 10 — non-vacuity

The 7-mutant run above, rather than a revert: it is strictly stronger, and it is what found the two
gaps.
