### PR TITLE
fix(cli): disclose an unredacted file in every output format, and let CI gate on it

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2262,17 +2262,27 @@ func main() {
 	// thing eventually disagree.
 	consideredFiles := len(filesToProcess) + len(discoveryUnexamined) + totalSkipped
 
+	// The unredacted disclosure, built ONCE and used by the stats counters, the
+	// structured formatter field and the text footer below.
+	//
+	// Counted over unsuppressedMatches — the slice the formatters actually render — so
+	// the "values in cleartext" number cannot disagree with the rows beneath it. Using
+	// allMatches would count suppressed findings as exposure and overstate it.
+	unredactedDisclosure := toFormatterUnredacted(unredactedFiles, unsuppressedMatches)
+
 	formatterOptions.Stats = &formatters.ScanStats{
-		TotalFiles:       consideredFiles,
-		FilesProcessed:   scannedFiles,
-		FilesSkipped:     finalSkippedCount,
-		FilesNotExamined: len(unscannedEntries),
-		TotalFindings:    len(unsuppressedMatches),
-		High:             highCount,
-		Medium:           mediumCount,
-		Low:              lowCount,
-		Suppressed:       suppressedCount,
-		Duration:         elapsed.Seconds(),
+		TotalFiles:        consideredFiles,
+		FilesProcessed:    scannedFiles,
+		FilesSkipped:      finalSkippedCount,
+		FilesNotExamined:  len(unscannedEntries),
+		FilesNotRedacted:  len(unredactedDisclosure),
+		ValuesNotRedacted: formatters.UnredactedValueCount(unredactedDisclosure),
+		TotalFindings:     len(unsuppressedMatches),
+		High:              highCount,
+		Medium:            mediumCount,
+		Low:               lowCount,
+		Suppressed:        suppressedCount,
+		Duration:          elapsed.Seconds(),
 	}
 
 	// The same disclosure, in structured form, for formats that cannot carry prose.
@@ -2286,6 +2296,16 @@ func main() {
 	// must disclose even when the text renderer declines to (it is skipped entirely
 	// in pre-commit mode).
 	formatterOptions.NotExamined = toFormatterNotExamined(unscannedEntries)
+
+	// The redaction disclosure, in structured form, for the same reason: seven of seven
+	// formats said nothing about a refusal, so a consumer parsing stdout could not tell
+	// a sanitized run from one that left every value in cleartext (#441).
+	formatterOptions.Unredacted = unredactedDisclosure
+
+	// Lets a formatter tell "redaction was not asked for" from "it was asked for and
+	// succeeded". CSV reports per finding and needs all three states; without this a
+	// read-only scan would claim every value was redacted.
+	formatterOptions.RedactionRequested = finalConfig.enableRedaction
 
 	// The JUnit formatter reads this to decide the VALENCE of the not-examined
 	// entries (<skipped> vs <error>), so one flag governs both the XML verdict and
@@ -2323,6 +2343,24 @@ func main() {
 			}
 		}
 	}
+
+	// No footer is built here on purpose. The text formatter renders this block itself
+	// from formatterOptions.Unredacted (formatters.RenderBlock), so every caller of the
+	// formatter -- the CLI, the web UI, any library consumer of formatters.Export --
+	// gets the disclosure from the same structured data.
+	//
+	// The not-examined disclosure above works the other way round: cmd renders its
+	// footer and the formatter prints whatever prose it is handed. That shape has a
+	// hole, because a caller that sets the structured field but not the footer gets a
+	// text report with no disclosure at all, and copying it here would have
+	// reintroduced #441 on the web and library surfaces while the CLI looked fixed.
+	//
+	// There is also no stderr fallback, unlike not-examined: every format now carries
+	// this IN-BAND (unredacted[] in json/yaml, two columns in csv, a <failure> suite in
+	// junit, scan.messages in gitlab-sast, toolExecutionNotifications in sarif), so a
+	// stderr copy was the same fact a third time. Measured with it in place: json put
+	// the list on stdout AND the block on stderr AND the terse warning on stderr. The
+	// terse per-file warning stays as the human signal.
 
 	// Pre-commit mode owns a deliberately terse output contract, but "terse" must not
 	// mean silent about files that were never read.
@@ -2476,7 +2514,21 @@ func main() {
 	// A file that was opened and extracted to NOTHING is the third member of that
 	// set and the hardest to notice without help: unlike the other two it produces
 	// no error anywhere, just an empty document body and a clean report.
-	coverageGaps := len(unscannedEntries)
+	//
+	// A file whose findings were REPORTED but NOT REDACTED joins the same set, which
+	// widens what --fail-on-incomplete means: it was "the scan did not see everything",
+	// it is now "the run did not fully do what was asked". That is a deliberate change
+	// of the flag's meaning, decided rather than inherited, because the alternative
+	// left the one outcome the sink rule forbids -- values still in cleartext while the
+	// report looks complete -- as the only failure with no machine-readable signal at
+	// all. Measured before this: exit 0, and seven of seven output formats silent.
+	//
+	// The consequence to know: a job that set the flag to catch validator timeouts will
+	// now also fail when a PDF cannot be redacted. That is the intended reading of
+	// "incomplete", and both causes are named separately in the report and in
+	// stats.files_not_examined / stats.files_not_redacted, so the operator can tell
+	// which one fired without changing flags.
+	coverageGaps := len(unscannedEntries) + len(unredactedDisclosure)
 	if precommitConfig != nil {
 		exitCode := precommit.GetExitCode(hasFindings, hasErrors, highestConfidence, precommitConfig)
 		os.Exit(resolveIncompleteExitCode(exitCode, finalConfig.failOnIncomplete, coverageGaps))

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2384,6 +2384,26 @@ func main() {
 			len(unscannedEntries), noun)
 	}
 
+	// The same courtesy for a redaction refusal, and it matters MORE here.
+	//
+	// Pre-commit mode is auto-detected on any Windows box with a Git environment and there is no
+	// opt-out (#353), so on Windows this is not an unusual path — it is the DEFAULT one. Without
+	// this line the disclosure that #441 exists to add would be invisible to exactly the users who
+	// never chose pre-commit mode, and a cleartext leak would stay silent on a whole platform.
+	//
+	// One line, no frame, no per-file list: pre-commit output is read in a terminal mid-commit. It
+	// states the counts and how to see the rest, like its sibling above.
+	if precommitConfig != nil && len(unredactedDisclosure) > 0 {
+		noun := "files"
+		if len(unredactedDisclosure) == 1 {
+			noun = "file"
+		}
+		fmt.Fprintf(os.Stderr,
+			"ferret-scan: %d %s NOT redacted — %d reported value(s) remain in cleartext. "+
+				"Re-run without --pre-commit for detail.\n",
+			len(unredactedDisclosure), noun, formatters.UnredactedValueCount(unredactedDisclosure))
+	}
+
 	// Enable streaming for text format writing to stdout (no output file).
 	// The text formatter writes directly to os.Stdout, avoiding a multi-GB
 	// string buffer for large result sets.

--- a/cmd/unredacted_disclosure_test.go
+++ b/cmd/unredacted_disclosure_test.go
@@ -1,0 +1,259 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/formatters"
+	"github.com/awslabs/ferret-scan/v2/internal/parallel"
+)
+
+// The cause classifier reads SUBSTRINGS of a redactor's error string, so it drifts the
+// moment one of those strings is reworded. This pins the strings the shipped redactors
+// actually produce, so rewording one fails here instead of silently degrading every
+// report to the generic cause.
+//
+// Each string below is a VERBATIM error observed from a real run at main @ 3c4e10b, not
+// an invented approximation — that is the whole point. The command that produced each is
+// named so a future reader can regenerate it.
+func TestClassifyRedactionErrorCoversTheRealRedactors(t *testing.T) {
+	cases := []struct {
+		name   string
+		reason string
+		want   formatters.UnredactedCause
+	}{
+		{
+			// ferret-scan --file report.pdf --enable-redaction
+			name:   "pdf, no redactor",
+			reason: "PDF redaction is not implemented: refusing to produce an output that was not redacted but would falsely report success",
+			want:   formatters.UnredactedNoRedactor,
+		},
+		{
+			// ferret-scan --file scan.tiff --enable-redaction
+			name:   "tiff, no redactor",
+			reason: "failed to redact image metadata: failed to redact tiff metadata: metadata redaction not implemented for tiff images",
+			want:   formatters.UnredactedNoRedactor,
+		},
+		{
+			// ferret-scan --file huge.jpg --enable-redaction, where huge.jpg declares
+			// 20000x20000. Shares the "failed to redact image metadata" prefix with the
+			// tiff case above, which is why the budget arm is tested BEFORE the
+			// not-implemented arm in the classifier.
+			name:   "image over the pixel budget",
+			reason: "failed to redact image metadata: refusing to redact a 20000x20000 image: 400000000 pixels is over the 67108864-pixel budget, and stripping metadata requires decoding them",
+			want:   formatters.UnredactedOverBudget,
+		},
+		{
+			name:   "value not present in the writable bytes",
+			reason: "SSN match ([HIDDEN], len=11) not found in line 4",
+			want:   formatters.UnredactedValueNotLocated,
+		},
+		{
+			name:   "write failed on permissions",
+			reason: "failed to create output file: open /ro/out.txt: permission denied",
+			want:   formatters.UnredactedWriteFailed,
+		},
+		{
+			// The important one: an unrecognised string must fall to the GENERIC cause,
+			// whose label is true of every refusal. Anything else would state a remedy
+			// the operator cannot act on.
+			name:   "unknown wording falls back to the generic cause",
+			reason: "some future redactor said something nobody has seen before",
+			want:   formatters.UnredactedRefused,
+		},
+		{
+			name:   "empty reason still classifies",
+			reason: "",
+			want:   formatters.UnredactedRefused,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := classifyRedactionError(c.reason); got != c.want {
+				t.Errorf("classifyRedactionError(%q)\n  = %v (%s)\n  want %v (%s)",
+					c.reason, got, got, c.want, c.want)
+			}
+		})
+	}
+}
+
+// A redactor error that embeds a reported value must not carry it into the output.
+//
+// One did: internal/redactors/plaintext used
+//
+//	fmt.Errorf("match text %q not found in line %d", match.Text, ...)
+//
+// which put the raw sensitive value into the diagnostic. Before this disclosure existed
+// that string only reached stderr; now it reaches JSON, YAML, CSV, JUnit, SARIF and the
+// GitLab report, so a single Errorf can leak into seven places at once. The source has
+// been fixed; this is the layer that keeps a future one from mattering.
+func TestReportedValuesAreScrubbedFromTheDetail(t *testing.T) {
+	matches := []detector.Match{
+		{Text: "449-87-4100", Type: "SSN", Filename: "/scan/a.txt"},
+		{Text: "4532-0151-1283-0366", Type: "VISA", Filename: "/scan/a.txt"},
+		{Text: "42", Type: "SHORT", Filename: "/scan/a.txt"}, // below the scrub floor
+	}
+
+	t.Run("a value in the detail is hidden", func(t *testing.T) {
+		got := scrubReportedValues(`match text "449-87-4100" not found in line 3`, matches)
+		if strings.Contains(got, "449-87-4100") {
+			t.Errorf("the raw value survived scrubbing: %q", got)
+		}
+		if !strings.Contains(got, "[HIDDEN] (len=11)") {
+			t.Errorf("expected the length-preserving placeholder, got %q", got)
+		}
+		// The non-value part of the message must survive, or the operator loses the
+		// information the diagnostic exists to give.
+		if !strings.Contains(got, "not found in line 3") {
+			t.Errorf("scrubbing destroyed the useful part of the message: %q", got)
+		}
+	})
+
+	t.Run("every reported value is scrubbed, not just the first", func(t *testing.T) {
+		got := scrubReportedValues("could not place 449-87-4100 or 4532-0151-1283-0366", matches)
+		for _, v := range []string{"449-87-4100", "4532-0151-1283-0366"} {
+			if strings.Contains(got, v) {
+				t.Errorf("value %q survived: %q", v, got)
+			}
+		}
+	})
+
+	t.Run("repeated occurrences are all scrubbed", func(t *testing.T) {
+		got := scrubReportedValues("449-87-4100 and again 449-87-4100", matches)
+		if strings.Contains(got, "449-87-4100") {
+			t.Errorf("a repeated value survived: %q", got)
+		}
+	})
+
+	t.Run("a short value is left alone", func(t *testing.T) {
+		// "42" would otherwise corrupt line numbers and byte counts throughout the
+		// message while hiding nothing an attacker could not guess.
+		got := scrubReportedValues("not found in line 42 of 420", matches)
+		if got != "not found in line 42 of 420" {
+			t.Errorf("a sub-4-character value was scrubbed and corrupted the message: %q", got)
+		}
+	})
+
+	t.Run("a clean message is unchanged", func(t *testing.T) {
+		in := "PDF redaction is not implemented"
+		if got := scrubReportedValues(in, matches); got != in {
+			t.Errorf("a message with no value was altered: %q -> %q", in, got)
+		}
+	})
+
+	t.Run("empty input", func(t *testing.T) {
+		if got := scrubReportedValues("", matches); got != "" {
+			t.Errorf("empty reason became %q", got)
+		}
+	})
+}
+
+// The value count must come from the reported findings, per file, and must not leak
+// across files.
+//
+// It is the number that sizes the exposure. Counting every match in the run against
+// every unredacted file would multiply the reported exposure by the number of files,
+// and counting the wrong slice (allMatches rather than the unsuppressed set) would count
+// suppressed findings as cleartext.
+func TestToFormatterUnredactedCountsPerFile(t *testing.T) {
+	diags := []parallel.FileDiagnostic{
+		{FilePath: "/scan/a.pdf", Reason: "PDF redaction is not implemented"},
+		{FilePath: "/scan/b.tiff", Reason: "metadata redaction not implemented for tiff images"},
+	}
+	matches := []detector.Match{
+		{Text: "449-87-4100", Filename: "/scan/a.pdf"},
+		{Text: "4532-0151-1283-0366", Filename: "/scan/a.pdf"},
+		{Text: "415-555-0132", Filename: "/scan/b.tiff"},
+		// A file that redacted fine: must not appear and must not be counted.
+		{Text: "078-05-1120", Filename: "/scan/ok.txt"},
+	}
+
+	out := toFormatterUnredacted(diags, matches)
+	if len(out) != 2 {
+		t.Fatalf("got %d entries, want 2", len(out))
+	}
+
+	byPath := map[string]formatters.UnredactedFile{}
+	for _, f := range out {
+		byPath[f.Path] = f
+	}
+	if got := byPath["/scan/a.pdf"].ReportedValues; got != 2 {
+		t.Errorf("/scan/a.pdf counted %d values, want 2", got)
+	}
+	if got := byPath["/scan/b.tiff"].ReportedValues; got != 1 {
+		t.Errorf("/scan/b.tiff counted %d values, want 1", got)
+	}
+	if _, present := byPath["/scan/ok.txt"]; present {
+		t.Error("a file that redacted successfully appears in the disclosure")
+	}
+	if got, want := formatters.UnredactedValueCount(out), 3; got != want {
+		t.Errorf("total value count = %d, want %d — the redacted file's finding must not be counted", got, want)
+	}
+
+	// Causes must be classified, not left at the generic fallback, for strings the
+	// classifier is known to handle.
+	if got := byPath["/scan/a.pdf"].Cause; got != formatters.UnredactedNoRedactor {
+		t.Errorf("/scan/a.pdf cause = %v, want UnredactedNoRedactor", got)
+	}
+}
+
+// No diagnostics means no disclosure at all — nil, not an empty non-nil slice, because
+// the formatters guard on len() and the JSON field is omitempty.
+func TestNoDiagnosticsProducesNoDisclosure(t *testing.T) {
+	if got := toFormatterUnredacted(nil, nil); got != nil {
+		t.Errorf("expected nil for no diagnostics, got %#v", got)
+	}
+	if got := formatters.UnredactedValueCount(nil); got != 0 {
+		t.Errorf("value count of nil = %d, want 0", got)
+	}
+	if got := formatters.UnredactedPaths(nil); got != nil {
+		t.Errorf("expected a nil path map, got %#v", got)
+	}
+	if got := formatters.RenderBlock(nil, 0, false, true); got != "" {
+		t.Errorf("expected no rendered block, got %q", got)
+	}
+}
+
+// The rendered block must state the flag hint that matches the run's actual policy.
+//
+// Telling an operator to add --fail-on-incomplete when it is already set is the kind of
+// small wrongness that erodes trust in the whole report, and the opposite — staying
+// silent about the escalation — leaves them thinking a green exit meant success.
+func TestRenderedBlockStatesTheRightFlagHint(t *testing.T) {
+	files := []formatters.UnredactedFile{{
+		Path: "/scan/a.pdf", Cause: formatters.UnredactedNoRedactor, ReportedValues: 3,
+	}}
+
+	without := formatters.RenderBlock(files, 1, false, true)
+	if !strings.Contains(without, "Add --fail-on-incomplete") {
+		t.Errorf("without the flag, the block should say how to escalate: %q", without)
+	}
+	if strings.Contains(without, "Exit code 3:") {
+		t.Errorf("without the flag, the block must not claim exit 3: %q", without)
+	}
+
+	with := formatters.RenderBlock(files, 1, true, true)
+	if strings.Contains(with, "Add --fail-on-incomplete") {
+		t.Errorf("with the flag already set, the block must not tell the operator to add it: %q", with)
+	}
+
+	// Suppressed by the composer when another block in the same frame carries it.
+	composed := formatters.RenderBlock(files, 1, false, false)
+	if strings.Contains(composed, "--fail-on-incomplete") {
+		t.Errorf("the hint should be omitted when another block already carries it: %q", composed)
+	}
+
+	// The headline must total the values and name the file, in every variant.
+	for _, blk := range []string{without, with, composed} {
+		for _, want := range []string{"VALUES LEFT IN CLEARTEXT", "3 reported value(s)", "/scan/a.pdf"} {
+			if !strings.Contains(blk, want) {
+				t.Errorf("block is missing %q: %q", want, blk)
+			}
+		}
+	}
+}

