### PR TITLE
fix(phone): stop reading a decimal fraction as an international dialing prefix

### DIFF
--- a/internal/validators/phone/decimal_fraction_test.go
+++ b/internal/validators/phone/decimal_fraction_test.go
@@ -37,8 +37,14 @@ func TestDecimalFractionIsNotAPhoneNumber(t *testing.T) {
 		{"csv coordinate pair, other fraction", "35.009 31.354"},
 		{"four-decimal precision", "32.0078 31.3992"},
 		{"svg path attribute", `<path d="M32.6982,23.9008 C33.0592,24.3698 32.0078 31.3992"/>`},
-		{"geojson coordinates", `{"coordinates":[[-122.0078,31.3992],[-122.0091,31.4002]]}`},
 		{"leading zero run", "1.0012 34.5678"},
+
+		// This row is a SHAPE GUARD, not a regression test: a comma-separated GeoJSON
+		// array already reported nothing on the parent commit, because the pattern
+		// wants whitespace between the groups. It is kept so that a future widening of
+		// the separator set cannot quietly admit the comma form, but it does not
+		// discriminate this fix -- the five rows above do.
+		{"geojson coordinates (shape guard only)", `{"coordinates":[[-122.0078,31.3992],[-122.0091,31.4002]]}`},
 	}
 
 	for _, c := range cases {

--- a/internal/validators/phone/decimal_fraction_test.go
+++ b/internal/validators/phone/decimal_fraction_test.go
@@ -1,0 +1,172 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package phone
+
+import (
+	"strings"
+	"testing"
+)
+
+// A decimal number's FRACTIONAL digits must not be read as the start of a phone
+// number.
+//
+// isEmbeddedInIdentifierAt treated '[a-z] [A-Z] [0-9] - _' as evidence of
+// embedding but not '.', so a match was allowed to begin immediately after a
+// decimal point. "35.008 31.354" matched as "008 31.354", and because a leading
+// "00" reads as an international dialing prefix it scored HIGH 100 -- higher than
+// a real "Phone: 415-555-0132", which scores 15.
+//
+// Measured on the public AWS Architecture Icons package (1,842 .svg, 4,012 files)
+// before this guard: 15,514 findings, 13,790 of them HIGH, essentially all PHONE
+// claiming ".00xx" path coordinates. SVG path data carries four decimal places so
+// ".00xx" turns up in about 1% of coordinates. After: 1,463 / 1,270, and the
+// entire remainder is a DIFFERENT defect (a "@5x" filename read as an email
+// address, #444) rather than anything this arm governs.
+func TestDecimalFractionIsNotAPhoneNumber(t *testing.T) {
+	v := NewValidator()
+
+	// Every case here is a real content shape, not an invented one: bare coordinate
+	// pairs as they appear in a CSV, an SVG path attribute copied from a stock icon,
+	// and a GeoJSON coordinates array.
+	cases := []struct {
+		name string
+		line string
+	}{
+		{"csv coordinate pair", "35.008 31.354"},
+		{"csv coordinate pair, other fraction", "35.009 31.354"},
+		{"four-decimal precision", "32.0078 31.3992"},
+		{"svg path attribute", `<path d="M32.6982,23.9008 C33.0592,24.3698 32.0078 31.3992"/>`},
+		{"geojson coordinates", `{"coordinates":[[-122.0078,31.3992],[-122.0091,31.4002]]}`},
+		{"leading zero run", "1.0012 34.5678"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			matches, err := v.ValidateContent(c.line, "geo.csv")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) != 0 {
+				got := make([]string, 0, len(matches))
+				for _, m := range matches {
+					got = append(got, m.Text)
+				}
+				t.Errorf("a decimal fraction was reported as a phone number: %s\n  matched %v\n"+
+					"  the fractional digits of a number are not a dialing prefix, and reporting them "+
+					"at HIGH means over-redaction of ordinary coordinate data", c.line, got)
+			}
+		})
+	}
+}
+
+// The other direction, and the reason the guard is not simply "a '.' before the
+// match means embedded".
+//
+// DOTTED PHONE NOTATION puts the match immediately after a digit and a '.' too:
+// in "1.415.555.0132" the reported match is "415.555.0132", preceded by '.'
+// preceded by '1'. A guard keyed on the neighbour alone would delete it, and
+// because only reported findings reach the redactor that would leave a real
+// number in cleartext -- trading a false positive for a leak.
+//
+// The discriminator is the separator after the match's first digit group: a
+// dotted number continues with dots, whereas "008 31.354" changes separator
+// immediately, which is what shows it has run out of one number and across a
+// boundary into the next.
+func TestDottedAndInternationalPhonesStillReport(t *testing.T) {
+	v := NewValidator()
+
+	cases := []struct {
+		name string
+		line string
+	}{
+		{"dotted, with a country code", "1.415.555.0132"},
+		{"dotted, with a country code and label", "Phone: 1.415.555.0132"},
+		{"dotted, bare", "415.555.0132"},
+		{"dotted, mid sentence", "Tel 1.415.555.0132 ext 4"},
+		{"plus international", "+44 20 7946 0958"},
+		{"00 international prefix", "0044 20 7946 0958"},
+		{"001 international prefix", "001 415 555 0132"},
+		{"labelled NANP", "Phone: 415-555-0132"},
+		{"parenthesised NANP", "Phone: (415) 555-0132"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			matches, err := v.ValidateContent(c.line, "directory.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) == 0 {
+				t.Errorf("a real phone number stopped being reported: %s\n  only reported findings "+
+					"reach the redactor, so suppressing this leaves the number in cleartext", c.line)
+			}
+		})
+	}
+}
+
+// isDecimalFractionTail is unit-tested directly, because the interesting cases are
+// boundary conditions that are awkward to reach through a whole validator run and
+// easy to get wrong in the direction that deletes findings.
+func TestIsDecimalFractionTail(t *testing.T) {
+	cases := []struct {
+		name  string
+		line  string
+		match string
+		want  bool
+	}{
+		// The defect: the match is the fraction of "35.008" and runs on into the next number.
+		{"fraction then space", "35.008 31.354", "008 31.354", true},
+		{"fraction, all digits", "35.008", "008", true},
+
+		// Dotted phone notation: same neighbour, must NOT be treated as embedded.
+		{"dotted phone after country code", "1.415.555.0132", "415.555.0132", false},
+
+		// Not a decimal point at all.
+		{"no digit before the dot", "v.4155550132", "4155550132", false},
+		{"dot at line start", ".4155550132", "4155550132", false},
+
+		// matchIndex < 2 cannot have "digit dot" before it.
+		{"match at index 0", "4155550132", "4155550132", false},
+		{"match at index 1", ".4155550132"[1:], "4155550132", false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			idx := strings.Index(c.line, c.match)
+			if idx < 0 {
+				t.Fatalf("test setup: %q does not contain %q", c.line, c.match)
+			}
+			if got := isDecimalFractionTail(c.line, idx, c.match); got != c.want {
+				t.Errorf("isDecimalFractionTail(%q, %d, %q) = %v, want %v",
+					c.line, idx, c.match, got, c.want)
+			}
+		})
+	}
+}
+
+// The false positive outranked the true positive, which is why this is a HIGH-band
+// defect and not a cosmetic one: a coordinate scored 100 while a labelled phone
+// number scored 15. This pins the ordering rather than either absolute number, so
+// it survives a future rebalance of the confidence table.
+func TestARealPhoneOutranksNothingItShouldNot(t *testing.T) {
+	v := NewValidator()
+
+	real, err := v.ValidateContent("Phone: 415-555-0132", "directory.txt")
+	if err != nil {
+		t.Fatalf("ValidateContent: %v", err)
+	}
+	if len(real) == 0 {
+		t.Fatal("the labelled phone number is not reported at all, so there is no ordering to check")
+	}
+
+	coord, err := v.ValidateContent("35.008 31.354", "geo.csv")
+	if err != nil {
+		t.Fatalf("ValidateContent: %v", err)
+	}
+	if len(coord) != 0 {
+		t.Fatalf("the coordinate is still reported at %.0f%% while the real number is at %.0f%% -- "+
+			"a false positive must never outrank a true one",
+			coord[0].Confidence, real[0].Confidence)
+	}
+}

