### PR TITLE
fix(redactors): check the WHOLE file before writing a redacted audio or video copy

### DIFF
--- a/internal/redactors/audio/redactor.go
+++ b/internal/redactors/audio/redactor.go
@@ -205,9 +205,14 @@ func (r *AudioRedactor) RedactDocument(originalPath string, outputPath string, m
 	// or in an encoding the search did not try, and every one of those looks like a success
 	// from the mapping count alone. Verifying the OUTPUT is the only assertion that cannot be
 	// satisfied by a partial job.
-	if residual := tagmeta.Residual(modified, ranges, matches); residual > 0 {
-		return nil, fmt.Errorf("%d reported value(s) remain in the %s metadata of %s after redaction; refusing to write a file that would look redacted",
-			residual, format, filepath.Base(originalPath))
+	// ResidualAnywhere, not Residual: the latter searches only `ranges`, which are the spans this
+	// pass already rewrote, so a value surviving OUTSIDE them cannot be seen. Measured on a real
+	// .m4a whose Artist tag existed in two places — the copy inside the mapped udta span was
+	// overwritten, the copy at offset 11613 was not, and this check returned 0 and wrote a file
+	// still containing a reported credit card number while reporting success (#449).
+	if residual := tagmeta.ResidualAnywhere(modified, matches); residual > 0 {
+		return nil, fmt.Errorf("%d reported value(s) remain anywhere in %s after redaction; refusing to write a file that would look redacted",
+			residual, filepath.Base(originalPath))
 	}
 
 	if r.outputManager != nil {

--- a/internal/redactors/tagmeta/overwrite.go
+++ b/internal/redactors/tagmeta/overwrite.go
@@ -22,6 +22,9 @@ package tagmeta
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
+	"io"
 	"sort"
 	"strings"
 	"unicode/utf16"
@@ -253,10 +256,56 @@ func Apply(buf []byte, plan []Occurrence) int {
 	return applied
 }
 
+// ResidualAnywhere counts reported values still present ANYWHERE in buf.
+//
+// This is the check a caller wants before writing a file. Residual, below, searches only the
+// regions it was handed — which are the regions the overwrite pass already rewrote — so it is
+// structurally unable to see a value that survives outside them. Measured on a real .m4a whose
+// Artist tag exiftool had written in two places:
+//
+//	Residual(output, mapped_ranges, [card]) = 0   // blind
+//	ResidualAnywhere(output, [card])        = 1   // present at offset 11613
+//
+// The mapped range covered [10892,11268); the surviving copy sat at 11613. The occurrence inside
+// the range was overwritten, the one outside was not, and the redactor wrote the file and reported
+// success with the value still in it. Residual's own doc comment claims to cover "a value ... in a
+// second region", which it cannot.
+//
+// Whole-buffer search is strictly stronger and cannot pass while a value survives anywhere, which
+// is the property the caller needs: the output is about to be handed to someone as sanitized.
+//
+// A value that appears in the media STREAM rather than in metadata will also be counted here, and
+// that is the honest outcome: a same-length tag overwrite cannot remove it, so writing the file
+// would be a false claim either way.
+func ResidualAnywhere(buf []byte, matches []detector.Match) int {
+	residual := 0
+	for _, m := range matches {
+		if m.Text == "" {
+			continue
+		}
+		if bytes.Contains(buf, []byte(m.Text)) ||
+			containsWide(buf, UTF16LE(m.Text)) ||
+			containsWide(buf, UTF16BE(m.Text)) {
+			residual++
+		}
+	}
+	return residual
+}
+
+// containsWide is bytes.Contains guarded against an empty needle, which would match everything.
+func containsWide(buf, needle []byte) bool {
+	return len(needle) > 0 && bytes.Contains(buf, needle)
+}
+
 // Residual counts reported values still present in the given regions of buf.
 //
 // Searched in both encodings, exactly as the overwrite is, so the check cannot pass because it
 // looked for something narrower than what was written.
+//
+// NOT SUFFICIENT AS A PRE-WRITE GATE. regions are the spans the overwrite already rewrote, so a
+// value surviving outside them is invisible here — see ResidualAnywhere above, which is what a
+// caller should use before writing. This remains for callers that genuinely mean "within these
+// spans", such as asserting a specific block was cleaned.
 //
 // A caller must treat a non-zero result as a refusal to write the file at all. Counting
 // replacements is not enough: a value can occur twice in one region, or in a second region, or
@@ -359,4 +408,108 @@ func OverallConfidence(mappings []redactors.RedactionMapping) float64 {
 		total += m.Confidence
 	}
 	return total / float64(len(mappings))
+}
+
+// ResidualInReader streams a written file and counts reported values still present in it.
+//
+// The streaming counterpart of ResidualAnywhere, for the video path, which never holds the whole
+// file in memory. It exists for the same reason: the video redactor's own residual check searches
+// only the tag BLOCKS it parsed, so a value living anywhere else — an XMP packet, a second metadata
+// location, the stream itself — is invisible to it, and the redactor wrote the file and reported
+// success with a reported SSN still in it (#449).
+//
+// Reads in fixed chunks with an overlap of maxNeedle-1 bytes, so a value straddling a chunk boundary
+// is still found. Memory is bounded by chunkBytes regardless of file size, which is what makes this
+// affordable on a movie: it costs one extra sequential read, not a buffer the size of the input.
+//
+// A value in the media stream rather than in metadata is counted too. That is deliberate: a
+// same-length tag overwrite cannot remove it, so writing the file would be a false claim of
+// sanitization either way, and the caller must refuse rather than pretend.
+func ResidualInReader(r io.ReaderAt, size int64, matches []detector.Match) (int, error) {
+	if size <= 0 || len(matches) == 0 {
+		return 0, nil
+	}
+
+	// Every encoding of every value, deduplicated, so one value counted once.
+	type needleSet struct {
+		forms [][]byte
+	}
+	sets := make([]needleSet, 0, len(matches))
+	maxNeedle := 0
+	for _, m := range matches {
+		if m.Text == "" {
+			continue
+		}
+		forms := [][]byte{[]byte(m.Text)}
+		if w := UTF16LE(m.Text); len(w) > 0 {
+			forms = append(forms, w)
+		}
+		if w := UTF16BE(m.Text); len(w) > 0 {
+			forms = append(forms, w)
+		}
+		for _, f := range forms {
+			if len(f) > maxNeedle {
+				maxNeedle = len(f)
+			}
+		}
+		sets = append(sets, needleSet{forms: forms})
+	}
+	if len(sets) == 0 {
+		return 0, nil
+	}
+
+	const chunkBytes = 1 << 20
+	overlap := maxNeedle - 1
+	if overlap < 0 {
+		overlap = 0
+	}
+
+	found := make([]bool, len(sets))
+	remaining := len(sets)
+
+	buf := make([]byte, chunkBytes+overlap)
+	var off int64
+	for off < size && remaining > 0 {
+		// Start each window `overlap` bytes before the new data so a straddling value is whole
+		// somewhere in exactly one window.
+		start := off - int64(overlap)
+		if start < 0 {
+			start = 0
+		}
+		want := int64(len(buf))
+		if start+want > size {
+			want = size - start
+		}
+		n, err := r.ReadAt(buf[:want], start)
+		if n > 0 {
+			window := buf[:n]
+			for i := range sets {
+				if found[i] {
+					continue
+				}
+				for _, f := range sets[i].forms {
+					if bytes.Contains(window, f) {
+						found[i] = true
+						remaining--
+						break
+					}
+				}
+			}
+		}
+		if err != nil && !errors.Is(err, io.EOF) {
+			return 0, fmt.Errorf("failed to re-read the redacted file at offset %d: %w", start, err)
+		}
+		if n == 0 {
+			break
+		}
+		off = start + int64(n)
+	}
+
+	residual := 0
+	for _, f := range found {
+		if f {
+			residual++
+		}
+	}
+	return residual, nil
 }

--- a/internal/redactors/tagmeta/residual_anywhere_test.go
+++ b/internal/redactors/tagmeta/residual_anywhere_test.go
@@ -1,0 +1,128 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package tagmeta
+
+import (
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+)
+
+// The pre-write gate must see a value that survives OUTSIDE the rewritten spans.
+//
+// Residual searches only the regions it is handed, and those regions are the spans the overwrite
+// pass just rewrote — so it is structurally unable to see the one failure mode that matters. It
+// therefore returned 0 for a file that still contained a reported credit card number, and the audio
+// redactor wrote that file and reported success (#449).
+//
+// Measured on a real .m4a: exiftool writes Artist to BOTH moov/udta/meta/ilst/©ART/data (mapped,
+// overwritten) AND an XMP packet (unmapped, untouched). Offsets 10973 and 11337; the mapped span
+// covered [10892,11268).
+//
+// This test reproduces that geometry rather than the whole file: one occurrence inside the region,
+// one outside, and the inside one already overwritten.
+func TestResidualAnywhereSeesWhatResidualCannot(t *testing.T) {
+	value := "4532-0151-1283-0366"
+
+	// A buffer shaped like the real failure: the in-region copy is overwritten, an out-of-region
+	// copy survives.
+	buf := make([]byte, 0, 256)
+	buf = append(buf, []byte("....ilst.©ART.data.")...)      // 19 bytes of container noise
+	regionStart := len(buf)                                  //
+	buf = append(buf, []byte("card ****-****-****-0366")...) // the OVERWRITTEN copy
+	regionEnd := len(buf)                                    //
+	buf = append(buf, []byte("...<x:xmpmeta><tiff:Artist>card ")...)
+	buf = append(buf, []byte(value)...) // the SURVIVING copy, outside the region
+	buf = append(buf, []byte("</tiff:Artist></x:xmpmeta>")...)
+
+	regions := []Region{{Start: regionStart, End: regionEnd, Label: "MP4 udta"}}
+	matches := []detector.Match{{Text: value, Type: "VISA"}}
+
+	if got := Residual(buf, regions, matches); got != 0 {
+		t.Fatalf("test setup: Residual should be blind here, got %d — the region no longer excludes "+
+			"the surviving copy, so this test is not reproducing #449", got)
+	}
+	if got := ResidualAnywhere(buf, matches); got != 1 {
+		t.Errorf("ResidualAnywhere = %d, want 1: a value surviving outside the rewritten spans is "+
+			"exactly what the pre-write gate exists to catch, and missing it means writing a file "+
+			"that looks redacted and is not", got)
+	}
+}
+
+// A fully cleaned buffer must pass, or the gate refuses every file and media redaction stops working.
+//
+// This is the other direction, and it is not hypothetical: a whole-buffer search is strictly
+// stricter, so the risk of the fix is refusing files that were being redacted correctly. Measured on
+// a real .m4a carrying only a Comment tag — one occurrence, inside the mapped span — the redactor
+// still writes the file and the value is gone from the bytes.
+func TestResidualAnywherePassesACleanedBuffer(t *testing.T) {
+	value := "4532-0151-1283-0366"
+	buf := []byte("....ilst.©cmt.data.card ****-****-****-0366....moov....")
+	matches := []detector.Match{{Text: value, Type: "VISA"}}
+
+	if got := ResidualAnywhere(buf, matches); got != 0 {
+		t.Errorf("ResidualAnywhere = %d on a buffer with no surviving value, want 0: a gate that "+
+			"refuses a correctly redacted file trades a leak for losing redaction entirely", got)
+	}
+}
+
+// Wide encodings must be searched, exactly as the overwrite writes them.
+//
+// A check that looked only for the narrow form would pass on a value stored as UTF-16, which is how
+// several container formats store text. Residual already does this; the replacement must not be
+// weaker than the thing it replaces.
+func TestResidualAnywhereSearchesWideEncodings(t *testing.T) {
+	value := "449-87-4100"
+
+	for _, tc := range []struct {
+		name string
+		buf  []byte
+	}{
+		{"utf-16 le", append([]byte("prefix"), UTF16LE(value)...)},
+		{"utf-16 be", append([]byte("prefix"), UTF16BE(value)...)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			matches := []detector.Match{{Text: value, Type: "SSN"}}
+			if got := ResidualAnywhere(tc.buf, matches); got != 1 {
+				t.Errorf("ResidualAnywhere = %d, want 1: a value stored in %s survived a check that "+
+					"only looked for the narrow form", got, tc.name)
+			}
+		})
+	}
+}
+
+// Counted per MATCH, not per occurrence, so the number is the count of values still exposed.
+//
+// Two surviving copies of one value is one exposed value, and reporting 2 would overstate it in a
+// message an operator reads. Three different values surviving is three.
+func TestResidualAnywhereCountsValuesNotOccurrences(t *testing.T) {
+	buf := []byte("aaa 449-87-4100 bbb 449-87-4100 ccc 4532-0151-1283-0366 ddd")
+	matches := []detector.Match{
+		{Text: "449-87-4100", Type: "SSN"},
+		{Text: "4532-0151-1283-0366", Type: "VISA"},
+	}
+	if got := ResidualAnywhere(buf, matches); got != 2 {
+		t.Errorf("ResidualAnywhere = %d, want 2 (two distinct values, one of them twice)", got)
+	}
+}
+
+// An empty match text must not count, and must not match everything.
+//
+// bytes.Contains with an empty needle is TRUE for any buffer, so an empty Text would make the gate
+// refuse every file — the same class of failure as the guard being blind, in the opposite direction.
+func TestResidualAnywhereIgnoresEmptyValues(t *testing.T) {
+	buf := []byte("nothing sensitive here")
+	matches := []detector.Match{{Text: "", Type: "EMPTY"}}
+
+	if got := ResidualAnywhere(buf, matches); got != 0 {
+		t.Errorf("ResidualAnywhere = %d for an empty match text, want 0: an empty needle matches "+
+			"every buffer and would refuse every file", got)
+	}
+	if got := ResidualAnywhere(nil, matches); got != 0 {
+		t.Errorf("ResidualAnywhere = %d on a nil buffer, want 0", got)
+	}
+	if got := ResidualAnywhere(buf, nil); got != 0 {
+		t.Errorf("ResidualAnywhere = %d with no matches, want 0", got)
+	}
+}

--- a/internal/redactors/video/redactor.go
+++ b/internal/redactors/video/redactor.go
@@ -216,7 +216,7 @@ func (r *VideoRedactor) RedactDocument(originalPath string, outputPath string, m
 		return nil, fmt.Errorf("%s: %w", name, err)
 	}
 
-	if err := r.write(originalPath, outputPath, size, blocks, name); err != nil {
+	if err := r.write(originalPath, outputPath, size, blocks, matches, name); err != nil {
 		return nil, err
 	}
 
@@ -395,7 +395,7 @@ func verifyCoordinatesScrubbed(blocks []*tagBlock) error {
 // A copy plus fixed-length patches, rather than assembling a new file: the media stream is
 // copied straight through without being interpreted, so nothing this code gets wrong can move
 // a sample offset.
-func (r *VideoRedactor) write(originalPath, outputPath string, size int64, blocks []*tagBlock, name string) error {
+func (r *VideoRedactor) write(originalPath, outputPath string, size int64, blocks []*tagBlock, matches []detector.Match, name string) error {
 	if r.outputManager != nil {
 		if err := r.outputManager.EnsureDirectoryExists(outputPath); err != nil {
 			return fmt.Errorf("failed to ensure output directory: %w", err)
@@ -447,6 +447,25 @@ func (r *VideoRedactor) write(originalPath, outputPath string, size int64, block
 	// proves the plan was complete; this proves the plan is what landed on disk.
 	if err := verifyWritten(dst, blocks); err != nil {
 		return fail(fmt.Errorf("%s: %w", name, err))
+	}
+
+	// FAIL CLOSED on the WHOLE FILE, not just the parsed tag blocks.
+	//
+	// r.residual above searches only the blocks this redactor parsed, so a value living anywhere
+	// else is invisible to it. Measured on a real .mp4: exiftool writes Artist to BOTH
+	// moov/udta/meta/ilst/©ART/data AND an XMP packet, the block copy was overwritten, the XMP copy
+	// was not, and this function wrote the file and reported success with a reported SSN still in
+	// it (#449).
+	//
+	// Streamed in 1MB windows with an overlap, so this costs one extra sequential read of the
+	// output and a bounded buffer rather than holding the movie in memory.
+	if residual, err := tagmeta.ResidualInReader(dst, size, matches); err != nil {
+		return fail(fmt.Errorf("%s: %w", name, err))
+	} else if residual > 0 {
+		// name is not repeated here: the caller already prefixes it, and a doubled filename in a
+		// refusal reads as two different files.
+		return fail(fmt.Errorf("%d reported value(s) remain anywhere in the redacted file; refusing to write a file that would look redacted",
+			residual))
 	}
 
 	if err := dst.Close(); err != nil {


### PR DESCRIPTION
## What was wrong

Both media redactors wrote a "redacted" copy that **still contained reported values**, and reported **success**.

Measured at `main @ 0610b7e` on **real media** — an iPad voice memo `.m4a` and an ordinary `.mp4` — with two tags set:

```
Artist  = Renee Mueller SSN 449-87-4100
Comment = card 4532-0151-1283-0366
```

Reported: `SSN 100`, `VISA 100`, `PERSON_NAME 92`, `AUTHOR_INFO 80`. In the written copy:

| reported value | source tag | in the "redacted" copy |
|---|---|---|
| `4532-0151-1283-0366` | `Comment` | redacted → `card ****-****-****-0366` |
| `449-87-4100` | `Artist` | **SURVIVES VERBATIM** |
| `Renee Mueller` | `Artist` | **SURVIVES VERBATIM** |

…with `files_not_redacted=0`, one copy written, **exit 0**, and nothing on any stream. Two of three HIGH findings left in cleartext in a file the tool said it sanitized.

## Why the existing fail-closed checks did not fire

Both are scoped to the bytes the overwrite pass **already rewrote**:

- audio: `tagmeta.Residual(modified, ranges, matches)` searches only `ranges`
- video: `r.residual(blocks, matches)` searches only the tag blocks it parsed

Each verifies *"nothing survives in the parts I rewrote"* when the property needed is *"nothing survives anywhere in the output"*. A value outside those spans is not missed by accident — it is **unreachable by construction**.

Proven rather than argued, same function, same real file:

```
Residual(output, mapped_ranges, [card]) = 0   ← blind
ResidualAnywhere(output, [card])        = 1   ← present at offset 11613
```

The mapped span covered `[10892,11268)`. `Residual`'s own doc comment claims to cover *"a value … in a second region"*, which it cannot.

## What is actually in the second place

```
offset 10973   …ilst ©ART data card 4532-…              mapped, overwritten
offset 11337   ns.adobe.com/tiff/1.0 <tiff:Artist>…     NOT mapped, untouched
```

An **XMP packet**. exiftool writes `Artist` to both `ItemList` and XMP. `Comment` is not duplicated into XMP, which is why one tag looked fine and the other did not — and why this reads as a per-atom bug until the offsets are examined. `Artist`, `Title` and `Author` are each written twice; `Comment` once.

## The fix

Two functions, and both redactors now gate on the whole output:

| | for |
|---|---|
| `ResidualAnywhere(buf, matches)` | audio, which holds the file in memory |
| `ResidualInReader(readerAt, size, matches)` | video, which does not |

The streaming form reads 1MB windows with a `maxNeedle-1` overlap, so a value straddling a boundary is still whole in exactly one window, and memory is bounded by the window rather than the movie.

Both search narrow, UTF-16LE and UTF-16BE — exactly as the overwrite writes them — so the check cannot pass by looking for something narrower than what was written. Counted per **value**, not per occurrence.

`Residual` is kept for callers that genuinely mean "within these spans", with its doc comment corrected to say it is **not** sufficient as a pre-write gate.

## Consequence to expect — please read before merging

Files that used to "succeed" now **refuse**. That is the point: a refusal is disclosed, a silent leak is not. But it is a real capability change — on a stripped `.m4a`, setting `Artist`, `Title` or `Author` produces an out-of-span XMP copy, so **those files are no longer redactable**. `Comment` still is.

The complete fix is to **map the XMP packet** so the value is redacted rather than refused. That is a span-discovery change in `internal/redactors/isobmff` and is filed separately. This change stops the leak while that work happens.

## Verified in both directions on real media

| fixture | outcome |
|---|---|
| leaky `.m4a` (Artist in ilst + XMP) | **refuses**, 0 copies written |
| leaky `.mp4` (Artist in ilst + XMP) | **refuses**, 0 copies written |
| clean `.m4a` (Comment only, in span) | **redacts**, value gone from the bytes, 1 copy |
| clean `.mp4` (Comment only, in span) | **redacts**, value gone from the bytes, 1 copy |

The controls matter as much as the leaks: a whole-buffer search is strictly stricter, so the risk of this fix is refusing files that were being redacted correctly. They are not.

## Test plan

`make pr-checklist BASE=origin/main`

```
=== summary: 10 ran, 0 failed, 5 need manual work ===
1 gofmt / go vet / go build      RAN — clean / clean / ok
2 full suite (-count=1)          RAN — 70 packages ok
3 golden regen                   RAN — 0 files changed
8 web / CSP                      N/A
11 cross-platform vet            RAN — linux darwin windows
12 flake (3 repeats)             RAN — audio, tagmeta, video
13 race (whole module)           RAN — 70 packages ok
-- -short mode / tree clean      RAN — ok / dirtied nothing
```

All five manual dimensions completed:

| # | dimension | result |
|---|---|---|
| 4 | redaction, every strategy | `simple`, `format_preserving`, `synthetic` on real media: 1 copy each, **0 cleartext remaining** |
| 5 | suppression | 1 rule generated by the **parent** binary and enabled, applied by mine: identical to the parent applying its own |
| 6 | timing | the extra read is the cost of this fix, so it is measured against SIZE on a real `.mp4` grown to 2/7/28/95MB, with a file that **redacts** (a refusal would short-circuit the write and hide it): **+0.00s, +0.00s, +0.02s, +0.11s** — about 1.2ms/MB at the top of the 100MB supported range |
| 7 | all 7 formats | every format emits valid non-empty output for a refused media file, 0 copies written |
| 10 | non-vacuity | the **parent binary writes a copy containing the SSN** for both real files (`copies=1 ssn_in_copy=1`) while this branch refuses; the unit tests do not compile against parent, since the API is new |

Five tests on the shared helpers, including the exact geometry of the real failure (one occurrence inside the region already overwritten, one outside surviving), the cleaned buffer that must still pass, both wide encodings, per-value counting, and an **empty match text** — which would otherwise match every buffer and refuse every file, the same failure in the opposite direction.

## Union

**Disjoint from #450**: no shared file, and `git merge-tree` is clean against it. Merge-base is `0610b7e`, current `origin/main`.

Note the two interact usefully rather than conflicting: once #450 lands, these refusals stop being stderr-only and appear in every output format with cause `reported value not found in the writable bytes`, and `--fail-on-incomplete` will gate on them.

Closes #449
