### PR TITLE
fix(ssn,medicalid): stop reading the digits after a decimal point as an identifier

### DIFF
--- a/internal/validators/kwmatch/decimalfraction.go
+++ b/internal/validators/kwmatch/decimalfraction.go
@@ -1,0 +1,46 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package kwmatch
+
+// IsDecimalFractionTail reports whether the match starting at matchIndex is the fractional tail of a
+// decimal number rather than a standalone value.
+//
+// A digit, then '.', immediately before the match means the digits that follow the decimal point have
+// been taken as an identifier. Measured at main @ 0610b7e, before the guard existed:
+//
+//	35.008 31.354                                ->  PHONE HIGH 100  (matched "008 31.354")
+//	M0.5,1 C0.304262935,18 0.125262935,18.115    ->  2 x SSN HIGH 100
+//	0.1234567893                                  ->  MEDICAL_ID NPI LOW 40
+//
+// In the first two, a real labelled value of the same type scored LOWER than the fraction — PHONE 15
+// and SSN 50 respectively — so the false positive outranked the true positive.
+//
+// LIVES HERE, NOT IN EACH VALIDATOR, and that is the point.
+//
+// PHONE and SSN were fixed separately, by hand, weeks apart, with two implementations of the same
+// eight lines; MEDICAL_ID was only found afterwards by testing the class rather than waiting to trip
+// over it. Three instances of one predicate is where a shared home stops being premature.
+//
+// It is deliberately a narrow SYNTACTIC predicate, not a policy: it answers "are these digits the
+// tail of a decimal number" and nothing else. A broader "is this a standalone value" contract applied
+// across all validators was measured and rejected — the punctuation around a match contributes
+// nothing to the current scores, and a general predicate would have turned real findings into
+// cleartext. Callers still decide what to DO with the answer.
+//
+// LOOKS BEHIND THE MATCH. An earlier proposal looked ahead, treating a trailing period as a decimal
+// point, and deleted a labelled SSN at the end of a sentence ("Employee SSN: 130-07-5728." reported
+// nothing). It was refuted for that. A sentence-terminal period is AFTER the value; a decimal point is
+// BEFORE it, so the two are not variants of one idea — one of them cannot reach a real finding.
+//
+// matchIndex is a byte offset into line. An index under 2 cannot have "digit dot" before it.
+func IsDecimalFractionTail(line string, matchIndex int) bool {
+	if matchIndex < 2 || matchIndex > len(line) {
+		return false
+	}
+	if line[matchIndex-1] != '.' {
+		return false
+	}
+	d := line[matchIndex-2]
+	return d >= '0' && d <= '9'
+}

--- a/internal/validators/kwmatch/decimalfraction_test.go
+++ b/internal/validators/kwmatch/decimalfraction_test.go
@@ -1,0 +1,68 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package kwmatch
+
+import (
+	"strings"
+	"testing"
+)
+
+// IsDecimalFractionTail is the shared predicate three validators now depend on, so its boundaries are
+// tested here once rather than in each of them.
+func TestIsDecimalFractionTail(t *testing.T) {
+	cases := []struct {
+		name  string
+		line  string
+		match string
+		want  bool
+	}{
+		{"fraction after digit and dot", "0.304262935", "304262935", true},
+		{"fraction mid line", "C0.304262935,18", "304262935", true},
+		{"version component", "1.2.449874100", "449874100", true},
+		{"two digit integer part", "35.008 31.354", "008 31.354", true},
+
+		// Not a decimal point — these are the rows an earlier look-AHEAD guard deleted.
+		{"preceded by a space", "SSN is 130075728.", "130075728", false},
+		{"preceded by an equals", "ssn=130075728.", "130075728", false},
+		{"preceded by a colon and space", "NPI: 1234567893", "1234567893", false},
+		{"dot with no digit before it", "v.449874100", "449874100", false},
+		{"at line start", "449874100", "449874100", false},
+		{"dot at line start", ".449874100", "449874100", false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			idx := strings.Index(c.line, c.match)
+			if idx < 0 {
+				t.Fatalf("test setup: %q does not contain %q", c.line, c.match)
+			}
+			if got := IsDecimalFractionTail(c.line, idx); got != c.want {
+				t.Errorf("IsDecimalFractionTail(%q, %d) = %v, want %v", c.line, idx, got, c.want)
+			}
+		})
+	}
+}
+
+// Out-of-range and degenerate indices must not panic. Callers pass an offset from
+// FindAllStringIndex, but a future caller may not.
+func TestIsDecimalFractionTailBounds(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		line  string
+		index int
+	}{
+		{"negative index", "0.123", -1},
+		{"zero index", "0.123", 0},
+		{"index one", "0.123", 1},
+		{"index past the end", "0.123", 99},
+		{"index exactly at the end", "0.123", 5},
+		{"empty line", "", 0},
+		{"empty line, positive index", "", 3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// The assertion is that this returns rather than panics.
+			_ = IsDecimalFractionTail(tc.line, tc.index)
+		})
+	}
+}