--- a/internal/validators/phone/validator.go
+++ b/internal/validators/phone/validator.go
@@ -1464,6 +1464,26 @@ func (v *Validator) isEmbeddedInIdentifierAt(match, line string, matchIndex int)
 			return false
 		}
 
+		// A '.' before the match can be a decimal point, in which case the match has
+		// claimed the FRACTIONAL digits of a number and read them as the start of a
+		// phone number. "35.008 31.354" matched as "008 31.354": the leading "00"
+		// reads as an international dialing prefix, which scores HIGH 100 -- higher
+		// than a real "Phone: 415-555-0132", which scores 15.
+		//
+		// Measured on the public AWS Architecture Icons package (1,842 .svg, 4,012
+		// files): 15,514 findings, 13,790 of them HIGH, essentially all PHONE
+		// claiming ".00xx" path coordinates. SVG path data carries four decimal
+		// places, so ".00xx" turns up in roughly 1% of coordinates. The same shape
+		// hits GeoJSON, coordinate CSVs and telemetry dumps.
+		//
+		// This is also the stated reason embedded .svg parts are excluded from
+		// scanning (internal/embedded/embedded.go), which makes a value in an
+		// embedded SVG a cleartext leak (#314) -- so the exclusion is downstream of
+		// this arm.
+		if charBefore == '.' && isDecimalFractionTail(line, matchIndex, match) {
+			return true
+		}
+
 		// If the character before is alphanumeric or common identifier separators, this phone is embedded
 		if (charBefore >= 'a' && charBefore <= 'z') ||
 			(charBefore >= 'A' && charBefore <= 'Z') ||
