### PR TITLE
fix(preprocessors): stop scanning an image's own filename and path as its content

### DIFF
--- a/internal/preprocessors/image_metadata_preprocessor.go
+++ b/internal/preprocessors/image_metadata_preprocessor.go
@@ -285,18 +285,35 @@ func (imp *ImageMetadataPreprocessor) createMinimalImageMetadata(filePath string
 		Tags:     make(map[string]string),
 	}
 
-	// Add basic file information
-	if stat, err := filepath.Abs(filePath); err == nil {
-		exifData.Tags["FileName"] = filepath.Base(stat)
-		exifData.Tags["FileExtension"] = strings.ToUpper(strings.TrimPrefix(filepath.Ext(stat), "."))
-	}
-
-	// Add file system metadata if available
-	if stat, err := filepath.Abs(filePath); err == nil {
-		if fileInfo, err := filepath.Abs(stat); err == nil {
-			exifData.Tags["FilePath"] = fileInfo
-		}
-	}
+	// The file's own NAME and PATH are deliberately NOT tags.
+	//
+	// Tags become scannable content, so putting them there made the tool scan its own input
+	// path and report findings from it. Measured on two PNGs with byte-identical content
+	// (sha 258c3a962b02796a) differing only in filename:
+	//
+	//	asset_64@5x.png  ->  2 x EMAIL HIGH 90   ("64@5x.png" parses as local@domain.tld)
+	//	asset_64_5x.png  ->  no findings
+	//
+	// and `grep -c @5x` on the bytes is 0. The public AWS icon package alone holds 328 such
+	// files, and every macOS or iOS asset directory is full of them.
+	//
+	// It generalised past the name: with FilePath a tag, a file inside a directory called
+	// "claim-449-87-4100" reported SSN MEDIUM 60 on byte-identical content, while a .txt in
+	// the same directory reported nothing — so the same exposure was type-dependent. And the
+	// finding was unredactable by construction: redaction returned rc=0 having written a
+	// "redacted" copy to an output path that still contained the SSN, which is the one
+	// outcome the sink rule forbids (#444).
+	//
+	// Nothing read these tags: no validator derives a finding type from them, no test asserts
+	// on them, and the path is already carried per finding in Match.Filename, where a consumer
+	// can see it without it being treated as document content.
+	//
+	// FileExtension stays. It describes the file's TYPE rather than reproducing a caller's
+	// string, so it cannot carry a value from the scanned tree.
+	//
+	// If path exposure is worth reporting, it needs its own finding kind marked unredactable
+	// rather than being smuggled in as content; that is noted on #444.
+	exifData.Tags["FileExtension"] = strings.ToUpper(strings.TrimPrefix(filepath.Ext(filePath), "."))
 
 	// Add a note about missing EXIF data
 	exifData.Tags["MetadataNote"] = "No EXIF data available for this image format"

