### PR TITLE
fix(release): grant the release job pull-requests: write, so the formula PR can open

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,25 @@ on:
 permissions:
   contents: write
   packages: write
+  # Needed because #425 switched the Homebrew formula from a direct push to main
+  # over to a pull request. A workflow that declares a permissions block gets NONE
+  # for every scope it does not list -- not the repository default -- so omitting
+  # this made `pull-requests` none, and goreleaser's PR step failed the v2.3.4
+  # release after the assets were already published:
+  #
+  #	pushing              branch=chore/brew-formula-2.3.4 file=HomebrewFormula/ferret-scan.rb
+  #	opening pull request base=awslabs:ferret-scan:main head=awslabs:ferret-scan:chore/brew-formula-2.3.4
+  #	release failed after 1m57s
+  #	  * homebrew formula: could not create pull request:
+  #	    POST https://api.github.com/repos/awslabs/ferret-scan/pulls:
+  #	    403 Resource not accessible by integration
+  #
+  # "Resource not accessible by integration" is the missing-scope signature. The
+  # separate org policy that forbids Actions from creating pull requests reports
+  # itself differently -- "GitHub Actions is not permitted to create or approve pull
+  # requests" -- so if THAT message appears on a future release, this line is not the
+  # remedy and the tap has to move to its own repository instead.
+  pull-requests: write
 
 jobs:
   goreleaser:


### PR DESCRIPTION
## What happened

Two releases in a row published their assets and then failed on the Homebrew formula, for two different reasons.

**v2.3.3** — direct push to a protected main:

```
homebrew formula: could not update "HomebrewFormula/ferret-scan.rb": 409
Could not update file: Changes must be made through a pull request.
```

#425 fixed that by switching to a pull request. **v2.3.4** then got one step further:

```
pushing              branch=chore/brew-formula-2.3.4 file=HomebrewFormula/ferret-scan.rb
opening pull request base=awslabs:ferret-scan:main head=awslabs:ferret-scan:chore/brew-formula-2.3.4
⨯ release failed after 1m57s
  * homebrew formula: could not create pull request:
    POST https://api.github.com/repos/awslabs/ferret-scan/pulls:
    403 Resource not accessible by integration
```

([run 32532641827](https://github.com/awslabs/ferret-scan/actions/runs/32532641827))

## Cause

`release.yml` declares its own `permissions:` block. A declared block gives **none** for every scope it does not list — it does not fall back to the repository default. The block was:

```yaml
permissions:
  contents: write
  packages: write
```

So `contents: write` let goreleaser create the branch and write the formula (both succeeded), while `pull-requests` was `none` and the POST was refused. This adds `pull-requests: write` and nothing else.

## State this leaves things in

| | v2.3.3 | v2.3.4 |
|---|---|---|
| assets published | yes | yes, 7 |
| formula written | no | yes, on `chore/brew-formula-2.3.4` |
| formula PR opened | n/a | no |
| brew smoke job | skipped | skipped |

`brew install` still serves **2.3.2**. #447 opens the v2.3.4 formula by hand to fix that now; this PR is what stops the next release needing a human.

The `brew install + smoke (macos)` job was skipped both times because it depends on the goreleaser job. It installs the generated formula from a throwaway local tap, so it will validate future releases once goreleaser stops exiting 1.

## What I could not verify, and how you will know

There is a **second, independent gate** I cannot read: an org-level policy can forbid Actions from creating pull requests at all. `gh api orgs/awslabs/actions/permissions/workflow` returns 403 for me (needs org admin).

I am confident this is not that gate, on the error string: the policy reports itself as *"GitHub Actions is not permitted to create or approve pull requests"*, whereas `Resource not accessible by integration` is the missing-scope signature. `can_approve_pull_request_reviews: False` on the repo governs **approvals**, not creation.

If the org message does appear on a future release, this line is not the remedy — the tap would need to move to its own repository (`awslabs/homebrew-ferret-scan`), where writing the formula needs no PR at all. That contingency is recorded in a comment beside the permission so the next person does not have to re-derive it.

## Test plan

Nothing to run locally — this is a workflow permission. Validated as far as it can be off a release:

- `release.yml` still parses as YAML.
- Scope reasoning verified against the two observed failures rather than assumed: `contents: write` demonstrably sufficed for the branch push and the asset upload (both succeeded in run 32532641827), and the only refused call was `POST /pulls`.
- The real proof is the next tagged release completing without a manual PR. Until one runs, this is unproven by construction, and the commit message says so.

Refs #425