### PR TITLE
fix(redactors): read image dimensions without decoding, and refuse a pixel bomb

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -958,7 +958,8 @@ Each strategy's behaviour is fixed and takes no options:
 |------|-----------------|
 | `.txt` `.csv` `.json` `.yaml` `.md` `.log` | Direct string replacement |
 | `.docx` `.xlsx` `.pptx` | XML element replacement inside ZIP |
-| `.jpg` `.png` `.tiff` `.gif` `.bmp` `.webp` | EXIF metadata removal only |
+| `.jpg` `.jpeg` `.png` | EXIF metadata removal only, by decode + re-encode; over 64M pixels is refused |
+| `.tiff` `.gif` `.bmp` `.webp` | ⚠️ Not yet implemented |
 | `.pdf` | ⚠️ Not yet implemented |
 
 See the [Redaction Guide](user-guides/README-Redaction.md) for full details including per-validator behaviour and synthetic token formats.

--- a/docs/user-guides/README-Redaction.md
+++ b/docs/user-guides/README-Redaction.md
@@ -93,7 +93,8 @@ ghp_16C7e42F...   →  ghp_ab3pMN5XQuRE  (same ghp_ prefix)
 | Excel | `.xlsx` | Shared strings + cell values inside ZIP |
 | PowerPoint | `.pptx` | Text elements inside ZIP |
 | Legacy Office | `.doc` `.xls` `.ppt` | Same-length in-place overwrite of stream bytes |
-| Images | `.jpg` `.png` `.tiff` `.gif` `.bmp` `.webp` | EXIF metadata removal only |
+| Images | `.jpg` `.jpeg` `.png` | EXIF metadata removal only, by decode + re-encode; images over 64M pixels are refused |
+| Other images | `.tiff` `.gif` `.bmp` `.webp` | ⚠️ Not redactable — **no output file is written** and the run says so |
 | Audio | `.mp3` `.wav` `.m4a` `.flac` | Same-length in-place overwrite of tag metadata |
 | Video | `.mp4` `.m4v` `.mov` | Same-length in-place overwrite of tag metadata; GPS payload zeroed |
 | PDF | `.pdf` | ⚠️ Not redactable — **no output file is written** and the run says so |
@@ -103,14 +104,36 @@ ghp_16C7e42F...   →  ghp_ab3pMN5XQuRE  (same ghp_ prefix)
 > extension or no extension. A `.env` holding a live credential is redacted exactly like
 > a `.txt`.
 >
-> **Note on images**: Only EXIF metadata (GPS, camera info, timestamps) is removed. Text embedded in image pixels is not redacted.
+> **Note on images**: Only EXIF metadata (GPS, camera info, timestamps) is removed. Text embedded
+> in image pixels is not redacted. Only **JPEG and PNG** have an implementation: a `.tiff` `.gif`
+> `.bmp` or `.webp` file with findings produces **no redacted copy**, and the run reports
+> `redaction incomplete … the original values remain in cleartext`, naming the file. An earlier
+> version of this table listed all six extensions as redacted, which was wrong in the dangerous
+> direction — it implied a stripped copy where none is written.
+>
+> Stripping EXIF from a JPEG or PNG works by decoding the pixels and re-encoding them, so peak
+> memory follows the image's **declared** width × height rather than its size on disk. Images over
+> **64M pixels** (2^26 — above every camera sold, including a 61MP full-frame sensor) are therefore
+> refused with the same disclosed warning, because a 4MB file can declare 400M pixels and a large
+> enough declaration would otherwise exhaust memory. One consequence worth knowing: because the
+> pixels are re-encoded, a redacted JPEG is **not** byte-identical to the original outside its
+> metadata.
 >
 > **Note on PDFs**: PDF redaction is on the roadmap. Until then a PDF with findings
 > produces **no redacted copy at all** — not an unchanged copy — and the run reports
