### PR TITLE
test(detector): size the column-assignment growth guard so noise cannot fail it

### DIFF
--- a/internal/detector/line_span_complexity_test.go
+++ b/internal/detector/line_span_complexity_test.go
@@ -153,13 +153,22 @@ func timeAssign(t *testing.T, matches []Match, wantDistinct bool) time.Duration 
 // that a scheduler hiccup cannot move in the direction that fails the build.
 //
 // Fixtures are rebuilt per attempt because timeAssign MUTATES its matches — it assigns the columns
-// it then asserts on — so reusing one slice would time an already-assigned run.
-func bestAssign(t *testing.T, k int, build func(int) []Match, wantDistinct bool) time.Duration {
+// it then asserts on — so reusing one slice would time an already-assigned run. mk is a thunk
+// rather than a (size, builder) pair so that every timing target here can use it whatever its
+// builder's arity: the first version of this helper took func(int) and so could only be applied to
+// one of the four tests, which left the other three on a single sample.
+//
+// That gap was not theoretical. TestAssignLineColumnsComplexityDistinctAndRepeated failed on a
+// macOS CI runner at base=40.67ms big=306.40ms against a 250ms ceiling, while the same commit
+// locally measured base=4.2-6.0ms big=18.8-23.5ms. The base being ~7x its local value says the
+// machine was loaded; the big term being ~13x says the load landed inside the big run. A spike in
+// one sample is precisely what best-of-N removes, and it is why all four targets now use it.
+func bestAssign(t *testing.T, mk func() []Match, wantDistinct bool) time.Duration {
 	t.Helper()
 	const attempts = 3
 	var best time.Duration
 	for i := 0; i < attempts; i++ {
-		d := timeAssign(t, build(k), wantDistinct)
+		d := timeAssign(t, mk(), wantDistinct)
 		if best == 0 || d < best {
 			best = d
 		}
@@ -175,8 +184,8 @@ func TestAssignLineColumnsComplexityRepeatedValue(t *testing.T) {
 
 	const baseK, bigK = 2000, 8000 // 4x
 
-	tBase := timeAssign(t, buildRepeatedOnOneLine(baseK), true)
-	tBig := timeAssign(t, buildRepeatedOnOneLine(bigK), true)
+	tBase := bestAssign(t, func() []Match { return buildRepeatedOnOneLine(baseK) }, true)
+	tBig := bestAssign(t, func() []Match { return buildRepeatedOnOneLine(bigK) }, true)
 
 	ratio := float64(tBig) / float64(tBase)
 	t.Logf("4x input, ONE repeated value: %.1fx (base=%v big=%v) — the cursor advances past "+
@@ -205,8 +214,8 @@ func TestAssignLineColumnsComplexityDistinctValues(t *testing.T) {
 	// signal did not change; the sample became large enough to see it. Measured, not guessed.
 	const baseK, bigK = 8000, 32000 // 4x
 
-	tBase := bestAssign(t, baseK, buildDistinctOnOneLine, true)
-	tBig := bestAssign(t, bigK, buildDistinctOnOneLine, true)
+	tBase := bestAssign(t, func() []Match { return buildDistinctOnOneLine(baseK) }, true)
+	tBig := bestAssign(t, func() []Match { return buildDistinctOnOneLine(bigK) }, true)
 
 	ratio := float64(tBig) / float64(tBase)
 	t.Logf("4x input, K DISTINCT values on one line: %.1fx (base=%v big=%v) — linear is 4x. "+
@@ -260,8 +269,8 @@ func TestAssignLineColumnsComplexityManyLines(t *testing.T) {
 
 	const baseN, bigN = 5000, 20000 // 4x
 
-	tBase := timeAssign(t, build(baseN), false)
-	tBig := timeAssign(t, build(bigN), false)
+	tBase := bestAssign(t, func() []Match { return build(baseN) }, false)
+	tBig := bestAssign(t, func() []Match { return build(bigN) }, false)
 
 	ratio := float64(tBig) / float64(tBase)
 	t.Logf("4x input, one match per line across many lines: %.1fx (base=%v big=%v)",
@@ -325,8 +334,8 @@ func TestAssignLineColumnsComplexityDistinctAndRepeated(t *testing.T) {
 	// and the mutation survived.
 	const distinct = 40
 
-	tBase := timeAssign(t, build(distinct, 500), false)
-	tBig := timeAssign(t, build(distinct, 2000), false) // 4x the repeats
+	tBase := bestAssign(t, func() []Match { return build(distinct, 500) }, false)
+	tBig := bestAssign(t, func() []Match { return build(distinct, 2000) }, false) // 4x the repeats
 
 	ratio := float64(tBig) / float64(tBase)
 	t.Logf("4x the repeats of %d distinct values on one line: %.1fx (base=%v big=%v) — linear is 4x",

--- a/internal/detector/line_span_complexity_test.go
+++ b/internal/detector/line_span_complexity_test.go
@@ -145,6 +145,28 @@ func timeAssign(t *testing.T, matches []Match, wantDistinct bool) time.Duration 
 	return elapsed
 }
 
+// bestAssign times AssignLineColumns over freshly built fixtures and returns the FASTEST run.
+//
+// Best-of-N, not a single sample, because this is a shared CI runner and the failure mode of a
+// ratio assertion is a spike in either term. A spike inflates a duration; it never deflates one, so
+// the minimum is the closest thing to the machine's actual cost and is the only summary statistic
+// that a scheduler hiccup cannot move in the direction that fails the build.
+//
+// Fixtures are rebuilt per attempt because timeAssign MUTATES its matches — it assigns the columns
+// it then asserts on — so reusing one slice would time an already-assigned run.
+func bestAssign(t *testing.T, k int, build func(int) []Match, wantDistinct bool) time.Duration {
+	t.Helper()
+	const attempts = 3
+	var best time.Duration
+	for i := 0; i < attempts; i++ {
+		d := timeAssign(t, build(k), wantDistinct)
+		if best == 0 || d < best {
+			best = d
+		}
+	}
+	return best
+}
+
 // TestAssignLineColumnsComplexityRepeatedValue: the cursor's own case must be linear.
 func TestAssignLineColumnsComplexityRepeatedValue(t *testing.T) {
 	if testing.Short() {
@@ -174,10 +196,17 @@ func TestAssignLineColumnsComplexityDistinctValues(t *testing.T) {
 		t.Skip("column-assignment complexity guard skipped in -short mode")
 	}
 
-	const baseK, bigK = 2000, 8000 // 4x
+	// 8000/32000, not 2000/8000. The smaller pair put the BASE at half a millisecond, where
+	// scheduler noise is a large fraction of the measurement: across ten local runs on an idle
+	// machine the ratio ranged 3.6x to 6.9x, a 2.3x spread against an 8x threshold, and a loaded
+	// Windows CI runner produced 8.9x and failed the build on main itself.
+	//
+	// At this size the base is ~2ms and the same ten runs span 3.76x to 4.28x — a 0.5x spread. The
+	// signal did not change; the sample became large enough to see it. Measured, not guessed.
+	const baseK, bigK = 8000, 32000 // 4x
 
-	tBase := timeAssign(t, buildDistinctOnOneLine(baseK), true)
-	tBig := timeAssign(t, buildDistinctOnOneLine(bigK), true)
+	tBase := bestAssign(t, baseK, buildDistinctOnOneLine, true)
+	tBig := bestAssign(t, bigK, buildDistinctOnOneLine, true)
 
 	ratio := float64(tBig) / float64(tBase)
 	t.Logf("4x input, K DISTINCT values on one line: %.1fx (base=%v big=%v) — linear is 4x. "+
@@ -195,9 +224,10 @@ func TestAssignLineColumnsComplexityDistinctValues(t *testing.T) {
 	// 148ms, which is comfortably inside a 4s ceiling, so it passed for as long as the
 	// quadratic existed. A growth bound is what actually pins the shape.
 	//
-	// 8x rather than 4x because both the value COUNT and the line LENGTH grow with K here, and
-	// these samples are milliseconds where scheduler noise is a large fraction. A return to
-	// O(K x line) would show 16x.
+	// 8x rather than 4x because both the value COUNT and the line LENGTH grow with K here. A return
+	// to O(K x line) would show 16x, so with the measurement now stable at ~4.2x this sits roughly
+	// midway between the real cost and the regression it guards against — headroom on both sides
+	// rather than the 8.0-against-a-3.6-to-6.9-spread it had before.
 	const maxGrowth = 8.0
 	if tBase > 0 && ratio > maxGrowth {
 		t.Errorf("4x input cost %.1fx (base=%v big=%v), over %.0fx: the per-value line rescan is "+


### PR DESCRIPTION
## Why

`TestAssignLineColumnsComplexityDistinctValues` fails intermittently on CI **including on `main`** ([run 32519930068](https://github.com/awslabs/ferret-scan/actions/runs/32519930068)), and has failed two PR branches that touch nothing in `internal/detector` — #451 among them. A guard that fails unrelated work is worse than no guard, because it trains people to re-run rather than read.

## The cause is the sample size, not the machine

The base measurement was **half a millisecond**:

| sizes | base | ratio across runs | spread |
|---|---|---|---|
| K=2000/8000 (current) | 0.46–0.69ms | 3.71x – 5.97x | **2.26** |
| K=8000/32000 | 1.93–2.22ms | 3.76x – 4.28x | **0.52** |

Ten local runs on an **idle** machine at the old size spanned 3.6x to 6.9x against an 8.0x threshold — the noise was most of the margin. A loaded Windows runner produced 8.9x and failed.

The test's own comment already said *"these samples are milliseconds where scheduler noise is a large fraction"*. The threshold was chosen anyway.

## What changed

Only the measurement, never the thing measured:

- **K=8000/32000**, keeping the 4x relationship. The signal did not change; the sample became large enough to see it.
- **`bestAssign` takes the fastest of three runs** per size. A scheduler spike inflates a duration and never deflates one, so the minimum is the only summary statistic a hiccup cannot move in the direction that fails the build. Fixtures are rebuilt per attempt because `timeAssign` mutates its matches — it assigns the columns it then asserts on.

After: **2.7x – 4.3x across eight consecutive runs.**

## Still non-vacuous — the actual risk of enlarging a fixture

With `useIndex` forced to `false` (the pre-#388/#440 per-value rescan):

```
run 1: cost 15.9x  FAIL
run 2: cost 16.1x  FAIL
run 3: cost 15.6x  FAIL
```

Exactly the 16x the comment predicts. So the 8x threshold now sits between a real cost of **2.7–4.3x** and a regression of **~16x**, with roughly 2x headroom on each side, where before it sat inside the noise band.

## Scope

No production code changes — `internal/detector/line_span_complexity_test.go` only.

The repeated-value and many-lines tests keep their sizes deliberately: neither asserts a **ratio**, only the absolute ceiling, so neither is noise-sensitive.

## Test plan

- Full suite: 70 packages, rc 0. gofmt clean.
- 8 consecutive runs of the guard: 2.7x–4.3x, all pass.
- Mutation: `useIndex` → `false` fails 3 of 3 at ~16x.
- Disjoint from #450 (`formatters`/`cmd`) and #451 (`redactors`) — no shared file.


---

## Follow-up commit: all four targets, not one

The first commit applied `bestAssign` to a single target, because the helper took
`(size, func(int) []Match)` and only `TestAssignLineColumnsComplexityDistinctValues` has a
one-argument builder. The other three kept a single sample — and CI found that gap on PR #466:

```
TestAssignLineColumnsComplexityDistinctAndRepeated
  macOS CI   base=40.674084ms  big=306.401083ms   against a 250ms ceiling
  local x5   base=4.2-6.0ms    big=18.8-23.5ms
```

The base at ~7x its local value says the runner was loaded; the big term at ~13x says the load
landed inside the big run. `bestAssign` now takes a thunk so arity is no longer a reason for a
target to keep a single sample, and all four use it.

**The ceiling is deliberately not raised.** Loosening a threshold trades away the discrimination
the guard exists for. Verified by reintroducing the quadratic hand-out the test names (`p := 0`
instead of the per-value pointer):

| | base | big | ratio | result |
|---|---|---|---|---|
| clean | 3.99 ms | 20.67 ms | 5.2x | PASS |
| quadratic | 28.20 ms | 427.02 ms | 15.1x | **FAIL** on both the 250 ms ceiling and the 8x ratio |

A 20x separation that best-of-3 does not narrow, and the mutated figures land on the profile this
test's own comment documents for the quadratic case (34-40 ms / 422-465 ms).