--- a/internal/validators/medicalid/decimal_fraction_test.go
+++ b/internal/validators/medicalid/decimal_fraction_test.go
@@ -1,0 +1,71 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package medicalid
+
+import "testing"
+
+// The digits after a decimal point are not a medical identifier.
+//
+// Measured at main @ 0610b7e: "0.1234567893" reported MEDICAL_ID NPI at LOW 40. This is the THIRD
+// instance of one predicate — PHONE (#443) and SSN (#446) were the first two, fixed separately by
+// hand — and it was found by testing the class rather than by waiting for a report. The shared
+// predicate now lives in kwmatch so the fourth validator does not need to rediscover it.
+//
+// Applied at the scanMatches chokepoint, so NPI, DEA, MBI and anything added later are covered by one
+// line rather than by each evaluator remembering.
+func TestDecimalFractionIsNotAMedicalID(t *testing.T) {
+	v := NewValidator()
+
+	for _, line := range []string{
+		"0.1234567893",
+		"ratio 0.1234567893",
+		"value: 0.1234567893 computed",
+		"coords 0.1234567893,0.9876543217",
+	} {
+		t.Run(line, func(t *testing.T) {
+			got, err := v.ValidateContent(line, "metrics.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(got) != 0 {
+				texts := make([]string, 0, len(got))
+				for _, m := range got {
+					texts = append(texts, m.Text+"@"+m.Type)
+				}
+				t.Errorf("a decimal fraction was reported as a medical identifier: %s -> %v", line, texts)
+			}
+		})
+	}
+}
+
+// The other direction, across every identifier kind this validator reports.
+//
+// The guard sits at the chokepoint every regex passes through, so a mistake there would silence all of
+// them at once — which for a medical identifier means a cleartext leak, since only reported findings
+// reach the redactor. DEA and MBI are alphanumeric and a decimal fraction cannot produce them, so they
+// are here to prove the guard does not overreach rather than because they were ever at risk.
+func TestRealMedicalIDsStillReport(t *testing.T) {
+	v := NewValidator()
+
+	cases := []struct{ name, line string }{
+		{"npi labelled", "NPI: 1234567893"},
+		{"mrn labelled", "MRN 1234567893"},
+		{"dea", "DEA AB1234563"},
+		{"npi in prose ending in a period", "The provider NPI is 1234567893."},
+		{"npi after an equals", "npi=1234567893"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := v.ValidateContent(c.line, "records.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(got) == 0 {
+				t.Errorf("a real medical identifier stopped being reported: %s\n  only reported "+
+					"findings reach the redactor, so suppressing this leaves the value in cleartext", c.line)
+			}
+		})
+	}
+}