@@ -1711,6 +1731,45 @@ func isWordByteASCII(b byte) bool {
 // (ami-050451375729, i-057034242931) is right, but it also swallowed every
 // number written the way North American numbers are dictated. A resource prefix
 // is alphabetic or multi-character; a bare single "1" is not one.
+// isDecimalFractionTail reports whether a match starting at matchIndex, whose
+// preceding character is '.', is the fractional tail of a decimal number rather
+// than the start of a phone number written with dots.
+//
+// The '.' must be a real decimal point -- a digit immediately before it -- so a
+// sentence-ending period is excluded (there charBefore is the space, not the '.')
+// and so is a bare ".5551234", which has no number in front of it.
+//
+// The discriminator against DOTTED PHONE NOTATION is the separator that follows
+// the match's first digit group. A dotted number continues with dots, so in
+// "1.415.555.0132" the match "415.555.0132" runs on in the same style and is a
+// phone; whereas in "35.008 31.354" the match "008 31.354" changes separator
+// immediately, which means it has run out of the number it started in and across
+// a boundary into the next one. Getting this wrong in the permissive direction
+// would silently drop "1.415.555.0132", so the exception is deliberate and is
+// pinned by a test.
+func isDecimalFractionTail(line string, matchIndex int, match string) bool {
+	// A digit must sit immediately before the '.', or it is not a decimal point.
+	if matchIndex < 2 {
+		return false
+	}
+	if d := line[matchIndex-2]; d < '0' || d > '9' {
+		return false
+	}
+
+	// Find the separator after the match's first run of digits. A match that is
+	// all digits has no separator and is a plain fractional tail.
+	for i := 0; i < len(match); i++ {
+		c := match[i]
+		if c >= '0' && c <= '9' {
+			continue
+		}
+		// Same-style continuation: still inside one dotted number, so treat the
+		// match as a phone and let the later arms judge it.
+		return c != '.'
+	}
+	return true
+}
+
 func isNANPCountryCodePrefix(line string, dashAt int) bool {
 	if dashAt <= 0 || dashAt >= len(line) || line[dashAt] != '-' {
 		return false


### PR DESCRIPTION
## What was wrong

`isEmbeddedInIdentifierAt` treats `[a-z] [A-Z] [0-9] - _` as evidence that a match sits inside an identifier — but not `.`. So a match was allowed to begin immediately after a decimal point and claim the **fractional digits** of a number:

```
35.008 31.354   ->  matched "008 31.354"  ->  PHONE HIGH 100.00%
```

The leading `00` reads as an international dialing prefix, which is what earns the 100. Meanwhile a real, labelled number scores 15:

```
Phone: 415-555-0132  ->  PHONE LOW 15.00%
```

**The false positive outranked the true positive by 85 points.** Since a HIGH finding drives redaction, ordinary coordinate data was being overwritten.

## Measured on real files

The public AWS Architecture Icons package (1,842 `.svg`, 4,012 files):

| build | files | total | high | medium | low |
|---|---|---|---|---|---|
| `main` | 4012 | 15,514 | **13,790** | 1,021 | 703 |
| this branch | 4012 | 1,463 | **1,270** | 113 | 80 |

A 90.8% reduction in findings and in HIGH. Real matched text from a stock icon: `0078 31.3992`, out of path data `M32.6982,23.9008 C33.0592,…`. SVG path data carries four decimal places, so `.00xx` turns up in roughly 1% of coordinates.

The entire 1,270 remainder is a **different** defect, filed as #444: a `@5x` retina filename is read as an email address, because the image preprocessor injects `FileName`/`FilePath` into the scanned text. Nothing in the remainder is governed by this arm.

**Not SVG-specific.** The reproduction above is a plain `.csv`; the same shape hits GeoJSON, coordinate CSVs and telemetry dumps.

## What it was destroying

Redacting a 3-row coordinate CSV on `main`, all three strategies:

| strategy | `main` output | this branch |
|---|---|---|
| `simple` | `alpha,35.[PHONE-REDACTED]` | no findings, no file written |
| `format_preserving` | `alpha,35.*** *1.354` | no findings, no file written |
| `synthetic` | `alpha,35.555 16.250` | no findings, no file written |

The `synthetic` row is the worst of the three: a real coordinate is silently replaced with a **plausible but false** one, which a downstream consumer cannot detect.

## Why the guard is not simply "a `.` before the match means embedded"

Dotted phone notation puts the match after a digit and a `.` too. In `1.415.555.0132` the reported match is `415.555.0132`, preceded by `.` preceded by `1`. A guard keyed on the neighbour alone would delete it — and because only reported findings reach the redactor, that trades a false positive for a **cleartext leak**.

`isDecimalFractionTail` discriminates on the separator after the match's first digit group. A dotted number continues with dots, so `415.555.0132` is a phone; `008 31.354` changes separator immediately, which shows it has run out of one number and crossed into the next. The `.` must also be a real decimal point (a digit immediately before it), which excludes a sentence-ending period — there `charBefore` is the space — and a bare `.5551234`.

Every one of these still reports, at **confidence identical to main**: `1.415.555.0132`, `Phone: 1.415.555.0132`, `415.555.0132`, `Tel 1.415.555.0132 ext 4`, `+44 20 7946 0958`, `0044 20 7946 0958`, `001 415 555 0132`, `Phone: 415-555-0132`, `Phone: (415) 555-0132`.

## Relationship to #314

This flood is the stated justification for excluding embedded `.svg` from scanning (`internal/embedded/embedded.go:169-196`), which makes a value inside an embedded SVG a cleartext leak (#314). This PR removes the reason for that exclusion, so #314 becomes tractable — though the better fix there is an SVG-aware extractor that emits `<text>`/`<title>`/`<desc>` and drops `d=`/`points=`/`transform=`, rather than admitting the whole file. I will revise #314 to say so.

Worth flagging for whoever picks it up: the example path strings quoted in that comment (`43.5968 15.4721 …`) produce **zero** findings even on `main`, because their fractions do not begin `00`. The flood is real; those illustrations are not reproducible, and probing with them alone would suggest the bug is dead.

## Tests

Four tests. Under **parent behaviour** (arm removed, helper retained so it compiles), five of six negative rows fail with real assertions plus the ordering test:

```
--- FAIL: TestDecimalFractionIsNotAPhoneNumber/csv_coordinate_pair
    a decimal fraction was reported as a phone number: 35.008 31.354
--- FAIL: TestARealPhoneOutranksNothingItShouldNot
    the coordinate is still reported at 85% while the real number is at 15%
```

The sixth negative row is labelled in the test as a **shape guard only** — a comma-separated GeoJSON array already reported nothing on the parent, so it does not discriminate this fix. Labelling it rather than deleting it keeps the guard against a future widening of the separator set without overstating the evidence.

`isDecimalFractionTail` is also unit-tested directly on its boundary conditions, including the dotted-phone exception and `matchIndex < 2`.

**Mutation-tested, all four killed:** deleting the arm; making it unconditional (which deletes dotted numbers); inverting the separator test; dropping the digit-before-the-dot check.

**Zero golden delta is genuine, not vacuity:** no golden *input* fixture contains a coordinate pair — the 70 files matching `.00x` are all `0.000` timing/confidence values in golden *outputs*. The corpus is structurally blind to this class, so the real corpus above was the only gate. A coordinate fixture is worth adding later.

## Test plan

`make pr-checklist BASE=origin/main`

```
=== summary: 10 ran, 0 failed, 5 need manual work ===
1 gofmt / go vet / go build      RAN — clean / clean / ok
2 full suite (-count=1)          RAN — 69 packages ok
3 golden regen                   RAN — 0 files changed
8 web / CSP                      N/A — no web/template/asset file touched
11 cross-platform vet            RAN — linux darwin windows
12 flake (3 repeats)             RAN — ./internal/validators/phone
13 race (whole module)           RAN — 69 packages ok
-- -short mode / tree clean      RAN — ok / dirtied nothing
```

All five manual dimensions completed:

| # | dimension | result |
|---|---|---|
| 4 | redaction, every strategy | the destruction table above; on this branch no coordinate file produces findings, so no file is written. `simple`/`format_preserving`/`synthetic` all verified |
| 5 | suppression | 3 rules generated by the **parent** binary and enabled, applied by mine: 3 findings → 0, identical to the parent applying its own |
| 6 | timing / O(n²) | N/2N/4N at 2000/4000/8000 rows, each row carrying a **distinct** phone *and* a distinct `00`-fraction coordinate. Findings floor 2000/4000/8000 — exactly linear. Growth 3.19× for 4× input (main 3.45×). `main` reports exactly **2×** the findings at every N: one real phone plus one coordinate FP per row |
| 7 | all 7 formats | text, json, yaml, csv, junit, gitlab-sast, sarif — all valid and non-empty on a real-phone file, all correctly empty on a coordinate file |
| 10 | non-vacuity | parent-behaviour run above, plus the four mutations |

**Union:** there are **0 other open PRs**, so there is nothing to union against. Merge-base is `3c4e10b`, which is current `origin/main`.

Closes #443
Refs #314, #444