--- a/internal/preprocessors/image_path_not_content_test.go
+++ b/internal/preprocessors/image_path_not_content_test.go
@@ -1,0 +1,127 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package preprocessors
+
+import (
+	"strings"
+	"testing"
+)
+
+// The file's own NAME and PATH must not become scannable content.
+//
+// createMinimalImageMetadata put both in exifData.Tags, and tags are rendered into the text the
+// validators read — so the tool scanned its own input path and reported findings from it. Measured
+// at main @ 0610b7e on two PNGs with BYTE-IDENTICAL content (sha 258c3a962b02796a) differing only
+// in filename:
+//
+//	asset_64@5x.png  ->  2 x EMAIL HIGH 90    "64@5x.png" parses as local@domain.tld
+//	asset_64_5x.png  ->  no findings
+//
+// and `grep -c @5x` on the bytes is 0. The public AWS icon package holds 328 such files; every
+// macOS and iOS asset directory is full of them. On that corpus: EMAIL 656 -> 0, plus 10
+// IMAGE_METADATA findings whose reported text WAS the path.
+//
+// It generalised past the name: a file inside a directory called "claim-449-87-4100" reported SSN
+// MEDIUM 60 on byte-identical content, while a .txt in the same directory reported nothing — the
+// same exposure was type-dependent. And redaction returned rc=0 having written a "redacted" copy to
+// an output path that still contained the SSN, so the finding was unredactable by construction
+// (#444).
+//
+// Asserted on the FORMATTED metadata rather than end to end, because that string is what reaches the
+// validators and because these are in-package methods over a plain map.
+func TestFileNameAndPathAreNotScannableContent(t *testing.T) {
+	imp := NewImageMetadataPreprocessor()
+
+	// The exact shapes that produced findings, as a path a scan could really encounter.
+	const path = "/scan/claim-449-87-4100/asset_64@5x.png"
+
+	meta, err := imp.createMinimalImageMetadata(path)
+	if err != nil {
+		t.Fatalf("createMinimalImageMetadata: %v", err)
+	}
+
+	for _, tag := range []string{"FileName", "FilePath"} {
+		if v, present := meta.Tags[tag]; present {
+			t.Errorf("tag %q is still set to %q — tags become scannable content, so the tool "+
+				"reports findings from its own input path", tag, v)
+		}
+	}
+
+	formatted := imp.formatImageMetadata(meta)
+	for _, leaked := range []string{
+		"asset_64@5x.png",   // the @Nx name that parses as an email address
+		"claim-449-87-4100", // a directory name carrying a value
+		path,                // the whole path
+	} {
+		if strings.Contains(formatted, leaked) {
+			t.Errorf("%q reaches the scanned text:\n--- formatted ---\n%s", leaked, formatted)
+		}
+	}
+}
+
+// FileExtension is deliberately KEPT.
+//
+// It describes the file's TYPE rather than reproducing a caller's string, so it cannot carry a value
+// out of the scanned tree. Pinned so a later cleanup does not remove it as collateral and quietly
+// change what a no-EXIF image reports.
+func TestFileExtensionSurvives(t *testing.T) {
+	imp := NewImageMetadataPreprocessor()
+
+	meta, err := imp.createMinimalImageMetadata("/scan/photo.PNG")
+	if err != nil {
+		t.Fatalf("createMinimalImageMetadata: %v", err)
+	}
+	if got := meta.Tags["FileExtension"]; got != "PNG" {
+		t.Errorf("FileExtension = %q, want %q", got, "PNG")
+	}
+	if !strings.Contains(imp.formatImageMetadata(meta), "PNG") {
+		t.Error("FileExtension no longer reaches the formatted metadata")
+	}
+}
+
+// A path with no extension must not panic or produce a stray tag.
+func TestMinimalMetadataOnAnAwkwardPath(t *testing.T) {
+	imp := NewImageMetadataPreprocessor()
+
+	for _, path := range []string{
+		"/scan/noextension",
+		"/scan/.hidden",
+		"trailing.dot.",
+		"",
+	} {
+		t.Run(path, func(t *testing.T) {
+			meta, err := imp.createMinimalImageMetadata(path)
+			if err != nil {
+				t.Fatalf("createMinimalImageMetadata(%q): %v", path, err)
+			}
+			if _, present := meta.Tags["FilePath"]; present {
+				t.Error("FilePath tag reappeared")
+			}
+			if _, present := meta.Tags["FileName"]; present {
+				t.Error("FileName tag reappeared")
+			}
+			// Must still be usable: the formatter runs over whatever is there.
+			_ = imp.formatImageMetadata(meta)
+		})
+	}
+}
+
+// The struct's FilePath FIELD is still populated, and that is correct.
+//
+// It is how the preprocessor and the router identify the file being handled; only the TAGS become
+// scannable content. Keeping the distinction explicit, because "remove the path" applied to both
+// would break the pipeline rather than fix a false positive.
+func TestFilePathFieldIsStillSet(t *testing.T) {
+	imp := NewImageMetadataPreprocessor()
+
+	const path = "/scan/photo.png"
+	meta, err := imp.createMinimalImageMetadata(path)
+	if err != nil {
+		t.Fatalf("createMinimalImageMetadata: %v", err)
+	}
+	if meta.FilePath != path {
+		t.Errorf("FilePath field = %q, want %q — the field identifies the file and is not "+
+			"scanned; only the tags were the problem", meta.FilePath, path)
+	}
+}


### PR DESCRIPTION
## What was wrong

`createMinimalImageMetadata` put the file's own **name and path** into `exifData.Tags`, and tags are rendered into the text the validators read. So the tool scanned its own input path and reported findings from it.

Two PNGs with **byte-identical content** (sha `258c3a962b02796a`) differing only in filename:

```
$ ferret-scan --file asset_64@5x.png --show-match
[HIGH] email EMAIL 90.00% line 2  asset_64@5x.png
[HIGH] email EMAIL 90.00% line 3  asset_64@5x.png

$ ferret-scan --file asset_64_5x.png --show-match
(no findings)

$ grep -c "@5x" asset_64@5x.png
0
```