-> `redaction incomplete … the original values remain in cleartext`, naming the file. Use
-> `--fail-on-incomplete` to turn that into exit code 3. An earlier version of this table
-> said the file was "copied unchanged", which was worse than wrong: it implied an output
-> file exists at the sanitized path.
+> `redaction incomplete … the original values remain in cleartext`, naming the file. An
+> earlier version of this table said the file was "copied unchanged", which was worse than
+> wrong: it implied an output file exists at the sanitized path.
+>
+> **Note on the exit code for a refusal**: every refusal above is disclosed on the console,
+> but none of them changes the exit code — a run that leaves values in cleartext still exits
+> `0`. `--fail-on-incomplete` does **not** cover this: it reports incomplete *scan* coverage
+> (a validator timeout or budget, or a file that could not be opened), and a refused
+> redaction is a fully scanned file. An earlier version of this page said
+> `--fail-on-incomplete` turned a PDF refusal into exit code 3; measured, it does not. Gate
+> CI on the presence of the warning, or on the redacted file existing, until
+> [#441](https://github.com/awslabs/ferret-scan/issues/441) gives these refusals an exit code
+> of their own.
 >
 > **Note on audio and video**: only the tag metadata is redacted — a comment, artist,
 > title, copyright, camera make and model, software, or GPS position. The audio or video

--- a/internal/redactors/image/pixel_budget_test.go
+++ b/internal/redactors/image/pixel_budget_test.go
@@ -1,0 +1,248 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package image
+
+import (
+	"image"
+	"image/jpeg"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/redactors"
+)
+
+// writeGrayJPEG writes an all-white greyscale JPEG of the given dimensions.
+//
+// Greyscale and uniform so the file stays small relative to its pixel count — which is the whole
+// point of the shape under test: a few kilobytes on disk declaring an enormous decoded size.
+func writeGrayJPEG(t *testing.T, path string, w, h int) {
+	t.Helper()
+	img := image.NewGray(image.Rect(0, 0, w, h))
+	for i := range img.Pix {
+		img.Pix[i] = 0xFF
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create %s: %v", path, err)
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			t.Fatalf("close %s: %v", path, err)
+		}
+	}()
+	if err := jpeg.Encode(f, img, &jpeg.Options{Quality: 90}); err != nil {
+		t.Fatalf("encode %s: %v", path, err)
+	}
+}
+
+// An image declaring more pixels than the budget must be REFUSED, and the refusal must say so.
+//
+// Stripping metadata decodes the pixels and re-encodes them, so peak memory follows the DECLARED
+// width x height — a number out of the file. Measured end to end on a 20000x20000 JPEG that is 4.47MB
+// on disk: 0.77GB of peak RSS before this change, 0.03GB after, because the file is now refused before
+// anything is decoded. Heap grew linearly with the declaration, so a larger one went further until the
+// process was OOM-killed (#378).
+//
+// The dimensions here are declared rather than materialised: the fixture is generated at a size the
+// test can afford, and the budget is lowered for the duration instead. Generating a real 400M-pixel
+// image would cost the test the very memory the change exists to avoid.
+func TestOversizeImageIsRefusedNotDecoded(t *testing.T) {
+	dir := t.TempDir()
+	in := filepath.Join(dir, "big.jpg")
+	out := filepath.Join(dir, "out.jpg")
+
+	// 600x600 = 360,000 pixels, against a budget of 1,000 for this test.
+	writeGrayJPEG(t, in, 600, 600)
+
+	restore := maxRedactablePixels
+	defer func() { maxRedactablePixels = restore }()
+	maxRedactablePixels = 1000
+
+	r := NewImageMetadataRedactor(nil, nil)
+	result, err := r.RedactDocument(in, out, nil, redactors.RedactionSimple)
+
+	if err == nil {
+		t.Fatal("an image past the pixel budget was accepted: peak memory then follows the " +
+			"DECLARED dimensions, which an attacker chooses")
+	}
+	if result != nil {
+		t.Errorf("expected a nil result on refusal, got %+v", result)
+	}
+	// The numbers have to be in the message: an operator needs to know which limit was hit and by
+	// how much, or the only remedy is guesswork.
+	for _, want := range []string{"600x600", "360000", "1000"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("refusal message %q does not mention %q", err.Error(), want)
+		}
+	}
+	// Fail-safe: no output file may survive a refusal, or it would be mistaken for a redacted copy.
+	if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
+		t.Errorf("an output file survived the refusal (stat err = %v) — that is indistinguishable "+
+			"from a successfully redacted document", statErr)
+	}
+}
+
+// The other direction: an image INSIDE the budget must still be redacted.
+//
+// Without this, `return error` unconditionally would pass the test above, and the redactor would stop
+// stripping metadata from every image — a leak dressed as a memory fix.
+func TestImageWithinTheBudgetIsStillRedacted(t *testing.T) {
+	dir := t.TempDir()
+	in := filepath.Join(dir, "ok.jpg")
+	out := filepath.Join(dir, "out.jpg")
+	writeGrayJPEG(t, in, 64, 64)
+
+	r := NewImageMetadataRedactor(nil, nil)
+	result, err := r.RedactDocument(in, out, nil, redactors.RedactionSimple)
+	if err != nil {
+		t.Fatalf("an image well inside the budget was refused: %v", err)
+	}
+	if result == nil || !result.Success {
+		t.Fatalf("expected a successful result, got %+v", result)
+	}
+	if _, statErr := os.Stat(out); statErr != nil {
+		t.Errorf("expected a redacted output file: %v", statErr)
+	}
+}
+
+// The budget must be compared against the DECLARED dimensions, so the check has to happen before any
+// pixel decode. Asserted by allocation, because that is the property that matters and the only one a
+// timing measurement cannot fake: a refusal that still decoded first would be just as slow and just as
+// memory-hungry as no refusal at all.
+func TestRefusalHappensBeforeAnyPixelDecode(t *testing.T) {
+	dir := t.TempDir()
+	in := filepath.Join(dir, "big.jpg")
+	out := filepath.Join(dir, "out.jpg")
+
+	// 2000x2000 = 4M pixels, so a full greyscale decode is ~4MB — an order of magnitude above the
+	// ceiling asserted below, and unmistakable if it happens.
+	writeGrayJPEG(t, in, 2000, 2000)
+
+	restore := maxRedactablePixels
+	defer func() { maxRedactablePixels = restore }()
+	maxRedactablePixels = 1000
+
+	r := NewImageMetadataRedactor(nil, nil)
+
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+
+	_, err := r.RedactDocument(in, out, nil, redactors.RedactionSimple)
+
+	runtime.ReadMemStats(&after)
+	allocated := after.TotalAlloc - before.TotalAlloc
+
+	if err == nil {
+		t.Fatal("the oversize image was not refused, so this measurement is meaningless")
+	}
+
+	const ceiling = 1 << 20 // 1MB; the pixels alone would be ~4MB
+	if allocated > ceiling {
+		t.Errorf("refusing a 4M-pixel image allocated %d bytes (> %d): the pixels are being decoded "+
+			"before the budget is consulted, which is the cost the budget exists to avoid",
+			allocated, ceiling)
+	}
+}
+
+// Reading dimensions must not decode pixels either.
+//
+// extractImageMetadata used image.Decode to read three header fields, so a large image was
+// materialised in full for its width, height and colour model — and then again by the re-encode.
+// Measured: removing this one decode took peak RSS on the 20000x20000 fixture from 0.77GB to 0.40GB,
+// which is what proves the two decodes were both happening.
+func TestMetadataExtractionDoesNotDecodePixels(t *testing.T) {
+	dir := t.TempDir()
+	in := filepath.Join(dir, "big.jpg")
+	writeGrayJPEG(t, in, 2000, 2000) // 4M pixels, ~4MB decoded
+
+	r := NewImageMetadataRedactor(nil, nil)
+
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+
+	meta, err := r.extractImageMetadata(in, FormatJPEG)
+
+	runtime.ReadMemStats(&after)
+	allocated := after.TotalAlloc - before.TotalAlloc
+
+	if err != nil {
+		t.Fatalf("extractImageMetadata: %v", err)
+	}
+
+	// Non-vacuity first: the dimensions must actually have been read, or a function that returned an
+	// empty struct would pass the allocation bound trivially.
+	if meta.Dimensions.Width != 2000 || meta.Dimensions.Height != 2000 {
+		t.Fatalf("dimensions = %dx%d, want 2000x2000 — the header was not read, so the allocation "+
+			"bound below proves nothing", meta.Dimensions.Width, meta.Dimensions.Height)
+	}
+	if meta.ColorModel == "" {
+		t.Error("ColorModel is empty: DecodeConfig reports one, and it is part of reported metadata")
+	}
+
+	const ceiling = 1 << 20 // 1MB; a full decode of 4M greyscale pixels is ~4MB
+	if allocated > ceiling {
+		t.Errorf("reading dimensions allocated %d bytes (> %d): image.Decode is back, so every large "+
+			"image is materialised twice — once for three header fields and once for the re-encode",
+			allocated, ceiling)
+	}
+}
+
+// The shipped budget must stay above real photography, or the fix trades a DoS for refusing ordinary
+// files. 61MP is the largest full-frame sensor sold; phone output is far smaller.
+func TestShippedBudgetAdmitsRealCameras(t *testing.T) {
+	const largestRealSensorPixels = 61_000_000
+	if maxRedactablePixels <= int64(largestRealSensorPixels) {
+		t.Errorf("maxRedactablePixels = %d, which would refuse a %d-pixel photograph from a camera "+
+			"people actually own", maxRedactablePixels, largestRealSensorPixels)
+	}
+	// And it must stay well under the shape it exists to refuse.
+	const bombPixels = 400_000_000
+	if maxRedactablePixels >= int64(bombPixels) {
+		t.Errorf("maxRedactablePixels = %d does not refuse the %d-pixel shape this guards against",
+			maxRedactablePixels, bombPixels)
+	}
+}
+
+// A header DecodeConfig cannot read leaves Dimensions at zero, so the budget is not consulted for
+// that file. That is safe only because the decoder the budget protects reads the same header and
+// fails the same way — this pins that reasoning rather than leaving it as an assumption.
+//
+// The failure must also be fail-safe: no output file may survive, or an unredacted copy would be
+// indistinguishable from a redacted one.
+func TestUnreadableHeaderFailsSafeRatherThanDecoding(t *testing.T) {
+	dir := t.TempDir()
+	in := filepath.Join(dir, "truncated.jpg")
+	out := filepath.Join(dir, "out.jpg")
+
+	// A JPEG SOI marker and nothing else: enough for format detection to route it here, not enough
+	// for either DecodeConfig or Decode.
+	if err := os.WriteFile(in, []byte{0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10}, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	r := NewImageMetadataRedactor(nil, nil)
+
+	// Non-vacuity: the premise is that dimensions really are unknown, which is what makes the
+	// budget a no-op for this file.
+	meta, err := r.extractImageMetadata(in, FormatJPEG)
+	if err != nil {
+		t.Fatalf("extractImageMetadata: %v", err)
+	}
+	if meta.Dimensions.Width != 0 || meta.Dimensions.Height != 0 {
+		t.Fatalf("dimensions = %dx%d, want 0x0 — this test is about the case where the header could "+
+			"not be read, and it no longer exercises it", meta.Dimensions.Width, meta.Dimensions.Height)
+	}
+
+	if _, err := r.RedactDocument(in, out, nil, redactors.RedactionSimple); err == nil {
+		t.Error("a file whose header cannot be decoded was reported as redacted")
+	}
+	if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
+		t.Errorf("an output file survived the failure (stat err = %v)", statErr)
+	}
+}