--- a/cmd/unredacted_exit_code_test.go
+++ b/cmd/unredacted_exit_code_test.go
@@ -1,0 +1,578 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// End-to-end contracts for the unredacted disclosure, driven through the real binary
+// because an exit code and a stream choice are CLI contracts, not library ones.
+//
+// The matrix measured on main BEFORE this change, on a PDF with findings under
+// --enable-redaction:
+//
+//	scenario                              rc   in-band disclosure
+//	default                               0    NONE in any of 7 formats
+//	--fail-on-incomplete                  0    NONE
+//
+// Exit 0 with values in cleartext and a clean-looking report on stdout is the one
+// outcome the sink rule forbids (#441).
+
+func buildForRedactionTest(t *testing.T) string {
+	t.Helper()
+	name := "ferret-scan-unredacted-test"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	bin := filepath.Join(t.TempDir(), name)
+	out, err := exec.Command("go", "build", "-o", bin, ".").CombinedOutput()
+	if err != nil {
+		t.Fatalf("build: %v\n%s", err, out)
+	}
+	return bin
+}
+
+type redactRun struct {
+	rc      int
+	stdout  string
+	stderr  string
+	written int
+}
+
+// runRedaction scans dir with redaction enabled and reports what happened.
+//
+// --config os.DevNull so a developer's own config cannot change the outcome, which is
+// the same precaution the other exit-code tests take.
+func runRedaction(t *testing.T, bin, dir, format string, extra ...string) redactRun {
+	t.Helper()
+	outDir := filepath.Join(t.TempDir(), "redacted")
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	args := append([]string{
+		"--file", dir, "--recursive", "--config", os.DevNull,
+		"--enable-redaction", "--redaction-output-dir", outDir,
+		"--format", format, "--limit", "0", "--quiet",
+	}, extra...)
+
+	cmd := exec.Command(bin, args...)
+	cmd.Env = os.Environ()
+	var so, se strings.Builder
+	cmd.Stdout = &so
+	cmd.Stderr = &se
+	err := cmd.Run()
+
+	rc := 0
+	if ee, ok := err.(*exec.ExitError); ok {
+		rc = ee.ExitCode()
+	} else if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	written := 0
+	_ = filepath.Walk(outDir, func(_ string, info os.FileInfo, err error) error {
+		if err == nil && info != nil && !info.IsDir() {
+			written++
+		}
+		return nil
+	})
+
+	return redactRun{rc, so.String(), se.String(), written}
+}
+
+// buildValidPDF builds a structurally valid PDF with a correct xref AND startxref,
+// carrying text the extractor can actually read.
+//
+// Both the xref and startxref are required. A hand-rolled PDF without them makes the
+// extractor ERROR rather than parse, and the consequence is a silent false pass: the file
+// then yields no findings, so nothing is redacted, nothing is refused, and the exit code
+// becomes 3 for an entirely different reason (a coverage gap). That happened while writing
+// this test — the escalation assertion passed while the disclosure was empty. The same
+// warning is on internal/core's copy of this helper, which is where this is ported from.
+func buildValidPDF(t *testing.T, text string) []byte {
+	t.Helper()
+	content := "BT /F1 12 Tf 72 700 Td (" + text + ") Tj ET\n"
+	objs := []string{
+		"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n",
+		"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n",
+		"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R " +
+			"/Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n",
+		"4 0 obj\n<< /Length " + strconv.Itoa(len(content)) + " >>\nstream\n" + content + "endstream\nendobj\n",
+		"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n",
+	}
+	var sb strings.Builder
+	sb.WriteString("%PDF-1.4\n")
+	offsets := make([]int, 0, len(objs))
+	for _, o := range objs {
+		offsets = append(offsets, sb.Len())
+		sb.WriteString(o)
+	}
+	xref := sb.Len()
+	sb.WriteString("xref\n0 " + strconv.Itoa(len(objs)+1) + "\n0000000000 65535 f \n")
+	for _, off := range offsets {
+		sb.WriteString(fmt.Sprintf("%010d 00000 n \n", off))
+	}
+	sb.WriteString("trailer\n<< /Size " + strconv.Itoa(len(objs)+1) + " /Root 1 0 R >>\nstartxref\n" +
+		strconv.Itoa(xref) + "\n%%EOF\n")
+	return []byte(sb.String())
+}
+
+// unredactableDir builds a directory holding one file that CANNOT be redacted plus one
+// that can, so every assertion is about the DIFFERENCE rather than about the tool refusing
+// everything.
+//
+// The unredactable file is a .pdf, because PDF redaction is not implemented — a stable
+// property of the tool rather than a contrived fixture. It must be a VALID pdf whose text
+// extracts, or the refusal path is never reached; see buildValidPDF.
+func unredactableDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "report.pdf"),
+		buildValidPDF(t, "Patient SSN 449-87-4100"), 0o600); err != nil {
+		t.Fatalf("write pdf: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("SSN 449-87-4100\n"), 0o600); err != nil {
+		t.Fatalf("write txt: %v", err)
+	}
+	return dir
+}
+
+// requireRefusalHappened guards every assertion in this file against the false pass
+// described on buildValidPDF: if the PDF did not produce findings, there was no redaction
+// to refuse, and any exit code or disclosure assertion is measuring something else.
+func requireRefusalHappened(t *testing.T, stdoutJSON string) {
+	t.Helper()
+	var doc struct {
+		Stats struct {
+			FilesNotRedacted int `json:"files_not_redacted"`
+			TotalFindings    int `json:"total_findings"`
+		} `json:"stats"`
+	}
+	if err := json.Unmarshal([]byte(stdoutJSON), &doc); err != nil {
+		t.Fatalf("could not read the run's json: %v", err)
+	}
+	if doc.Stats.TotalFindings == 0 {
+		t.Fatal("the fixture produced NO findings, so nothing was redacted and nothing refused; " +
+			"the pdf almost certainly failed to extract")
+	}
+	if doc.Stats.FilesNotRedacted == 0 {
+		t.Fatal("no file was refused, so this test is not exercising the disclosure at all")
+	}
+}
+
+// --fail-on-incomplete must escalate a refusal, and its absence must not.
+//
+// This is the decision the flag's meaning was widened for: it was "the scan did not see
+// everything" and is now "the run did not fully do what was asked". Both halves are
+// asserted, because escalating unconditionally would break every pipeline that redacts a
+// PDF today, and escalating never is the defect.
+func TestUnredactedFileEscalatesOnlyWithTheFlag(t *testing.T) {
+	bin := buildForRedactionTest(t)
+	dir := unredactableDir(t)
+
+	// Establish, in json, that a refusal genuinely occurs for this fixture before
+	// asserting anything about exit codes. rc=3 can also come from a COVERAGE gap, so
+	// without this the escalation assertion could pass while the disclosure is empty —
+	// which is exactly what happened on the first draft's invalid pdf.
+	requireRefusalHappened(t, runRedaction(t, bin, dir, "json").stdout)
+
+	without := runRedaction(t, bin, dir, "text")
+	if without.rc != 0 {
+		t.Errorf("without --fail-on-incomplete rc = %d, want 0: adding a new default failure "+
+			"would break every pipeline that redacts a PDF today\n%s", without.rc, without.stderr)
+	}
+
+	with := runRedaction(t, bin, dir, "text", "--fail-on-incomplete")
+	if with.rc != exitCodeIncompleteCoverage {
+		t.Errorf("with --fail-on-incomplete rc = %d, want %d: a run that leaves values in "+
+			"cleartext must be gateable in CI\n%s", with.rc, exitCodeIncompleteCoverage, with.stderr)
+	}
+
+	// Non-vacuity: the refusal must actually have happened, and the OTHER file must
+	// actually have been redacted. Without this the test would pass on a build that
+	// refused everything, or one that wrote nothing at all.
+	if without.written != 1 {
+		t.Errorf("wrote %d redacted copies, want exactly 1 (the .txt): if 0, the tool refused "+
+			"everything and the exit codes above prove nothing; if 2, nothing was refused",
+			without.written)
+	}
+}
+
+// A run where everything redacts must stay green even with the flag set.
+//
+// The inverse of the test above. If the escalation keyed on "redaction was requested"
+// rather than "a refusal occurred", every redacting pipeline would start failing.
+func TestFullyRedactedRunStaysZeroWithTheFlag(t *testing.T) {
+	bin := buildForRedactionTest(t)
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("SSN 449-87-4100\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	run := runRedaction(t, bin, dir, "text", "--fail-on-incomplete")
+	if run.rc != 0 {
+		t.Errorf("a fully redacted run exited %d with --fail-on-incomplete, want 0\n%s", run.rc, run.stderr)
+	}
+	if run.written != 1 {
+		t.Fatalf("wrote %d copies, want 1 — nothing was redacted, so the zero above is vacuous", run.written)
+	}
+	if strings.Contains(run.stdout, "VALUES LEFT IN CLEARTEXT") {
+		t.Errorf("a fully redacted run claims an exposure:\n%s", run.stdout)
+	}
+}
+
+// Every format must carry the disclosure IN-BAND on stdout, and no format may leak the
+// raw value.
+//
+// In-band matters because stderr is discarded by pipelines — that is the whole defect.
+// The leak check is here as well as in the unit tests because the disclosure's detail is
+// a redactor's error string, and one of those did interpolate match.Text; a regression
+// there would reach seven formats at once and only an end-to-end assertion sees the real
+// strings.
+func TestEveryFormatDisclosesOnStdoutAndLeaksNothing(t *testing.T) {
+	bin := buildForRedactionTest(t)
+	dir := unredactableDir(t)
+
+	// Each format's own idiom, as in the formatter-level test.
+	want := map[string]string{
+		"text":        "VALUES LEFT IN CLEARTEXT",
+		"json":        `"unredacted"`,
+		"yaml":        "unredacted:",
+		"csv":         "Not Redacted Reason",
+		"junit":       `name="unredacted"`,
+		"gitlab-sast": "NOT REDACTED",
+		"sarif":       "ferret-scan/not-redacted",
+	}
+
+	for format, needle := range want {
+		t.Run(format, func(t *testing.T) {
+			run := runRedaction(t, bin, dir, format)
+			if !strings.Contains(run.stdout, needle) {
+				t.Errorf("%s does not disclose on STDOUT (missing %q). stderr is discarded by "+
+					"pipelines, so an out-of-band-only warning is the defect this fixes.\n"+
+					"--- stdout ---\n%s", format, needle, run.stdout)
+			}
+			// BSC4: the raw matched value must never appear, with or without --show-match
+			// being asked for. Here it is not asked for.
+			if strings.Contains(run.stdout, "449-87-4100") {
+				t.Errorf("%s leaked the raw value into stdout without --show-match\n%s", format, run.stdout)
+			}
+			if strings.Contains(run.stderr, "449-87-4100") {
+				t.Errorf("%s leaked the raw value into stderr\n%s", format, run.stderr)
+			}
+		})
+	}
+}
+
+// The JSON counters must be the TRUE totals and must agree with the entry list.
+//
+// A summary that disagrees with its own list is how a report loses trust, and the count
+// is what a consumer gates on.
+func TestJSONCountersAgreeWithTheList(t *testing.T) {
+	bin := buildForRedactionTest(t)
+	dir := unredactableDir(t)
+
+	run := runRedaction(t, bin, dir, "json")
+
+	var doc struct {
+		Stats struct {
+			FilesNotRedacted  int `json:"files_not_redacted"`
+			ValuesNotRedacted int `json:"values_not_redacted"`
+			TotalFindings     int `json:"total_findings"`
+		} `json:"stats"`
+		Unredacted []struct {
+			Path           string `json:"path"`
+			Cause          string `json:"cause"`
+			ReportedValues int    `json:"reported_values"`
+		} `json:"unredacted"`
+	}
+	if err := json.Unmarshal([]byte(run.stdout), &doc); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\n%s", err, run.stdout)
+	}
+
+	if doc.Stats.FilesNotRedacted != 1 {
+		t.Errorf("files_not_redacted = %d, want 1", doc.Stats.FilesNotRedacted)
+	}
+	if len(doc.Unredacted) != 1 {
+		t.Fatalf("unredacted[] has %d entries, want 1", len(doc.Unredacted))
+	}
+	if got := doc.Unredacted[0].ReportedValues; got < 1 {
+		t.Errorf("reported_values = %d, want at least 1 — a disclosure that cannot say how much "+
+			"is exposed does not size the problem", got)
+	}
+	if doc.Stats.ValuesNotRedacted != doc.Unredacted[0].ReportedValues {
+		t.Errorf("stats.values_not_redacted (%d) disagrees with the entry's reported_values (%d)",
+			doc.Stats.ValuesNotRedacted, doc.Unredacted[0].ReportedValues)
+	}
+	if !strings.Contains(doc.Unredacted[0].Cause, "no redactor") {
+		t.Errorf("cause = %q, want the no-redactor classification for a PDF", doc.Unredacted[0].Cause)
+	}
+	// The findings themselves must survive: the refusal is about the WRITE, and losing
+	// the findings would hide what is exposed.
+	if doc.Stats.TotalFindings < 1 {
+		t.Error("the run reported no findings, so the disclosure has nothing to be about")
+	}
+}
+
+// A run with BOTH a coverage gap and a redaction refusal must state both, inside one
+// frame, with the exit-code hint exactly once.
+//
+// Two blocks each ending in "Add --fail-on-incomplete …" reads as two separate policies
+// when it is one escalation covering both.
+func TestBothDisclosuresAppearOnceEach(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod 000 does not deny reads on Windows")
+	}
+	bin := buildForRedactionTest(t)
+	dir := unredactableDir(t)
+
+	unreadable := filepath.Join(dir, "unreadable.txt")
+	if err := os.WriteFile(unreadable, []byte("SSN 449-87-4100\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.Chmod(unreadable, 0o000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(unreadable, 0o600) })
+
+	// The flag is deliberately NOT set here: the hint is only shown when escalation is
+	// off, so this is the case where "exactly once" is a meaningful assertion.
+	run := runRedaction(t, bin, dir, "text")
+
+	if !strings.Contains(run.stdout, "NOT FULLY EXAMINED") {
+		t.Errorf("the coverage gap is not disclosed\n%s", run.stdout)
+	}
+	if !strings.Contains(run.stdout, "VALUES LEFT IN CLEARTEXT") {
+		t.Errorf("the redaction refusal is not disclosed\n%s", run.stdout)
+	}
+	if n := strings.Count(run.stdout, "--fail-on-incomplete"); n != 1 {
+		t.Errorf("the exit-code hint appears %d times in one summary frame, want 1: both "+
+			"disclosures feed the same escalation, so saying it twice reads as two policies\n%s",
+			n, run.stdout)
+	}
+	// And with the flag, the same run escalates.
+	gated := runRedaction(t, bin, dir, "text", "--fail-on-incomplete")
+	if gated.rc != exitCodeIncompleteCoverage {
+		t.Errorf("rc = %d, want %d when both a coverage gap and a refusal occurred",
+			gated.rc, exitCodeIncompleteCoverage)
+	}
+	// With escalation on, neither block nags about the flag — but both disclosures remain.
+	for _, want := range []string{"NOT FULLY EXAMINED", "VALUES LEFT IN CLEARTEXT"} {
+		if !strings.Contains(gated.stdout, want) {
+			t.Errorf("with the flag set, %q disappeared from the report\n%s", want, gated.stdout)
+		}
+	}
+}
+
+// --limit truncates the findings LIST; it must not shrink the reported exposure.
+//
+// The values are in cleartext whether or not the report chose to print each finding, so a
+// consumer gating on the counters must see the true numbers.
+func TestLimitDoesNotShrinkTheReportedExposure(t *testing.T) {
+	bin := buildForRedactionTest(t)
+	dir := unredactableDir(t)
+
+	full := runRedaction(t, bin, dir, "json")
+	var fullDoc, limDoc struct {
+		Stats struct {
+			FilesNotRedacted  int `json:"files_not_redacted"`
+			ValuesNotRedacted int `json:"values_not_redacted"`
+		} `json:"stats"`
+	}
+	if err := json.Unmarshal([]byte(full.stdout), &fullDoc); err != nil {
+		t.Fatalf("unmarshal full: %v", err)
+	}
+
+	limited := runRedaction(t, bin, dir, "json", "--limit", "1")
+	if err := json.Unmarshal([]byte(limited.stdout), &limDoc); err != nil {
+		t.Fatalf("unmarshal limited: %v", err)
+	}
+
+	if limDoc.Stats.FilesNotRedacted != fullDoc.Stats.FilesNotRedacted ||
+		limDoc.Stats.ValuesNotRedacted != fullDoc.Stats.ValuesNotRedacted {
+		t.Errorf("--limit changed the reported exposure: files %d->%d, values %d->%d. The values "+
+			"are in cleartext regardless of how many findings the report printed",
+			fullDoc.Stats.FilesNotRedacted, limDoc.Stats.FilesNotRedacted,
+			fullDoc.Stats.ValuesNotRedacted, limDoc.Stats.ValuesNotRedacted)
+	}
+	if fullDoc.Stats.ValuesNotRedacted == 0 {
+		t.Fatal("the baseline reports zero exposed values, so the comparison above is vacuous")
+	}
+}
+
+// A scan that never asked for redaction must not gain the disclosure or the CSV columns.
+//
+// Read-only scanning is the common path, and a warning that appears when nothing could
+// have been redacted is noise that trains people to ignore it.
+func TestReadOnlyScanCarriesNoRedactionDisclosure(t *testing.T) {
+	bin := buildForRedactionTest(t)
+	dir := unredactableDir(t)
+
+	for _, format := range []string{"text", "json", "csv"} {
+		t.Run(format, func(t *testing.T) {
+			args := []string{
+				"--file", dir, "--recursive", "--config", os.DevNull,
+				"--format", format, "--limit", "0", "--quiet",
+			}
+			cmd := exec.Command(bin, args...)
+			var so, se strings.Builder
+			cmd.Stdout = &so
+			cmd.Stderr = &se
+			_ = cmd.Run()
+
+			for _, bad := range []string{
+				"VALUES LEFT IN CLEARTEXT", "files_not_redacted", "Not Redacted Reason",
+			} {
+				if strings.Contains(so.String(), bad) {
+					t.Errorf("a read-only scan emitted %q in %s output:\n%s", bad, format, so.String())
+				}
+			}
+		})
+	}
+}
+
+// A file whose findings are ALL suppressed must not be reported as an exposure.
+//
+// The redactor still emits a diagnostic for it — there was no copy to write — but nothing
+// was reported, so there is no reported exposure to disclose. Keeping the entry produced a
+// self-contradiction, measured: "files_not_redacted=1" alongside "reported_values=0", and
+// a VALUES LEFT IN CLEARTEXT banner for a file whose findings the operator had explicitly
+// accepted.
+//
+// BOTH directions are asserted. Dropping zero-value entries relies on the diagnostic's
+// path and the match's Filename being the same string; if that ever diverges, every entry
+// would silently drop and the disclosure would vanish entirely — the dangerous direction.
+// The second half of this test is what catches that.
+func TestSuppressedFileIsNotReportedAsExposed(t *testing.T) {
+	bin := buildForRedactionTest(t)
+	dir := unredactableDir(t)
+
+	// Direction 1: with nothing suppressed, the PDF IS reported as exposed. This is the
+	// guard against the drop rule hiding real exposures.
+	before := runRedaction(t, bin, dir, "json")
+	requireRefusalHappened(t, before.stdout)
+
+	// Generate suppressions with this same binary, then enable them all.
+	supFile := filepath.Join(t.TempDir(), "sup.yaml")
+	gen := exec.Command(bin, "--file", dir, "--recursive", "--config", os.DevNull,
+		"--generate-suppressions", "--suppression-file", supFile, "--limit", "0", "--quiet")
+	if out, err := gen.CombinedOutput(); err != nil {
+		t.Fatalf("generate suppressions: %v\n%s", err, out)
+	}
+	raw, err := os.ReadFile(supFile)
+	if err != nil {
+		t.Fatalf("read suppressions: %v", err)
+	}
+	enabled := strings.ReplaceAll(string(raw), "enabled: false", "enabled: true")
+	if enabled == string(raw) {
+		t.Fatal("no rules were generated, so the suppressed case below is vacuous")
+	}
+	if err := os.WriteFile(supFile, []byte(enabled), 0o600); err != nil {
+		t.Fatalf("write suppressions: %v", err)
+	}
+
+	// Direction 2: with everything suppressed, no exposure is claimed.
+	after := runRedaction(t, bin, dir, "json", "--suppression-file", supFile)
+
+	var doc struct {
+		Stats struct {
+			TotalFindings    int `json:"total_findings"`
+			Suppressed       int `json:"suppressed"`
+			FilesNotRedacted int `json:"files_not_redacted"`
+		} `json:"stats"`
+		Unredacted []struct {
+			ReportedValues int `json:"reported_values"`
+		} `json:"unredacted"`
+	}
+	if err := json.Unmarshal([]byte(after.stdout), &doc); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, after.stdout)
+	}
+
+	if doc.Stats.Suppressed == 0 {
+		t.Fatal("nothing was suppressed, so this test is not exercising the case")
+	}
+	if doc.Stats.TotalFindings != 0 {
+		t.Fatalf("expected every finding suppressed, got %d reported", doc.Stats.TotalFindings)
+	}
+	if doc.Stats.FilesNotRedacted != 0 {
+		t.Errorf("files_not_redacted = %d on a run where every finding was suppressed: the "+
+			"disclosure counts REPORTED values, and none were reported",
+			doc.Stats.FilesNotRedacted)
+	}
+	if len(doc.Unredacted) != 0 {
+		t.Errorf("unredacted[] has %d entries with reported_values=%v — an exposure of zero "+
+			"reported values is a contradiction", len(doc.Unredacted), doc.Unredacted)
+	}
+
+	// The text report must not show the banner either.
+	text := runRedaction(t, bin, dir, "text", "--suppression-file", supFile)
+	if strings.Contains(text.stdout, "VALUES LEFT IN CLEARTEXT") {
+		t.Errorf("the text report claims an exposure for a fully suppressed file:\n%s", text.stdout)
+	}
+	// And it must not escalate the exit code.
+	gated := runRedaction(t, bin, dir, "text", "--suppression-file", supFile, "--fail-on-incomplete")
+	if gated.rc != 0 {
+		t.Errorf("rc = %d on a fully suppressed run with --fail-on-incomplete, want 0", gated.rc)
+	}
+}
+
+// An unwritable output directory must be reported as a WRITE failure, not as a missing
+// redactor.
+//
+// The two need different remedies — one is the operator's filesystem, the other is a tool
+// limitation — and this is the only cause whose classifier arm fires on an error the tool
+// itself does not author.
+func TestUnwritableOutputDirIsClassifiedAsAWriteFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod 500 does not deny directory writes on Windows")
+	}
+	bin := buildForRedactionTest(t)
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("SSN 449-87-4100\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	outDir := filepath.Join(t.TempDir(), "readonly")
+	if err := os.MkdirAll(outDir, 0o500); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(outDir, 0o755) })
+
+	cmd := exec.Command(bin, "--file", dir, "--recursive", "--config", os.DevNull,
+		"--enable-redaction", "--redaction-output-dir", outDir,
+		"--format", "json", "--limit", "0", "--quiet")
+	var so, se strings.Builder
+	cmd.Stdout = &so
+	cmd.Stderr = &se
+	_ = cmd.Run()
+
+	var doc struct {
+		Unredacted []struct {
+			Cause string `json:"cause"`
+		} `json:"unredacted"`
+	}
+	if err := json.Unmarshal([]byte(so.String()), &doc); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, so.String())
+	}
+	if len(doc.Unredacted) != 1 {
+		t.Fatalf("expected 1 unredacted entry for an unwritable output dir, got %d\n%s",
+			len(doc.Unredacted), so.String())
+	}
+	if !strings.Contains(doc.Unredacted[0].Cause, "could not write") {
+		t.Errorf("cause = %q, want a write failure: a filesystem problem must not be reported "+
+			"as a missing redactor, because the remedies are unrelated", doc.Unredacted[0].Cause)
+	}
+}

