### PR TITLE
chore(brew): update the Homebrew formula to 2.3.4

### DIFF
--- a/HomebrewFormula/ferret-scan.rb
+++ b/HomebrewFormula/ferret-scan.rb
@@ -5,41 +5,41 @@
 class FerretScan < Formula
   desc "Find and redact sensitive data before it leaks — PII, secrets, credit cards, metadata"
   homepage "https://github.com/awslabs/ferret-scan"
-  version "2.3.2"
+  version "2.3.4"
   license "Apache-2.0"
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/awslabs/ferret-scan/releases/download/v2.3.2/ferret-scan_2.3.2_darwin_amd64"
-      sha256 "e4df3df9e3a9d3d1358ec58f58b1bbe7a573bc17d95b94e9d7362a959a39f539"
+      url "https://github.com/awslabs/ferret-scan/releases/download/v2.3.4/ferret-scan_2.3.4_darwin_amd64"
+      sha256 "05008fb9d6ba2c871d361047f687fa89cd4a944d20f71c8464486f330387e4d2"
 
       define_method(:install) do
-        bin.install "ferret-scan_2.3.2_darwin_amd64" => "ferret-scan"
+        bin.install "ferret-scan_2.3.4_darwin_amd64" => "ferret-scan"
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/awslabs/ferret-scan/releases/download/v2.3.2/ferret-scan_2.3.2_darwin_arm64"
-      sha256 "808fc46d20296cb12f8f6fbc89e0920bb4a45953a9f010b4aa876b720b488108"
+      url "https://github.com/awslabs/ferret-scan/releases/download/v2.3.4/ferret-scan_2.3.4_darwin_arm64"
+      sha256 "f9f7652cc695a2d1ba97fdf127e83de72a761b6c9b56bbbe062415a317f456c6"
 
       define_method(:install) do
-        bin.install "ferret-scan_2.3.2_darwin_arm64" => "ferret-scan"
+        bin.install "ferret-scan_2.3.4_darwin_arm64" => "ferret-scan"
       end
     end
   end
 
   on_linux do
     if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
-      url "https://github.com/awslabs/ferret-scan/releases/download/v2.3.2/ferret-scan_2.3.2_linux_amd64"
-      sha256 "992220e9a34da5b203d14d7c2e7afcb86d3cdd8d7a72de025f4cf331cd9dd3fc"
+      url "https://github.com/awslabs/ferret-scan/releases/download/v2.3.4/ferret-scan_2.3.4_linux_amd64"
+      sha256 "558f208c7e3383d1df7d995b59baa299f74b631d800f8dbdb85cd07c6c990876"
       define_method(:install) do
-        bin.install "ferret-scan_2.3.2_linux_amd64" => "ferret-scan"
+        bin.install "ferret-scan_2.3.4_linux_amd64" => "ferret-scan"
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/awslabs/ferret-scan/releases/download/v2.3.2/ferret-scan_2.3.2_linux_arm64"
-      sha256 "e05e03bbee00fbe72b64b4c8dba4d9fc3b01267f82700e42555da59272bf2098"
+      url "https://github.com/awslabs/ferret-scan/releases/download/v2.3.4/ferret-scan_2.3.4_linux_arm64"
+      sha256 "bb7a21b8e3dd876e2ac11b61631f6c659025b685395a053c69c5416e441af643"
       define_method(:install) do
-        bin.install "ferret-scan_2.3.2_linux_arm64" => "ferret-scan"
+        bin.install "ferret-scan_2.3.4_linux_arm64" => "ferret-scan"
       end
     end
   end


### PR DESCRIPTION
Generated by goreleaser during the v2.3.4 release, then opened by hand because the release could not open it itself.

## Why this is a manual PR

`#425` switched the formula from a direct push to main over to a pull request, which is correct — main is protected, and the direct push had failed v2.3.3 with:

```
could not update "HomebrewFormula/ferret-scan.rb": 409
Could not update file: Changes must be made through a pull request.
```

The v2.3.4 release got one step further and then failed on a different thing:

```
pushing   repository=awslabs/ferret-scan branch=chore/brew-formula-2.3.4 file=HomebrewFormula/ferret-scan.rb
opening pull request   base=awslabs:ferret-scan:main head=awslabs:ferret-scan:chore/brew-formula-2.3.4
⨯ release failed after 1m57s
  * homebrew formula: could not create pull request:
    POST https://api.github.com/repos/awslabs/ferret-scan/pulls: 403 Resource not accessible by integration
```

The branch and the formula were written correctly; only the PR creation was refused. `.github/workflows/release.yml` grants the job `contents: write` and `packages: write`, but opening a pull request needs `pull-requests: write`. That is a gap in #425 and is fixed separately so the next release completes on its own.

## What this contains

Exactly what goreleaser generated — `version "2.3.4"` plus the four platform `sha256` values computed from the published v2.3.4 assets. Not hand-edited.

## Effect

`brew install` currently serves **2.3.2**, because v2.3.3's release failed before writing the formula and v2.3.4's failed at the PR step. Merging this moves it to **2.3.4**, which carries 14 commits of fixes including a memory-exhaustion refusal (#442) and two denial-of-service fixes (#423, #440).

## Verification

The `brew install + smoke (macos)` job was skipped on both failed releases because it depends on the goreleaser job. It downloads the generated formula as a workflow artifact and installs it from a throwaway local tap, so it validates the formula independently of whether this commit has landed — it will run on this PR.