--- a/internal/redactors/image/redactor.go
+++ b/internal/redactors/image/redactor.go
@@ -53,6 +53,27 @@ type ImageMetadataRedactor struct {
 }
 
 // ImageFormat represents the type of image format
+// maxRedactablePixels bounds the declared width x height of an image this redactor will decode.
+//
+// Stripping metadata from a JPEG or PNG here decodes the pixels and re-encodes them, so peak memory
+// follows the DECLARED dimensions — a number taken from the file. Measured cost of one decode is
+// about 1 byte per pixel for greyscale and nearer 2.5 for colour, so this budget is roughly 64MB to
+// 160MB per image; the worker pool caps concurrency at 8, which bounds the whole run at about 1.3GB
+// rather than at whatever an attacker declares.
+//
+// 64M pixels (2^26) is chosen to sit above every camera that produces files people actually scan —
+// 61MP is the largest full-frame sensor sold, and phone output is far smaller — while refusing the
+// 400M-pixel shape that is trivial to synthesise. An image past it is REFUSED with an error, which
+// removes the output file, so the refusal is visible rather than a silently unredacted copy.
+//
+// Raising it multiplies by 8. Lowering it starts refusing real photographs. Neither is free, which is
+// why the number is stated with its measurement rather than left as a round guess.
+//
+// A var rather than a const only so a test can lower it and exercise the refusal without generating a
+// 400M-pixel fixture — which would cost the test the very memory this exists to avoid. Nothing in
+// production writes it.
+var maxRedactablePixels int64 = 1 << 26
+
 type ImageFormat int
 
 const (
@@ -297,19 +318,31 @@ func (imr *ImageMetadataRedactor) extractImageMetadata(filePath string, format I
 		Metadata: make(map[string]interface{}),
 	}
 
-	// Decode image to get dimensions and color model
-	img, _, err := image.Decode(file)
+	// Read the header for dimensions and colour model. DecodeConfig, NOT Decode: the pixels are
+	// not wanted here, and decoding them is the whole cost.
+	//
+	// image.Decode allocated the full pixel buffer to read three header fields, and the re-encode
+	// below decodes them AGAIN — so a large image was materialised twice. Measured on a 20000x20000
+	// (400M-pixel) JPEG that is 4.47MB on disk: 0.77GB of peak RSS under --enable-redaction, against
+	// 27MB for the same file without it (the default scan path never decodes pixels). Heap scaled
+	// linearly with declared width x height and nothing capped it, so a larger declaration went
+	// further and could OOM the process (#378).
+	//
+	// Verified equivalent before swapping: DecodeConfig reports identical Width, Height and
+	// ColorModel TYPE to a full Decode on the bomb fixture and on four real JPEG/PNG files, and the
+	// colour model reaches reported metadata as fmt.Sprintf("%T", ...) so a difference would have
+	// been visible.
+	cfg, _, err := image.DecodeConfig(file)
 	if err != nil {
 		imr.logEvent("image_decode_failed", false, map[string]interface{}{
 			"error": err.Error(),
 		})
 	} else {
-		bounds := img.Bounds()
 		metadata.Dimensions = ImageDimensions{
-			Width:  bounds.Dx(),
-			Height: bounds.Dy(),
+			Width:  cfg.Width,
+			Height: cfg.Height,
 		}
-		metadata.ColorModel = fmt.Sprintf("%T", img.ColorModel())
+		metadata.ColorModel = fmt.Sprintf("%T", cfg.ColorModel)
 	}
 
 	// Extract EXIF data for supported formats
@@ -381,6 +414,30 @@ func (imr *ImageMetadataRedactor) redactImageMetadata(originalPath, outputPath s
 	}
 
 	var redactionMap []redactors.RedactionMapping
+
+	// Refuse an image whose declared pixel count is past the budget, BEFORE opening anything.
+	//
+	// Stripping metadata here means decoding the pixels and re-encoding them, so peak memory is set
+	// by the DECLARED width x height — a number out of the file, not a real one. Measured on a
+	// 20000x20000 JPEG that is 4.47MB on disk: 0.40GB of resident memory for the single remaining
+	// decode, and heap grows linearly with the declaration, so a larger one goes further until the
+	// process is OOM-killed. An attacker adds a detectable EXIF field to route the file here, which
+	// is what makes it reachable.
+	//
+	// Refusing is what the surrounding code already does for a format it cannot strip safely, and it
+	// inherits that path's guarantee: the error removes the output file, so a refusal can never be
+	// mistaken for a redacted document.
+	if px := int64(metadata.Dimensions.Width) * int64(metadata.Dimensions.Height); px > maxRedactablePixels {
+		imr.logEvent("image_pixel_budget_exceeded", false, map[string]interface{}{
+			"width":  metadata.Dimensions.Width,
+			"height": metadata.Dimensions.Height,
+			"pixels": px,
+			"budget": maxRedactablePixels,
+		})
+		return nil, fmt.Errorf("refusing to redact a %dx%d image: %d pixels is over the %d-pixel "+
+			"budget, and stripping metadata requires decoding them",
+			metadata.Dimensions.Width, metadata.Dimensions.Height, px, maxRedactablePixels)
+	}
 
 	// Open original file
 	originalFile, err := os.Open(originalPath)


### PR DESCRIPTION
## What was wrong

Stripping EXIF from a JPEG or PNG decodes the pixels and re-encodes them, so peak memory follows the image's **declared** width × height — a number taken from the file — and nothing bounded it. Two costs were stacked:

1. `extractImageMetadata` called `image.Decode` to read three header fields (width, height, colour model), materialising the whole pixel buffer for information that lives in the header. The re-encode then decoded it **again**.
2. Nothing checked the declaration before decoding, so a small file could ask for an arbitrarily large allocation.

A 4.5MB file declaring 400M pixels is trivial to synthesise, and an EXIF field is enough to route it to the redactor.

## Measured

Peak RSS on a 20000×20000 greyscale JPEG (4.5MB on disk) under `--enable-redaction`:

| build | peak RSS | real | outcome |
|---|---|---|---|
| `main` | **0.77 GB** | 2.79s | redacted |
| `DecodeConfig` only | **0.40 GB** | — | redacted — proves *both* decodes were happening |
| both changes | **0.03 GB** | 0.04s | refused, disclosed |

RSS on `main` grows linearly with the declared pixel count, with no ceiling — so a larger declaration goes further:

| declared px | main RSS | fix RSS | findings (main = fix) |
|---|---|---|---|
| 36,000,000 | 0.09 GB | 0.06 GB | 5 = 5 |
| 100,000,000 | 0.21 GB | 0.03 GB | 5 = 5 |
| 196,000,000 | 0.39 GB | 0.03 GB | 5 = 5 |
| 400,000,000 | 0.77 GB | 0.03 GB | 5 = 5 |

## The fix

`image.DecodeConfig` instead of `image.Decode`, plus a **64M-pixel (2²⁶)** budget checked before either file is opened. Both `jpeg.Decode` and `png.Decode` sit behind that one check — they are the only two decoders in the package.

The budget sits above every camera producing files people actually scan (61MP is the largest full-frame sensor sold) and well under the 400M-pixel shape. An image past it is **refused**, taking the path the redactor already uses for a format it cannot strip safely — which removes the output file, so a refusal can never be mistaken for a redacted copy:

```
WARNING: redaction incomplete — 1 of 1 file(s) have findings but no redacted copy was
written; the original values remain in cleartext:
  b20000.jpg: failed to redact image metadata: refusing to redact a 20000x20000 image:
  400000000 pixels is over the 67108864-pixel budget, and stripping metadata requires
  decoding them
```

## Non-vacuity

"Refuse everything" would also make the numbers look good, so both directions are pinned:

- A 6000×6000 (36M px) image is **under** the budget and is still redacted, to a **byte-identical** output to `main` (sha `ae3dd34f064467f9`), EXIF stripped.
- 400 ordinary photographs **with distinct EXIF values**: 400 of 400 redacted on both builds, `total_findings` **370 / 740 / 1480** at N=100/200/400 — exactly 2× and 4×, identical between `main` and this branch. Timing linear (3.39× main, 3.22× fix for 4× input), and this branch is ~20% **faster** because the second decode is gone.
- Detection output cannot change: `extractImageMetadata` is confined to this package and `Dimensions`/`ColorModel` never leave it. `DecodeConfig` was verified to report identical Width, Height and ColorModel type to a full `Decode` on the bomb fixture and on four real JPEG/PNG files.

## Tests

Six tests, asserting by **allocation** rather than timing — a refusal that decoded first would be just as expensive as no refusal, and only an allocation bound catches that. They cover the refusal and the numbers in its message, that an under-budget image is still redacted, that neither the refusal nor metadata extraction decodes pixels, that the shipped budget stays between a 61MP sensor and the 400M-pixel shape, and that an unreadable header fails safe rather than reaching a decoder with dimensions unknown.

The budget is a `var` rather than a `const` only so a test can lower it and exercise the refusal without generating a 400M-pixel fixture, which would cost the test the very memory this exists to avoid. Nothing in production writes it.

**Mutation-tested — all four killed:** reverting `DecodeConfig` → `Decode`; deleting the budget check; inverting it to refuse everything; lowering the budget below a real sensor.

Under **parent semantics** (both behaviours reverted, symbol kept so it compiles) the 3 tests asserting new behaviour fail and the 3 regression/pin guards pass — which is the intended shape.

## Docs

Second commit corrects two pre-existing claims, both wrong in the dangerous direction:

1. Both file-type tables listed `.jpg .png .tiff .gif .bmp .webp` as "EXIF metadata removal only". Only JPEG and PNG have an implementation — a TIFF with findings produces **no redacted copy** (verified on a real TIFF; GIF and BMP take the same path, since only `image/jpeg` and `image/png` are registered).
2. The Redaction Guide said `--fail-on-incomplete` turned a PDF refusal into exit code 3. **Measured, it does not** — a real 14KB PDF with 3 findings and no redacted copy exits `0`. The reason is structural: `resolveIncompleteExitCode` is a function of scan coverage only, and a refused redaction is a fully *scanned* file. Filed as #441.

Also notes that the re-encode means a redacted JPEG is not byte-identical to the original outside its metadata (23051 → 22875 bytes on a sample photograph).

## Test plan

`make pr-checklist BASE=origin/main`

```
=== summary: 10 ran, 0 failed, 5 need manual work ===
1 gofmt / go vet / go build      RAN — clean / clean / ok
2 full suite (-count=1)          RAN — 68 packages ok
3 golden regen                   RAN — 0 files changed
8 web / CSP                      N/A — no web/template/asset file touched
11 cross-platform vet            RAN — linux darwin windows
12 flake (3 repeats)             RAN — ./internal/redactors/image
13 race (whole module)           RAN — 68 packages ok
-- -short mode / tree clean      RAN — ok / dirtied nothing
```

The five manual dimensions, all completed:

| # | dimension | result |
|---|---|---|
| 4 | redaction, every strategy | `simple`, `format_preserving`, `synthetic` × {txt, ordinary jpg, under-budget jpg, bomb}: no cleartext anywhere, bomb refused under all three. `.docx` verified by unzipping the part — `SSN ***-**-4100` inside `word/document.xml` (grepping the compressed bytes returns 0 either way) |
| 5 | suppression | generated by the **parent** binary (4 rules, enabled), applied by mine: 4 findings → 0, identical to the parent applying its own |
| 6 | timing / O(n²) | N/2N/4N at 100/200/400 files with **distinct** EXIF values, findings floor `total_findings` 370/740/1480 (exactly 2×/4×) — linear, and faster than main at every N. Plus the declared-pixel curve above, with findings > 0 at every size |
| 7 | all 7 formats | text, json, yaml, csv, junit, gitlab-sast, sarif — all valid and non-empty for **both** the refused and the redacted image; findings identical between the two, so the refusal touches only the write path |
| 10 | non-vacuity | mutation tests above, plus the parent-semantics run |

**Union:** merged with all 10 open PRs (#425–#428, #430, #433, #435, #437, #439, #440) — 0 pairwise conflicts, union builds, gofmt clean, vet clean, **70 packages pass**.

Closes #378
Refs #441