`64@5x.png` parses as `local@domain.tld`, and the string is **not in the file**. `@2x`/`@3x`/`@5x` is Apple's retina asset convention, so this is not an odd name: the public AWS Architecture Icons package alone holds **328** of them, and every macOS or iOS asset directory is full of them.

## Real-corpus effect

That corpus (1,842 `.svg` + 2,170 `.png`):

| | main | this branch |
|---|---|---|
| EMAIL | **656** (654 HIGH) | **0** |
| IMAGE_METADATA | **10** | **0** |
| all validators | 1463 | 797 |

The 10 `IMAGE_METADATA` findings are the same defect wearing another type — their reported **text was the injected value**:

```
text='/Users/…/Icon-package_01302026.31b40d12…'
text='Arch_AWS-Elemental-Appliances-&-Software_16.png'
```

So all 666 removed findings are one bug, and the report was additionally echoing a local filesystem path as a finding's value.

## It generalised past the name

With `FilePath` a tag, a file inside a directory called `claim-449-87-4100` reported **SSN MEDIUM 60** on byte-identical content — while a `.txt` in the same directory reported nothing, so the same exposure was **type-dependent**.

And the finding was **unredactable by construction**: redaction returned rc=0 having written a "redacted" copy to an output path that *still contained the SSN*. That is the one outcome the sink rule forbids.

## Scope, measured rather than assumed

- **Only the no-EXIF path injected.** An image carrying real EXIF renders just its real tags. So EXIF-bearing files are entirely unaffected — verified at scale: 1500/3000/6000 findings on 300/600/1200 real JPEGs with distinct EXIF PII, **identical before and after**.
- **Audio does the same thing** (`audioMeta.Properties["FilePath"]`) but it never reaches the scanned buffer: a `.m4a` in the same SSN-named directory reports nothing. Checked before touching it.
- **Nothing read the two tags**: no validator derives a finding type from them, no test asserts on them, and the path is already carried per finding in `Match.Filename`, where a consumer sees it without it being treated as document content.
- **`FileExtension` is kept.** It describes the file's *type* rather than reproducing a caller's string, so it cannot carry a value out of the scanned tree.
- **The struct's `FilePath` field is untouched.** It identifies the file for the preprocessor and router; only the tags were the problem. A test pins that distinction so "remove the path" is not later applied to both.

## Test plan

`make pr-checklist BASE=origin/main` — **10 ran, 0 failed**, 69 packages, golden 0 files changed, race clean, cross-platform vet clean.

All five manual dimensions:

| # | dimension | result |
|---|---|---|
| 4 | redaction, every strategy | `main` writes a "redacted" copy for a **clean icon** in all three strategies — to a path that still holds the SSN. This branch finds nothing, so writes nothing |
| 5 | suppression | 5 rules generated by the **parent** binary and enabled, applied by mine: 5 → 0, identical to the parent applying its own |
| 6 | timing / O(n²) | 300/600/1200 **real** JPEGs with **distinct** EXIF PII so the floor is real: findings 1500/3000/6000, growth **2.96x for 4x input** against main's 2.91x (best-of-3). Marginally faster — less text to scan |
| 7 | all 7 formats | the icon reports **0** in all seven; the EXIF JPEG still reports (3 text rows / 5 json findings) in all seven; all structured formats valid |
| 10 | non-vacuity | on parent the tests fail with real assertions: `tag "FileName" is still set to "asset_64@5x.png"`, `"claim-449-87-4100" reaches the scanned text` |

**TP/FP**: 2 false positives killed on byte-identical controls; real EXIF metadata fully preserved (5 findings before and after, same values, same confidences).

## Union

Disjoint from all four open code PRs — **no shared file** with #450, #451, #453 or #454, and `git merge-tree` clean against each.

## Follow-ups, not in this PR

- If path exposure is worth reporting it needs its **own finding kind**, explicitly marked unredactable so the disclosure machinery fires instead of a false success. Noted on #444 rather than smuggled in as content.
- Found while building the timing fixture: **PNG metadata is never read**. `exiftool` writes `Artist` into a PNG text chunk, `exiftool -s3 -Artist` reads it back, and the preprocessor still reports `MetadataNote: No EXIF data available for this image format`. A PNG carrying PII in its metadata is therefore not scanned at all — a detection gap, so a leak by the sink rule. Filed separately.

Closes #444
