### PR TITLE
fix(office): bound the TOTAL bytes one container materialises to temp

### DIFF
--- a/internal/preprocessors/meta-extractors/meta-extract-officelib/extraction_budget_test.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-officelib/extraction_budget_test.go
@@ -1,0 +1,214 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package metaextractofficelib
+
+import (
+	"archive/zip"
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/embedded"
+)
+
+// The AGGREGATE bytes one container may materialise must be bounded, not just the per-part size.
+//
+// MaxEmbeddedMediaSize bounds a single part; nothing bounded the sum. Measured at main @ 0610b7e on a
+// 1.43MB .docx holding 30 parts that each declare 49MB — just under the per-part cap:
+//
+//	peak temp disk   1.44 GB      (7x embedded.BudgetBytes)
+//	peak RSS         0.27 GB      so this is DISK exhaustion, not memory
+//	warnings         none, and the scan reported success
+//
+// After: peak temp 0.23 GB, and the truncation is disclosed as a coverage loss.
+//
+// embedded.BudgetBytes existed as a declared constant that no production code consulted — only
+// comments and a test asserting it was positive. This is the check it was written for.
+//
+// Asserted on the extractor rather than end to end, because the property is "the sum of what this
+// function writes is bounded" and that is exactly what it returns.
+func TestAggregateExtractionBudgetIsEnforced(t *testing.T) {
+	// Parts sized so that the third one crosses embedded.BudgetBytes. Deliberately each UNDER
+	// MaxEmbeddedMediaSize, because a per-part cap is what already existed and what the aggregate
+	// budget has to catch beyond.
+	const per = 40 * 1024 * 1024
+	parts := int(embedded.BudgetBytes/per) + 2
+
+	path := buildDocxWithParts(t, parts, per)
+
+	media, notExamined, err := ExtractEmbeddedMediaForProcessing(path)
+	if err != nil {
+		t.Fatalf("ExtractEmbeddedMediaForProcessing: %v", err)
+	}
+
+	// Non-vacuity first: some parts must have been extracted, or a function that refused
+	// everything would satisfy the bound trivially.
+	if len(media) == 0 {
+		t.Fatal("no parts were extracted at all, so the bound below proves nothing")
+	}
+	if len(media) >= parts {
+		t.Errorf("extracted %d of %d parts — the aggregate budget did not bite, so a container can "+
+			"still materialise parts x per-part-cap bytes of temp", len(media), parts)
+	}
+
+	// Everything it did extract must fit the budget.
+	var total int64
+	for _, m := range media {
+		info, statErr := os.Stat(m.TempFilePath)
+		if statErr != nil {
+			continue
+		}
+		total += info.Size()
+	}
+	// One part's overshoot is allowed by construction: the budget is charged AFTER the copy with
+	// the bytes actually written, because charging the DECLARED size first would let a lying
+	// declaration deny the rest of the document.
+	if total > embedded.BudgetBytes+per {
+		t.Errorf("materialised %d bytes, over the %d-byte budget plus one part's allowance",
+			total, embedded.BudgetBytes)
+	}
+
+	// And the truncation must be DISCLOSED, not silent — a partial scan reported as complete is
+	// the failure this whole family is about.
+	if len(notExamined) == 0 {
+		t.Error("parts were dropped with no note, so a truncated scan reports as complete")
+	}
+	found := false
+	for _, n := range notExamined {
+		if bytes.Contains([]byte(n), []byte("budget")) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("no note mentions the budget, so the operator cannot tell this from a read error: %v",
+			notExamined)
+	}
+
+	for _, m := range media {
+		_ = os.Remove(m.TempFilePath)
+	}
+}
+
+// A document within the budget must be entirely unaffected.
+//
+// The risk of an aggregate bound is that it starts refusing ordinary documents, which would trade a
+// disk-exhaustion fix for a coverage loss — and a coverage loss is a cleartext leak by the sink rule.
+func TestOrdinaryDocumentIsUnaffectedByTheBudget(t *testing.T) {
+	const parts, per = 6, 32 * 1024
+	path := buildDocxWithParts(t, parts, per)
+
+	media, notExamined, err := ExtractEmbeddedMediaForProcessing(path)
+	if err != nil {
+		t.Fatalf("ExtractEmbeddedMediaForProcessing: %v", err)
+	}
+	defer func() {
+		for _, m := range media {
+			_ = os.Remove(m.TempFilePath)
+		}
+	}()
+
+	if len(media) != parts {
+		t.Errorf("extracted %d of %d parts from a document well inside the budget", len(media), parts)
+	}
+	if len(notExamined) != 0 {
+		t.Errorf("a document inside the budget produced coverage notes: %v", notExamined)
+	}
+}
+
+// The budget is per container, so scanning two documents must not exhaust it for the second.
+//
+// A package-level counter would have passed every test above and then silently truncated the second
+// document of a directory scan.
+func TestBudgetIsPerContainerNotGlobal(t *testing.T) {
+	const per = 40 * 1024 * 1024
+	parts := int(embedded.BudgetBytes/per) + 2
+	first := buildDocxWithParts(t, parts, per)
+	second := buildDocxWithParts(t, 4, 32*1024)
+
+	m1, _, err := ExtractEmbeddedMediaForProcessing(first)
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	for _, m := range m1 {
+		_ = os.Remove(m.TempFilePath)
+	}
+
+	m2, notExamined, err := ExtractEmbeddedMediaForProcessing(second)
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	defer func() {
+		for _, m := range m2 {
+			_ = os.Remove(m.TempFilePath)
+		}
+	}()
+
+	if len(m2) != 4 {
+		t.Errorf("the second document extracted %d of 4 parts — the budget is leaking across "+
+			"containers, so a directory scan would truncate everything after the first big file",
+			len(m2))
+	}
+	if len(notExamined) != 0 {
+		t.Errorf("the second document produced coverage notes: %v", notExamined)
+	}
+}
+
+// buildDocxWithParts writes a minimal but structurally valid .docx with the requested embedded parts.
+//
+// The parts are highly compressible so the fixture stays small on disk while declaring a large
+// uncompressed size — the shape that makes this a bomb rather than a big file. Written with
+// writestr, NOT a streaming writer: a streamed entry leaves UncompressedSize64 unset, the copy reads
+// nothing, and the test passes while measuring an empty extraction. That happened while developing
+// this, and the first measurement was vacuous because of it.
+func buildDocxWithParts(t *testing.T, parts, per int) string {
+	t.Helper()
+
+	const ct = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Default Extension="png" ContentType="image/png"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>`
+	const rels = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>`
+	const doc = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>Patient SSN 449-87-4100</w:t></w:r></w:p></w:body></w:document>`
+
+	path := filepath.Join(t.TempDir(), "parts.docx")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	defer func() {
+		if cerr := f.Close(); cerr != nil {
+			t.Fatalf("close: %v", cerr)
+		}
+	}()
+
+	z := zip.NewWriter(f)
+	for name, body := range map[string]string{
+		"[Content_Types].xml": ct,
+		"_rels/.rels":         rels,
+		"word/document.xml":   doc,
+	} {
+		w, werr := z.Create(name)
+		if werr != nil {
+			t.Fatalf("create %s: %v", name, werr)
+		}
+		if _, werr = w.Write([]byte(body)); werr != nil {
+			t.Fatalf("write %s: %v", name, werr)
+		}
+	}
+
+	// A PNG signature so the part is admitted, then compressible padding.
+	payload := make([]byte, per)
+	copy(payload, []byte("\x89PNG\r\n\x1a\n"))
+	for i := 0; i < parts; i++ {
+		w, werr := z.Create(filepath.ToSlash(filepath.Join("word", "media", "image"+itoa(i)+".png")))
+		if werr != nil {
+			t.Fatalf("create part %d: %v", i, werr)
+		}
+		if _, werr = w.Write(payload); werr != nil {
+			t.Fatalf("write part %d: %v", i, werr)
+		}
+	}
+	if err := z.Close(); err != nil {
+		t.Fatalf("zip close: %v", err)
+	}
+	return path
+}

--- a/internal/preprocessors/meta-extractors/meta-extract-officelib/office-extractor.go
+++ b/internal/preprocessors/meta-extractors/meta-extract-officelib/office-extractor.go
@@ -773,6 +773,12 @@ func extractEmbeddedImages(reader *zip.ReadCloser, metadata *Metadata) error {
 	var tempFiles []string
 	var embeddedMedia []EmbeddedMedia
 
+	// One budget per container. This loop and ExtractEmbeddedMediaForProcessing each get their
+	// own, because they run at different times over the same archive and neither peak overlaps
+	// the other -- this one deletes its temp files before returning. The doubled decompression
+	// WORK is a separate inefficiency, measured and noted on #379, not addressed here.
+	budget := newExtractionBudget()
+
 	defer func() {
 		// Clean up temp files
 		for _, tempFile := range tempFiles {
@@ -806,7 +812,7 @@ func extractEmbeddedImages(reader *zip.ReadCloser, metadata *Metadata) error {
 		}
 
 		// Extract media to temp file
-		tempFile, err := extractImageToTemp(file)
+		tempFile, err := extractImageToTemp(file, budget)
 		if err != nil {
 			// Silent HERE, deliberately, and not the same omission as the one #374 fixed.
 			//
@@ -845,8 +851,52 @@ func extractEmbeddedImages(reader *zip.ReadCloser, metadata *Metadata) error {
 	return nil
 }
 
+// extractionBudget bounds the TOTAL bytes one container may materialise to temp, across all of its
+// embedded parts.
+//
+// MaxEmbeddedMediaSize bounds a single part; nothing bounded the sum. Measured at main @ 0610b7e on a
+// 1.43MB .docx holding 30 parts that each declare 49MB -- just under the per-part cap:
+//
+//	peak temp disk   1.44 GB
+//	peak RSS         0.27 GB   (this is a DISK exhaustion, not a memory one)
+//	wall             1.87s
+//	warnings         none, and the scan reported success
+//
+// 1.44GB is already 7x embedded.BudgetBytes, which existed as a declared constant that no production
+// code consulted -- only comments and a test asserting it was positive. With MaxDispatchedParts at
+// 512 the ceiling is about 25GB of temp from a ~25MB container.
+//
+// This is the "declared size bounds declared size" shape again: each part is checked against a cap,
+// and the caps compose to nothing. Bounding the AGGREGATE is the only check an attacker cannot
+// satisfy by splitting one large part into many admissible ones.
+type extractionBudget struct {
+	remaining int64
+}
+
+func newExtractionBudget() *extractionBudget {
+	return &extractionBudget{remaining: embedded.BudgetBytes}
+}
+
+// reserve claims n bytes, reporting whether the budget allows it.
+//
+// Charged AFTER the copy with the bytes actually written, not before with the declared size: a lying
+// declaration would otherwise exhaust the budget on parts that never materialise, turning an
+// over-claim into a denial of service against the rest of the document. The per-part LimitReader
+// already bounds any single copy, so the worst overshoot is one part's cap.
+func (b *extractionBudget) reserve(n int64) bool {
+	if b == nil {
+		return true
+	}
+	if n > b.remaining {
+		b.remaining = 0
+		return false
+	}
+	b.remaining -= n
+	return true
+}
+
 // extractImageToTemp extracts an image from ZIP to a temporary file
-func extractImageToTemp(file *zip.File) (string, error) {
+func extractImageToTemp(file *zip.File, budget *extractionBudget) (string, error) {
 	rc, err := file.Open()
 	if err != nil {
 		return "", err
@@ -901,6 +951,14 @@ func extractImageToTemp(file *zip.File) (string, error) {
 			MaxEmbeddedMediaSize)
 	}
 
+	// Charge the AGGREGATE budget with the bytes actually written. Over budget means the temp
+	// file is removed like any other refusal, so a bomb leaves nothing behind.
+	if !budget.reserve(n) {
+		os.Remove(tempFile.Name())
+		return "", fmt.Errorf("would exceed the %d-byte total embedded extraction budget for this document (%w)",
+			embedded.BudgetBytes, embedded.ErrBudgetExhausted)
+	}
+
 	return tempFile.Name(), nil
 }
 
@@ -937,6 +995,11 @@ func ExtractEmbeddedMediaForProcessing(filePath string) ([]EmbeddedMedia, []stri
 	var notExamined []string
 	refused := 0
 
+	// The aggregate budget for this container. Unlike the metadata loop, every refusal here is
+	// DISCLOSED through notExamined, so a document truncated by the budget says so rather than
+	// reporting a partial scan as complete.
+	budget := newExtractionBudget()
+
 	for _, file := range reader.File {
 		if !isEmbeddedPartPath(file.Name) {
 			continue
@@ -964,7 +1027,7 @@ func ExtractEmbeddedMediaForProcessing(filePath string) ([]EmbeddedMedia, []stri
 		}
 
 		// Extract media to temp file
-		tempFile, err := extractImageToTemp(file)
+		tempFile, err := extractImageToTemp(file, budget)
 		if err != nil {
 			// DISCLOSE rather than skip. Every error this can return means a part that the
 			// router was going to be asked about was not made available to it: the size


### PR DESCRIPTION
## What was wrong

`MaxEmbeddedMediaSize` bounds a **single** embedded part. Nothing bounded the **sum**.

Measured at `main @ 0610b7e` on a 1.43 MB `.docx` holding 30 parts that each declare 49 MB — deliberately just *under* the 50 MB per-part cap:

| | main | this branch |
|---|---|---|
| peak temp disk | **1.44 GB** | **0.23 GB** |
| peak RSS | 0.27 GB | 0.22 GB |
| wall | 1.87s | 2.15s |
| disclosure | **none**, reported success | `Files: 1 scanned, 1 NOT examined` |

1.44 GB is already **7× `embedded.BudgetBytes`**, and with `MaxDispatchedParts` at 512 the ceiling is roughly **25 GB of temp from a ~25 MB container**. Note the peak RSS barely moves: this is **disk** exhaustion, not memory, so `--max-live-bytes` cannot see it either.

`embedded.BudgetBytes` and `embedded.ErrBudgetExhausted` existed as declared constants that **no production code consulted** — only comments and a test asserting the constant was positive. This is the check they were written for.

It is the "declared size bounds declared size" shape again: each part is checked against a cap, and the caps compose to nothing. Bounding the **aggregate** is the only check an attacker cannot satisfy by splitting one oversized part into many admissible ones.

## Design decisions worth reviewing

**Charged after the copy, not before.** `reserve()` takes the bytes actually written, not `file.UncompressedSize64`. Charging the *declared* size first would let one lying entry exhaust the budget and deny the rest of the document — turning an over-claim into a denial of service against everything after it. The per-part `LimitReader` already bounds any single copy, so the worst overshoot is one part's cap, and the test allows exactly that.

**One budget per container, per loop.** Two functions materialise parts for a single scan: `extractEmbeddedImages` (metadata counting, `:422`) and `ExtractEmbeddedMediaForProcessing` (the scanning path, via `office_metadata_preprocessor.go:187`). Each gets its own. Their peaks do not overlap — the first deletes its temp files before returning — so the bound holds either way.

A package-level counter would have passed every test here and then silently truncated the **second** document of a directory scan. `TestBudgetIsPerContainerNotGlobal` pins that.

**Disclosed, not silent.** The scanning loop already routes extraction errors into `notExamined`, so a budget refusal travels as a coverage loss and the note names the budget — an operator can tell it from a read error. `--fail-on-incomplete` gives **rc 3** on the bomb and **rc 0** on an ordinary document.

The metadata loop stays silent by its existing documented design: it deletes every temp file it creates and only affects `EmbeddedMediaCount`, which is rendered into scanned text, so changing that is a separate decision.

## Test plan

`make pr-checklist BASE=origin/main` — **10 ran, 0 failed**; 69 packages; golden 0 files changed; race clean; cross-platform vet clean.

All five manual dimensions, on **real** documents:

| # | dimension | result |
|---|---|---|
| 4 | redaction, every strategy | a real `.docx` with 6 real embedded PNGs: `simple`, `format_preserving`, `synthetic` all write 1 copy, **0 cleartext in the zip**, and all **6 media parts preserved** — identical before and after |
| 5 | suppression | 2 rules generated by the **parent** binary and enabled, applied by mine: 2 → 0, identical to the parent applying its own |
| 6 | timing / O(n²) | 25/50/100 **real** embedded PNGs, findings floor **2/2/2** at every size, growth **2.54x for 4x parts** against main's 2.48x (best-of-3) |
| 7 | all 7 formats | all valid; the bomb discloses in 6 of 7; `normal.docx` rc 0 everywhere. csv shows nothing because csv carries no not-examined channel at all — a pre-existing gap, documented in #450, not introduced here |
| 10 | non-vacuity | on parent: `extracted 7 of 7 parts — the aggregate budget did not bite` |

**Mutation-tested, both killed:** removing the check extracts 7 of 7 parts with no note; resetting the budget per part instead of per container does the same.

**A document inside the budget is entirely unaffected** — same 2 findings, same 12 embedded properties, no coverage note.

### A fixture trap worth knowing

The parts must be written with a **non-streaming** zip writer. A streamed entry leaves `UncompressedSize64` unset, the copy reads nothing, and my first measurement was of an **empty** extraction — 30 temp files of 0 bytes and a "peak" of 0.27 GB that was just the process. The router log gave it away with `"file_size":0`. The test comment records this so the next fixture does not repeat it.

## Union

Disjoint from all five open code PRs — **no shared file** with #450, #451, #453, #454 or #455, and `merge-tree` clean against each. Merge-base is `0610b7e`.

## Not in this PR

**#379's second clause — every part is materialised twice.** Confirmed: both loops call `extractImageToTemp` for every admitted part, so the decompression work is doubled (the peaks do not overlap, so it costs I/O and wall time rather than peak disk). Removing the duplication means changing what `extractEmbeddedImages` is for, which is a refactor with its own blast radius — worth doing deliberately, not as a rider on a safety fix. So this PR closes the budget half; the issue stays open for the other.

Refs #379