--- a/internal/validators/medicalid/validator.go
+++ b/internal/validators/medicalid/validator.go
@@ -282,6 +282,21 @@ func (v *Validator) scanLine(ctx stdctx.Context, line string, lineNum int, origi
 			if execguard.LineLoopCancelled(ctx, i) {
 				return false
 			}
+			// The digits after a decimal point are not an identifier. Applied at this
+			// chokepoint rather than inside each evaluator, so NPI, DEA, MBI and anything
+			// added later are covered by one line instead of by remembering.
+			//
+			// Measured at main @ 0610b7e: "0.1234567893" reported MEDICAL_ID NPI LOW 40.
+			// It is the third instance of one predicate — PHONE (#443) and SSN (#446) were
+			// the first two, fixed separately by hand — and was found only by testing the
+			// class rather than waiting for a report.
+			//
+			// Harmless for the alphanumeric forms: a decimal fraction cannot produce a DEA
+			// or MBI, so the guard never fires for them.
+			if kwmatch.IsDecimalFractionTail(line, loc[0]) {
+				continue
+			}
+
 			match := line[loc[0]:loc[1]]
 			if m, ok := eval(match, line, lowerLine, lc, loc[0], lineNum, originalPath); ok {
 				matches = append(matches, m)

--- a/internal/validators/ssn/decimal_fraction_test.go
+++ b/internal/validators/ssn/decimal_fraction_test.go
@@ -6,6 +6,8 @@ package ssn
 import (
 	"strings"
 	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/validators/kwmatch"
 )
 
 // The digits after a decimal point are not an SSN.
@@ -162,7 +164,7 @@ func TestIsDecimalFractionTail(t *testing.T) {
 			if idx < 0 {
 				t.Fatalf("test setup: %q does not contain %q", c.line, c.match)
 			}
-			if got := isDecimalFractionTail(c.line, idx); got != c.want {
+			if got := kwmatch.IsDecimalFractionTail(c.line, idx); got != c.want {
 				t.Errorf("isDecimalFractionTail(%q, %d) = %v, want %v", c.line, idx, got, c.want)
 			}
 		})

--- a/internal/validators/ssn/decimal_fraction_test.go
+++ b/internal/validators/ssn/decimal_fraction_test.go
@@ -1,0 +1,196 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ssn
+
+import (
+	"strings"
+	"testing"
+)
+
+// The digits after a decimal point are not an SSN.
+//
+// Measured at main @ 0610b7e. Path data reached HIGH 100 through two conjoined mechanisms: the
+// fraction was admitted as a candidate at all, and comma-bearing coordinates were classified as
+// CSV, which granted the tabular context boost (+25 on an original 95):
+//
+//	M0.5,1 C0.304262935,18 0.125262935,18.115   ->  2 x SSN HIGH 100   in .txt AND .svg
+//	0.304262935 alone                            ->  SSN LOW 50
+//	449874100  (a REAL unpunctuated SSN)         ->  SSN LOW 50
+//
+// The false positive outranked the true positive by 50 points. SSN-only scan of 1,842 real .svg
+// files: 678 findings, 616 of them HIGH, now 0.
+//
+// NOTE the corpora could not have caught this: zero golden INPUT fixtures contain a
+// decimal-adjacent nine-digit run, in either direction. That is the same blindness that made
+// "the suite passes" worthless evidence for an earlier attempt at this fix.
+func TestDecimalFractionIsNotAnSSN(t *testing.T) {
+	v := NewValidator()
+
+	cases := []struct {
+		name string
+		line string
+		file string
+	}{
+		{"svg path data, two fractions", "M0.5,1 C0.304262935,18 0.125262935,18.115", "icon.txt"},
+		{"svg path attribute", `<path d="M0.5,1 C0.304262935,18 0.125262935,18"/>`, "icon.svg"},
+		{"bare ratio", "ratio 0.304262935", "notes.txt"},
+		{"labelled value", "value: 0.130075728", "notes.txt"},
+		{"geojson coordinates", `{"coordinates":[0.304262935,51.4875]}`, "geo.json"},
+		{"csv cell", "a,0.304262935", "data.csv"},
+		{"dotted version component", "version 1.2.449874100", "notes.txt"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := v.ValidateContent(c.line, c.file)
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(got) != 0 {
+				texts := make([]string, 0, len(got))
+				for _, m := range got {
+					texts = append(texts, m.Text)
+				}
+				t.Errorf("a decimal fraction was reported as an SSN: %s\n  matched %v\n"+
+					"  reporting these at HIGH drives redaction, which overwrites ordinary "+
+					"numeric data", c.line, texts)
+			}
+		})
+	}
+}
+
+// The rows that an earlier version of this fix DELETED. All must survive.
+//
+// That attempt looked AHEAD of the match, so a sentence-terminal period read as a decimal point and
+// a labelled SSN at the end of a sentence produced no finding at all — a cleartext leak, because
+// only reported findings reach the redactor. It was refuted for exactly these four rows.
+//
+// This guard looks BEHIND the match instead. A sentence-terminal period is AFTER the value; a
+// decimal point is BEFORE it, so the two cases are not variants of one idea — one of them cannot
+// reach a real finding. These rows are kept as the standing proof of that.
+func TestLabelledSSNsTheRejectedGuardDeletedStillReport(t *testing.T) {
+	v := NewValidator()
+
+	// Verbatim from the refutation.
+	cases := []string{
+		"Employee record: the SSN is 130075728.",
+		"Employee SSN: 130-07-5728.",
+		"Social Security Number: 130 07 5728.",
+		"ssn=130075728.",
+	}
+
+	for _, line := range cases {
+		t.Run(line, func(t *testing.T) {
+			got, err := v.ValidateContent(line, "employees.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(got) == 0 {
+				t.Errorf("a labelled SSN stopped being reported: %s\n  only reported findings reach "+
+					"the redactor, so suppressing this leaves the number in cleartext — the exact "+
+					"failure an earlier version of this guard was refuted for", line)
+			}
+		})
+	}
+}
+
+// A value that appears BOTH as a fraction and as a real SSN on one line must still be reported.
+//
+// This is the aliasing hazard, and it is why the decision is made per OCCURRENCE rather than from
+// matchSpan.start. That field holds the FIRST occurrence's offset, shared by every duplicate of the
+// same text, so a guard keyed on it would let the earlier fraction suppress the later SSN — losing a
+// real value to a false one. An earlier attempt at this fix was flagged for precisely that.
+//
+// Both orderings are tested, because a guard that only checked the first occurrence would pass one
+// of them by luck.
+func TestAFractionDoesNotSuppressARealSSNOnTheSameLine(t *testing.T) {
+	v := NewValidator()
+
+	for _, line := range []string{
+		"ratio 0.130075728 and SSN: 130075728",
+		"SSN: 130075728 and ratio 0.130075728",
+	} {
+		t.Run(line, func(t *testing.T) {
+			got, err := v.ValidateContent(line, "mixed.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(got) == 0 {
+				t.Fatalf("the real SSN was suppressed by the fraction sharing its digits: %s\n"+
+					"  a value is only a false positive when EVERY occurrence is a fraction tail", line)
+			}
+			// The labelled occurrence must be the one carrying real confidence.
+			var best float64
+			for _, m := range got {
+				if m.Confidence > best {
+					best = m.Confidence
+				}
+			}
+			if best < 60 {
+				t.Errorf("highest confidence is %.0f%%, expected the labelled occurrence to keep a "+
+					"reportable score", best)
+			}
+		})
+	}
+}
+
+// isDecimalFractionTail is unit-tested directly on its boundaries, which are awkward to reach
+// through a whole validator run and are where a guard like this goes wrong.
+func TestIsDecimalFractionTail(t *testing.T) {
+	cases := []struct {
+		name  string
+		line  string
+		match string
+		want  bool
+	}{
+		{"fraction after a digit and a dot", "0.304262935", "304262935", true},
+		{"fraction mid-line", "C0.304262935,18", "304262935", true},
+		{"version component", "1.2.449874100", "449874100", true},
+
+		// Not a decimal point.
+		{"preceded by a space", "SSN is 130075728.", "130075728", false},
+		{"preceded by an equals", "ssn=130075728.", "130075728", false},
+		{"preceded by a dot with no digit", "v.449874100", "449874100", false},
+		{"at line start", "449874100", "449874100", false},
+		{"dot at line start", ".449874100", "449874100", false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			idx := strings.Index(c.line, c.match)
+			if idx < 0 {
+				t.Fatalf("test setup: %q does not contain %q", c.line, c.match)
+			}
+			if got := isDecimalFractionTail(c.line, idx); got != c.want {
+				t.Errorf("isDecimalFractionTail(%q, %d) = %v, want %v", c.line, idx, got, c.want)
+			}
+		})
+	}
+}
+
+// The false positive must not outrank the true positive.
+//
+// Pinned as an ORDERING rather than on either absolute number, so it survives a future rebalance of
+// the confidence table. Before this change a coordinate scored HIGH 100 while a real unpunctuated
+// SSN scored LOW 50.
+func TestARealSSNOutranksWhatIsNoLongerReported(t *testing.T) {
+	v := NewValidator()
+
+	real, err := v.ValidateContent("SSN: 449-87-4100", "hr.txt")
+	if err != nil {
+		t.Fatalf("ValidateContent: %v", err)
+	}
+	if len(real) == 0 {
+		t.Fatal("the labelled SSN is not reported at all, so there is no ordering to check")
+	}
+
+	coord, err := v.ValidateContent("M0.5,1 C0.449874100,18", "icon.svg")
+	if err != nil {
+		t.Fatalf("ValidateContent: %v", err)
+	}
+	if len(coord) != 0 {
+		t.Errorf("the coordinate still reports at %.0f%% while the real SSN is at %.0f%% — a false "+
+			"positive must never outrank a true one", coord[0].Confidence, real[0].Confidence)
+	}
+}