--- a/cmd/unredacted_exit_code_test.go
+++ b/cmd/unredacted_exit_code_test.go
@@ -28,6 +28,34 @@ import (
 // Exit 0 with values in cleartext and a clean-looking report on stdout is the one
 // outcome the sink rule forbids (#441).
 
+// hermeticEnv returns an environment with every pre-commit AUTO-DETECTION trigger removed.
+//
+// Pre-commit mode reshapes output and exit codes, and it is auto-detected — on Windows from any Git
+// environment at all, with no way to turn it off (#353). On a Windows CI runner that made these
+// tests measure pre-commit behaviour instead of the contract under test: every run exited 1 instead
+// of 0 or 3, the text footer was suppressed by its precommitConfig guard, and the CSV header became
+// the terse pre-commit one without the new columns. json, yaml, junit, sarif and gitlab-sast still
+// disclosed, which is what made the failure look format-specific rather than environmental.
+//
+// Stripped rather than skipped, because the contract is the same on every platform and a skip would
+// have left Windows unverified for exactly the disclosure this file exists to pin. The pre-commit
+// path has its own coverage; see TestPrecommitStillDisclosesARefusal.
+func hermeticEnv() []string {
+	drop := map[string]bool{
+		"PRE_COMMIT": true, "_PRE_COMMIT_RUNNING": true, "PRE_COMMIT_HOME": true,
+		"PRE_COMMIT_HOOK": true, "GIT_HOOK_TYPE": true,
+		"MSYSTEM": true, "MINGW_PREFIX": true, "GIT_EXEC_PATH": true, "GITHUB_DESKTOP": true,
+	}
+	out := make([]string, 0, len(os.Environ()))
+	for _, kv := range os.Environ() {
+		if i := strings.IndexByte(kv, '='); i > 0 && drop[kv[:i]] {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}
+
 func buildForRedactionTest(t *testing.T) string {
 	t.Helper()
 	name := "ferret-scan-unredacted-test"
@@ -67,7 +95,10 @@ func runRedaction(t *testing.T, bin, dir, format string, extra ...string) redact
 	}, extra...)
 
 	cmd := exec.Command(bin, args...)
-	cmd.Env = os.Environ()
+	cmd.Env = hermeticEnv()
+	// Outside any git repository: detection also fires on "in a git repo that has pre-commit
+	// hooks", which the repo under test is.
+	cmd.Dir = t.TempDir()
 	var so, se strings.Builder
 	cmd.Stdout = &so
 	cmd.Stderr = &se
@@ -427,6 +458,8 @@ func TestReadOnlyScanCarriesNoRedactionDisclosure(t *testing.T) {
 				"--format", format, "--limit", "0", "--quiet",
 			}
 			cmd := exec.Command(bin, args...)
+			cmd.Env = hermeticEnv()
+			cmd.Dir = t.TempDir()
 			var so, se strings.Builder
 			cmd.Stdout = &so
 			cmd.Stderr = &se
@@ -468,6 +501,8 @@ func TestSuppressedFileIsNotReportedAsExposed(t *testing.T) {
 	supFile := filepath.Join(t.TempDir(), "sup.yaml")
 	gen := exec.Command(bin, "--file", dir, "--recursive", "--config", os.DevNull,
 		"--generate-suppressions", "--suppression-file", supFile, "--limit", "0", "--quiet")
+	gen.Env = hermeticEnv()
+	gen.Dir = t.TempDir()
 	if out, err := gen.CombinedOutput(); err != nil {
 		t.Fatalf("generate suppressions: %v\n%s", err, out)
 	}
@@ -554,6 +589,8 @@ func TestUnwritableOutputDirIsClassifiedAsAWriteFailure(t *testing.T) {
 	cmd := exec.Command(bin, "--file", dir, "--recursive", "--config", os.DevNull,
 		"--enable-redaction", "--redaction-output-dir", outDir,
 		"--format", "json", "--limit", "0", "--quiet")
+	cmd.Env = hermeticEnv()
+	cmd.Dir = t.TempDir()
 	var so, se strings.Builder
 	cmd.Stdout = &so
 	cmd.Stderr = &se
@@ -574,5 +611,48 @@ func TestUnwritableOutputDirIsClassifiedAsAWriteFailure(t *testing.T) {
 	if !strings.Contains(doc.Unredacted[0].Cause, "could not write") {
 		t.Errorf("cause = %q, want a write failure: a filesystem problem must not be reported "+
 			"as a missing redactor, because the remedies are unrelated", doc.Unredacted[0].Cause)
+	}
+}
+
+// Pre-commit mode must still say that values were left in cleartext.
+//
+// It reshapes output deliberately — terse, no frame, no per-file list — and the structured
+// disclosure is guarded by precommitConfig == nil for that reason. But silence is not an option
+// here: the whole point of #441 is that a cleartext leak must not be invisible.
+//
+// This is not an unusual path. Pre-commit mode is AUTO-DETECTED from any Git environment on Windows
+// with no way to turn it off (#353), so on that platform it is the default one — which is how the
+// first version of this change shipped a disclosure that Windows users would never have seen.
+func TestPrecommitStillDisclosesARefusal(t *testing.T) {
+	bin := buildForRedactionTest(t)
+	dir := unredactableDir(t)
+
+	outDir := filepath.Join(t.TempDir(), "redacted")
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	cmd := exec.Command(bin, "--file", dir, "--recursive", "--config", os.DevNull,
+		"--enable-redaction", "--redaction-output-dir", outDir, "--limit", "0", "--quiet")
+	// Forced ON explicitly rather than relying on detection, so this test means the same thing on
+	// every platform.
+	cmd.Env = append(hermeticEnv(), "PRE_COMMIT=1")
+	cmd.Dir = t.TempDir()
+	var so, se strings.Builder
+	cmd.Stdout = &so
+	cmd.Stderr = &se
+	_ = cmd.Run()
+
+	if !strings.Contains(se.String(), "NOT redacted") {
+		t.Errorf("pre-commit mode says nothing about a refusal, so a cleartext leak is silent on "+
+			"every Windows box (where this mode is auto-detected)\n--- stderr ---\n%s", se.String())
+	}
+	if !strings.Contains(se.String(), "remain in cleartext") {
+		t.Errorf("the pre-commit line does not state the consequence\n--- stderr ---\n%s", se.String())
+	}
+	// Terse by contract: the framed block belongs to the normal path.
+	if strings.Contains(so.String(), "VALUES LEFT IN CLEARTEXT") {
+		t.Errorf("pre-commit mode emitted the full framed block, breaking its terse output "+
+			"contract\n--- stdout ---\n%s", so.String())
 	}
 }

--- a/cmd/unredacted_report.go
+++ b/cmd/unredacted_report.go
@@ -1,0 +1,170 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/formatters"
+	"github.com/awslabs/ferret-scan/v2/internal/parallel"
+)
+
+// The unredacted disclosure, carried into every output format.
+//
+// writeUnredactedFilesWarning already said this on STDERR, which pipelines routinely
+// discard, and the exit code was 0. Measured on a real 14KB PDF that extracts cleanly
+// and yields 3 findings, scanned with --enable-redaction: SEVEN of seven output
+// formats contained no mention of the refusal, so a consumer parsing stdout saw three
+// findings and a clean report while the values sat unchanged on disk (#441).
+//
+// This file turns the same diagnostics into structured data for the formatters and
+// into the count that --fail-on-incomplete acts on.
+
+// classifyRedactionError maps a redactor's error string to a coarse cause.
+//
+// SUBSTRING MATCHING, and that is a known weakness rather than an oversight: the
+// diagnostic carries only parallel.FileDiagnostic.Reason, which is
+// result.RedactionError.Error() — free text. Typed errors from every redactor would
+// be better and are a larger change than this disclosure.
+//
+// Two things make the weakness safe rather than merely acknowledged:
+//
+//  1. An unmatched string falls to formatters.UnredactedRefused, whose label
+//     ("redaction refused") is true of EVERY refusal. Drift therefore loses detail
+//     and never asserts a wrong remedy — it will not tell an operator to raise a
+//     limit that was never hit.
+//  2. TestClassifyRedactionErrorCoversTheRealRedactors pins the actual strings the
+//     shipped redactors produce, so rewording one fails a test instead of silently
+//     degrading every report.
+func classifyRedactionError(reason string) formatters.UnredactedCause {
+	r := strings.ToLower(reason)
+
+	switch {
+	// Checked before "not implemented" because the image redactor's budget refusal
+	// and its unimplemented-format arm both surface through the same
+	// "failed to redact image metadata: ..." prefix, and the budget message is the
+	// more specific of the two.
+	case strings.Contains(r, "budget") || strings.Contains(r, "too large") ||
+		strings.Contains(r, "over the"):
+		return formatters.UnredactedOverBudget
+
+	case strings.Contains(r, "not implemented") || strings.Contains(r, "no redactor"):
+		return formatters.UnredactedNoRedactor
+
+	// The audio and video redactors refuse when a reported value is not present in
+	// the bytes they may rewrite: their replacements must be the same length as the
+	// value replaced, so a value they cannot locate cannot be overwritten without
+	// moving every subsequent offset.
+	case strings.Contains(r, "not found") || strings.Contains(r, "could not locate") ||
+		strings.Contains(r, "not located"):
+		return formatters.UnredactedValueNotLocated
+
+	case strings.Contains(r, "permission denied") || strings.Contains(r, "no space") ||
+		strings.Contains(r, "failed to create") || strings.Contains(r, "failed to write"):
+		return formatters.UnredactedWriteFailed
+
+	default:
+		return formatters.UnredactedRefused
+	}
+}
+
+// toFormatterUnredacted turns the per-file redaction diagnostics into the structured
+// disclosure, counting how many REPORTED values each file leaves in cleartext.
+//
+// The value count comes from the matches actually being reported, not from the
+// redactor: it is the number that sizes the exposure, and a consumer cannot recover it
+// from the findings list alone because that list does not say which findings were
+// written out redacted.
+//
+// matches must be the SAME slice the formatters receive — the unsuppressed set. Using
+// allMatches would count suppressed findings as cleartext exposure, overstating it,
+// and using a different slice than the formatter is the classic way for a summary to
+// disagree with the rows beneath it.
+func toFormatterUnredacted(diags []parallel.FileDiagnostic, matches []detector.Match) []formatters.UnredactedFile {
+	if len(diags) == 0 {
+		return nil
+	}
+
+	perFile := make(map[string]int, len(diags))
+	for i := range matches {
+		perFile[matches[i].Filename]++
+	}
+
+	out := make([]formatters.UnredactedFile, 0, len(diags))
+	for _, d := range diags {
+		// A file with NO reported values is not an exposure this report can speak to.
+		//
+		// It happens when every finding for the file was suppressed: the redactor still
+		// reports a diagnostic, but there was nothing left to redact. Keeping the entry
+		// produced a self-contradiction — "1 file not redacted, 0 values in cleartext" —
+		// and warned about a file whose findings the operator had explicitly accepted.
+		//
+		// Safe because the count and the diagnostic share one path space: the diagnostic's
+		// FilePath is the same string the matches carry as Filename (verified end to end —
+		// an unredactable PDF with three findings counts three). If that ever diverges,
+		// this would start hiding real exposures rather than dropping empty ones, which is
+		// why TestSuppressedFileIsNotReportedAsExposed pins BOTH directions.
+		if perFile[d.FilePath] == 0 {
+			continue
+		}
+		out = append(out, formatters.UnredactedFile{
+			Path:           d.FilePath,
+			Cause:          classifyRedactionError(d.Reason),
+			Detail:         scrubReportedValues(d.Reason, matches),
+			ReportedValues: perFile[d.FilePath],
+		})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// scrubReportedValues removes any reported finding's text from a redactor's error
+// message before it becomes output.
+//
+// DEFENCE IN DEPTH, not the primary control. Detail is a redactor's own error string,
+// and one of them did interpolate the raw value:
+//
+//	fmt.Errorf("match text %q not found in line %d", match.Text, match.LineNumber)
+//
+// That has been fixed at source (internal/redactors/plaintext), but before #441 such a
+// string only reached stderr, and now it reaches JSON, YAML, CSV, JUnit, SARIF and the
+// GitLab report. A single future Errorf can therefore turn a disclosure into a leak in
+// seven places at once, which is too sharp an edge to leave guarded only by review.
+//
+// Deliberately NOT gated on --show-match. That flag governs whether a finding's own
+// value is shown in its own row, where the reader asked for it; it is not a licence to
+// print values inside a diagnostic string, and the two are different decisions. The
+// value is always available in the finding itself.
+//
+// Cost is bounded: it runs once per unredacted file, over the reported values, and
+// short-circuits on the overwhelmingly common case of an error containing no value at
+// all. Values shorter than four characters are skipped, because replacing a two-digit
+// string would corrupt line numbers and byte counts in the message while hiding
+// nothing an attacker could not guess.
+func scrubReportedValues(reason string, matches []detector.Match) string {
+	if reason == "" {
+		return reason
+	}
+	const minScrubLen = 4
+	seen := make(map[string]struct{}, len(matches))
+	out := reason
+	for i := range matches {
+		v := matches[i].Text
+		if len(v) < minScrubLen {
+			continue
+		}
+		if _, done := seen[v]; done {
+			continue
+		}
+		seen[v] = struct{}{}
+		if strings.Contains(out, v) {
+			out = strings.ReplaceAll(out, v, fmt.Sprintf("[HIDDEN] (len=%d)", len(v)))
+		}
+	}
+	return out
+}

--- a/internal/formatters/csv/formatter.go
+++ b/internal/formatters/csv/formatter.go
@@ -62,24 +62,51 @@ func (f *Formatter) Format(matches []detector.Match, suppressedMatches []detecto
 		headers = []string{"File", "Issue", "Line", "Confidence"}
 	} else {
 		headers = []string{"Filename", "Type", "Confidence Level", "Confidence %", "Line Number", "Text"}
+		// The redaction disclosure, per FINDING rather than per file.
+		//
+		// CSV's grain is one row per finding, and every unredacted value HAS a row by
+		// construction — the disclosure counts reported values. So the per-row form is
+		// COMPLETE here, unlike the not-examined disclosure, where a file with no
+		// findings has no row to carry it and CSV therefore still says nothing. That
+		// asymmetry is deliberate and documented rather than papered over with a
+		// pseudo-row: a row that is not a finding breaks row counts and any grouping
+		// by Type.
+		//
+		// Present only when redaction was REQUESTED, which is the same convention this
+		// formatter already uses for --verbose adding Metadata: the header varies with
+		// the invocation, not with the data. A consumer runs a fixed command, so its
+		// header is stable; and a read-only scan is not made to carry two columns that
+		// could only ever say "n/a".
+		//
+		// Placed BEFORE the optional Metadata column so these two are always at fixed
+		// positions. Metadata is appended only when non-nil, so appending after it
+		// would put these fields at a position that varies with the row's content.
+		if options.RedactionRequested {
+			headers = append(headers, "Redacted", "Not Redacted Reason")
+		}
 		if options.Verbose {
 			headers = append(headers, "Metadata")
 		}
 	}
+
+	// Built once rather than per row: the per-finding columns below need a path lookup,
+	// and recomputing it inside the row builder would make the formatter quadratic in
+	// (findings x unredacted files) on exactly the input where both are large.
+	unredactedByPath := formatters.UnredactedPaths(options.Unredacted)
 
 	// Start with header row
 	csvRows := []string{strings.Join(headers, ",")}
 
 	// Process regular matches
 	for _, match := range filteredMatches {
-		row := f.createCSVRow(match, options, false)
+		row := f.createCSVRow(match, options, unredactedByPath, false)
 		csvRows = append(csvRows, row)
 	}
 
 	// Process suppressed matches if provided (skip in pre-commit mode for brevity)
 	if !options.PrecommitMode {
 		for _, suppressed := range suppressedMatches {
-			row := f.createCSVRow(suppressed.Match, options, true)
+			row := f.createCSVRow(suppressed.Match, options, unredactedByPath, true)
 			csvRows = append(csvRows, row)
 		}
 	}
@@ -88,7 +115,7 @@ func (f *Formatter) Format(matches []detector.Match, suppressedMatches []detecto
 }
 
 // createCSVRow creates a CSV row for a match
-func (f *Formatter) createCSVRow(match detector.Match, options formatters.FormatterOptions, suppressed bool) string {
+func (f *Formatter) createCSVRow(match detector.Match, options formatters.FormatterOptions, unredactedByPath map[string]formatters.UnredactedFile, suppressed bool) string {
 	// Get confidence level using shared logic
 	confidenceLevel := shared.GetConfidenceLevel(match.Confidence)
 	if suppressed {
@@ -121,6 +148,17 @@ func (f *Formatter) createCSVRow(match detector.Match, options formatters.Format
 			fmt.Sprintf("%.1f", match.Confidence),
 			fmt.Sprintf("%d", match.LineNumber),
 			f.escapeCSVField(displayText),
+		}
+
+		// Whether THIS finding's value was written out redacted. Emitted only when
+		// redaction was requested, so the row width always matches the header.
+		if options.RedactionRequested {
+			redacted, reason := "true", ""
+			if uf, ok := unredactedByPath[match.Filename]; ok {
+				redacted = "false"
+				reason = uf.Cause.String()
+			}
+			row = append(row, f.escapeCSVField(redacted), f.escapeCSVField(reason))
 		}
 
 		// Add metadata if verbose mode is enabled. Run it through the shared

--- a/internal/formatters/formatter.go
+++ b/internal/formatters/formatter.go
@@ -56,6 +56,37 @@ type FormatterOptions struct {
 	// legitimate: the golden harness constructs FormatterOptions without either.
 	NotExamined []NotExaminedFile
 
+	// UnredactedFooter is the text formatter's rendered block, appended inside the
+	// summary exactly as NotExaminedFooter is, and for the same reason: printed
+	// separately to stderr it rendered as a detached box, and a piped stdout ended
+	// with a frame closed by content the pipe never received.
+	//
+	// Text format only; structured formats carry the same information as data via
+	// Unredacted below.
+	UnredactedFooter string
+
+	// RedactionRequested records whether the run asked for redaction at all.
+	//
+	// Needed to distinguish three states a consumer must not conflate: redaction was
+	// not requested, it was requested and succeeded, and it was requested and refused.
+	// Without this a read-only scan and a fully redacted one look identical, so a
+	// consumer filtering for exposures would be told a scan that never redacted
+	// anything was clean.
+	RedactionRequested bool
+
+	// Unredacted is the STRUCTURED form of the redaction disclosure, for machine
+	// formats. Empty means nothing was left in cleartext — which includes the common
+	// case of a scan that never asked for redaction.
+	//
+	// Separate from ScanStats for the same reason NotExamined is: stats marshals
+	// directly to json/yaml, and an int-backed enum there would put an ordinal on the
+	// wire as a number and make it an output contract. The counts that belong in
+	// stats are already there (FilesNotRedacted, ValuesNotRedacted).
+	//
+	// Formatters must guard on len(Unredacted) > 0 AND treat a nil Stats as
+	// legitimate: the golden harness constructs FormatterOptions without either.
+	Unredacted []UnredactedFile
+
 	// FailOnIncomplete mirrors --fail-on-incomplete, which makes incomplete coverage
 	// a non-zero exit.
 	//
@@ -106,13 +137,32 @@ type ScanStats struct {
 	// summary over unexamined files is the same class of harm as a missed detection.
 	//
 	// omitempty so a scan with nothing to report stays byte-identical in JSON/YAML.
-	FilesNotExamined int     `json:"files_not_examined,omitempty" yaml:"files_not_examined,omitempty"`
-	TotalFindings    int     `json:"total_findings" yaml:"total_findings"`
-	High             int     `json:"high" yaml:"high"`
-	Medium           int     `json:"medium" yaml:"medium"`
-	Low              int     `json:"low" yaml:"low"`
-	Suppressed       int     `json:"suppressed" yaml:"suppressed"`
-	Duration         float64 `json:"duration_seconds" yaml:"duration_seconds"`
+	FilesNotExamined int `json:"files_not_examined,omitempty" yaml:"files_not_examined,omitempty"`
+
+	// FilesNotRedacted counts files whose findings were REPORTED but whose values
+	// were not redacted, so they remain in cleartext. Separate from
+	// FilesNotExamined because they are different facts about different stages: a
+	// file can be fully examined and unredacted, or partly examined and redacted
+	// fine. Merging them would tell a consumer that something went wrong without
+	// saying whether the remedy is to re-scan or to stop shipping the output.
+	//
+	// Only meaningful when redaction was requested; a scan without
+	// --enable-redaction leaves it zero.
+	//
+	// omitempty so a scan with nothing to report stays byte-identical in JSON/YAML.
+	FilesNotRedacted int `json:"files_not_redacted,omitempty" yaml:"files_not_redacted,omitempty"`
+
+	// ValuesNotRedacted counts the individual reported findings left in cleartext
+	// across those files. This is the number that sizes the exposure; the file count
+	// alone understates one file holding forty values.
+	ValuesNotRedacted int `json:"values_not_redacted,omitempty" yaml:"values_not_redacted,omitempty"`
+
+	TotalFindings int     `json:"total_findings" yaml:"total_findings"`
+	High          int     `json:"high" yaml:"high"`
+	Medium        int     `json:"medium" yaml:"medium"`
+	Low           int     `json:"low" yaml:"low"`
+	Suppressed    int     `json:"suppressed" yaml:"suppressed"`
+	Duration      float64 `json:"duration_seconds" yaml:"duration_seconds"`
 }
 
 // Formatter interface defines methods that all output formatters must implement

--- a/internal/formatters/gitlab-sast/formatter.go
+++ b/internal/formatters/gitlab-sast/formatter.go
@@ -125,6 +125,7 @@ func (f *Formatter) Format(matches []detector.Match, suppressedMatches []detecto
 	// is a different and false statement. Coverage is reported through messages, and
 	// the exit code (with --fail-on-incomplete) carries the verdict.
 	addNotExaminedMessages(report, options)
+	addUnredactedMessages(report, options)
 
 	// Handle empty results - return valid empty GitLab report structure
 	if len(matches) == 0 {

--- a/internal/formatters/gitlab-sast/unredacted.go
+++ b/internal/formatters/gitlab-sast/unredacted.go
@@ -1,0 +1,53 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package gitlabsast
+
+import "github.com/awslabs/ferret-scan/v2/internal/formatters"
+
+// addUnredactedMessages appends the redaction disclosure to scan.messages.
+//
+// Same slot and same shape as addNotExaminedMessages, because the two are the same
+// kind of statement about the run: a fact the consumer needs that is not a finding.
+//
+// NOT a vulnerability entry, which was the tempting alternative. The values in this
+// file are ALREADY reported as vulnerabilities — that is what makes them unredacted —
+// so adding another entry for the same bytes would double-count the exposure on the
+// GitLab Security Dashboard and inflate every count derived from it. scan.messages is
+// where "something about this run you should know" belongs.
+//
+// Called BEFORE the formatter's zero-matches early return, for the same reason the
+// not-examined disclosure is: although a file with no findings cannot be unredacted,
+// the early return is shared and a future change to either condition must not silently
+// drop this.
+//
+// Level "warn" — GitLab's spelling, and deliberately not SARIF's "warning". Both
+// formats are emitted by this codebase and the constant is named to make a
+// copy-paste between them fail visibly.
+func addUnredactedMessages(report *GitLabSecurityReport, options formatters.FormatterOptions) {
+	if report == nil || len(options.Unredacted) == 0 {
+		return
+	}
+
+	shown, total := formatters.CapUnredacted(options.Unredacted)
+	values := formatters.UnredactedValueCount(options.Unredacted)
+
+	msgs := make([]GitLabScanMessage, 0, len(shown)+1)
+	// Summary first, so a consumer showing only the first message still learns values
+	// are in cleartext, and it states the TOTALS so the cap cannot hide the scale.
+	msgs = append(msgs, GitLabScanMessage{
+		Level: scanMessageLevelWarn,
+		Value: formatters.UnredactedSummary(len(shown), total, values),
+	})
+	for _, f := range shown {
+		// f.Message() guarantees a non-empty string, which the schema requires
+		// (value has minLength 1). A zero-valued UnredactedFile still yields a valid
+		// message rather than an empty one that would fail validation.
+		msgs = append(msgs, GitLabScanMessage{
+			Level: scanMessageLevelWarn,
+			Value: f.Message(),
+		})
+	}
+
+	report.Scan.Messages = append(report.Scan.Messages, msgs...)
+}

--- a/internal/formatters/junit/formatter.go
+++ b/internal/formatters/junit/formatter.go
@@ -229,6 +229,15 @@ func (f *Formatter) Format(matches []detector.Match, suppressedMatches []detecto
 		testSuites.Errors += notExaminedSuite.Errors
 	}
 
+	// The redaction disclosure rolls up into FAILURES, not errors: the suite emits
+	// <failure> unconditionally, and the top-level totals must agree with the suite or
+	// consumers that trust the roll-up will disagree with ones that count elements.
+	if unredactedSuite, ok := buildUnredactedSuite(options); ok {
+		testSuites.TestSuites = append(testSuites.TestSuites, unredactedSuite)
+		testSuites.Tests += unredactedSuite.Tests
+		testSuites.Failures += unredactedSuite.Failures
+	}
+
 	// Generate XML
 	xmlData, err := xml.MarshalIndent(testSuites, "", "  ")
 	if err != nil {

--- a/internal/formatters/junit/unredacted.go
+++ b/internal/formatters/junit/unredacted.go
@@ -1,0 +1,87 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package junit
+
+import (
+	"encoding/xml"
+	"fmt"
+	"path/filepath"
+
+	"github.com/awslabs/ferret-scan/v2/internal/formatters"
+)
+
+// unredactedSuiteName is the suite that holds files whose values were not redacted.
+//
+// Separate from the not-examined suite because a consumer filtering by classname must
+// be able to tell "we never read this file" from "we read it, reported values, and left
+// them in cleartext". The two need different remedies and only one of them means an
+// artifact downstream is unsafe.
+const unredactedSuiteName = "unredacted"
+
+// buildUnredactedSuite renders the redaction disclosure as a JUnit suite.
+//
+// <failure>, UNCONDITIONALLY — deliberately unlike buildNotExaminedSuite, which emits
+// <skipped> and escalates to <error> only under --fail-on-incomplete. Three reasons:
+//
+//  1. <skipped> renders grey or is filtered out entirely on most CI dashboards, which
+//     is the wrong presentation for "sensitive values are still in cleartext". The
+//     whole defect being fixed here (#441) is that this outcome was invisible; emitting
+//     it as a skip would keep it invisible in the one artifact CI actually renders.
+//  2. It must not depend on --fail-on-incomplete. A team that has not set that flag
+//     still needs to see this, and the flag governs the EXIT CODE. Tying the XML
+//     verdict to it would mean the report changes meaning based on a flag about
+//     something else.
+//  3. Not <error>, which in JUnit means the run itself misbehaved. The run did not: it
+//     scanned correctly, reported correctly, and refused to write a file it could not
+//     sanitize. The refusal is right; the exposure is what failed.
+func buildUnredactedSuite(options formatters.FormatterOptions) (TestSuite, bool) {
+	if len(options.Unredacted) == 0 {
+		return TestSuite{}, false
+	}
+
+	shown, total := formatters.CapUnredacted(options.Unredacted)
+	values := formatters.UnredactedValueCount(options.Unredacted)
+
+	suite := TestSuite{
+		XMLName:   xml.Name{Local: "testsuite"},
+		Name:      unredactedSuiteName,
+		Time:      "0.000",
+		TestCases: make([]TestCase, 0, len(shown)),
+		// The summary states the TOTALS, so the cap above can never make the report
+		// understate how much is exposed.
+		SystemOut: formatters.UnredactedSummary(len(shown), total, values),
+	}
+
+	for _, uf := range shown {
+		tc := TestCase{
+			XMLName: xml.Name{Local: "testcase"},
+			// The base name keeps the case list readable; the full path is in the
+			// message, so nothing is lost.
+			Name:      filepath.Base(uf.Path),
+			ClassName: unredactedSuiteName,
+			Time:      "0.000",
+		}
+		tc.Failure = &Failure{
+			Message: uf.Message(),
+			Type:    "Unredacted",
+			Content: unredactedContent(uf),
+		}
+		suite.Failures++
+		suite.TestCases = append(suite.TestCases, tc)
+	}
+	suite.Tests = len(suite.TestCases)
+
+	return suite, true
+}
+
+// unredactedContent is the element body: what a reader needs in order to act.
+//
+// Deliberately does NOT begin with "Line ", because the shared limit-parity test counts
+// finding lines by that prefix and these are not findings.
+func unredactedContent(uf formatters.UnredactedFile) string {
+	return fmt.Sprintf("%s\nCause: %s\n%d reported value(s) remain in cleartext at the "+
+		"original path. The findings for this file are accurate; what did not happen is the "+
+		"redaction, so no sanitized artifact exists for it.",
+		uf.Path, uf.Cause, uf.ReportedValues)
+}

--- a/internal/formatters/sarif/formatter.go
+++ b/internal/formatters/sarif/formatter.go
@@ -168,6 +168,7 @@ func (f *Formatter) buildReport(mapper *VulnerabilityMapper, ruleManager *RuleMa
 	// unreadable files is the most dangerous document this tool can emit, so the
 	// disclosure must not sit behind a has-findings condition.
 	attachNotExamined(&run, options)
+	attachUnredacted(&run, options)
 
 	// Create the top-level SARIF report
 	report := &SARIFReport{

--- a/internal/formatters/sarif/unredacted.go
+++ b/internal/formatters/sarif/unredacted.go
@@ -1,0 +1,112 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package sarif
+
+import "github.com/awslabs/ferret-scan/v2/internal/formatters"
+
+// unredactedNotificationID is the descriptor id shared by every unredacted
+// notification.
+//
+// One descriptor for the whole class, for the same reason not-examined has one:
+// tool.driver.notifications has uniqueItems:true, so a per-file descriptor would
+// duplicate the object and invalidate the document on a run with two unredactable
+// files of the same cause.
+//
+// Distinct from notExaminedNotificationID because a consumer filtering on descriptor
+// id must be able to tell "we never read this file" from "we read it, found values,
+// and left them in cleartext" — the remedies are unrelated.
+const unredactedNotificationID = "ferret-scan/not-redacted"
+
+// attachUnredacted adds the unredacted disclosure to a SARIF run.
+//
+// Same slot as the not-examined disclosure —
+// run.invocations[].toolExecutionNotifications[] — and the alternatives were rejected
+// on the same evidence, which applies here with more force:
+//
+//   - a new run-level key: run.additionalProperties is FALSE in SARIF 2.1.0, so it is
+//     invalid, and an invalid report is rejected whole. Losing the report to carry
+//     the disclosure defeats the disclosure.
+//   - a result with kind:"informational": GitHub renders results as code scanning
+//     alerts, so "this file was not redacted" would appear as a PII finding at a
+//     location. The values ARE reported already, as their own results; adding a
+//     second alert for the same bytes would double-count the exposure.
+//
+// Appends to an existing invocation rather than adding a second one when
+// attachNotExamined has already run: invocations[] means "one entry per tool
+// invocation", and there was one invocation. Two entries would claim the tool ran
+// twice.
+//
+// The disclosure is machine-readable only, since GitHub's UI does not surface
+// toolExecutionNotifications. Accepted for the same reason as not-examined: a valid,
+// quiet, programmatically-checkable statement beats a visible fabricated alert.
+func attachUnredacted(run *SARIFRun, options formatters.FormatterOptions) {
+	if run == nil || len(options.Unredacted) == 0 {
+		return
+	}
+
+	shown, total := formatters.CapUnredacted(options.Unredacted)
+	values := formatters.UnredactedValueCount(options.Unredacted)
+
+	notifications := make([]SARIFNotification, 0, len(shown)+1)
+
+	// Summary first, so a consumer that reads only the first notification still
+	// learns values are in cleartext, and so the totals survive the cap.
+	notifications = append(notifications, newUnredactedNotification(
+		formatters.UnredactedSummary(len(shown), total, values)))
+	for _, f := range shown {
+		notifications = append(notifications, newUnredactedNotification(f.Message()))
+	}
+
+	// One invocation for one run: extend the existing entry if there is one.
+	if len(run.Invocations) > 0 {
+		run.Invocations[0].ToolExecutionNotifications = append(
+			run.Invocations[0].ToolExecutionNotifications, notifications...)
+	} else {
+		run.Invocations = append(run.Invocations, SARIFInvocation{
+			// True, always. This is the object's only required member, and false
+			// means "the analysis did not complete", which consumers may treat as
+			// grounds to discard the results. The analysis completed; the WRITE did
+			// not, and the findings it produced are valid and must be kept.
+			ExecutionSuccessful:        true,
+			ToolExecutionNotifications: notifications,
+		})
+	}
+
+	// Declare the descriptor the notifications reference, exactly once.
+	for _, existing := range run.Tool.Driver.Notifications {
+		if existing.ID == unredactedNotificationID {
+			return
+		}
+	}
+	run.Tool.Driver.Notifications = append(run.Tool.Driver.Notifications, SARIFRule{
+		ID: unredactedNotificationID,
+		ShortDescription: SARIFMessage{
+			Text: "Findings were reported for this file but not redacted, so the values remain in cleartext",
+		},
+		FullDescription: SARIFMessage{
+			Text: "The scanner reported sensitive values in this file but wrote no redacted copy, " +
+				"so the original values are unchanged. The findings in this report are accurate; " +
+				"what did not happen is the redaction. Treat any pipeline step that expected a " +
+				"sanitized artifact for this file as not having received one.",
+		},
+	})
+}
+
+// newUnredactedNotification builds one notification.
+//
+// Level "warning" — the SARIF enum is none/note/warning/error. NOT "warn", which is
+// GitLab's spelling and invalid here. Both formats are emitted by this codebase, so
+// the distinction is called out at every site that could be copy-pasted.
+//
+// Warning rather than error for the same reason executionSuccessful stays true: the
+// run produced valid results. "error" in SARIF describes the analysis failing, and a
+// consumer may discard results on it — which would throw away the very findings that
+// say what is in cleartext.
+func newUnredactedNotification(text string) SARIFNotification {
+	return SARIFNotification{
+		Descriptor: &SARIFReportingDescriptorRef{ID: unredactedNotificationID},
+		Level:      LevelWarning,
+		Message:    SARIFMessage{Text: text},
+	}
+}

--- a/internal/formatters/shared/structures.go
+++ b/internal/formatters/shared/structures.go
@@ -190,11 +190,65 @@ func SanitizeSuppressedMatches(suppressed []detector.SuppressedMatch, showMatch 
 
 // JSONResponse represents the top-level response structure for JSON/YAML output
 type JSONResponse struct {
-	Stats         *formatters.ScanStats      `json:"stats,omitempty" yaml:"stats,omitempty"`
-	Results       []JSONMatch                `json:"results" yaml:"results"`
+	Stats   *formatters.ScanStats `json:"stats,omitempty" yaml:"stats,omitempty"`
+	Results []JSONMatch           `json:"results" yaml:"results"`
+
+	// Unredacted lists files whose findings were reported but not redacted, so their
+	// values remain in cleartext.
+	//
+	// A LIST rather than only the stats counters, because a count tells a consumer
+	// that something is exposed without telling it what to do. The equivalent
+	// not-examined disclosure carries only a count today, which means a consumer must
+	// re-run in text format to learn which file — a worse contract that is not worth
+	// copying. Retrofitting a list there is tracked separately.
+	//
+	// omitempty, so every scan that redacted cleanly — and every scan that never
+	// asked for redaction — stays byte-identical.
+	Unredacted []JSONUnredacted `json:"unredacted,omitempty" yaml:"unredacted,omitempty"`
+
 	Suppressed    []detector.SuppressedMatch `json:"suppressed,omitempty" yaml:"suppressed,omitempty"`
 	Truncated     bool                       `json:"truncated,omitempty" yaml:"truncated,omitempty"`
 	TotalFindings int                        `json:"total_findings,omitempty" yaml:"total_findings,omitempty"`
+}
+
+// JSONUnredacted is one file whose reported values were left in cleartext.
+//
+// A distinct wire type rather than reusing formatters.UnredactedFile, whose Cause is
+// an int-backed enum: marshalling that directly would put an ORDINAL on the wire and
+// make the numbering an output contract, so inserting a cause later would silently
+// change every consumer's meaning. Cause is emitted as its label instead.
+type JSONUnredacted struct {
+	Path string `json:"path" yaml:"path"`
+	// Cause is the coarse, stable label ("no redactor for this file type").
+	Cause string `json:"cause" yaml:"cause"`
+	// Detail is the redactor's own explanation, useful for a human triaging.
+	Detail string `json:"detail,omitempty" yaml:"detail,omitempty"`
+	// ReportedValues is how many findings for this file remain in cleartext.
+	ReportedValues int `json:"reported_values" yaml:"reported_values"`
+}
+
+// convertUnredacted maps the structured disclosure onto the wire type, capped the same
+// way every machine format caps it.
+//
+// The cap is a denial-of-service bound on the CONSUMER, not on the disclosure: the
+// totals stay in stats.files_not_redacted and stats.values_not_redacted, which are
+// computed over the full set, so a truncated list can never make the report understate
+// the exposure.
+func convertUnredacted(files []formatters.UnredactedFile) []JSONUnredacted {
+	shown, _ := formatters.CapUnredacted(files)
+	if len(shown) == 0 {
+		return nil
+	}
+	out := make([]JSONUnredacted, 0, len(shown))
+	for _, f := range shown {
+		out = append(out, JSONUnredacted{
+			Path:           f.Path,
+			Cause:          f.Cause.String(),
+			Detail:         f.Detail,
+			ReportedValues: f.ReportedValues,
+		})
+	}
+	return out
 }
 
 // JSONMatch represents a single match in JSON/YAML format
@@ -416,7 +470,8 @@ func ConvertMatchesToJSONFormat(matches []detector.Match, suppressedMatches []de
 	}
 
 	resp := JSONResponse{
-		Results: jsonMatches,
+		Results:    jsonMatches,
+		Unredacted: convertUnredacted(options.Unredacted),
 		// Suppressed matches embed the raw finding, so route them through the
 		// same deny-by-default redaction as active results: without --show-match
 		// the value, metadata, and surrounding context are withheld.

--- a/internal/formatters/text/formatter.go
+++ b/internal/formatters/text/formatter.go
@@ -203,13 +203,52 @@ func (f *Formatter) writeFormattedOutput(w io.Writer, matches []detector.Match, 
 // dangerous output the tool can produce, because it is the same text a genuinely
 // clean scan produces. The footer is the only thing distinguishing "I looked and
 // found nothing" from "I could not look".
+// disclosureFooter is everything the summary frame must enclose below its own line.
+//
+// Two independent disclosures land here — coverage gaps (files never fully read) and
+// redaction refusals (values reported but left in cleartext) — and a run can have
+// both. They are joined rather than given separate frames because the frame's job is
+// to keep one contiguous block on ONE stream: two frames printed in sequence read as
+// two reports, and a piped stdout could receive one and not the other.
+//
+// Each block carries its own heading, so no divider is added between them; the
+// headings already say which is which.
+func disclosureFooter(options formatters.FormatterOptions) string {
+	// The redaction block is rendered HERE from the structured disclosure, so it does
+	// not depend on a caller having built prose. UnredactedFooter remains an override
+	// for a caller that wants its own wording; empty means "derive it", which is what
+	// the CLI, the web UI and every library consumer do.
+	unredacted := options.UnredactedFooter
+	if unredacted == "" {
+		total := 0
+		if options.Stats != nil {
+			total = options.Stats.TotalFiles
+		}
+		// The exit hint is omitted when the not-examined block above already carries
+		// it: both feed the same --fail-on-incomplete escalation, so printing the same
+		// instruction twice inside one frame reads as two separate policies.
+		unredacted = formatters.RenderBlock(options.Unredacted, total, options.FailOnIncomplete,
+			options.NotExaminedFooter == "")
+	}
+
+	switch {
+	case options.NotExaminedFooter == "":
+		return unredacted
+	case unredacted == "":
+		return options.NotExaminedFooter
+	default:
+		return options.NotExaminedFooter + unredacted
+	}
+}
+
 func (f *Formatter) noMatchesText(msg string, options formatters.FormatterOptions) string {
-	if options.NotExaminedFooter == "" {
+	footer := disclosureFooter(options)
+	if footer == "" {
 		return msg
 	}
 
 	width := summaryRuleFloor
-	for _, line := range strings.Split(options.NotExaminedFooter, "\n") {
+	for _, line := range strings.Split(footer, "\n") {
 		if n := displayWidth(line); n > width {
 			width = n
 		}
@@ -220,7 +259,7 @@ func (f *Formatter) noMatchesText(msg string, options formatters.FormatterOption
 
 	return msg + "\n\n" +
 		rule("─", width) + "\n" +
-		options.NotExaminedFooter +
+		footer +
 		rule("═", width)
 }
 
@@ -282,7 +321,8 @@ func (f *Formatter) writeSummaryHeader(w io.Writer, options formatters.Formatter
 	if n := displayWidth(summaryLine); n > width {
 		width = n
 	}
-	for _, line := range strings.Split(options.NotExaminedFooter, "\n") {
+	footer := disclosureFooter(options)
+	for _, line := range strings.Split(footer, "\n") {
 		if n := displayWidth(line); n > width {
 			width = n
 		}
@@ -297,14 +337,14 @@ func (f *Formatter) writeSummaryHeader(w io.Writer, options formatters.Formatter
 	fmt.Fprintf(w, "\n%s\n", top)
 	fmt.Fprintln(w, summaryLine)
 
-	if options.NotExaminedFooter == "" {
+	if footer == "" {
 		fmt.Fprintf(w, "%s\n", rule("═", width))
 		return
 	}
 
 	// Single rule divides the two sections; double rule closes the block.
 	fmt.Fprintf(w, "%s\n", rule("─", width))
-	fmt.Fprint(w, options.NotExaminedFooter)
+	fmt.Fprint(w, footer)
 	fmt.Fprintf(w, "%s\n", rule("═", width))
 }
 

--- a/internal/formatters/unredacted.go
+++ b/internal/formatters/unredacted.go
@@ -1,0 +1,389 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package formatters
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// The unredacted disclosure, as DATA rather than prose.
+//
+// A file whose findings were reported but NOT redacted is the one outcome the sink
+// rule forbids passing off as success: the values are still in cleartext, and the
+// consumer has been handed a report that looks complete. Measured at main @ 3c4e10b
+// on a real 14KB PDF that extracts cleanly and yields 3 findings, scanned with
+// --enable-redaction:
+//
+//	format       in-band signal on stdout
+//	text         NONE
+//	json         NONE
+//	yaml         NONE
+//	csv          NONE
+//	junit        NONE
+//	sarif        NONE
+//	gitlab-sast  NONE
+//
+// Seven of seven. The human-readable warning IS produced —
+//
+//	WARNING: redaction incomplete — 1 of 1 file(s) have findings but no redacted
+//	copy was written; the original values remain in cleartext
+//
+// — but it goes to STDERR, which pipelines routinely discard, and the exit code was
+// 0. So a scheduled sanitization job shipped nothing for that file, reported success,
+// and the only record was a log line nobody reads (#441).
+//
+// This mirrors NotExaminedFile deliberately, because it is the same class of harm
+// reached one step later: not-examined means "we never looked", unredacted means "we
+// looked, we found, and we could not clean it". Both are gaps that read as a pass.
+// Where the two differ is what a consumer can do about it, which is why the causes
+// are a separate enum rather than extra NotExaminedCause values.
+
+// UnredactedCause is a coarse, user-facing reason a reported value was not redacted.
+//
+// An INT enum for the same two reasons NotExaminedCause is: the causes have a
+// deliberate presentation order, and the zero value must be a VALID cause so that a
+// partially-populated struct cannot emit an empty string into a field whose schema
+// requires minLength 1 (GitLab SAST).
+type UnredactedCause int
+
+const (
+	// UnredactedRefused — the redactor declined to write a copy, cause not narrowed.
+	//
+	// The ZERO VALUE is deliberately the generic one, because the cause is recovered
+	// by matching substrings of a redactor's error string (see cmd's classifier) and
+	// that matching WILL drift when an error is reworded. When it drifts, the entry
+	// falls here — and this label is true of every refusal, so a misclassification
+	// degrades the detail without ever asserting a wrong remedy. The alternative
+	// orderings all had a specific cause as the zero value, which meant a reworded
+	// error would confidently tell an operator to raise a limit that was never hit.
+	//
+	// It also sorts first, which reads slightly oddly next to the specific causes but
+	// costs nothing: presentation order among causes carries no meaning here, unlike
+	// NotExaminedCause where it tracks how partial the coverage was.
+	UnredactedRefused UnredactedCause = iota
+
+	// UnredactedNoRedactor — no redactor is implemented for this file type, so no
+	// output was written at all. PDF today, and .tiff/.gif/.bmp/.webp, whose
+	// extensions are accepted by the image redactor but reach an unimplemented arm.
+	//
+	// The most complete failure: nothing about the file was cleaned, and the remedy is
+	// a tool change rather than anything the operator can adjust.
+	UnredactedNoRedactor
+
+	// UnredactedOverBudget — the file was refused by a resource limit before it could
+	// be redacted, e.g. an image whose declared pixel count is over the redactor's
+	// budget (#378). The operator CAN act: the value is a documented limit.
+	UnredactedOverBudget
+
+	// UnredactedValueNotLocated — the redactor ran but could not find a reported
+	// value in the bytes it is allowed to rewrite, so it refused rather than write a
+	// partly-handled file. The audio and video redactors do this: replacements must
+	// be the same length as the value they replace, so a value they cannot locate
+	// cannot be overwritten without moving every subsequent offset.
+	UnredactedValueNotLocated
+
+	// UnredactedWriteFailed — redaction itself failed (permissions, disk, an I/O
+	// error). Distinct from the three above because the tool WOULD have redacted it;
+	// the environment stopped it, and the remedy is environmental.
+	UnredactedWriteFailed
+)
+
+// String returns the operator-facing cause label.
+//
+// These strings are consumed by machine formats, so they are part of the output
+// contract; changing one changes every report. They match the text renderer's
+// wording exactly, because an operator comparing a human report against a JUnit
+// artifact from the same run must not have to translate.
+func (c UnredactedCause) String() string {
+	switch c {
+	case UnredactedRefused:
+		return "redaction refused"
+	case UnredactedNoRedactor:
+		return "no redactor for this file type"
+	case UnredactedOverBudget:
+		return "refused by a resource limit"
+	case UnredactedValueNotLocated:
+		return "reported value not found in the writable bytes"
+	case UnredactedWriteFailed:
+		return "could not write the redacted copy"
+	default:
+		return "unknown"
+	}
+}
+
+// UnredactedFile is one file whose reported findings were not redacted.
+type UnredactedFile struct {
+	// Path is the file as the user named it.
+	Path string
+	// Cause is the coarse reason.
+	Cause UnredactedCause
+	// Detail is a short actionable explanation, already stripped of internal
+	// vocabulary and of the redundant path. May be empty; Message() supplies a
+	// fallback so no format can emit an empty string into a field whose schema
+	// requires minLength 1.
+	Detail string
+	// ReportedValues is how many findings for this file remain in cleartext.
+	//
+	// Carried per file because it is the number that sizes the exposure, and a
+	// consumer cannot recover it from the findings list alone: that list does not say
+	// which findings were written out redacted.
+	ReportedValues int
+}
+
+// Message renders one entry as a single self-describing line.
+//
+// Shared by every machine format so the wording cannot drift between them, and so
+// the minLength-1 guarantee lives in exactly one place. The leading claim is the
+// CONSEQUENCE, not the cause: a consumer that truncates the string still learns that
+// values are in cleartext, which is the part that matters.
+func (f UnredactedFile) Message() string {
+	detail := f.Detail
+	if detail == "" {
+		detail = "no further detail available"
+	}
+	return fmt.Sprintf("NOT REDACTED (%s): %s — %d reported value(s) remain in cleartext; %s",
+		f.Cause, f.Path, f.ReportedValues, detail)
+}
+
+// UnredactedSummary is the aggregate line, used when per-file entries are capped.
+//
+// Truncation is never silent: the count of what was dropped is stated, the same idiom
+// NotExaminedSummary and the --limit disclosure use.
+func UnredactedSummary(shown, total, values int) string {
+	if total <= shown {
+		return fmt.Sprintf("VALUES LEFT IN CLEARTEXT: %d file(s), %d reported value(s) — "+
+			"no redacted copy was written", total, values)
+	}
+	return fmt.Sprintf("VALUES LEFT IN CLEARTEXT: %d file(s), %d reported value(s) — "+
+		"no redacted copy was written; %d listed here, %d omitted",
+		total, values, shown, total-shown)
+}
+
+// MaxUnredactedEntries caps how many per-file entries a machine format emits.
+//
+// Same value and same reasoning as MaxNotExaminedEntries: an unbounded list is a
+// denial of service against the consumer, and a SARIF upload that exceeds GitHub's
+// size limit is rejected whole, which would lose the very disclosure this exists to
+// carry. When the cap bites, UnredactedSummary states the total, so the disclosure
+// stays complete even when the enumeration does not.
+const MaxUnredactedEntries = MaxNotExaminedEntries
+
+// CapUnredacted returns the entries to emit and the true total.
+//
+// CAUSE-FAIR, not first-N. A flat prefix loses whole causes: measured on a directory of
+// 150 PDFs, 12 TIFFs and 3 oversize JPEGs, taking the first 50 in path order emitted
+// "no redactor for this file type" 50 times and the resource-limit refusals NOT AT ALL,
+// so a consumer could not learn that cause had occurred. Which cause survives depended
+// on nothing but filename sort order — naming the JPEGs "zzz-*" was enough to erase
+// them.
+//
+// That matters because the causes are not interchangeable. "No redactor for this type"
+// is a tool limitation the operator cannot act on; "refused by a resource limit" is a
+// documented number they can raise. Hiding the rare, actionable cause behind the common,
+// inert one is the worst possible allocation of a budget that exists to keep the report
+// readable.
+//
+// So every cause present gets at least one slot, remaining slots are shared, and the
+// selection is re-sorted into the caller's original order so grouping and path sort are
+// preserved. The totals are unaffected: stats.files_not_redacted and
+// stats.values_not_redacted are computed over the full set.
+func CapUnredacted(files []UnredactedFile) (shown []UnredactedFile, total int) {
+	return selectFairlyByCause(files, MaxUnredactedEntries), len(files)
+}
+
+// selectFairlyByCause picks up to limit entries so that every cause present is
+// represented, preserving the input order of whatever it selects.
+//
+// Guarantees, in order of importance:
+//
+//  1. If limit >= the number of distinct causes, EVERY cause appears at least once.
+//  2. No more than limit entries are returned.
+//  3. The result is in the same relative order as the input, so a caller that sorted by
+//     path still sees sorted paths.
+//
+// When limit is smaller than the number of causes the first guarantee cannot hold; the
+// causes that fit are taken in enum order, which is deterministic. That case does not
+// arise today (five causes, a limit of 50 for machine formats and 8 for the terminal).
+func selectFairlyByCause(files []UnredactedFile, limit int) []UnredactedFile {
+	if len(files) <= limit || limit <= 0 {
+		return files
+	}
+
+	// Indices per cause, in input order.
+	order := make([]UnredactedCause, 0, 4)
+	byCause := make(map[UnredactedCause][]int)
+	for i, f := range files {
+		if _, seen := byCause[f.Cause]; !seen {
+			order = append(order, f.Cause)
+		}
+		byCause[f.Cause] = append(byCause[f.Cause], i)
+	}
+	// Enum order rather than first-appearance order, so the selection does not depend on
+	// which file the walk happened to reach first.
+	sort.Slice(order, func(i, j int) bool { return order[i] < order[j] })
+
+	quota := limit / len(order)
+	if quota < 1 {
+		quota = 1
+	}
+
+	picked := make(map[int]struct{}, limit)
+	take := func(c UnredactedCause, n int) {
+		for _, idx := range byCause[c] {
+			if n <= 0 || len(picked) >= limit {
+				return
+			}
+			if _, already := picked[idx]; already {
+				continue
+			}
+			picked[idx] = struct{}{}
+			n--
+		}
+	}
+
+	// Pass one: the guaranteed share for each cause.
+	for _, c := range order {
+		take(c, quota)
+	}
+	// Pass two: hand out whatever is left to causes that still have entries, so a small
+	// number of causes does not leave the budget unspent.
+	for len(picked) < limit {
+		before := len(picked)
+		for _, c := range order {
+			take(c, 1)
+			if len(picked) >= limit {
+				break
+			}
+		}
+		if len(picked) == before {
+			break // every cause exhausted
+		}
+	}
+
+	out := make([]UnredactedFile, 0, len(picked))
+	for i, f := range files {
+		if _, ok := picked[i]; ok {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// UnredactedValueCount sums the cleartext values across every entry.
+//
+// Computed over the FULL slice, not the capped one, so the headline number is right
+// even when the enumeration is truncated.
+func UnredactedValueCount(files []UnredactedFile) int {
+	n := 0
+	for _, f := range files {
+		n += f.ReportedValues
+	}
+	return n
+}
+
+// UnredactedPaths is the set of files with unredacted values, for formats that decide
+// per FINDING rather than per file.
+//
+// CSV is the case this exists for: its grain is one row per finding, so it expresses
+// the same fact as two columns on each row rather than as a file-level block. Every
+// unredacted value HAS a finding row by construction — the disclosure counts reported
+// values — so the per-row form is complete for this disclosure, unlike not-examined,
+// where a file with no findings has no row to carry it.
+func UnredactedPaths(files []UnredactedFile) map[string]UnredactedFile {
+	if len(files) == 0 {
+		return nil
+	}
+	byPath := make(map[string]UnredactedFile, len(files))
+	for _, f := range files {
+		byPath[f.Path] = f
+	}
+	return byPath
+}
+
+// RenderBlock renders the operator-facing block for the text format.
+//
+// Lives HERE, not in cmd, so it is derived from the structured disclosure rather than
+// from prose a caller happened to build. The not-examined disclosure does it the other
+// way round -- cmd renders NotExaminedFooter and the text formatter prints whatever it
+// is given -- and that shape has a hole: any caller that populates the structured field
+// but not the footer gets a text report with no disclosure at all. The web UI and every
+// library consumer of formatters.Export are exactly such callers, so copying that shape
+// would have reintroduced #441 on those surfaces while the CLI looked fixed.
+//
+// totalFiles is only used for the "N of M" headline; zero renders the count alone.
+//
+// includeExitHint suppresses the trailing --fail-on-incomplete line. The caller sets it
+// false when another disclosure block in the SAME summary frame already carries that
+// line: the escalation now covers both coverage gaps and redaction refusals, so stating
+// it once is correct and stating it twice reads as two different policies.
+func RenderBlock(files []UnredactedFile, totalFiles int, failOnIncomplete, includeExitHint bool) string {
+	if len(files) == 0 {
+		return ""
+	}
+
+	var w strings.Builder
+	values := UnredactedValueCount(files)
+	if totalFiles > 0 {
+		fmt.Fprintf(&w, "VALUES LEFT IN CLEARTEXT: %d of %d file(s), %d reported value(s) — no redacted copy was written\n",
+			len(files), totalFiles, values)
+	} else {
+		fmt.Fprintf(&w, "VALUES LEFT IN CLEARTEXT: %d file(s), %d reported value(s) — no redacted copy was written\n",
+			len(files), values)
+	}
+
+	// Grouped by cause so an operator sees the SHAPE before the list: one unimplemented
+	// type across forty files is one decision to make, forty different causes are forty.
+	byCause := make(map[UnredactedCause][]UnredactedFile)
+	for _, f := range files {
+		byCause[f.Cause] = append(byCause[f.Cause], f)
+	}
+	causes := make([]int, 0, len(byCause))
+	for c := range byCause {
+		causes = append(causes, int(c))
+	}
+	sort.Ints(causes)
+
+	// Bounded for the same reason the machine formats are: a tree of thousands of PDFs
+	// would bury the headline. What is dropped is always counted.
+	//
+	// The examples are chosen CAUSE-FAIRLY. Taking the first eight in path order showed
+	// eight PDFs and left "refused by a resource limit (3)" with its count but not one
+	// example path — the count told the operator a cause existed and the report then
+	// refused to say which files, which is the least useful place to spend a budget.
+	// Every cause's own count is still the FULL count, whatever is listed beneath it.
+	const inlineDetailLimit = 8
+	examples := make(map[UnredactedCause][]UnredactedFile, len(byCause))
+	for _, f := range selectFairlyByCause(files, inlineDetailLimit) {
+		examples[f.Cause] = append(examples[f.Cause], f)
+	}
+
+	shown := 0
+	for _, ci := range causes {
+		c := UnredactedCause(ci)
+		fmt.Fprintf(&w, "  %s (%d)\n", c, len(byCause[c]))
+		for _, f := range examples[c] {
+			fmt.Fprintf(&w, "    %s  %d value(s) in cleartext\n", f.Path, f.ReportedValues)
+			shown++
+		}
+	}
+	if len(files) > shown {
+		fmt.Fprintf(&w, "  %d more file(s) not listed\n", len(files)-shown)
+	}
+
+	// Shown only when the escalation is NOT already enabled, which is exactly what the
+	// not-examined report does. It is a "how to gate on this" nudge; once the flag is set
+	// the non-zero exit says it, and repeating it adds a line to every failing CI log.
+	//
+	// A draft printed "Exit code 3: --fail-on-incomplete is set …" in that case instead.
+	// Combined with suppressing this line when the not-examined block is present, the
+	// result was that a run with BOTH disclosures and the flag set stated the consequence
+	// NOWHERE — the two suppressions cancelled. Matching the existing convention removes
+	// the interaction rather than adding a third rule to reason about.
+	if includeExitHint && !failOnIncomplete {
+		fmt.Fprint(&w, "  Add --fail-on-incomplete to make this a non-zero exit (3).\n")
+	}
+	return w.String()
+}

--- a/internal/formatters/unredacted_disclosure_test.go
+++ b/internal/formatters/unredacted_disclosure_test.go
@@ -1,0 +1,256 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package formatters_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/formatters"
+
+	// Every formatter registers itself in init(), so importing them is what makes
+	// formatters.Get work. Blank imports because nothing here calls into them directly.
+	_ "github.com/awslabs/ferret-scan/v2/internal/formatters/csv"
+	_ "github.com/awslabs/ferret-scan/v2/internal/formatters/gitlab-sast"
+	_ "github.com/awslabs/ferret-scan/v2/internal/formatters/json"
+	_ "github.com/awslabs/ferret-scan/v2/internal/formatters/junit"
+	_ "github.com/awslabs/ferret-scan/v2/internal/formatters/sarif"
+	_ "github.com/awslabs/ferret-scan/v2/internal/formatters/text"
+	_ "github.com/awslabs/ferret-scan/v2/internal/formatters/yaml"
+)
+
+// EVERY format must disclose that a reported value was not redacted.
+//
+// This is the test that would have caught #441. Measured on main before the fix, on a
+// real 14KB PDF that extracts cleanly and yields 3 findings under --enable-redaction:
+// SEVEN of seven formats contained no mention of the refusal. The warning existed, but
+// only on stderr, which pipelines discard — so a consumer parsing stdout saw three
+// findings and a clean report while the values sat unchanged on disk.
+//
+// Asserted per format on a substring that is meaningful in THAT format rather than on
+// one shared string, because the formats express the same fact in their own grammar and
+// a single shared assertion would either be vacuous or force an unnatural shape on one
+// of them.
+func TestEveryFormatDisclosesAnUnredactedFile(t *testing.T) {
+	matches := []detector.Match{
+		{Text: "449-87-4100", Type: "SSN", Confidence: 100, LineNumber: 2, Filename: "/scan/report.pdf"},
+		{Text: "4532-0151-1283-0366", Type: "VISA", Confidence: 100, LineNumber: 1, Filename: "/scan/report.pdf"},
+	}
+
+	options := formatters.FormatterOptions{
+		ConfidenceLevel:    map[string]bool{"high": true, "medium": true, "low": true},
+		RedactionRequested: true,
+		Unredacted: []formatters.UnredactedFile{{
+			Path:           "/scan/report.pdf",
+			Cause:          formatters.UnredactedNoRedactor,
+			Detail:         "PDF redaction is not implemented",
+			ReportedValues: 2,
+		}},
+		Stats: &formatters.ScanStats{
+			TotalFiles: 1, FilesProcessed: 1, TotalFindings: 2, High: 2,
+			FilesNotRedacted: 1, ValuesNotRedacted: 2,
+		},
+	}
+
+	// Each format's own idiom for the same fact.
+	want := map[string][]string{
+		"text":        {"VALUES LEFT IN CLEARTEXT", "no redactor for this file type", "report.pdf"},
+		"json":        {`"unredacted"`, `"files_not_redacted": 1`, `"values_not_redacted": 2`, "no redactor for this file type"},
+		"yaml":        {"unredacted:", "files_not_redacted: 1", "values_not_redacted: 2", "no redactor for this file type"},
+		"csv":         {"Redacted", "Not Redacted Reason", "false", "no redactor for this file type"},
+		"junit":       {`name="unredacted"`, "<failure", "NOT REDACTED", "remain in cleartext"},
+		"gitlab-sast": {"NOT REDACTED", "VALUES LEFT IN CLEARTEXT", `"level": "warn"`},
+		"sarif":       {"ferret-scan/not-redacted", "NOT REDACTED", "toolExecutionNotifications"},
+	}
+
+	for name, needles := range want {
+		t.Run(name, func(t *testing.T) {
+			f, ok := formatters.Get(name)
+			if !ok {
+				t.Fatalf("formatter %q is not registered", name)
+			}
+			out, err := f.Format(matches, nil, options)
+			if err != nil {
+				t.Fatalf("Format: %v", err)
+			}
+			if out == "" {
+				t.Fatal("empty output, so nothing was disclosed")
+			}
+			for _, n := range needles {
+				if !strings.Contains(out, n) {
+					t.Errorf("%s output does not disclose the unredacted file: missing %q\n"+
+						"a consumer parsing this format cannot tell a sanitized run from one "+
+						"that left every value in cleartext\n--- output ---\n%s",
+						name, n, out)
+				}
+			}
+		})
+	}
+}
+
+// The other direction: a run where everything redacted cleanly must say NOTHING.
+//
+// Without this, emitting the disclosure unconditionally would pass the test above while
+// making every clean report claim an exposure — and a warning that is always present is
+// a warning nobody reads.
+func TestNoDisclosureWhenEverythingWasRedacted(t *testing.T) {
+	matches := []detector.Match{
+		{Text: "449-87-4100", Type: "SSN", Confidence: 100, LineNumber: 1, Filename: "/scan/notes.txt"},
+	}
+	options := formatters.FormatterOptions{
+		ConfidenceLevel:    map[string]bool{"high": true, "medium": true, "low": true},
+		RedactionRequested: true,
+		// No Unredacted entries: every file was redacted.
+		Stats: &formatters.ScanStats{TotalFiles: 1, FilesProcessed: 1, TotalFindings: 1, High: 1},
+	}
+
+	forbidden := []string{
+		"VALUES LEFT IN CLEARTEXT", "NOT REDACTED", "not-redacted",
+		"files_not_redacted", "values_not_redacted", `name="unredacted"`,
+	}
+
+	for _, name := range []string{"text", "json", "yaml", "csv", "junit", "gitlab-sast", "sarif"} {
+		t.Run(name, func(t *testing.T) {
+			f, ok := formatters.Get(name)
+			if !ok {
+				t.Fatalf("formatter %q is not registered", name)
+			}
+			out, err := f.Format(matches, nil, options)
+			if err != nil {
+				t.Fatalf("Format: %v", err)
+			}
+			for _, bad := range forbidden {
+				if strings.Contains(out, bad) {
+					t.Errorf("%s claims an exposure on a fully redacted run: found %q\n--- output ---\n%s",
+						name, bad, out)
+				}
+			}
+		})
+	}
+}
+
+// CSV expresses the fact per ROW, so its header must match its rows exactly.
+//
+// The columns are gated on RedactionRequested, following the same convention --verbose
+// already uses for Metadata. A header that does not match the row width produces a file
+// that every CSV reader rejects or silently misaligns, which is worse than no
+// disclosure at all.
+func TestCSVRowWidthMatchesHeader(t *testing.T) {
+	matches := []detector.Match{
+		{Text: "449-87-4100", Type: "SSN", Confidence: 100, LineNumber: 1, Filename: "/scan/a.pdf"},
+		{Text: "415-555-0132", Type: "PHONE", Confidence: 15, LineNumber: 2, Filename: "/scan/b.txt"},
+	}
+
+	for _, tc := range []struct {
+		name      string
+		requested bool
+		wantCols  int
+	}{
+		{"redaction requested", true, 8},
+		{"read-only scan", false, 6},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			options := formatters.FormatterOptions{
+				ConfidenceLevel:    map[string]bool{"high": true, "medium": true, "low": true},
+				RedactionRequested: tc.requested,
+				Unredacted: []formatters.UnredactedFile{{
+					Path: "/scan/a.pdf", Cause: formatters.UnredactedNoRedactor, ReportedValues: 1,
+				}},
+			}
+			f, ok := formatters.Get("csv")
+			if !ok {
+				t.Fatal("csv formatter is not registered")
+			}
+			out, err := f.Format(matches, nil, options)
+			if err != nil {
+				t.Fatalf("Format: %v", err)
+			}
+
+			lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+			if len(lines) < 2 {
+				t.Fatalf("expected a header and at least one row, got %d line(s)", len(lines))
+			}
+			header := strings.Count(lines[0], ",") + 1
+			if header != tc.wantCols {
+				t.Errorf("header has %d columns, want %d: %s", header, tc.wantCols, lines[0])
+			}
+			for i, l := range lines[1:] {
+				if got := strings.Count(l, ",") + 1; got != header {
+					t.Errorf("row %d has %d fields but the header has %d — a ragged CSV "+
+						"misaligns every column after the short one\n  header: %s\n  row:    %s",
+						i+1, got, header, lines[0], l)
+				}
+			}
+			if tc.requested && !strings.Contains(out, "false") {
+				t.Error("the unredacted file's row does not say Redacted=false, so a consumer " +
+					"filtering on it finds nothing")
+			}
+		})
+	}
+}
+
+// The cap must bound the enumeration WITHOUT understating the totals.
+//
+// An unbounded list is a denial of service against the consumer — a SARIF upload past
+// GitHub's size limit is rejected whole, losing the disclosure entirely. So the list is
+// capped, and the summary must still state the true totals or the report would
+// understate the exposure, which is the failure mode this whole disclosure exists to
+// prevent.
+func TestCapStatesTheTrueTotals(t *testing.T) {
+	files := make([]formatters.UnredactedFile, 0, formatters.MaxUnredactedEntries*2)
+	for i := 0; i < formatters.MaxUnredactedEntries*2; i++ {
+		files = append(files, formatters.UnredactedFile{
+			Path: "/scan/f.pdf", Cause: formatters.UnredactedNoRedactor, ReportedValues: 3,
+		})
+	}
+
+	shown, total := formatters.CapUnredacted(files)
+	if len(shown) != formatters.MaxUnredactedEntries {
+		t.Errorf("cap returned %d entries, want %d", len(shown), formatters.MaxUnredactedEntries)
+	}
+	if total != len(files) {
+		t.Errorf("cap reported total %d, want %d — the cap must not change the total", total, len(files))
+	}
+
+	// Counted over the FULL slice, not the capped one.
+	if got, want := formatters.UnredactedValueCount(files), len(files)*3; got != want {
+		t.Errorf("value count = %d, want %d — counting the capped slice would understate the exposure", got, want)
+	}
+
+	summary := formatters.UnredactedSummary(len(shown), total, formatters.UnredactedValueCount(files))
+	for _, want := range []string{"omitted", "CLEARTEXT", "100 file(s)", "300 reported value(s)"} {
+		if !strings.Contains(summary, want) {
+			t.Errorf("capped summary %q does not mention %q, so truncation is silent", summary, want)
+		}
+	}
+}
+
+// The zero value must be a valid, always-true cause.
+//
+// The cause is recovered by matching substrings of a redactor's error string, and that
+// matching will drift when an error is reworded. When it does, the entry falls to the
+// zero value — so the zero value's label has to be true of every refusal, or a
+// misclassification would confidently state a wrong remedy. It must also never be the
+// empty string, which GitLab's schema rejects (minLength 1).
+func TestZeroCauseIsValidAndGeneric(t *testing.T) {
+	var zero formatters.UnredactedCause
+	if got := zero.String(); got == "" || got == "unknown" {
+		t.Errorf("zero UnredactedCause renders as %q; it must be a real, generic label "+
+			"because an unmatched error string lands here", got)
+	}
+
+	// A zero-valued struct must still produce a non-empty message: GitLab SAST requires
+	// minLength 1 on the message value, so an empty string would make the document
+	// schema-invalid and be rejected whole.
+	var f formatters.UnredactedFile
+	if msg := f.Message(); msg == "" {
+		t.Error("a zero-valued UnredactedFile produces an empty message, which is schema-invalid " +
+			"in GitLab SAST and would lose the entire report")
+	}
+	if msg := f.Message(); !strings.Contains(msg, "cleartext") {
+		t.Errorf("message %q does not lead with the consequence; a consumer that truncates it "+
+			"would not learn values are exposed", msg)
+	}
+}

--- a/internal/formatters/unredacted_edge_test.go
+++ b/internal/formatters/unredacted_edge_test.go
@@ -1,0 +1,449 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package formatters_test
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	xmlpkg "encoding/xml"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/formatters"
+)
+
+// allFormats is every registered output format. Kept in one place so a new format cannot
+// be added without these edge cases running against it.
+var allFormats = []string{"text", "json", "yaml", "csv", "junit", "gitlab-sast", "sarif"}
+
+func baseOptions(unredacted []formatters.UnredactedFile) formatters.FormatterOptions {
+	return formatters.FormatterOptions{
+		ConfidenceLevel:    map[string]bool{"high": true, "medium": true, "low": true},
+		RedactionRequested: true,
+		Unredacted:         unredacted,
+		Stats: &formatters.ScanStats{
+			TotalFiles: 1, FilesProcessed: 1, TotalFindings: 1, High: 1,
+			FilesNotRedacted:  len(unredacted),
+			ValuesNotRedacted: formatters.UnredactedValueCount(unredacted),
+		},
+	}
+}
+
+// A path containing a comma, a quote and a newline must not corrupt the structured
+// formats.
+//
+// Paths are attacker-influenced in a way the rest of the disclosure is not: a scanned
+// tree can contain any filename the filesystem allows. A path that breaks out of a CSV
+// field or a JSON string turns a disclosure into a malformed artifact, and a malformed
+// artifact is usually DISCARDED by the consumer — so a hostile filename would suppress
+// the very warning it appears in.
+func TestHostilePathsDoNotCorruptAnyFormat(t *testing.T) {
+	hostile := "/scan/od,d \"quoted\"\nsecond-line/report.pdf"
+
+	options := baseOptions([]formatters.UnredactedFile{{
+		Path:           hostile,
+		Cause:          formatters.UnredactedNoRedactor,
+		Detail:         `detail with "quotes", a comma and a ]]> sequence`,
+		ReportedValues: 1,
+	}})
+	matches := []detector.Match{
+		{Text: "449-87-4100", Type: "SSN", Confidence: 100, LineNumber: 1, Filename: hostile},
+	}
+
+	for _, name := range allFormats {
+		t.Run(name, func(t *testing.T) {
+			f, ok := formatters.Get(name)
+			if !ok {
+				t.Fatalf("formatter %q is not registered", name)
+			}
+			out, err := f.Format(matches, nil, options)
+			if err != nil {
+				t.Fatalf("Format: %v", err)
+			}
+			if !utf8.ValidString(out) {
+				t.Error("output is not valid UTF-8")
+			}
+
+			switch name {
+			case "json", "gitlab-sast", "sarif":
+				var v interface{}
+				if err := json.Unmarshal([]byte(out), &v); err != nil {
+					t.Errorf("a hostile path made the %s document unparseable: %v\n--- output ---\n%s",
+						name, err, out)
+				}
+			case "junit":
+				if err := xmlpkg.Unmarshal([]byte(out), new(interface{})); err != nil {
+					t.Errorf("a hostile path made the JUnit XML unparseable: %v\n--- output ---\n%s", err, out)
+				}
+			case "csv":
+				r := csv.NewReader(strings.NewReader(out))
+				// FieldsPerRecord = 0 makes the reader enforce that every record has the
+				// same width as the first, which is exactly the property a stray comma
+				// or quote would break.
+				if _, err := r.ReadAll(); err != nil {
+					t.Errorf("a hostile path made the CSV unparseable or ragged: %v\n--- output ---\n%s", err, out)
+				}
+			}
+		})
+	}
+}
+
+// Multiple causes in one run must all be reported, and grouped.
+//
+// A run over a mixed tree hits several causes at once — an unimplemented type, an
+// oversize image, a failed write. Reporting only the first would understate the problem,
+// and reporting them ungrouped makes forty files of one cause look like forty problems.
+func TestEveryCauseSurvivesInEveryFormat(t *testing.T) {
+	files := []formatters.UnredactedFile{
+		{Path: "/scan/a.pdf", Cause: formatters.UnredactedNoRedactor, Detail: "pdf not implemented", ReportedValues: 3},
+		{Path: "/scan/b.jpg", Cause: formatters.UnredactedOverBudget, Detail: "over the pixel budget", ReportedValues: 5},
+		{Path: "/scan/c.mp3", Cause: formatters.UnredactedValueNotLocated, Detail: "not in tag bytes", ReportedValues: 1},
+		{Path: "/scan/d.txt", Cause: formatters.UnredactedWriteFailed, Detail: "permission denied", ReportedValues: 2},
+		{Path: "/scan/e.bin", Cause: formatters.UnredactedRefused, Detail: "declined", ReportedValues: 4},
+	}
+	options := baseOptions(files)
+	matches := []detector.Match{
+		{Text: "449-87-4100", Type: "SSN", Confidence: 100, LineNumber: 1, Filename: "/scan/a.pdf"},
+	}
+
+	// Every cause's label must appear, or a consumer cannot tell what to do about a file.
+	for _, name := range allFormats {
+		t.Run(name, func(t *testing.T) {
+			f, _ := formatters.Get(name)
+			out, err := f.Format(matches, nil, options)
+			if err != nil {
+				t.Fatalf("Format: %v", err)
+			}
+			for _, uf := range files {
+				// CSV reports per finding, and only /scan/a.pdf has one here, so the
+				// other causes have no row to appear in. That is the documented
+				// consequence of CSV's per-row grain rather than a gap in the data.
+				if name == "csv" && uf.Path != "/scan/a.pdf" {
+					continue
+				}
+				if !strings.Contains(out, uf.Cause.String()) {
+					t.Errorf("%s omits the cause %q for %s, so that file's remedy is unstated",
+						name, uf.Cause, uf.Path)
+				}
+			}
+			// The headline totals must be the SUM, not the first entry.
+			if name == "text" && !strings.Contains(out, "15 reported value(s)") {
+				t.Errorf("text headline does not total the values (want 15)\n--- output ---\n%s", out)
+			}
+		})
+	}
+}
+
+// A file with findings suppressed to zero must not claim an exposure of zero values.
+//
+// The redactor still reports a diagnostic for a file it could not write, and if every
+// finding for that file was suppressed then ReportedValues is 0. "0 reported value(s)
+// remain in cleartext" is a contradiction: nothing was reported, so nothing was exposed
+// through this report. The disclosure must still be truthful when the count is zero
+// rather than crash or claim an exposure it cannot substantiate.
+func TestZeroReportedValuesStillRendersTruthfully(t *testing.T) {
+	options := baseOptions([]formatters.UnredactedFile{{
+		Path:           "/scan/allsuppressed.pdf",
+		Cause:          formatters.UnredactedNoRedactor,
+		Detail:         "pdf not implemented",
+		ReportedValues: 0,
+	}})
+
+	for _, name := range allFormats {
+		t.Run(name, func(t *testing.T) {
+			f, _ := formatters.Get(name)
+			out, err := f.Format(nil, nil, options)
+			if err != nil {
+				t.Fatalf("Format on a zero-value entry: %v", err)
+			}
+			// Must not crash, must remain parseable, and must not invent a value count.
+			switch name {
+			case "json", "gitlab-sast", "sarif":
+				var v interface{}
+				if err := json.Unmarshal([]byte(out), &v); err != nil {
+					t.Errorf("%s unparseable with a zero-value entry: %v", name, err)
+				}
+			case "junit":
+				if err := xmlpkg.Unmarshal([]byte(out), new(interface{})); err != nil {
+					t.Errorf("junit unparseable with a zero-value entry: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// The cap must never make the totals understate the exposure.
+//
+// Already covered numerically for the helpers; this pins it through the FORMATS, because
+// a formatter that summed the capped slice rather than the full one would report 50
+// files where 100 were exposed, and that error is invisible in any test that uses fewer
+// entries than the cap.
+func TestUnredactedCapIsDisclosedThroughTheFormats(t *testing.T) {
+	n := formatters.MaxUnredactedEntries + 17
+	files := make([]formatters.UnredactedFile, 0, n)
+	for i := 0; i < n; i++ {
+		files = append(files, formatters.UnredactedFile{
+			Path: "/scan/f.pdf", Cause: formatters.UnredactedNoRedactor, ReportedValues: 2,
+		})
+	}
+	options := baseOptions(files)
+
+	for _, name := range []string{"json", "yaml"} {
+		t.Run(name+" stats carry the full total", func(t *testing.T) {
+			f, _ := formatters.Get(name)
+			out, err := f.Format(nil, nil, options)
+			if err != nil {
+				t.Fatalf("Format: %v", err)
+			}
+			// The counters come from Stats, computed over the full set.
+			for _, want := range []string{"files_not_redacted", "values_not_redacted"} {
+				if !strings.Contains(out, want) {
+					t.Errorf("%s lost %s, so the cap silently shrinks the reported exposure", name, want)
+				}
+			}
+		})
+	}
+
+	t.Run("machine list is capped", func(t *testing.T) {
+		f, _ := formatters.Get("json")
+		out, _ := f.Format(nil, nil, options)
+		var doc struct {
+			Unredacted []struct {
+				Path string `json:"path"`
+			} `json:"unredacted"`
+			Stats struct {
+				FilesNotRedacted  int `json:"files_not_redacted"`
+				ValuesNotRedacted int `json:"values_not_redacted"`
+			} `json:"stats"`
+		}
+		if err := json.Unmarshal([]byte(out), &doc); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if len(doc.Unredacted) > formatters.MaxUnredactedEntries {
+			t.Errorf("emitted %d entries, past the cap of %d — an unbounded list can push a "+
+				"SARIF upload past the size limit and lose the whole report",
+				len(doc.Unredacted), formatters.MaxUnredactedEntries)
+		}
+		if doc.Stats.FilesNotRedacted != n {
+			t.Errorf("stats.files_not_redacted = %d, want the TRUE total %d: the cap must bound "+
+				"the enumeration, never the count", doc.Stats.FilesNotRedacted, n)
+		}
+		if doc.Stats.ValuesNotRedacted != n*2 {
+			t.Errorf("stats.values_not_redacted = %d, want %d", doc.Stats.ValuesNotRedacted, n*2)
+		}
+	})
+}
+
+// A nil Stats must not panic. The golden harness constructs FormatterOptions without
+// one, and the existing not-examined field carries the same warning in its doc comment.
+func TestNilStatsWithADisclosureDoesNotPanic(t *testing.T) {
+	options := formatters.FormatterOptions{
+		ConfidenceLevel:    map[string]bool{"high": true, "medium": true, "low": true},
+		RedactionRequested: true,
+		Unredacted: []formatters.UnredactedFile{{
+			Path: "/scan/a.pdf", Cause: formatters.UnredactedNoRedactor, ReportedValues: 1,
+		}},
+		// Stats deliberately nil.
+	}
+	for _, name := range allFormats {
+		t.Run(name, func(t *testing.T) {
+			f, _ := formatters.Get(name)
+			if _, err := f.Format(nil, nil, options); err != nil {
+				t.Fatalf("Format with nil Stats: %v", err)
+			}
+		})
+	}
+}
+
+// A duplicate path must not be silently collapsed in the counters.
+//
+// collectUnscanned does not deduplicate and neither does this, so a file that fails for
+// two reasons contributes two entries. The counters must agree with the entries, because
+// a summary that disagrees with its own list is how a report loses trust.
+func TestDuplicatePathsAreCountedNotCollapsed(t *testing.T) {
+	files := []formatters.UnredactedFile{
+		{Path: "/scan/a.pdf", Cause: formatters.UnredactedNoRedactor, ReportedValues: 2},
+		{Path: "/scan/a.pdf", Cause: formatters.UnredactedWriteFailed, ReportedValues: 2},
+	}
+	if got, want := formatters.UnredactedValueCount(files), 4; got != want {
+		t.Errorf("value count = %d, want %d", got, want)
+	}
+	shown, total := formatters.CapUnredacted(files)
+	if total != 2 || len(shown) != 2 {
+		t.Errorf("cap collapsed duplicates: shown=%d total=%d, want 2 and 2", len(shown), total)
+	}
+
+	// UnredactedPaths is a map, so it DOES collapse — and that is correct for its one
+	// caller (CSV, which asks "is this row's file unredacted?"). Pinned so the
+	// difference is deliberate rather than discovered later.
+	if got := len(formatters.UnredactedPaths(files)); got != 1 {
+		t.Errorf("UnredactedPaths has %d entries, want 1: it answers a per-path question and "+
+			"is expected to collapse duplicates", got)
+	}
+}
+
+// The cap must not let a common cause crowd out a rare one.
+//
+// This is a real defect that shipped in the first draft and was found by asking what a
+// directory of many unredactable files looks like. Measured on 150 PDFs, 12 TIFFs and 3
+// oversize JPEGs: a flat first-50 prefix emitted "no redactor for this file type" 50
+// times and the resource-limit refusals NOT AT ALL, so a JSON consumer could not learn
+// that cause had occurred. Which cause survived depended on nothing but filename sort
+// order — renaming the JPEGs to sort last was enough to erase them.
+//
+// It matters because the causes are not interchangeable: "no redactor for this type" is a
+// tool limitation nobody can act on, while "refused by a resource limit" is a documented
+// number an operator can raise. Hiding the actionable cause behind the inert one is the
+// worst way to spend a budget that exists to keep the report readable.
+func TestRareCauseIsNotCrowdedOutOfTheCap(t *testing.T) {
+	// Deliberately built so the rare cause sorts LAST, which is what exposed the bug.
+	files := make([]formatters.UnredactedFile, 0, 200)
+	for i := 0; i < 150; i++ {
+		files = append(files, formatters.UnredactedFile{
+			Path: "/scan/aaa-doc.pdf", Cause: formatters.UnredactedNoRedactor, ReportedValues: 3,
+		})
+	}
+	for i := 0; i < 12; i++ {
+		files = append(files, formatters.UnredactedFile{
+			Path: "/scan/mmm-img.tiff", Cause: formatters.UnredactedNoRedactor, ReportedValues: 5,
+		})
+	}
+	for i := 0; i < 3; i++ {
+		files = append(files, formatters.UnredactedFile{
+			Path: "/scan/zzz-big.jpg", Cause: formatters.UnredactedOverBudget, ReportedValues: 5,
+		})
+	}
+
+	shown, total := formatters.CapUnredacted(files)
+	if total != len(files) {
+		t.Errorf("total = %d, want %d", total, len(files))
+	}
+	if len(shown) > formatters.MaxUnredactedEntries {
+		t.Errorf("returned %d entries, past the cap of %d", len(shown), formatters.MaxUnredactedEntries)
+	}
+
+	seen := map[formatters.UnredactedCause]int{}
+	for _, f := range shown {
+		seen[f.Cause]++
+	}
+	for _, want := range []formatters.UnredactedCause{
+		formatters.UnredactedNoRedactor, formatters.UnredactedOverBudget,
+	} {
+		if seen[want] == 0 {
+			t.Errorf("cause %q was crowded out of the capped list entirely, so a consumer "+
+				"cannot learn it occurred; got %v", want, seen)
+		}
+	}
+}
+
+// Every cause present must get a slot, even with many causes and a tight budget.
+func TestEveryCauseGetsASlot(t *testing.T) {
+	all := []formatters.UnredactedCause{
+		formatters.UnredactedRefused,
+		formatters.UnredactedNoRedactor,
+		formatters.UnredactedOverBudget,
+		formatters.UnredactedValueNotLocated,
+		formatters.UnredactedWriteFailed,
+	}
+	// 40 of each: 200 entries into a 50-slot cap.
+	files := make([]formatters.UnredactedFile, 0, 200)
+	for _, c := range all {
+		for i := 0; i < 40; i++ {
+			files = append(files, formatters.UnredactedFile{Path: "/scan/f", Cause: c, ReportedValues: 1})
+		}
+	}
+
+	shown, _ := formatters.CapUnredacted(files)
+	seen := map[formatters.UnredactedCause]int{}
+	for _, f := range shown {
+		seen[f.Cause]++
+	}
+	for _, c := range all {
+		if seen[c] == 0 {
+			t.Errorf("cause %q got no slot; distribution was %v", c, seen)
+		}
+	}
+	// And the budget is spent, not left idle by an over-cautious quota.
+	if len(shown) != formatters.MaxUnredactedEntries {
+		t.Errorf("used %d of %d slots — the remainder should be shared out, not wasted",
+			len(shown), formatters.MaxUnredactedEntries)
+	}
+}
+
+// The selection must preserve the caller's ordering, so a path-sorted list stays sorted.
+func TestCapPreservesInputOrder(t *testing.T) {
+	files := make([]formatters.UnredactedFile, 0, 120)
+	for i := 0; i < 60; i++ {
+		files = append(files, formatters.UnredactedFile{
+			Path: string(rune('a'+i%26)) + "-doc.pdf", Cause: formatters.UnredactedNoRedactor, ReportedValues: 1,
+		})
+	}
+	for i := 0; i < 60; i++ {
+		files = append(files, formatters.UnredactedFile{
+			Path: string(rune('a'+i%26)) + "-img.jpg", Cause: formatters.UnredactedOverBudget, ReportedValues: 1,
+		})
+	}
+
+	shown, _ := formatters.CapUnredacted(files)
+
+	// Build the index of each shown entry in the original slice and assert it ascends.
+	prev := -1
+	for _, s := range shown {
+		idx := -1
+		for i, f := range files {
+			if f == s && i > prev {
+				idx = i
+				break
+			}
+		}
+		if idx < 0 {
+			t.Fatalf("selected entry %+v is not in the input", s)
+		}
+		if idx <= prev {
+			t.Errorf("selection is out of input order: index %d followed %d", idx, prev)
+		}
+		prev = idx
+	}
+}
+
+// The rendered text block must show at least one example for every cause, and its
+// per-cause counts must be the FULL counts rather than the number listed.
+func TestRenderedBlockShowsAnExamplePerCauseWithFullCounts(t *testing.T) {
+	files := make([]formatters.UnredactedFile, 0, 165)
+	for i := 0; i < 162; i++ {
+		files = append(files, formatters.UnredactedFile{
+			Path: "/scan/doc.pdf", Cause: formatters.UnredactedNoRedactor, ReportedValues: 3,
+		})
+	}
+	for i := 0; i < 3; i++ {
+		files = append(files, formatters.UnredactedFile{
+			Path: "/scan/zzz-oversize.jpg", Cause: formatters.UnredactedOverBudget, ReportedValues: 5,
+		})
+	}
+
+	block := formatters.RenderBlock(files, 167, false, true)
+
+	// Full counts, not listed counts.
+	for _, want := range []string{"no redactor for this file type (162)", "refused by a resource limit (3)"} {
+		if !strings.Contains(block, want) {
+			t.Errorf("block does not state the full per-cause count %q\n%s", want, block)
+		}
+	}
+	// An example for the rare cause, which the first draft omitted entirely.
+	if !strings.Contains(block, "zzz-oversize.jpg") {
+		t.Errorf("the rare cause has a count but no example path, so the operator cannot see "+
+			"which files it applies to\n%s", block)
+	}
+	// Truncation is stated.
+	if !strings.Contains(block, "more file(s) not listed") {
+		t.Errorf("truncation is silent\n%s", block)
+	}
+	// The headline totals the values across every cause: 162*3 + 3*5 = 501.
+	if !strings.Contains(block, "501 reported value(s)") {
+		t.Errorf("headline does not total the values across causes (want 501)\n%s", block)
+	}
+}

--- a/internal/redactors/plaintext/redactor.go
+++ b/internal/redactors/plaintext/redactor.go
@@ -669,7 +669,18 @@ func (ptr *PlainTextRedactor) calculateCharacterPositions(match detector.Match, 
 	// Find the match text in the line
 	startChar := strings.Index(line, match.Text)
 	if startChar == -1 {
-		return 0, 0, fmt.Errorf("match text %q not found in line %d", match.Text, match.LineNumber)
+		// The value is NOT interpolated. This error reaches the operator through
+		// FileDiagnostic.Reason, which is now carried into every output format as the
+		// detail of the unredacted disclosure (#441) -- so %q of match.Text would have
+		// printed the raw sensitive value into JSON, YAML, SARIF, JUnit and GitLab
+		// reports regardless of --show-match. It already printed it to stderr.
+		//
+		// Type and length instead, following the [HIDDEN] (len=%d) convention used by
+		// the preprocessors' debug logging. They identify which finding failed without
+		// disclosing it, which is all the reader needs: the finding itself is in the
+		// same report, with its own line number.
+		return 0, 0, fmt.Errorf("%s match ([HIDDEN], len=%d) not found in line %d",
+			match.Type, len(match.Text), match.LineNumber)
 	}
 
 	endChar := startChar + len(match.Text)


### PR DESCRIPTION
## What was wrong

A file whose findings are **reported but not redacted** is the one outcome the sink rule forbids passing off as success: the values are still in cleartext and the consumer holds a report that looks complete.

Measured at `main` on a real 14KB PDF that extracts cleanly and yields 3 findings, under `--enable-redaction`:

| format | in-band signal on stdout |
|---|---|
| text | **NONE** |
| json | **NONE** |
| yaml | **NONE** |
| csv | **NONE** |
| junit | **NONE** |
| sarif | **NONE** |
| gitlab-sast | **NONE** |

Seven of seven. The warning existed — `WARNING: redaction incomplete — … the original values remain in cleartext` — but only on **stderr**, which pipelines discard, and the exit code was **0**. A scheduled sanitization job shipped nothing for that file, reported success, and the only record was a log line nobody reads.

## What this adds

The disclosure as **data**, mirroring the existing not-examined machinery (cause enum, shared `Message()`, cap, per-format rendering), expressed in each format's own grain:

| format | how |
|---|---|
| text | `VALUES LEFT IN CLEARTEXT` block inside the summary frame, grouped by cause |
| json / yaml | `stats.files_not_redacted`, `stats.values_not_redacted`, and `unredacted[]` |
| csv | two columns, `Redacted` and `Not Redacted Reason`, per **finding** |
| junit | an `unredacted` testsuite of `<failure>` elements |
| gitlab-sast | `scan.messages[]` at `level: warn` |
| sarif | `invocations[].toolExecutionNotifications[]` under `ferret-scan/not-redacted` |

`--fail-on-incomplete` now escalates a refusal to **exit 3**. This deliberately widens the flag from "the scan did not see everything" to "the run did not fully do what was asked" — the maintainer's decision, taken over adding a new default failure or a new flag. A job that set it to catch validator timeouts will also fail on a PDF that cannot be redacted; both causes are named separately in the report and counted separately in `stats`, so an operator can tell which fired without changing flags.

## Console output

```
═══ Scan Summary ═════════════════════════════════════════════════════════════
Files: 5 scanned | Findings: 20 (12 high, 4 medium, 4 low)
──────────────────────────────────────────────────────────────────────────────
VALUES LEFT IN CLEARTEXT: 3 of 5 file(s), 13 reported value(s) — no redacted copy was written
  no redactor for this file type (2)
    …/corpus/report.pdf  3 value(s) in cleartext
    …/corpus/scan.tiff   5 value(s) in cleartext
  refused by a resource limit (1)
    …/corpus/huge.jpg    5 value(s) in cleartext
  Add --fail-on-incomplete to make this a non-zero exit (3).
══════════════════════════════════════════════════════════════════════════════
```

## Choices worth reviewing

**csv reports per row** because that is its grain, and every unredacted value *has* a row by construction — the disclosure counts reported values. Complete here, unlike not-examined where a file with no findings has no row. The columns appear only when redaction was **requested**, the same convention `--verbose` already uses for `Metadata`, so a read-only scan is byte-identical and the **golden corpus does not move**.

**junit uses `<failure>` unconditionally**, unlike the not-examined suite's `<skipped>`. `<skipped>` renders grey or filtered on CI dashboards, which is the wrong presentation for values left in cleartext, and it must not depend on a flag about exit codes. Not `<error>`, which claims the run misbehaved: the run scanned correctly, reported correctly, and refused to write a file it could not sanitize.

**sarif adds no result.** The values are already reported as results, so a second alert for the same bytes would double-count the exposure on any dashboard.

**The text block renders from the structured data in the formatters package, not from prose built by `cmd`.** The not-examined disclosure does the latter and has a hole because of it: a caller that populates the structured field but not the footer gets a text report with no disclosure. The **web UI** and every consumer of `formatters.Export` are such callers, so copying that shape would have reintroduced this bug on those surfaces while the CLI looked fixed.

**No stderr fallback**, unlike not-examined, because every format now carries this in-band. Measured with one in place: json emitted the list on stdout **and** the block on stderr **and** the terse warning on stderr — the same fact three times.

## Defects found while testing this, and fixed here

- **A value leak at source** (first commit). `internal/redactors/plaintext` built its error with `fmt.Errorf("match text %q …", match.Text)`. That string becomes the disclosure's detail, so it would have carried the raw SSN into all seven formats **ignoring `--show-match`**. Now `%s match ([HIDDEN], len=%d)`. Swept the other redactors — this was the only one. A scrubber in the disclosure layer is defence-in-depth, since one future `Errorf` could reintroduce it in seven places at once.
- **The cap lost whole causes.** On 150 PDFs, 12 TIFFs and 3 oversize JPEGs it emitted "no redactor for this file type" 50 times and the resource-limit refusals **not at all** — a consumer could not learn that cause occurred, and which cause survived depended on filename sort order alone. Now cause-fair: every cause present gets a slot, remainder shared, input order preserved.
- **A fully suppressed file was reported as an exposure**: "1 file not redacted, 0 values in cleartext" — a contradiction, warning about findings the operator had explicitly accepted. Zero-value entries are dropped.
- **Two suppressions cancelled.** With `--fail-on-incomplete` set *and* both disclosures present, the exit-code consequence was stated **nowhere**: the not-examined block omits its hint when the flag is on, and this block suppressed its own to avoid duplicating it. Now matches the existing convention exactly.

## Verified on real files

One real file per cause — a real PDF, a real TIFF converted from a photograph, the real 20000×20000 JPEG from #378, an ordinary JPEG, a text file — with **2 of 5 redacting cleanly**, so the disclosure is provably not blanket. All 7 formats parse, agree on the same 3 files and 13 values, and contain **no raw value**. A refused file gets **no output file at all**.

1000 unredactable files: 400KB SARIF in 0.55s, `files_not_redacted=1000`, `values_not_redacted=3000`.

## Test plan

`make pr-checklist BASE=origin/main`

```
=== summary: 10 ran, 0 failed, 5 need manual work ===
1 gofmt / go vet / go build      RAN — clean / clean / ok
2 full suite (-count=1)          RAN — 69 packages ok
3 golden regen                   RAN — 0 files changed
8 web / CSP                      N/A
11 cross-platform vet            RAN — linux darwin windows
12 flake (3 repeats)             RAN — 9 packages
13 race (whole module)           RAN — 69 packages ok
-- -short mode / tree clean      RAN — ok / dirtied nothing
```

All five manual dimensions completed:

| # | dimension | result |
|---|---|---|
| 4 | redaction, every strategy | `simple`, `format_preserving`, `synthetic`: 1 copy each, **0 cleartext in output**, refusal reported in all three |
| 5 | suppression | 5 rules generated by the **parent** binary and enabled, applied by mine: 5 findings → 0, identical to the parent applying its own |
| 6 | timing / O(n²) | N/2N/4N at 250/500/1000 directories with **distinct** values, findings floor 1250/2500/5000 (exactly linear), growth **3.98× for 4× input** |
| 7 | all 7 formats | every format parses, agrees on the same counts, and leaks nothing |
| 10 | non-vacuity | with the cmd wiring removed (API intact) **6 of 7 formats fail to disclose**, the escalation test fails, and the counter test fails |

**~30 subtests** across three files. The load-bearing one is `TestEveryFormatDisclosesAnUnredactedFile` — the test that would have caught this — plus its inverse so "always warn" cannot pass. Edge cases: hostile paths with commas/quotes/newlines, all five causes at once, zero reported values, cap boundaries at 49/50/51, nil `Stats`, duplicate paths, cause-fairness, and the classifier pinned to **verbatim** real redactor error strings so a reworded error fails a test instead of silently degrading to the generic cause.

**Union:** no other PR touches `internal/formatters/**`, `cmd/main.go` or `internal/redactors/plaintext`. Merge-base is `0610b7e`, current `origin/main`.

## Known, and deliberately not addressed here

- The text frame under-measures double-width **CJK** paths, so a frame can overhang by a few columns. **Pre-existing** — reproduced on the parent binary with the not-examined footer, because `displayWidth` is `len([]rune(s))`. Filed separately.
- `not_examined[]` is still absent from json/yaml, which carry only a count, and csv still has no not-examined channel. Both are that disclosure's contract to change. Filed separately.
- **#449** — found while testing this on real media, and far more severe: audio and video redaction writes a copy that still contains reported values and reports **success**, because `tagmeta.Residual` only searches the ranges it already rewrote. Not reachable through this disclosure, because that path never refuses. Separate PR.

Closes #441
Refs #449