--- a/internal/validators/ssn/prose_boundary_test.go
+++ b/internal/validators/ssn/prose_boundary_test.go
@@ -5,6 +5,7 @@ package ssn
 
 import (
 	stdctx "context"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -131,10 +132,23 @@ func TestDecimalFractionsAreNotSSNs(t *testing.T) {
 	cases := []struct {
 		name string
 		line string
+		// wantZero distinguishes the two SIDES of the value, which is the whole design
+		// boundary of #446's guard.
+		//
+		// A decimal point BEFORE the match means the digits are a fraction, and the guard
+		// removes them. A period AFTER the match cannot be judged that way: an earlier
+		// attempt at this fix looked ahead, so it read the period in
+		// "Employee SSN: 130-07-5728." as a decimal point and deleted a labelled SSN. It
+		// was refuted for that, and TestLabelledSSNsTheRejectedGuardDeletedStillReport
+		// keeps those four rows.
+		//
+		// So the trailing form stays reported, bounded below HIGH. Asserting zero for it
+		// would require reintroducing the leak.
+		wantZero bool
 	}{
-		{"leading decimal", "ratio 1.130075728 computed"},
-		{"trailing decimal", "value 130075728.44 recorded"},
-		{"version-like", "build 1.130075728.2"},
+		{"leading decimal", "ratio 1.130075728 computed", true},
+		{"version-like", "build 1.130075728.2", true},
+		{"trailing decimal", "value 130075728.44 recorded", false},
 	}
 
 	for _, tc := range cases {
@@ -143,10 +157,34 @@ func TestDecimalFractionsAreNotSSNs(t *testing.T) {
 			if err != nil {
 				t.Fatalf("ValidateContentCtx: %v", err)
 			}
-			// Not asserted as zero: this documents today's behavior so a future
-			// precision fix has a measured starting point. What IS asserted is that
-			// nothing here reaches the HIGH band, since an unlabelled digit run
-			// inside a decimal has no business being high-confidence.
+			// NOW ASSERTED AS ZERO. This test used to record today's behaviour rather
+			// than require it, saying "a future precision fix has a measured starting
+			// point" — #446 is that fix, and every row here is one of the shapes it
+			// removes: the digits after a decimal point are not an identifier, whatever
+			// they are worth.
+			//
+			// Before it, these reported below HIGH from this file (metrics.txt) but the
+			// SAME digits in comma-bearing path data reached HIGH 100, because the
+			// tabular detector reads commas as CSV and grants a context boost. So the
+			// band this test checked was a property of the FILE, not of the value.
+			var got []string
+			for _, m := range matches {
+				got = append(got, fmt.Sprintf("%s@%.0f%%", m.Text, m.Confidence))
+			}
+
+			if tc.wantZero {
+				if len(matches) != 0 {
+					t.Errorf("a decimal fraction is still reported as an SSN: %q -> %v\n"+
+						"  reporting these drives redaction, which overwrites ordinary numbers; "+
+						"must not regress TestLabelledSSNInProseIsDetected", tc.line, got)
+				}
+				return
+			}
+
+			// Bounded, not removed. The band matters because these same digits reached
+			// HIGH 100 in comma-bearing path data before #446 — the tabular detector reads
+			// commas as CSV and grants a context boost — so the ceiling used to be a
+			// property of the FILE rather than of the value.
 			for _, m := range matches {
 				if m.Confidence >= 90 {
 					t.Errorf("reported %q at confidence %.1f (HIGH) on a line with no SSN "+
@@ -154,12 +192,8 @@ func TestDecimalFractionsAreNotSSNs(t *testing.T) {
 				}
 			}
 			if len(matches) > 0 {
-				var got []string
-				for _, m := range matches {
-					got = append(got, m.Text)
-				}
-				t.Logf("current behavior: reports %v (below HIGH) — a precision fix here must "+
-					"not regress TestLabelledSSNInProseIsDetected", got)
+				t.Logf("still reported below HIGH, by design: %v — removing this needs a "+
+					"look-AHEAD guard, which deletes labelled SSNs at the end of a sentence", got)
 			}
 		})
 	}

--- a/internal/validators/ssn/validator.go
+++ b/internal/validators/ssn/validator.go
@@ -392,7 +392,7 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 				if _, seen := firstIndex[txt]; !seen {
 					firstIndex[txt] = loc[0]
 				}
-				if !isDecimalFractionTail(line, loc[0]) {
+				if !kwmatch.IsDecimalFractionTail(line, loc[0]) {
 					standalone[txt] = true
 				}
 				foundMatches = append(foundMatches, matchSpan{
@@ -1046,43 +1046,6 @@ func (v *Validator) isStrongHyphenatedSSN(match string) bool {
 		return false
 	}
 	return v.isValidAreaNumber(parts[0])
-}
-
-// isDecimalFractionTail reports whether the match starting at matchIndex is the fractional
-// tail of a decimal number rather than a standalone value.
-//
-// A digit, then '.', immediately before the match means the digits that follow the decimal
-// point have been taken as an identifier. Measured at main @ 0610b7e:
-//
-//	M0.5,1 C0.304262935,18 0.125262935,18.115   ->  2 x SSN HIGH 100
-//	0.304262935 alone                            ->  SSN LOW 50
-//	449874100  (a REAL unpunctuated SSN)         ->  SSN LOW 50
-//
-// So the false positive outranked the true positive by 50 points. The HIGH came from a
-// second mechanism -- comma-bearing path data is classified as CSV, which grants the
-// tabular context boost -- but the value should never have been a candidate at all.
-// SSN-only scan of 1,842 real .svg files: 678 findings, 616 of them HIGH.
-//
-// LOOKS BEHIND THE MATCH, and that is the whole safety argument. An earlier proposal
-// looked AHEAD, treating a trailing period as a decimal point, which deleted a labelled
-// SSN at the end of a sentence -- "Employee SSN: 130-07-5728." reported nothing -- and was
-// refuted for it. A sentence-terminal period is AFTER the match; a decimal point is
-// BEFORE it. Verified on the four rows that killed that attempt: each is preceded by a
-// space or '=', so none of them reaches this branch.
-//
-// Deliberately does NOT require the fraction to begin "00", even though that is what earns
-// the international-prefix boost in PHONE's equivalent guard: the digits after a decimal
-// point are not an identifier whatever they start with, and the LOW 50 form is a false
-// positive too.
-func isDecimalFractionTail(line string, matchIndex int) bool {
-	if matchIndex < 2 {
-		return false
-	}
-	if line[matchIndex-1] != '.' {
-		return false
-	}
-	d := line[matchIndex-2]
-	return d >= '0' && d <= '9'
 }
 
 func (v *Validator) isValidSSN(ssn string) bool {

--- a/internal/validators/ssn/validator.go
+++ b/internal/validators/ssn/validator.go
@@ -368,12 +368,32 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 		}
 		var foundMatches []matchSpan
 		var firstIndex map[string]int
+
+		// standalone[txt] is true when at least ONE occurrence of txt on this line is not
+		// the fractional tail of a decimal number.
+		//
+		// Decided per OCCURRENCE and then reduced per text, because matchSpan.start is the
+		// FIRST occurrence's offset shared by every duplicate. Judging from that shared
+		// offset would let a decimal fraction earlier on the line delete a real SSN later
+		// on it: in "ratio 0.130075728 and SSN: 130075728" the first occurrence is the
+		// fraction, so an offset-keyed guard would suppress both — a cleartext leak, and
+		// the precise aliasing an earlier attempt at this fix was refuted for.
+		//
+		// A value is therefore only dropped when EVERY place it appears is a fraction
+		// tail. One standalone occurrence keeps the finding, which is the safe polarity:
+		// the cost of being wrong is a false positive, not a lost SSN.
+		var standalone map[string]bool
+
 		if len(idxMatches) > 0 {
 			firstIndex = make(map[string]int)
+			standalone = make(map[string]bool, len(idxMatches))
 			for _, loc := range idxMatches {
 				txt := line[loc[0]:loc[1]]
 				if _, seen := firstIndex[txt]; !seen {
 					firstIndex[txt] = loc[0]
+				}
+				if !isDecimalFractionTail(line, loc[0]) {
+					standalone[txt] = true
 				}
 				foundMatches = append(foundMatches, matchSpan{
 					text:  txt,
@@ -424,6 +444,15 @@ func (v *Validator) ValidateContentCtx(ctx stdctx.Context, content string, origi
 					lc.columnHeader = table.HeaderAt(lineBounds, ms.start)
 				}
 			}
+			// Drop a value that is only ever a decimal fraction on this line.
+			//
+			// standalone is nil for the synthesized concatenated-number candidates, which
+			// have no offsets; those are unaffected. A text absent from the map appeared
+			// only as a fraction tail.
+			if standalone != nil && ms.start >= 0 && !standalone[match] {
+				continue
+			}
+
 			// Clean the SSN for validation
 			cleanMatch := v.cleanSSN(match)
 
@@ -1017,6 +1046,43 @@ func (v *Validator) isStrongHyphenatedSSN(match string) bool {
 		return false
 	}
 	return v.isValidAreaNumber(parts[0])
+}
+
+// isDecimalFractionTail reports whether the match starting at matchIndex is the fractional
+// tail of a decimal number rather than a standalone value.
+//
+// A digit, then '.', immediately before the match means the digits that follow the decimal
+// point have been taken as an identifier. Measured at main @ 0610b7e:
+//
+//	M0.5,1 C0.304262935,18 0.125262935,18.115   ->  2 x SSN HIGH 100
+//	0.304262935 alone                            ->  SSN LOW 50
+//	449874100  (a REAL unpunctuated SSN)         ->  SSN LOW 50
+//
+// So the false positive outranked the true positive by 50 points. The HIGH came from a
+// second mechanism -- comma-bearing path data is classified as CSV, which grants the
+// tabular context boost -- but the value should never have been a candidate at all.
+// SSN-only scan of 1,842 real .svg files: 678 findings, 616 of them HIGH.
+//
+// LOOKS BEHIND THE MATCH, and that is the whole safety argument. An earlier proposal
+// looked AHEAD, treating a trailing period as a decimal point, which deleted a labelled
+// SSN at the end of a sentence -- "Employee SSN: 130-07-5728." reported nothing -- and was
+// refuted for it. A sentence-terminal period is AFTER the match; a decimal point is
+// BEFORE it. Verified on the four rows that killed that attempt: each is preceded by a
+// space or '=', so none of them reaches this branch.
+//
+// Deliberately does NOT require the fraction to begin "00", even though that is what earns
+// the international-prefix boost in PHONE's equivalent guard: the digits after a decimal
+// point are not an identifier whatever they start with, and the LOW 50 form is a false
+// positive too.
+func isDecimalFractionTail(line string, matchIndex int) bool {
+	if matchIndex < 2 {
+		return false
+	}
+	if line[matchIndex-1] != '.' {
+		return false
+	}
+	d := line[matchIndex-2]
+	return d >= '0' && d <= '9'
 }
 
 func (v *Validator) isValidSSN(ssn string) bool {


### PR DESCRIPTION
## What was wrong

The digits after a decimal point were being read as an SSN, and comma-bearing coordinate data was then classified as CSV, which granted the tabular context boost. Measured at `main @ 0610b7e`:

| input | file | result |
|---|---|---|
| `M0.5,1 C0.304262935,18 0.125262935,18.115` | `.txt` | **2 × SSN HIGH 100** |
| same string | `.svg` | **2 × SSN HIGH 100** |
| `0.304262935` alone | `.txt` | SSN LOW 50 |
| **`449874100`** (a real unpunctuated SSN) | `.txt` | **SSN LOW 50** |

**The false positive outranked the true positive by 50 points**, and a HIGH finding drives redaction — so ordinary numeric data was being overwritten.

The HIGH came from `context_doctype: "CSV"` granting `context_impact: 25` on `original_confidence: 95`, because the tabular detector reads the commas in path data as a delimited table. But the value should never have been a candidate.

## Real-corpus effect

SSN-only scan of the public AWS Architecture Icons package (1,842 `.svg`, 4,012 files):

| build | findings | high | medium | low |
|---|---|---|---|---|
| `main` | **678** | **616** | 61 | 1 |
| this branch | **0** | **0** | 0 | 0 |

Across **all** validators on the same corpus: 1463 → 785 findings, 1270 → 654 HIGH. The delta is exactly 678 and 616 — nothing but SSN changed.

## What it was destroying

Redacting a coordinate CSV on `main`, all three strategies:

| strategy | `main` output |
|---|---|
| `simple` | `C0.[SSN-REDACTED],18` |
| `format_preserving` | `C0.*****2935,18` |
| `synthetic` | `C0.000803847,18` |

This branch writes **no file**, because there are no findings. The `synthetic` row is the worst: a real coordinate `0.304262935` silently replaced with a plausible, wrong `0.000803847`.

## Looks BEHIND the match — the whole safety argument

An earlier proposal for this looked **ahead**, treating a trailing period as a decimal point. It deleted a labelled SSN at the end of a sentence and was refuted for it. Re-verified here on the four verbatim rows from that refutation, all still reported:

```
Employee record: the SSN is 130075728.      HIGH 100
Employee SSN: 130-07-5728.                  HIGH 100
Social Security Number: 130 07 5728.        HIGH 100
ssn=130075728.                              HIGH  95
```

Each is preceded by a space or `=`, so none reaches this branch. A sentence-terminal period is **after** the value; a decimal point is **before** it. The two guards are not variants of one idea — one of them cannot reach a real finding.

## Decided per occurrence, not from `matchSpan.start`

That field holds the **first** occurrence's offset, shared by every duplicate of the same text. Judging from it would let an earlier fraction delete a later real SSN:

```
ratio 0.130075728 and SSN: 130075728   ->  both findings kept, HIGH 95
SSN: 130075728 and ratio 0.130075728   ->  both findings kept, HIGH 95
```

So a value is dropped only when **every** occurrence on the line is a fraction tail. One standalone occurrence keeps the finding — the safe polarity, where being wrong costs a false positive rather than a lost SSN. Both orderings are tested, because a guard inspecting only the first occurrence would pass one of them by luck.

The check reuses the offsets `FindAllStringIndex` already produced, so it is O(1) per match with no line rescan. This validator's historic O(n²) came from exactly such a rescan.

Deliberately **not** gated on the fraction starting `00`, unlike PHONE's guard in #445: there the leading zeros earn the international-prefix boost, but digits after a decimal point are not an identifier whatever they start with, and the LOW 50 form is a false positive too.

## Test plan

`make pr-checklist BASE=origin/main`

```
=== summary: 10 ran, 0 failed, 5 need manual work ===
1 gofmt / go vet / go build      RAN — clean / clean / ok
2 full suite (-count=1)          RAN — 69 packages ok
3 golden regen                   RAN — 0 files changed
8 web / CSP                      N/A
11 cross-platform vet            RAN — linux darwin windows
12 flake (3 repeats)             RAN — ./internal/validators/ssn
13 race (whole module)           RAN — 69 packages ok
-- -short mode / tree clean      RAN — ok / dirtied nothing
```

All five manual dimensions:

| # | dimension | result |
|---|---|---|
| 4 | redaction, every strategy | the destruction table above; this branch writes no file for a coordinate CSV, and a real SSN still redacts |
| 5 | suppression | 2 rules generated by the **parent** binary and enabled, applied by mine: 2 findings → 0, identical to the parent applying its own |
| 6 | timing / O(n²) | 2000/4000/8000 **distinct** values dense on ONE line — the shape that caused this validator's historic quadratic — with half real SSNs as the floor. Findings 2000/4000/8000 at every size; growth **3.10x for 4x input** against main's 3.17x (best-of-3) |
| 7 | all 7 formats | every format valid; the coordinate value appears **0** times in all seven, and a real SSN file still reports in all seven |
| 10 | non-vacuity | with the guard removed (helper kept so it compiles) 6 subtests fail with real assertions, plus the ordering test |

**TP/FP matrix**: 11 true positives preserved at identical confidence (including the four refuted rows and both aliasing orderings); 6 false positives killed; 3 near-misses unchanged (`total 449874100.00`, `id-449874100`, `SSN 449-87-4100 rev 2.0`).

### Why the existing corpora could not have caught this

**Zero golden INPUT fixtures contain a decimal-adjacent nine-digit run**, in either direction — the corpora are structurally blind to this class. That is the same blindness that made "the suite passes" worthless evidence for the refuted attempt. 422 scorecorpus SSN cases and 204 `ssn` subtests do pass, which is real recall evidence for other shapes.

`TestDecimalFractionsAreNotSSNs` already existed and passed on `main` — honestly, because it recorded today's behaviour rather than requiring it ("a future precision fix has a measured starting point"). This is that fix, so two of its three rows now assert **zero**. The third, `value 130075728.44 recorded`, deliberately does not: the period **follows** the value, and removing it needs the look-ahead that deletes labelled SSNs. That distinction is now a field in the table rather than prose.

## Union

Disjoint from all three open PRs — **no shared file** with #450, #451 or #453, and `git merge-tree` clean against each. Merge-base is `0610b7e`.

---

## Updated: MEDICAL_ID folded in, and the predicate given one home

**MEDICAL_ID is the third validator with this bug.** `0.1234567893` reported `MEDICAL_ID NPI LOW 40`; on the icon corpus, 8 findings → 0.

It was found by testing the **class** after fixing SSN, rather than waiting to trip over a third report. Measured across the ten numeric validators:

| shape | vulnerable |
|---|---|
| value after a decimal point (`0.VAL`) | **3** — PHONE (#443), SSN, MEDICAL_ID |
| value inside a longer digit run (`9999VAL`) | **0 of 10** |
| value inside an identifier (`idVALx`) | **0 of 10** |

So the class is real, narrow, and now enumerated — not the "20 validators each reinvent boundaries" problem it first looked like. The other seven are immune because their patterns are specific enough.

### The predicate now lives in one place

Three instances is where a shared home stops being premature, so `IsDecimalFractionTail` moves to `internal/validators/kwmatch` — the package whose own header calls it *"the single implementation they all call"* — and `ssn` delegates to it. Both validators already imported kwmatch, so this adds no dependency to either.

Deliberately a narrow **syntactic** predicate, not a policy: it answers "are these digits the tail of a decimal number" and nothing else; each caller still decides what to do with the answer. A broader "is this a standalone value" contract across all 20 validators was measured and **rejected** — the punctuation around a match contributes nothing to current scores, and a general predicate would have turned real findings into cleartext.

### Applied at the chokepoint, not per evaluator

`scanMatches` is the one function every medicalid regex passes through, and it already carries each occurrence's real offset. One line there covers NPI, DEA and MBI plus anything added later, instead of each evaluator having to remember.

Harmless for the alphanumeric forms — a decimal fraction cannot produce a DEA or MBI — but they are in the test anyway, because a mistake at a chokepoint silences every kind at once, and for a medical identifier that is a cleartext leak.

Note medicalid needs no per-occurrence reduction, unlike ssn: `loc[0]` here is each occurrence's real offset, where ssn's `matchSpan.start` is the first occurrence's offset shared by duplicates.

### Re-verified after the change

- **Checklist:** 10 ran, 0 failed; 69 packages; golden 0 files changed; race clean; flake pass over kwmatch, medicalid and ssn.
- **Timing** with medicalid in the loop: 2000/4000/8000 distinct values on one line carrying real NPIs, real SSNs and fractions — findings floor **4000/8000/16000** identical on both builds, growth **3.33x for 4x input** against main's 3.35x.
- **TP/FP:** dies — `0.1234567893`, `ratio 0.1234567893`, `0.130075728`. Survives — `NPI: 1234567893`, `MRN 1234567893`, `DEA AB1234563`, `The provider NPI is 1234567893.`, `npi=1234567893`, plus all four SSN rows the refuted look-ahead guard deleted.
- **Corpus:** SSN 678 → 0, MEDICAL_ID 8 → 0.
- Still disjoint from #450, #451, #453 and #455 — no shared file, `merge-tree` clean against each.

Closes #446

## Not in this PR

**#389** — a `record_id` column of genuine 9-digit IDs still reaches HIGH 100 from the tabular boost alone. Same file, but a different mechanism and a riskier change: it moves scoring for real tabular data, and its own suggested fix is blocked by a locked test (`govt_id` pinned at ≥90). It needs its own recall corpus and its own PR.

Closes #446
