### PR TITLE
fix(personname): decide which bytes are the name — tab boundaries, particles, routing words, font families (#462, #422, #434, #406)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Nineteen validators, each purpose-built. Enable a subset with `--checks CREDIT_C
 | `IP_ADDRESS` | IPv4 / IPv6 addresses | Skips RFC1918 / reserved / test ranges; context-keyword gated |
 | `PASSPORT` | Passport numbers | US / UK / CA / EU + MRZ |
 | `VIN` | Vehicle Identification Numbers | ISO 3779, position-9 check digit, WMI manufacturer lookup |
-| `PERSON_NAME` | Personal names | Embedded name databases, titles, cultural variations |
+| `PERSON_NAME` | Personal names | Embedded name databases, titles, nobiliary particles, cultural variations |
 | `CLOUD_RESOURCES` | Cloud resource identifiers | AWS ARNs, Azure IDs, GCP, OCI, IBM CRN, Alibaba |
 | `INTELLECTUAL_PROPERTY` | IP / confidentiality markers | Patents, trademarks, copyrights, trade secrets |
 | `SOCIAL_MEDIA` | Social media handles / profiles | Requires configuration to activate |

--- a/docs/testing/SCORE_CORPUS.md
+++ b/docs/testing/SCORE_CORPUS.md
@@ -134,23 +134,26 @@ make score-mutation-check   # prove the gate still catches real regressions
 Sample output:
 
 ```
-scorecorpus  141 cases, 177 gated labels, 16 check(s)
+scorecorpus  154 cases, 202 gated labels, 16 check(s)
 
 check      TP  FN(miss)  FN(band)  FP(H+M)  FP(low)  recall_all  recall_hm  prec_hm
 CREDIT_CARD    3         0         0        0        0      1.0000     1.0000   1.0000
 EMAIL          3         0         0        2        0      1.0000     1.0000   0.6000
 IP_ADDRESS     2         0         0        0        0      1.0000     1.0000   1.0000
-SSN          155         0         0       45        0      1.0000     0.9935   0.7739
+PERSON_NAME   26         0         0        0        0      1.0000     1.0000   1.0000
+SSN          155         0         0       12       33      1.0000     0.9935   0.9277
 ...
-TOTAL        177         0         0       47        0      1.0000     0.9944   0.7892
+TOTAL        202         0         0       14       33      1.0000     0.9950   0.9349
 
-redaction sink (core.RedactFile, label-driven; 169 labels)
+not gated, baselined:  extra_same_span 0   undecided 1 cases / 0 findings
+
+redaction sink (core.RedactFile, label-driven; 196 labels)
   strategy              whole_leak   residue4
   simple                         0          0
-  format_preserving              0        817
+  format_preserving              0        829
 
 suppression layer (a rule must silence exactly what it names)
-  rules exercised 55   silenced 55   collateral 0   ineffective 0
+  rules exercised 62   silenced 62   collateral 0   ineffective 0
 ```
 
 Cost, measured: **~1.0s** for the in-process layers, ~5s including the executable

--- a/internal/core/help_coverage_test.go
+++ b/internal/core/help_coverage_test.go
@@ -1,0 +1,98 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package core
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/help"
+)
+
+// `ferret-scan --help checks` and `--help <check_name>` are built by registering every
+// validator that implements help.Provider (cmd/main.go), keyed by lower-cased check name.
+// Registration is a type assertion, so a validator that stops satisfying the interface does not
+// fail to compile — it silently disappears from the checks list and from its own help page,
+// with no test noticing.
+//
+// internal/help/help_order_test.go cannot catch that: it builds fakeProvider values, so it
+// tests the ORDERING of whatever it is handed rather than whether the real validators are all
+// there. This is the coverage gate, and it derives its expectations from
+// validatorConstructors — the documented single source of truth for which validators exist —
+// so adding a validator without help fails here rather than shipping a blank page.
+
+func TestEveryValidatorProvidesHelp(t *testing.T) {
+	for _, name := range CheckNames() {
+		t.Run(name, func(t *testing.T) {
+			validators := BuildValidatorSet(map[string]bool{name: true}, nil, nil)
+			v, ok := validators[name]
+			if !ok {
+				t.Fatalf("BuildValidatorSet did not construct %q, so its help cannot be checked", name)
+			}
+
+			provider, ok := v.(help.Provider)
+			if !ok {
+				t.Fatalf("%q does not implement help.Provider, so it is absent from "+
+					"`--help checks` and has no `--help %s` page", name, strings.ToLower(name))
+			}
+
+			info := provider.GetCheckInfo()
+
+			// The name is the lookup key. A mismatch means `--help <name>` finds nothing even
+			// though the provider is registered, because registration keys on info.Name.
+			if info.Name != name {
+				t.Errorf("GetCheckInfo().Name = %q, want %q: help is registered under the "+
+					"value from GetCheckInfo, so a mismatch makes the page unreachable",
+					info.Name, name)
+			}
+
+			// The checks list prints ShortDescription against each name; an empty one renders
+			// a name with a blank column.
+			if strings.TrimSpace(info.ShortDescription) == "" {
+				t.Errorf("%q has no ShortDescription, so `--help checks` lists it blank", name)
+			}
+			if strings.TrimSpace(info.DetailedDescription) == "" {
+				t.Errorf("%q has no DetailedDescription, so its help page is empty", name)
+			}
+		})
+	}
+}
+
+// TestHelpDoesNotLeakInternalNotes keeps developer notes out of user-facing output. `--help
+// person_name` printed a raw "// TODO: Document rationale for surname database reduction ..."
+// line to users, because the marker sat inside the DetailedDescription string rather than in a
+// Go comment.
+func TestHelpDoesNotLeakInternalNotes(t *testing.T) {
+	markers := []string{"// TODO", "// FIXME", "// XXX", "// HACK", "TODO:", "FIXME:"}
+
+	for _, name := range CheckNames() {
+		t.Run(name, func(t *testing.T) {
+			validators := BuildValidatorSet(map[string]bool{name: true}, nil, nil)
+			provider, ok := validators[name].(help.Provider)
+			if !ok {
+				t.Skip("no help provider; reported by TestEveryValidatorProvidesHelp")
+			}
+			info := provider.GetCheckInfo()
+
+			// Every user-visible string on the page, not just the description.
+			fields := append([]string{
+				info.ShortDescription,
+				info.DetailedDescription,
+				info.ConfigurationInfo,
+			}, info.Patterns...)
+			fields = append(fields, info.SupportedFormats...)
+			fields = append(fields, info.Examples...)
+
+			for _, text := range fields {
+				for _, marker := range markers {
+					if strings.Contains(text, marker) {
+						t.Errorf("%q help contains %q, which reaches the user verbatim via "+
+							"`--help %s`; put developer notes in a Go comment instead",
+							name, marker, strings.ToLower(name))
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/scorecorpus/cases_personname.go
+++ b/internal/scorecorpus/cases_personname.go
@@ -210,6 +210,57 @@ var PersonNameCases = []Case{
 		Redactable: true,
 	},
 	{
+		Name:   "person_routing_word_before_name",
+		Origin: "authored 2026-08-22 for #434; bands measured against the real CLI",
+		Rationale: "A memo header or salutation that is not followed by punctuation. Go's regexp " +
+			"finds leftmost NON-OVERLAPPING matches, so the routing word did not merely get " +
+			"included in the span — it CONSUMED the given name and the real name was never a " +
+			"candidate. The same header therefore behaved two different wrong ways:\n" +
+			"  \"Attn Marcus Whitfield\"      -> NONE  (never reported, so never redacted)\n" +
+			"  \"Attention Marcus Whitfield\" -> 81 on the whole string, routing word inside " +
+			"the reported value\n" +
+			"Pinned to the punctuated form's behaviour, which was already correct: " +
+			"\"Attn: Marcus Holloway\" -> 92. Both now agree.\n" +
+			"The cause was isolated by length rather than by vocabulary: \"X Marcus Holloway\" " +
+			"-> 92 already worked, because a one-letter token cannot start a name token and so " +
+			"consumes nothing.",
+		Checks: []string{"PERSON_NAME"},
+		Input: "Attn Marcus Whitfield\n" +
+			"Attention Marcus Whitfield\n" +
+			"Dear Marcus Holloway\n" +
+			"Regards Marcus Holloway\n" +
+			"Cc Marcus Holloway\n",
+		Labels: []Label{
+			{Line: 1, Value: "Marcus Whitfield", Types: []string{"PERSON_NAME"}, MinBand: BandHigh},
+			{Line: 2, Value: "Marcus Whitfield", Types: []string{"PERSON_NAME"}, MinBand: BandHigh},
+			{Line: 3, Value: "Marcus Holloway", Types: []string{"PERSON_NAME"}, MinBand: BandHigh},
+			{Line: 4, Value: "Marcus Holloway", Types: []string{"PERSON_NAME"}, MinBand: BandHigh},
+			{Line: 5, Value: "Marcus Holloway", Types: []string{"PERSON_NAME"}, MinBand: BandHigh},
+		},
+		Redactable: true,
+	},
+	{
+		Name:   "fp__masking_is_limited_to_routing_words",
+		Origin: "harvested from a 714-document real-corpus measurement, 2026-08-22",
+		Rationale: "The counterweight to person_routing_word_before_name. Reaching a name behind " +
+			"a routing word works by masking that word and re-running the patterns, and the first " +
+			"version of it masked every Title-Case function word. That recovered the salutation " +
+			"names AND exposed 18 findings on 714 real documents that had been hidden behind an " +
+			"ordinary function word, almost all false: \"Firm Fixed Price\" (7 hits, behind " +
+			"\"For\"), \"Fixed Price\", \"Epic House\", \"Advice Regarding Grant\" at 100.\n" +
+			"So the mask list is routingWordsMap — salutations and memo headers only — not " +
+			"functionWordsMap. These lines pin that: each has a Title-Case function word in front " +
+			"of a noun phrase whose last token is a real surname, which is exactly the shape the " +
+			"broad mask lit up. Widening the mask again fails here.",
+		Checks: []string{"PERSON_NAME"},
+		Input: "For Firm Fixed Price contracts only.\n" +
+			"The Fixed Price applies.\n" +
+			"About Epic House today.\n" +
+			"With Person Sessions scheduled.\n",
+		Negative:   true,
+		Redactable: true,
+	},
+	{
 		Name:   "fp__eponym_technical_terms",
 		Origin: "authored 2026-08 for scorecorpus; behavior verified against the real CLI",
 		Rationale: "Scientific terms that ARE people's surnames: van der Waals, von Neumann, " +

--- a/internal/scorecorpus/cases_personname.go
+++ b/internal/scorecorpus/cases_personname.go
@@ -178,6 +178,38 @@ var PersonNameCases = []Case{
 		Redactable: true,
 	},
 	{
+		Name:   "person_lowercase_particles_recovered",
+		Origin: "promoted out of quarantine 2026-08-22 by the #422 particle patterns; bands measured against the real CLI",
+		Rationale: "Was person_lowercase_particles_UNSUPPORTED. Every pattern required each name " +
+			"token to start with a capital, so a lowercase particle terminated the match and these " +
+			"names produced no candidate at all — never reported, therefore never redacted, a " +
+			"cleartext leak concentrated on non-Anglo names.\n" +
+			"Measured before and after, same fixture, same flags:\n" +
+			"  Ana de la Cruz  NONE -> 77   |   Carlos dos Santos  NONE -> 77\n" +
+			"  Jan van der Berg  NONE -> 77 |   Piet de Vries       NONE -> 77\n" +
+			"MEDIUM rather than HIGH is the ceiling working as designed, not a shortfall: the " +
+			"particle pattern is not a formal-name pattern, so it earns no title/suffix boost.\n" +
+			"The quarantine rationale predicted that a particle-aware regex would also light up " +
+			"the fp__eponym_technical_terms negatives below, and that it therefore needed a gate " +
+			"underneath it. It did light them up: \"Discussed von Neumann\" and \"Applied de " +
+			"Morgan\" both appeared, because the token after the particle is a genuine surname. " +
+			"The gate is requiresBothNamesKnown — for this pattern the GIVEN half must be a known " +
+			"name too, which is exactly the structure fp__latin_and_prose_particles named. Both " +
+			"negative cases are silent with these labels asserted.",
+		Checks: []string{"PERSON_NAME"},
+		Input: "Signed by Ana de la Cruz.\n" +
+			"Signed by Carlos dos Santos.\n" +
+			"Signed by Jan van der Berg.\n" +
+			"Signed by Piet de Vries.\n",
+		Labels: []Label{
+			{Line: 1, Value: "Ana de la Cruz", Types: []string{"PERSON_NAME"}, MinBand: BandMedium},
+			{Line: 2, Value: "Carlos dos Santos", Types: []string{"PERSON_NAME"}, MinBand: BandMedium},
+			{Line: 3, Value: "Jan van der Berg", Types: []string{"PERSON_NAME"}, MinBand: BandMedium},
+			{Line: 4, Value: "Piet de Vries", Types: []string{"PERSON_NAME"}, MinBand: BandMedium},
+		},
+		Redactable: true,
+	},
+	{
 		Name:   "fp__eponym_technical_terms",
 		Origin: "authored 2026-08 for scorecorpus; behavior verified against the real CLI",
 		Rationale: "Scientific terms that ARE people's surnames: van der Waals, von Neumann, " +
@@ -219,29 +251,27 @@ var PersonNameCases = []Case{
 // changes a number and fails until explained.
 var PersonNameQuarantine = []Case{
 	{
-		Name:   "person_lowercase_particles_UNSUPPORTED",
-		Origin: "authored 2026-08 for scorecorpus; measured against the real CLI",
-		Rationale: "Surnames with a lowercase nobiliary particle are NOT detected: de la Cruz, " +
-			"dos Santos, van der Berg, von Mises, de Vries, van den Heuvel, al-Rashid, El-Sayed. " +
-			"Isolated to prove the particle is the sole cause — capitalising it works and the " +
-			"correct lowercase form does not:\n" +
-			"  \"Ana de la Cruz\" -> NONE   |   \"Ana De La Cruz\" -> 94   |   \"Ana Cruz\" -> 92\n" +
-			"Measured 0 of 4 Dutch/German, 1 of 4 Arabic, 0 of 3 Hispanic-with-particle. Roughly " +
-			"a quarter of Dutch surnames carry one. An undetected name is never redacted, so this " +
-			"is a cleartext leak concentrated on non-Anglo names.\n" +
-			"Quarantined rather than labelled because the fix is not a pattern change alone: a " +
-			"particle-aware regex also matches the eponym negatives above, so it needs the " +
-			"surname-anchored gate underneath it.\n" +
-			"As of 2026-08-19 this case owns the Dutch particle line exclusively: the surname " +
-			"data gap it used to share with person_locale_surnames_UNSUPPORTED is closed, and " +
-			"that case was promoted to person_locale_surnames_recovered. What remains here is " +
-			"purely the lowercase particle.",
+		Name:   "person_hyphenated_particle_UNSUPPORTED",
+		Origin: "narrowed from person_lowercase_particles_UNSUPPORTED 2026-08-22; measured against the real CLI",
+		Rationale: "What remains of the particle gap after #422: the particle attached to the " +
+			"surname by a HYPHEN rather than separated by a space — al-Rashid, El-Sayed, " +
+			"de-la-Cruz. The space-separated forms this case used to hold are now detected and " +
+			"were promoted to person_lowercase_particles_recovered.\n" +
+			"A different shape, not a shorter version of the same one: nameParticleRun joins the " +
+			"particle to the surname with nameSpace, and hyphenated_last_name requires a CAPITAL " +
+			"after the hyphen, so a lowercase hyphenated particle satisfies neither.\n" +
+			"Isolated by holding the surname constant at one the database carries, so the cause " +
+			"is the hyphen alone and not a data gap (measured 2026-08-22 against the real CLI):\n" +
+			"  \"Ana de la Cruz\" -> 77   |   \"Ana de-la-Cruz\" -> NONE   |   \"Ana Cruz\" -> 92\n" +
+			"  \"Jan van Berg\"   -> 77   |   \"Jan van-Berg\"   -> NONE   |   \"Jan Berg\"  -> 92\n" +
+			"The al-Rashid and El-Sayed lines below have BOTH causes: the hyphen shape above and " +
+			"a surname the list does not carry (\"Mohammed Rashid\" and \"Layla Sayed\" are also " +
+			"NONE), so they need the data fix of person_locale_surnames_recovered as well.",
 		Checks: []string{"PERSON_NAME"},
-		Input: "Signed by Ana de la Cruz.\n" +
-			"Signed by Carlos dos Santos.\n" +
-			"Signed by Jan van der Berg.\n" +
-			"Signed by Piet de Vries.\n" +
-			"Signed by Mohammed al-Rashid.\n",
+		Input: "Signed by Ana de-la-Cruz.\n" +
+			"Signed by Jan van-Berg.\n" +
+			"Signed by Mohammed al-Rashid.\n" +
+			"Signed by Layla El-Sayed.\n",
 		Redactable: true,
 	},
 }

--- a/internal/scorecorpus/testdata/baseline.json
+++ b/internal/scorecorpus/testdata/baseline.json
@@ -93,8 +93,8 @@
       "extra_same_span": 0
     },
     "PERSON_NAME": {
-      "tp": 21,
-      "tp_high_medium": 21,
+      "tp": 26,
+      "tp_high_medium": 26,
       "fn_missed": 0,
       "fn_band": 0,
       "fp_high_medium": 0,
@@ -157,11 +157,11 @@
       "residue4": 0
     }
   },
-  "sink_labels": 191,
+  "sink_labels": 196,
   "suppression": {
-    "cases": 61,
-    "targeted": 61,
-    "silenced": 61,
+    "cases": 62,
+    "targeted": 62,
+    "silenced": 62,
     "collateral": 0,
     "ineffective": 0
   },
@@ -170,8 +170,8 @@
     "findings": 0
   },
   "global": {
-    "cases": 152,
-    "labels": 197,
-    "negatives": 27
+    "cases": 154,
+    "labels": 202,
+    "negatives": 28
   }
 }

--- a/internal/scorecorpus/testdata/baseline.json
+++ b/internal/scorecorpus/testdata/baseline.json
@@ -93,8 +93,8 @@
       "extra_same_span": 0
     },
     "PERSON_NAME": {
-      "tp": 17,
-      "tp_high_medium": 17,
+      "tp": 21,
+      "tp_high_medium": 21,
       "fn_missed": 0,
       "fn_band": 0,
       "fp_high_medium": 0,
@@ -157,11 +157,11 @@
       "residue4": 0
     }
   },
-  "sink_labels": 187,
+  "sink_labels": 191,
   "suppression": {
-    "cases": 60,
-    "targeted": 60,
-    "silenced": 60,
+    "cases": 61,
+    "targeted": 61,
+    "silenced": 61,
     "collateral": 0,
     "ineffective": 0
   },
@@ -170,8 +170,8 @@
     "findings": 0
   },
   "global": {
-    "cases": 151,
-    "labels": 193,
+    "cases": 152,
+    "labels": 197,
     "negatives": 27
   }
 }

--- a/internal/validators/personname/font_name_test.go
+++ b/internal/validators/personname/font_name_test.go
@@ -1,0 +1,134 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package personname
+
+import (
+	"strings"
+	"testing"
+)
+
+// A font family name satisfies the Title-Case name shape, and the surname gate then
+// accepts it whenever the LAST token is a real surname — Roman, Black and Vera all are.
+// Measured on shipped code before this fix:
+//
+//	Times New Roman -> 81   Arial Black -> 80   Bitstream Vera -> 80
+//
+// These arrive from the legacy .doc font table: one of 714 real documents reported
+// "Times New Roman" at 81 that way.
+
+// measuredFontFalsePositives are the three families that actually fired. They carry the
+// load in these tests — the rest of fontFamiliesMap is silent already, so asserting
+// against it alone would prove nothing.
+var measuredFontFalsePositives = []string{
+	"Times New Roman",
+	"Arial Black",
+	"Bitstream Vera",
+}
+
+func TestMeasuredFontNamesAreNotPeople(t *testing.T) {
+	v := NewValidator()
+
+	for _, font := range measuredFontFalsePositives {
+		t.Run(font, func(t *testing.T) {
+			matches, err := v.ValidateContent(font, "deck.doc")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) != 0 {
+				t.Errorf("%q reported as PERSON_NAME: %v", font, matchTexts(matches))
+			}
+		})
+	}
+}
+
+// TestStyledFontNameIsCoveredWithoutItsOwnEntry pins why the map needs no "... Bold"
+// entries: the four-token span is rejected because the style word is not a surname, so
+// the value that reaches the map is already the base family.
+func TestStyledFontNameIsCoveredWithoutItsOwnEntry(t *testing.T) {
+	v := NewValidator()
+
+	for _, line := range []string{
+		"Times New Roman Bold",
+		"Arial Black Italic",
+	} {
+		t.Run(line, func(t *testing.T) {
+			if fontFamiliesMap[strings.ToLower(line)] {
+				t.Fatalf("%q has its own entry, so this test no longer proves the base "+
+					"family is what gets reported", line)
+			}
+			matches, err := v.ValidateContent(line, "deck.doc")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) != 0 {
+				t.Errorf("%q reported as PERSON_NAME: %v", line, matchTexts(matches))
+			}
+		})
+	}
+}
+
+// TestFontEntriesAreMultiWord keeps dead weight out. Every pattern in this validator
+// requires at least two tokens, so a single-word entry could never match anything and
+// would only imply a protection that is not there.
+func TestFontEntriesAreMultiWord(t *testing.T) {
+	for family := range fontFamiliesMap {
+		if len(strings.Fields(family)) < 2 {
+			t.Errorf("%q is a single word: no pattern can produce it, so the entry has no "+
+				"effect", family)
+		}
+	}
+}
+
+// TestNoFontEntryLooksLikeARealName is the safety gate on the vocabulary itself.
+//
+// Suppressing an exact phrase is only safe while that phrase is not something a person
+// could be called. If both the first and last token of an entry are in the name
+// databases, the entry is a plausible full name — "Grace Black" would be — and
+// suppressing it would delete a real person's name from the report, which means it is
+// never redacted either.
+func TestNoFontEntryLooksLikeARealName(t *testing.T) {
+	v := NewValidator()
+	v.ensureNamesLoaded()
+
+	for family := range fontFamiliesMap {
+		words := strings.Fields(family)
+		if len(words) < 2 {
+			continue // reported by TestFontEntriesAreMultiWord
+		}
+		first, last := words[0], words[len(words)-1]
+		if v.firstNames[first] && v.lastNames[last] {
+			t.Errorf("%q has a known given name (%q) AND a known surname (%q): it is a "+
+				"plausible person name, so suppressing the whole phrase risks deleting a "+
+				"real one", family, first, last)
+		}
+	}
+}
+
+// TestFontSuppressionIsExactPhrase is the counterweight. The failure mode this fix had
+// to avoid is a token-level list, which would silence every person named Roman or Black.
+func TestFontSuppressionIsExactPhrase(t *testing.T) {
+	v := NewValidator()
+
+	// One case per measured false positive, using the exact token that made each family
+	// reportable. A token that is NOT in the surname database would prove nothing here:
+	// "Julia Arial" is unreported before and after this change, because "Arial" is not a
+	// surname the data carries, so it never reached the font map either way.
+	for _, tc := range []struct{ line, want string }{
+		{"Marcus Roman signed the form.", "Marcus Roman"},
+		{"Sarah Black approved it.", "Sarah Black"},
+		{"Report by Daniel Vera.", "Daniel Vera"},
+		{"Andrea Roman and Peter Black attended.", "Andrea Roman"},
+	} {
+		t.Run(tc.want, func(t *testing.T) {
+			matches, err := v.ValidateContent(tc.line, "memo.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if findMatch(matches, tc.want) == nil {
+				t.Errorf("want %q, got %v: a person sharing a token with a font family "+
+					"must still be reported", tc.want, matchTexts(matches))
+			}
+		})
+	}
+}

--- a/internal/validators/personname/help.go
+++ b/internal/validators/personname/help.go
@@ -14,7 +14,7 @@ func (v *Validator) GetCheckInfo() help.CheckInfo {
 
 It identifies various name formats including first and last names, names with titles (Mr./Ms./Dr.), names with suffixes (Jr./Sr./III), and names with middle initials. The validator uses an embedded database of ~5,200 common first names and ~2,100 surnames with database-first optimization for 98% performance improvement.
 
-// TODO: Document rationale for surname database reduction and validate detection accuracy
+A name is reported only when its SURNAME is confirmed by the database, or when a title or generational suffix explicitly states that the tokens are a person's name. A name admitted on that marker alone is capped inside MEDIUM, so it always reaches review and redaction but never outranks a database-confirmed name.
 
 The check analyzes surrounding context to distinguish between person names and business/product names. It applies confidence adjustments based on contextual keywords, validates names against common test data patterns, and includes enhanced technical context detection for reduced false positives.
 
@@ -26,9 +26,16 @@ The check analyzes surrounding context to distinguish between person names and b
 - **Multiple Names** - Three or more name components (e.g., "Mary Jane Watson")
 - **Hyphenated Names** - Hyphenated last names (e.g., "Sarah Smith-Jones")
 - **Names with Apostrophes** - Cultural variations (e.g., "Patrick O'Connor")
+- **Names with a Nobiliary Particle** - A connective inside a multi-word surname, in either spelling (e.g., "Ana de la Cruz", "Dr. Marco Di Salvo")
+- **Two-Column Table Rows** - A name split across adjacent table cells (e.g., a "First Name / Last Name" spreadsheet row). Requires BOTH tokens to be database-confirmed, because a tab is a column boundary rather than a word space
+
+**Deliberately Not Reported:**
+- **Routing words** - A salutation or memo header in front of a name is excluded from the reported value, so "Attn Marcus Whitfield" reports "Marcus Whitfield" rather than nothing or the whole string
+- **Font family names** - Document formatting such as "Times New Roman" or "Arial Black", matched as a whole phrase only, so a person named Roman or Black is unaffected
+- **Leading function words** - An article, pronoun or preposition before a real surname ("The Grace", "Via Morgan"), unless the name database recognizes the word as a name itself ("Will Smith", "May Chen")
 
 **Cultural Support:**
-The validator supports Western name patterns and can be extended for other cultural naming conventions. It includes recognition of common titles, suffixes, and name structures used in English-speaking countries.`,
+Beyond Western First/Last forms, the validator recognizes multi-word surnames carrying a nobiliary or patronymic particle — Dutch and German (van, von, van der, van den), Iberian (de, del, de la, dos, das), Italian (di, della, dal) and Arabic (bin, bint, ibn, al) — in both the lowercase and capitalized spellings. A particle attached to the surname by a HYPHEN (al-Rashid, El-Sayed) is not yet matched. It includes recognition of common titles, suffixes, and name structures used in English-speaking countries.`,
 
 		Patterns: []string{
 			"First Last (e.g., John Smith)",
@@ -38,6 +45,9 @@ The validator supports Western name patterns and can be extended for other cultu
 			"First Last Suffix (e.g., Robert Johnson Jr.)",
 			"First Hyphenated-Last (e.g., Sarah Smith-Jones)",
 			"First O'Last (e.g., Patrick O'Connor)",
+			"First particle Last (e.g., Ana de la Cruz, Ludwig van Beethoven)",
+			"Title First particle Last (e.g., Dr. Marco Di Salvo)",
+			"First<TAB>Last across two table columns (e.g., a First Name / Last Name spreadsheet row)",
 		},
 
 		SupportedFormats: []string{
@@ -48,6 +58,8 @@ The validator supports Western name patterns and can be extended for other cultu
 			"Hyphenated surnames and compound names",
 			"Names with apostrophes (Irish, French origins)",
 			"Multiple first names or compound first names",
+			"Multi-word surnames with a nobiliary or patronymic particle, lowercase or capitalized (Dutch, German, Iberian, Italian, Arabic)",
+			"Names split across two adjacent table or spreadsheet columns",
 		},
 
 		ConfidenceFactors: []help.ConfidenceFactor{

--- a/internal/validators/personname/particle_test.go
+++ b/internal/validators/personname/particle_test.go
@@ -1,0 +1,207 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package personname
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+)
+
+// Every pattern here requires each name token to start with a capital, so a
+// lowercase nobiliary particle terminated the match and the name was never a
+// candidate. That defeated the off-list-surname marker: a title says "the following
+// tokens are a person" regardless of whether the surname is on any list, but the
+// pattern carrying the title never matched in the first place.
+//
+// The capitalised spelling failed the other way round. name_with_title accepts
+// exactly two name tokens after the title, so "Dr. Marco Di Salvo" was reported as
+// "Dr. Marco Di" — a value that stops mid-surname, which is worse than a miss
+// because it reaches the redactor and leaves the rest of the name in cleartext.
+
+// findMatch returns the match whose text equals want, or nil.
+func findMatch(matches []detector.Match, want string) *detector.Match {
+	for i := range matches {
+		if matches[i].Text == want {
+			return &matches[i]
+		}
+	}
+	return nil
+}
+
+func matchTexts(matches []detector.Match) []string {
+	out := make([]string, 0, len(matches))
+	for _, m := range matches {
+		out = append(out, m.Text)
+	}
+	return out
+}
+
+// TestLowercaseParticleNameIsReported is the recall gate for #422. A name absent
+// from the report is never handed to the redactor, so each of these was a cleartext
+// leak of a real person's name.
+func TestLowercaseParticleNameIsReported(t *testing.T) {
+	v := NewValidator()
+
+	for _, tc := range []struct {
+		line, want, lastName string
+	}{
+		{"Dr. Ludwig van Beethoven wrote the report.", "Dr. Ludwig van Beethoven", "Beethoven"},
+		{"Dr. Otto von Bismarck signed it.", "Dr. Otto von Bismarck", "Bismarck"},
+		{"Mr. Ahmed bin Salman attended.", "Mr. Ahmed bin Salman", "Salman"},
+		{"Prof. Maria de la Cruz presented.", "Prof. Maria de la Cruz", "Cruz"},
+		{"Dr. Jan van den Broek reviewed it.", "Dr. Jan van den Broek", "Broek"},
+		{"Ms. Sofia della Rocca approved.", "Ms. Sofia della Rocca", "Rocca"},
+	} {
+		t.Run(tc.want, func(t *testing.T) {
+			matches, err := v.ValidateContent(tc.line, "memo.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			m := findMatch(matches, tc.want)
+			if m == nil {
+				t.Fatalf("want %q reported, got %v", tc.want, matchTexts(matches))
+			}
+
+			// The pattern that fired must be the particle-aware one. Without this the
+			// test would keep passing if some other pattern happened to cover the span,
+			// and would no longer be testing the particle at all.
+			if got := m.Metadata["pattern"]; got != "name_with_title_and_particle" {
+				t.Errorf("matched by pattern %v, want name_with_title_and_particle", got)
+			}
+
+			// Surname parsing must survive the title: if the new pattern were missing
+			// from the ParseNameComponents title case, LastName would still be right but
+			// FirstName would be the title. Assert the surname explicitly, because it is
+			// what the database lookup and the redaction span depend on.
+			comps, ok := m.Metadata["name_components"].(NameComponents)
+			if !ok {
+				t.Fatalf("name_components missing or wrong type: %T", m.Metadata["name_components"])
+			}
+			if comps.LastName != tc.lastName {
+				t.Errorf("LastName = %q, want %q (components: %+v)", comps.LastName, tc.lastName, comps)
+			}
+			if isTitle(comps.FirstName) {
+				t.Errorf("FirstName = %q is a title, so the title was not stripped", comps.FirstName)
+			}
+		})
+	}
+}
+
+// TestOffListParticleSurnameStaysBelowHigh pins the ceiling. These surnames are not
+// in the ~2.3K list, so the finding is admitted on the title marker alone and must
+// never present as HIGH — the same rule the unverified-surname ceiling applies to
+// every other marker-admitted name.
+func TestOffListParticleSurnameStaysBelowHigh(t *testing.T) {
+	v := NewValidator()
+
+	for _, line := range []string{
+		"Dr. Ludwig van Beethoven wrote the report.",
+		"Dr. Otto von Bismarck signed it.",
+	} {
+		t.Run(line, func(t *testing.T) {
+			matches, err := v.ValidateContent(line, "memo.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) == 0 {
+				t.Fatalf("no finding, so the ceiling is untested")
+			}
+			for _, m := range matches {
+				if m.Confidence > unverifiedSurnameCeiling {
+					t.Errorf("%q scored %.0f, above the %.0f ceiling for an off-list surname",
+						m.Text, m.Confidence, unverifiedSurnameCeiling)
+				}
+			}
+		})
+	}
+}
+
+// TestCapitalisedParticleSpanReachesTheSurname is the span gate. Before the fix each
+// of these was reported truncated at the particle, so the reported value — the value
+// the redactor replaces — stopped mid-surname.
+func TestCapitalisedParticleSpanReachesTheSurname(t *testing.T) {
+	v := NewValidator()
+
+	for _, tc := range []struct{ line, want, truncated string }{
+		{"Dr. Marco Di Salvo", "Dr. Marco Di Salvo", "Dr. Marco Di"},
+		{"Dr. Anna Della Rosa", "Dr. Anna Della Rosa", "Dr. Anna Della"},
+		{"Ms. Carla Da Costa", "Ms. Carla Da Costa", "Ms. Carla Da"},
+		{"Dr. Paulo Dos Santos", "Dr. Paulo Dos Santos", "Dr. Paulo Dos"},
+		{"Mrs. Elena Del Rio", "Mrs. Elena Del Rio", "Mrs. Elena Del"},
+		{"Dr. Piet Van Der Berg", "Dr. Piet Van Der Berg", "Dr. Piet Van"},
+	} {
+		t.Run(tc.want, func(t *testing.T) {
+			matches, err := v.ValidateContent(tc.line, "memo.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if findMatch(matches, tc.want) == nil {
+				t.Errorf("want the full span %q, got %v", tc.want, matchTexts(matches))
+			}
+			if m := findMatch(matches, tc.truncated); m != nil {
+				t.Errorf("still reporting the truncated span %q at %.0f: redaction of that "+
+					"value leaves the rest of the surname in cleartext", m.Text, m.Confidence)
+			}
+		})
+	}
+}
+
+// TestParticleSpanDoesNotAbsorbAFollowingWord is the precision counterpart. The
+// extra token the titled pattern accepts is restricted to a particle for exactly
+// this reason: a pattern that simply allowed a fourth token would swallow the next
+// word of the sentence.
+func TestParticleSpanDoesNotAbsorbAFollowingWord(t *testing.T) {
+	v := NewValidator()
+
+	for _, tc := range []struct{ line, want string }{
+		{"Dr. John Smith Reviewed the chart.", "Dr. John Smith"},
+		{"Dr. Sarah Chen Approved the change.", "Dr. Sarah Chen"},
+		{"Dr. Maria Lopez Signed the form.", "Dr. Maria Lopez"},
+	} {
+		t.Run(tc.want, func(t *testing.T) {
+			matches, err := v.ValidateContent(tc.line, "memo.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if findMatch(matches, tc.want) == nil {
+				t.Fatalf("want %q, got %v", tc.want, matchTexts(matches))
+			}
+			for _, m := range matches {
+				if len(m.Text) > len(tc.want) && strings.HasPrefix(m.Text, tc.want) {
+					t.Errorf("span %q absorbed the following word", m.Text)
+				}
+			}
+		})
+	}
+}
+
+// TestParticleSetExcludesEnglishFunctionWords keeps the set closed. "of" and "and"
+// are ordinary English function words, not nobiliary particles, and admitting them
+// would turn every "<Capital> of <Capital>" organisation name into a candidate.
+func TestParticleSetExcludesEnglishFunctionWords(t *testing.T) {
+	v := NewValidator()
+
+	for _, line := range []string{
+		"Institute of Technology",
+		"Bank of America",
+		"Department of Justice",
+		"Smith and Wesson",
+	} {
+		t.Run(line, func(t *testing.T) {
+			matches, err := v.ValidateContent(line, "doc.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			for _, m := range matches {
+				for _, fw := range []string{" of ", " and "} {
+					if strings.Contains(m.Text, fw) {
+						t.Errorf("reported %q: %q was treated as a particle", m.Text, strings.TrimSpace(fw))
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/validators/personname/patterns.go
+++ b/internal/validators/personname/patterns.go
@@ -80,15 +80,56 @@ func wrapNamePattern(core string) string {
 	return `(?:^|[^` + nameLetter + `])(` + core + `)(?:[^` + nameLetter + `]|$)`
 }
 
+// nameParticle matches a nobiliary or patronymic particle — the connective inside a
+// multi-word surname (van Beethoven, von Bismarck, de Silva, Di Salvo, bin Salman).
+//
+// Every other pattern here requires each name token to begin with a capital, so a
+// lowercase particle terminated the match: "Dr. Ludwig van Beethoven" produced no
+// candidate at all, and the title marker that would have admitted the off-list
+// surname never got the chance to apply. Capitalised spellings are accepted on the
+// same footing because English usage varies ("Di Salvo", "Van Damme", "De Luca"), and
+// a capitalised particle caused the mirror-image defect: name_with_title claimed
+// "Dr. Marco Di" and left "Salvo" out of the reported value.
+//
+// The set is closed and small on purpose. "of" and "and" are deliberately absent:
+// they are ordinary English function words, and admitting them would match
+// "Institute of Technology". Even for the particles listed, the surname bar in
+// CalculateConfidenceWithComponents still applies, so "Ministerio de Educación" is
+// rejected on the surname rather than on the particle.
+const nameParticle = `(?:[Vv]an|[Vv]on|[Dd]ell[ao]|[Dd]el|[Dd]en|[Dd]er|[Dd]es|[Dd]os|[Dd]as|[Dd]al|[Dd]e|[Dd]a|[Dd]i|[Dd]o|[Dd]u|[Tt]en|[Tt]er|[Ll]a|[Ll]e|[Ee]l|[Aa]l|[Bb]int|[Bb]in|[Ii]bn)`
+
+// nameParticleRun allows one or two particles so the common compounds are matched in
+// full: "de la Cruz", "van der Berg", "van den Broek".
+const nameParticleRun = `(?:` + nameParticle + nameSpace + `){1,2}`
+
 // requiresBothNamesKnown reports whether a pattern's candidates must have BOTH a
 // database-confirmed given name and a database-confirmed surname, rather than the
 // surname-only bar that CalculateConfidenceWithComponents applies to the rest.
 //
-// Only the tab-separated pattern needs it: its two tokens sit in different table
-// columns, so their adjacency is a layout artefact rather than evidence that they
-// form one name.
+// Two patterns need it, for the same underlying reason — the shape they match is
+// something document text produces on its own, so the surname alone is not enough to
+// tell a name from a coincidence:
+//
+//   - tab_separated_name: its tokens sit in different table columns, so their
+//     adjacency is a layout artefact rather than evidence that they form one name.
+//
+//   - name_with_particle: a lowercase particle between two capitalised words is
+//     ordinary prose as often as it is a name. "Discussed von Neumann architecture"
+//     and "Applied de Morgan's law" both have a genuine surname after the particle,
+//     and both are eponyms rather than data subjects. Requiring the GIVEN half to be
+//     a known name is what separates them from "Ana de la Cruz", and it is what the
+//     fp__latin_and_prose_particles corpus case prescribes.
+//
+// The titled variant is deliberately NOT here. Its title is an explicit statement
+// that the following tokens name a person, which is evidence the database cannot
+// supply — that is the whole reason "Dr. Ludwig van Beethoven" is reportable when
+// the surname is off-list. Nothing writes "Dr. Applied de Morgan".
 func requiresBothNamesKnown(patternName string) bool {
-	return patternName == tabSeparatedNamePattern
+	switch patternName {
+	case tabSeparatedNamePattern, "name_with_particle":
+		return true
+	}
+	return false
 }
 
 // PatternManager manages name detection patterns
@@ -181,6 +222,36 @@ func (pm *PatternManager) compileAllPatterns() {
 			description: "Name with suffix: First Last Jr.",
 			priority:    8,
 			cultural:    []string{"western", "american", "academic"},
+		},
+		{
+			// "Ludwig van Beethoven", "Maria de la Cruz", "Ahmed bin Salman".
+			//
+			// Priority sits with three_part_name: this is the same three-token shape,
+			// with a particle in the middle slot instead of a middle name.
+			name:        "name_with_particle",
+			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29}` + nameSpace + nameParticleRun + `[` + nameUpper + `][` + nameLower + `]{1,29}`,
+			description: "Name with a nobiliary particle: First van Last",
+			priority:    6,
+			cultural:    []string{"dutch", "german", "spanish", "portuguese", "italian", "arabic"},
+		},
+		{
+			// The titled form of the pattern above, and the fix for the truncation a
+			// CAPITALISED particle used to cause: name_with_title matches exactly two
+			// name tokens after the title, so "Dr. Marco Di Salvo" was reported as
+			// "Dr. Marco Di" — a name whose reported value stops mid-surname.
+			//
+			// Restricting the extra token to a particle is what keeps this safe: a
+			// pattern that simply allowed a fourth token would claim
+			// "Dr. John Smith Reviewed" and put the following word inside the name.
+			//
+			// Registered in hasExplicitNameMarker and isFormalNamePattern alongside
+			// name_with_title — the title is the same evidence of personhood here, and
+			// it is what admits an off-list surname such as "Beethoven" at all.
+			name:        "name_with_title_and_particle",
+			pattern:     `(?:Mr|Ms|Mrs|Dr|Prof|Sir|Dame|Lord|Lady)\.` + nameSpace + `[` + nameUpper + `][` + nameLower + `]{1,29}` + nameSpace + nameParticleRun + `[` + nameUpper + `][` + nameLower + `]{1,29}`,
+			description: "Titled name with a nobiliary particle: Dr. First van Last",
+			priority:    8,
+			cultural:    []string{"western", "formal", "dutch", "german"},
 		},
 		{
 			name:        "three_part_name",
@@ -390,7 +461,7 @@ func ParseNameComponents(nameText string, pattern NamePattern) NameComponents {
 
 	// Parse based on pattern type
 	switch pattern.Name {
-	case "name_with_title", "name_with_multiple_titles":
+	case "name_with_title", "name_with_title_and_particle", "name_with_multiple_titles":
 		components = parseNameWithTitle(tokens, components)
 	case "name_with_suffix", "name_with_professional_suffix":
 		components = parseNameWithSuffix(tokens, components)

--- a/internal/validators/personname/patterns.go
+++ b/internal/validators/personname/patterns.go
@@ -36,6 +36,41 @@ const (
 	nameLetter = nameUpper + nameLower
 )
 
+// nameSpace is the separator allowed BETWEEN the tokens of one name: a run of
+// ordinary spaces.
+//
+// It deliberately excludes the tab, which the `\s+` these patterns used to use
+// would accept. A tab is a column boundary in extracted table and spreadsheet
+// content, not a word space, so `\s+` glued two adjacent cells into a single
+// "name". Measured over 714 real Office/PDF documents before this change: 95 of
+// 1931 PERSON_NAME findings (4.9%) spanned a tab and 32 of those presented as
+// HIGH — a two-column table row "Preventative<TAB>Strong" scored 100, and
+// "Financial Services<TAB>Washington" scored 100, because the second cell
+// happened to hold a real surname.
+//
+// The tab still separates: wrapNamePattern's boundary class is "not a letter",
+// so a tab bounds a name rather than joining two. \n cannot appear here at all —
+// ValidateContentCtx splits content on newlines before these patterns run — and
+// \f/\r are excluded for the same reason as the tab.
+//
+// A genuine "First Name | Last Name" two-column row does exist, and excluding
+// the tab here would make it unreportable. tabSeparatedNamePattern below keeps
+// that shape reachable on stricter evidence rather than on the tab alone.
+const nameSpace = `[ ]+`
+
+// nameTabSpace is a separator run containing at least one tab, used only by
+// tabSeparatedNamePattern. It tolerates spaces around the tab so a padded cell
+// boundary ("Marcus \t Holloway") is still one candidate.
+const nameTabSpace = `[ ]*\t[ \t]*`
+
+// tabSeparatedNamePattern is the one pattern whose tokens may be separated by a
+// tab. Because a tab is a column boundary, the shape "X<TAB>Y" is far weaker
+// evidence of a name than "X Y" is, so findNamesInLine requires BOTH tokens to
+// be database-confirmed for this pattern alone (see requiresBothNamesKnown).
+// Every other pattern keeps the surname-only bar documented in
+// CalculateConfidenceWithComponents.
+const tabSeparatedNamePattern = "tab_separated_name"
+
 // wrapNamePattern turns a "core" name pattern into a boundary-anchored pattern
 // with the name captured in group 1. The leading/trailing groups consume a
 // non-letter character (or the string start/end) so the match does not run into
@@ -43,6 +78,17 @@ const (
 // cannot. Callers must read submatch group 1 (see FindMatches).
 func wrapNamePattern(core string) string {
 	return `(?:^|[^` + nameLetter + `])(` + core + `)(?:[^` + nameLetter + `]|$)`
+}
+
+// requiresBothNamesKnown reports whether a pattern's candidates must have BOTH a
+// database-confirmed given name and a database-confirmed surname, rather than the
+// surname-only bar that CalculateConfidenceWithComponents applies to the rest.
+//
+// Only the tab-separated pattern needs it: its two tokens sit in different table
+// columns, so their adjacency is a layout artefact rather than evidence that they
+// form one name.
+func requiresBothNamesKnown(patternName string) bool {
+	return patternName == tabSeparatedNamePattern
 }
 
 // PatternManager manages name detection patterns
@@ -68,10 +114,31 @@ func (pm *PatternManager) compileAllPatterns() {
 	}{
 		{
 			name:        "basic_western_name",
-			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `][` + nameLower + `]{1,29}`,
+			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29}` + nameSpace + `[` + nameUpper + `][` + nameLower + `]{1,29}`,
 			description: "Basic Western name format: First Last (minimum 2 chars each)",
 			priority:    5,
 			cultural:    []string{"western", "english", "european"},
+		},
+		{
+			// A name split across two table columns: "First Name | Last Name".
+			//
+			// This is the only pattern that may span a tab, and it exists so that
+			// excluding the tab from nameSpace does not silently drop a real
+			// two-column roster row. It is the weakest candidate finder here — a tab
+			// says the two tokens are in DIFFERENT cells, which is evidence against a
+			// name relationship, not for it — so requiresBothNamesKnown demands a
+			// database hit on BOTH tokens rather than the usual surname-only bar.
+			//
+			// Measured over 714 real Office/PDF documents: 95 tab-spanning findings
+			// (44 distinct values) were reported before this change, and in 94 of the
+			// 95 the left-hand token was not a known given name ("Closed<TAB>Cook",
+			// "Project<TAB>Sun", "Preventative<TAB>Strong"), so the both-known bar
+			// removes them while keeping "Marcus<TAB>Holloway" reportable.
+			name:        tabSeparatedNamePattern,
+			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29}` + nameTabSpace + `[` + nameUpper + `][` + nameLower + `]{1,29}`,
+			description: "Name split across two table columns: First<TAB>Last",
+			priority:    2,
+			cultural:    []string{"tabular", "database"},
 		},
 		{
 			name: "all_caps_name",
@@ -83,21 +150,21 @@ func (pm *PatternManager) compileAllPatterns() {
 			// CODE", "TODO FIXME") is rejected, and the common-word-bigram gate
 			// keeps DB-colliding word pairs out of the HIGH bucket. Low priority —
 			// all-caps is weaker evidence than mixed-case.
-			pattern:     `[` + nameUpper + `]{2,30}\s+[` + nameUpper + `]{2,30}`,
+			pattern:     `[` + nameUpper + `]{2,30}` + nameSpace + `[` + nameUpper + `]{2,30}`,
 			description: "All-caps name: FIRST LAST",
 			priority:    3,
 			cultural:    []string{"western", "formal"},
 		},
 		{
 			name:        "name_with_middle_initial",
-			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `]\.\s+[` + nameUpper + `][` + nameLower + `]{1,29}`,
+			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29}` + nameSpace + `[` + nameUpper + `]\.` + nameSpace + `[` + nameUpper + `][` + nameLower + `]{1,29}`,
 			description: "Name with middle initial: First M. Last",
 			priority:    7,
 			cultural:    []string{"western", "american"},
 		},
 		{
 			name:        "name_with_title",
-			pattern:     `(?:Mr|Ms|Mrs|Dr|Prof|Sir|Dame|Lord|Lady)\.\s+[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `][` + nameLower + `]{1,29}`,
+			pattern:     `(?:Mr|Ms|Mrs|Dr|Prof|Sir|Dame|Lord|Lady)\.` + nameSpace + `[` + nameUpper + `][` + nameLower + `]{1,29}` + nameSpace + `[` + nameUpper + `][` + nameLower + `]{1,29}`,
 			description: "Name with title: Dr. First Last",
 			priority:    8,
 			cultural:    []string{"western", "formal"},
@@ -110,42 +177,42 @@ func (pm *PatternManager) compileAllPatterns() {
 			// suffix. Jr/Sr/III/IV plus the academic suffixes cover the common
 			// cases; wrapNamePattern supplies the trailing boundary that stops
 			// "IV"/"III" matching inside "IVory"/"IIIumination".
-			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `][` + nameLower + `]{1,29}\s+(?:Jr\.?|Sr\.?|III|IV|PhD|MD|Esq\.?)`,
+			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29}` + nameSpace + `[` + nameUpper + `][` + nameLower + `]{1,29}` + nameSpace + `(?:Jr\.?|Sr\.?|III|IV|PhD|MD|Esq\.?)`,
 			description: "Name with suffix: First Last Jr.",
 			priority:    8,
 			cultural:    []string{"western", "american", "academic"},
 		},
 		{
 			name:        "three_part_name",
-			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `][` + nameLower + `]{1,29}`,
+			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29}` + nameSpace + `[` + nameUpper + `][` + nameLower + `]{1,29}` + nameSpace + `[` + nameUpper + `][` + nameLower + `]{1,29}`,
 			description: "Three-part name: First Middle Last",
 			priority:    6,
 			cultural:    []string{"western", "hispanic", "compound"},
 		},
 		{
 			name:        "hyphenated_last_name",
-			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `][` + nameLower + `]{1,29}-[` + nameUpper + `][` + nameLower + `]{1,29}`,
+			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29}` + nameSpace + `[` + nameUpper + `][` + nameLower + `]{1,29}-[` + nameUpper + `][` + nameLower + `]{1,29}`,
 			description: "Hyphenated last name: First Last-Name",
 			priority:    7,
 			cultural:    []string{"western", "modern", "compound"},
 		},
 		{
 			name:        "name_with_apostrophe_first",
-			pattern:     `[` + nameUpper + `][` + nameLower + `]*'[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `][` + nameLower + `]{1,29}`,
+			pattern:     `[` + nameUpper + `][` + nameLower + `]*'[` + nameUpper + `][` + nameLower + `]{1,29}` + nameSpace + `[` + nameUpper + `][` + nameLower + `]{1,29}`,
 			description: "Name with apostrophe in first name: O'Connor Smith",
 			priority:    7,
 			cultural:    []string{"irish", "scottish", "western"},
 		},
 		{
 			name:        "name_with_apostrophe_last",
-			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `][` + nameLower + `]*'[` + nameUpper + `][` + nameLower + `]{1,29}`,
+			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29}` + nameSpace + `[` + nameUpper + `][` + nameLower + `]*'[` + nameUpper + `][` + nameLower + `]{1,29}`,
 			description: "Name with apostrophe in last name: David O'Connor",
 			priority:    7,
 			cultural:    []string{"irish", "scottish", "western"},
 		},
 		{
 			name:        "compound_first_name",
-			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29}-[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `][` + nameLower + `]{1,29}`,
+			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29}-[` + nameUpper + `][` + nameLower + `]{1,29}` + nameSpace + `[` + nameUpper + `][` + nameLower + `]{1,29}`,
 			description: "Compound first name: Mary-Jane Smith",
 			priority:    6,
 			cultural:    []string{"western", "compound", "modern"},
@@ -167,7 +234,7 @@ func (pm *PatternManager) compileAllPatterns() {
 			// Priority 8 puts it above both partial patterns (6 and 7) so the full
 			// span wins the overlap rather than tying with a fragment of itself.
 			name:        "compound_first_and_hyphenated_last",
-			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29}-[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `][` + nameLower + `]{1,29}-[` + nameUpper + `][` + nameLower + `]{1,29}`,
+			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29}-[` + nameUpper + `][` + nameLower + `]{1,29}` + nameSpace + `[` + nameUpper + `][` + nameLower + `]{1,29}-[` + nameUpper + `][` + nameLower + `]{1,29}`,
 			description: "Hyphen in both parts: Anne-Marie Delacroix-Webb",
 			priority:    8,
 			cultural:    []string{"western", "french", "compound", "modern"},
@@ -187,49 +254,49 @@ func (pm *PatternManager) compileAllPatterns() {
 			// run away across a sentence; priority 8 matches the sibling above so the
 			// widest span wins over the partials it contains.
 			name:        "compound_first_and_multiword_last",
-			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29}-[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `][` + nameLower + `]{1,29}`,
+			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29}-[` + nameUpper + `][` + nameLower + `]{1,29}` + nameSpace + `[` + nameUpper + `][` + nameLower + `]{1,29}` + nameSpace + `[` + nameUpper + `][` + nameLower + `]{1,29}`,
 			description: "Compound first name with two-part surname: Jean-Claude Van Damme",
 			priority:    8,
 			cultural:    []string{"western", "french", "dutch", "compound"},
 		},
 		{
 			name:        "name_with_multiple_titles",
-			pattern:     `(?:Dr|Prof)\.\s+(?:Mr|Ms|Mrs)\.\s+[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `][` + nameLower + `]{1,29}`,
+			pattern:     `(?:Dr|Prof)\.` + nameSpace + `(?:Mr|Ms|Mrs)\.` + nameSpace + `[` + nameUpper + `][` + nameLower + `]{1,29}` + nameSpace + `[` + nameUpper + `][` + nameLower + `]{1,29}`,
 			description: "Multiple titles: Dr. Ms. First Last",
 			priority:    9,
 			cultural:    []string{"academic", "formal"},
 		},
 		{
 			name:        "four_part_name",
-			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `][` + nameLower + `]{1,29}`,
+			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29}` + nameSpace + `[` + nameUpper + `][` + nameLower + `]{1,29}` + nameSpace + `[` + nameUpper + `][` + nameLower + `]{1,29}` + nameSpace + `[` + nameUpper + `][` + nameLower + `]{1,29}`,
 			description: "Four-part name: First Middle Middle Last",
 			priority:    4,
 			cultural:    []string{"hispanic", "compound", "formal"},
 		},
 		{
 			name:        "last_comma_first",
-			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29},\s+[` + nameUpper + `][` + nameLower + `]{1,29}`,
+			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29},` + nameSpace + `[` + nameUpper + `][` + nameLower + `]{1,29}`,
 			description: "Last, First format (database/directory style)",
 			priority:    8,
 			cultural:    []string{"formal", "database", "directory"},
 		},
 		{
 			name:        "last_comma_first_middle",
-			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29},\s+[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `][` + nameLower + `]{1,29}`,
+			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29},` + nameSpace + `[` + nameUpper + `][` + nameLower + `]{1,29}` + nameSpace + `[` + nameUpper + `][` + nameLower + `]{1,29}`,
 			description: "Last, First Middle format",
 			priority:    8,
 			cultural:    []string{"formal", "database", "directory"},
 		},
 		{
 			name:        "last_comma_first_initial",
-			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29},\s+[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `]\.`,
+			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29},` + nameSpace + `[` + nameUpper + `][` + nameLower + `]{1,29}` + nameSpace + `[` + nameUpper + `]\.`,
 			description: "Last, First M. format",
 			priority:    8,
 			cultural:    []string{"formal", "database", "directory"},
 		},
 		{
 			name:        "name_with_professional_suffix",
-			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29}\s+[` + nameUpper + `][` + nameLower + `]{1,29},\s+(?:PhD|MD|DDS|JD|EdD|PharmD|PsyD|DVM|RN|CPA|PE)`,
+			pattern:     `[` + nameUpper + `][` + nameLower + `]{1,29}` + nameSpace + `[` + nameUpper + `][` + nameLower + `]{1,29},` + nameSpace + `(?:PhD|MD|DDS|JD|EdD|PharmD|PsyD|DVM|RN|CPA|PE)`,
 			description: "Name with professional suffix: John Smith, PhD",
 			priority:    9,
 			cultural:    []string{"academic", "professional", "formal"},

--- a/internal/validators/personname/routing_word_test.go
+++ b/internal/validators/personname/routing_word_test.go
@@ -1,0 +1,310 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package personname
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/context"
+)
+
+// Go's regexp finds leftmost NON-OVERLAPPING matches. A Title-Case routing word in
+// front of a name therefore does not merely widen the span — it CONSUMES the given
+// name, and the real name is never offered as a candidate:
+//
+//	"Attn Marcus Holloway"      basic_western_name claims "Attn Marcus", the scan
+//	                            resumes at "Holloway", one token cannot match, and
+//	                            nothing at all is reported.
+//	"Attention Marcus Holloway" three_part_name claims the whole string, so the
+//	                            routing word sits inside the reported value.
+//	"X Marcus Holloway"         reported 92 — a one-letter token cannot start a name
+//	                            token, so it consumes nothing. This is what pins the
+//	                            cause to the consumed token rather than to scoring.
+//
+// The first form is a cleartext leak: an unreported name is never handed to the
+// redactor. The scorecorpus mutation for this fix shows it directly — removing the
+// mask turns 5 labels into whole_leak in the redacted artifact.
+
+var routingWordLines = []string{
+	"Attn Marcus Holloway",
+	"Attention Marcus Holloway",
+	"Dear Marcus Holloway",
+	"Regards Marcus Holloway",
+	"Sincerely Marcus Holloway",
+	"Thanks Marcus Holloway",
+	"Cc Marcus Holloway",
+	"Bcc Marcus Holloway",
+	"Fwd Marcus Holloway",
+	"Subject Marcus Holloway",
+	"Re Marcus Holloway",
+}
+
+func TestRoutingWordDoesNotHideTheName(t *testing.T) {
+	v := NewValidator()
+
+	for _, line := range routingWordLines {
+		t.Run(line, func(t *testing.T) {
+			matches, err := v.ValidateContent(line, "memo.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if findMatch(matches, "Marcus Holloway") == nil {
+				t.Fatalf("%q did not report \"Marcus Holloway\", got %v — an unreported "+
+					"name is never redacted", line, matchTexts(matches))
+			}
+		})
+	}
+}
+
+// TestRoutingWordIsNotInsideTheReportedValue is the other half. The value reported is
+// the value the redactor replaces, so a span carrying the routing word redacts the
+// wrong bytes even when the name is found.
+func TestRoutingWordIsNotInsideTheReportedValue(t *testing.T) {
+	v := NewValidator()
+
+	for _, line := range routingWordLines {
+		routing := strings.Fields(line)[0]
+		t.Run(line, func(t *testing.T) {
+			matches, err := v.ValidateContent(line, "memo.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			for _, m := range matches {
+				if strings.Contains(m.Text, routing) {
+					t.Errorf("reported %q at %.0f: the routing word %q is inside the value",
+						m.Text, m.Confidence, routing)
+				}
+			}
+		})
+	}
+}
+
+// TestUnpunctuatedRoutingWordAgreesWithPunctuated states the contract as an equality.
+// The punctuated form was always correct — the colon is a boundary the patterns cannot
+// cross — so the fix is that dropping the punctuation must not change the answer.
+func TestUnpunctuatedRoutingWordAgreesWithPunctuated(t *testing.T) {
+	v := NewValidator()
+
+	for _, pair := range []struct{ bare, punctuated string }{
+		{"Attn Marcus Holloway", "Attn: Marcus Holloway"},
+		{"Attention Marcus Holloway", "Attention: Marcus Holloway"},
+		{"Dear Marcus Holloway", "Dear, Marcus Holloway"},
+	} {
+		t.Run(pair.bare, func(t *testing.T) {
+			bare, err := v.ValidateContent(pair.bare, "memo.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			punct, err := v.ValidateContent(pair.punctuated, "memo.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(punct) == 0 {
+				t.Fatalf("the punctuated form reported nothing, so the comparison is empty")
+			}
+			if findMatch(bare, punct[0].Text) == nil {
+				t.Errorf("punctuated %q reports %q, bare %q reports %v",
+					pair.punctuated, punct[0].Text, pair.bare, matchTexts(bare))
+			}
+		})
+	}
+}
+
+// TestMaskBoundsRatherThanJoins pins the reason maskChar is '#' and not a space.
+// nameSpace accepts a RUN of spaces, so blanking the routing word would let the tokens
+// on either side of the hole join into one candidate — and its text, read back from the
+// original line, would be a string that is not a name and was never in the document as
+// one.
+func TestMaskBoundsRatherThanJoins(t *testing.T) {
+	v := NewValidator()
+
+	for _, line := range []string{
+		"Holloway Attn Marcus",
+		"Chen Dear Sarah",
+	} {
+		t.Run(line, func(t *testing.T) {
+			matches, err := v.ValidateContent(line, "memo.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			tokens := strings.Fields(line)
+			joined := tokens[0] + " " + tokens[2]
+			for _, m := range matches {
+				if m.Text == joined {
+					t.Errorf("reported %q: the two sides joined across the masked word", m.Text)
+				}
+			}
+		})
+	}
+}
+
+// TestMaskedMatchTextComesFromTheOriginalLine guards the offset invariant. A match
+// found in the masked line must index the original line unchanged, so no reported
+// value may contain the mask character.
+func TestMaskedMatchTextComesFromTheOriginalLine(t *testing.T) {
+	v := NewValidator()
+	const line = "Prepared for the team. Attn Marcus Holloway please review by Friday."
+
+	matches, err := v.ValidateContent(line, "memo.txt")
+	if err != nil {
+		t.Fatalf("ValidateContent: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Fatalf("no finding, so the invariant is untested")
+	}
+	for _, m := range matches {
+		if strings.ContainsRune(m.Text, maskChar) {
+			t.Errorf("reported %q, which carries the mask character: the text was taken "+
+				"from the masked line instead of the original", m.Text)
+		}
+		if !strings.Contains(line, m.Text) {
+			t.Errorf("reported %q, which does not appear in the line at all", m.Text)
+		}
+	}
+}
+
+// TestMaskingCannotLoseAName pins the property that makes masking safe, and the reason
+// maskNonNameGivenWords needs no name-database check of its own.
+//
+// findPatternCandidates keeps the unmasked candidates and ADDS the masked ones, so
+// masking a word that turns out to be a real given name cannot remove the name: the
+// original candidate is still there. The test forces that situation by putting a real
+// given name into the mask list, which is the only way to exercise it — every word
+// actually in routingWordsMap is a non-name, so asserting against today's list would
+// pass whether the property held or not.
+//
+// routingWordsMap is a package variable and these tests do not run in parallel, so the
+// insert is safe as long as it is undone.
+func TestMaskingCannotLoseAName(t *testing.T) {
+	v := NewValidator()
+
+	for _, tc := range []struct{ word, line, want string }{
+		{"will", "Will Smith attended", "Will Smith"},
+		{"may", "May Chen signed", "May Chen"},
+	} {
+		t.Run(tc.want, func(t *testing.T) {
+			if routingWordsMap[tc.word] {
+				t.Fatalf("%q is already a routing word, so it no longer forces the case "+
+					"this test exists for — pick a word that is not in the map", tc.word)
+			}
+			routingWordsMap[tc.word] = true
+			defer delete(routingWordsMap, tc.word)
+
+			matches, err := v.ValidateContent(tc.line, "memo.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if findMatch(matches, tc.want) == nil {
+				t.Errorf("want %q, got %v: masking a real given name removed the name, so "+
+					"the masked pass is replacing candidates instead of adding to them",
+					tc.want, matchTexts(matches))
+			}
+		})
+	}
+}
+
+// TestMaskingKeepsTheNameBytesCovered is the companion property. A masked-pass candidate
+// can be WIDER than an unmasked finding and then win the containment rule in
+// deduplicateMatches, so a finding can disappear from the output — but only in favour of
+// a longer span that contains it, which still covers the same bytes for the redactor.
+func TestMaskingKeepsTheNameBytesCovered(t *testing.T) {
+	v := NewValidator()
+	const line = "Attn Marcus Holloway Smith"
+
+	matches, err := v.ValidateContent(line, "memo.txt")
+	if err != nil {
+		t.Fatalf("ValidateContent: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Fatalf("no finding at all for %q", line)
+	}
+	covered := false
+	for _, m := range matches {
+		if strings.Contains(m.Text, "Holloway Smith") {
+			covered = true
+		}
+		if strings.Contains(m.Text, "Attn") {
+			t.Errorf("reported %q: the routing word is inside the value", m.Text)
+		}
+	}
+	if !covered {
+		t.Errorf("no reported value covers \"Holloway Smith\": %v — the surname bytes are "+
+			"no longer handed to the redactor", matchTexts(matches))
+	}
+}
+
+// TestMaskIsLimitedToRoutingWords is the precision counterweight, measured rather than
+// assumed: masking every Title-Case function word exposed 18 findings on 714 real
+// documents that had been hidden behind one, almost all false. These are that shape.
+func TestMaskIsLimitedToRoutingWords(t *testing.T) {
+	v := NewValidator()
+
+	for _, line := range []string{
+		"For Firm Fixed Price contracts only.",
+		"The Fixed Price applies.",
+		"About Epic House today.",
+		"With Person Sessions scheduled.",
+	} {
+		t.Run(line, func(t *testing.T) {
+			matches, err := v.ValidateContent(line, "doc.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) != 0 {
+				t.Errorf("%q reported %v: the mask reached beyond routing words", line, matchTexts(matches))
+			}
+		})
+	}
+}
+
+// TestRoutingWordMaskAppliesOnBothScoringPaths is the dual-path guard. The candidate
+// finder is shared by findNamesInLine and findNamesInLineWithContext precisely so this
+// cannot drift, and this test is what would notice if it did.
+func TestRoutingWordMaskAppliesOnBothScoringPaths(t *testing.T) {
+	v := NewValidator()
+	const line = "Attn Marcus Holloway"
+
+	plain, err := v.ValidateContent(line, "memo.txt")
+	if err != nil {
+		t.Fatalf("ValidateContent: %v", err)
+	}
+	withCtx, err := v.ValidateWithContext(line, "memo.txt", context.ContextInsights{
+		DocumentType:          "correspondence",
+		Domain:                "hr",
+		SemanticContext:       map[string]float64{"person": 0.9},
+		ConfidenceAdjustments: map[string]float64{},
+	})
+	if err != nil {
+		t.Fatalf("ValidateWithContext: %v", err)
+	}
+
+	if findMatch(plain, "Marcus Holloway") == nil {
+		t.Errorf("ValidateContent lost the name: %v", matchTexts(plain))
+	}
+	if findMatch(withCtx, "Marcus Holloway") == nil {
+		t.Errorf("ValidateWithContext lost the name — the candidate finder is not shared: %v",
+			matchTexts(withCtx))
+	}
+}
+
+// TestRoutingWordAfterASurnameIsUnchanged records a limitation rather than a fix.
+// "Holloway Attn Marcus Whitfield" is claimed whole by four_part_name, and the
+// containment rule in deduplicateMatches then drops the correct inner span because it
+// compares lengths and not confidence. Measured identical before and after this change
+// (82 both ways), so it is pre-existing and out of scope here — pinned so that a future
+// change to overlap resolution has to decide about it deliberately.
+func TestRoutingWordAfterASurnameIsUnchanged(t *testing.T) {
+	v := NewValidator()
+	const line = "Holloway Attn Marcus Whitfield"
+
+	matches, err := v.ValidateContent(line, "memo.txt")
+	if err != nil {
+		t.Fatalf("ValidateContent: %v", err)
+	}
+	if findMatch(matches, line) == nil {
+		t.Skipf("the pre-existing four_part_name span for %q no longer appears (%v); if "+
+			"overlap resolution changed deliberately, update this expectation", line, matchTexts(matches))
+	}
+}

--- a/internal/validators/personname/tab_boundary_test.go
+++ b/internal/validators/personname/tab_boundary_test.go
@@ -1,0 +1,203 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package personname
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/context"
+)
+
+// A tab is a column boundary in extracted table and spreadsheet content, not a
+// word space. Every name pattern used to join its tokens with `\s+`, and Go's \s
+// includes \t, so two adjacent cells were glued into one "name" whenever the
+// right-hand cell happened to hold a real surname.
+//
+// Measured over 714 real Office/PDF documents before the fix: 95 of 1931
+// PERSON_NAME findings spanned a tab and 32 of those presented as HIGH — a
+// two-column status table produced "Preventative<TAB>Strong" at 100.
+//
+// The fix is not "a tab never joins a name": a genuine "First Name | Last Name"
+// roster row does exist. It is that a tab is WEAKER evidence than a space, so the
+// one pattern allowed to span it must clear a stricter bar (both tokens confirmed
+// by the name database) instead of the surname-only bar used elsewhere.
+
+// tabbedTableCells are real values reported before the fix, taken from the
+// 714-document corpus. In each one the left token is not a given name, so the
+// adjacency is a table layout and nothing more.
+var tabbedTableCells = []string{
+	"Preventative\tStrong",
+	"Closed\tCook",
+	"Project\tSun",
+	"Healthcare\tJohnson",
+	"Launched\tJohnson",
+	"Circle\tRyan",
+	"Closed\tHolland",
+	"Project\tWashington",
+	"Change Log\tMajor",
+	"Financial Services\tWashington",
+	"Data Handling Standard\tLink",
+}
+
+func TestTabbedTableCellsAreNotOneName(t *testing.T) {
+	v := NewValidator()
+
+	for _, line := range tabbedTableCells {
+		t.Run(strings.ReplaceAll(line, "\t", "<TAB>"), func(t *testing.T) {
+			matches, err := v.ValidateContent(line, "table.tsv")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			for _, m := range matches {
+				if strings.Contains(m.Text, "\t") {
+					t.Errorf("reported a name spanning a column boundary: %q at %.0f", m.Text, m.Confidence)
+				}
+			}
+		})
+	}
+}
+
+// TestTabbedCellsWouldMatchWithASpace is the non-vacuity gate for the test above.
+//
+// Replacing each tab with a space must still produce a finding. Without this, the
+// suite above would keep passing if the patterns stopped matching for some
+// unrelated reason (a broken character class, an empty name database) and would
+// no longer be testing the column boundary at all.
+func TestTabbedCellsWouldMatchWithASpace(t *testing.T) {
+	v := NewValidator()
+
+	for _, line := range tabbedTableCells {
+		spaced := strings.ReplaceAll(line, "\t", " ")
+		t.Run(spaced, func(t *testing.T) {
+			matches, err := v.ValidateContent(spaced, "prose.txt")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) == 0 {
+				t.Fatalf("%q produced no finding, so the tab variant proves nothing "+
+					"about column boundaries", spaced)
+			}
+		})
+	}
+}
+
+// TestTwoColumnRosterNameIsStillReported pins the recall side. These are the rows
+// that make a blanket "a tab never joins a name" rule wrong: both tokens are
+// database-confirmed name parts, so the row is a person split across two columns
+// and dropping it would leave the name unredactable.
+func TestTwoColumnRosterNameIsStillReported(t *testing.T) {
+	v := NewValidator()
+
+	for _, line := range []string{
+		"Marcus\tHolloway",
+		"Sarah\tChen",
+		"Michael\tJohnson",
+		"Marcus \t Holloway", // padded cell boundary
+	} {
+		t.Run(strings.ReplaceAll(line, "\t", "<TAB>"), func(t *testing.T) {
+			matches, err := v.ValidateContent(line, "roster.tsv")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			if len(matches) == 0 {
+				t.Fatalf("%q lost the name entirely: a First/Last column pair must "+
+					"stay reportable, or it is never redacted", line)
+			}
+		})
+	}
+}
+
+// TestTabbedRowReportsTheNameNotTheLabelCell covers the case that improves in both
+// directions. "Nomination<TAB>Christian Kelley" used to be reported verbatim, so
+// the value handed downstream carried a foreign label cell inside it. The name is
+// still found — with the correct span.
+func TestTabbedRowReportsTheNameNotTheLabelCell(t *testing.T) {
+	v := NewValidator()
+
+	for _, tc := range []struct{ line, want string }{
+		{"Nomination\tChristian Kelley", "Christian Kelley"},
+		{"Barclays\tRob Jackson", "Rob Jackson"},
+		{"Lost\tAlex Goff", "Alex Goff"},
+	} {
+		t.Run(tc.want, func(t *testing.T) {
+			matches, err := v.ValidateContent(tc.line, "table.tsv")
+			if err != nil {
+				t.Fatalf("ValidateContent: %v", err)
+			}
+			found := false
+			for _, m := range matches {
+				if m.Text == tc.want {
+					found = true
+				}
+				if strings.Contains(m.Text, "\t") {
+					t.Errorf("value still carries the label cell: %q", m.Text)
+				}
+			}
+			if !found {
+				var got []string
+				for _, m := range matches {
+					got = append(got, m.Text)
+				}
+				t.Errorf("want %q reported from %q, got %v", tc.want, tc.line, got)
+			}
+		})
+	}
+}
+
+// TestTabGateAppliesOnBothScoringPaths guards against the dual-path trap: this
+// validator scores through findNamesInLine OR findNamesInLineWithContext
+// depending on the caller, and a gate added to only one of them is dead code for
+// every caller that takes the other.
+func TestTabGateAppliesOnBothScoringPaths(t *testing.T) {
+	v := NewValidator()
+	const line = "Preventative\tStrong"
+
+	insights := context.ContextInsights{
+		DocumentType:          "employee_directory",
+		Domain:                "hr",
+		SemanticContext:       map[string]float64{"person": 0.9},
+		ConfidenceAdjustments: map[string]float64{},
+	}
+
+	plain, err := v.ValidateContent(line, "table.tsv")
+	if err != nil {
+		t.Fatalf("ValidateContent: %v", err)
+	}
+	withCtx, err := v.ValidateWithContext(line, "table.tsv", insights)
+	if err != nil {
+		t.Fatalf("ValidateWithContext: %v", err)
+	}
+
+	for _, m := range plain {
+		if strings.Contains(m.Text, "\t") {
+			t.Errorf("ValidateContent reported %q across a column boundary", m.Text)
+		}
+	}
+	for _, m := range withCtx {
+		if strings.Contains(m.Text, "\t") {
+			t.Errorf("ValidateWithContext reported %q across a column boundary — the "+
+				"gate is missing from the context path", m.Text)
+		}
+	}
+}
+
+// TestRequiresBothNamesKnownIsScopedToTheTabPattern keeps the stricter bar from
+// spreading. CalculateConfidenceWithComponents documents why the general rule is
+// surname-only (both-known costs 30 recall points), so exactly one pattern may opt
+// in to both-known.
+func TestRequiresBothNamesKnownIsScopedToTheTabPattern(t *testing.T) {
+	pm := NewPatternManager()
+
+	var strict []string
+	for _, p := range pm.GetPatterns() {
+		if requiresBothNamesKnown(p.Name) {
+			strict = append(strict, p.Name)
+		}
+	}
+
+	if len(strict) != 1 || strict[0] != tabSeparatedNamePattern {
+		t.Errorf("both-known bar must apply to %q alone, got %v", tabSeparatedNamePattern, strict)
+	}
+}

--- a/internal/validators/personname/tab_boundary_test.go
+++ b/internal/validators/personname/tab_boundary_test.go
@@ -183,21 +183,32 @@ func TestTabGateAppliesOnBothScoringPaths(t *testing.T) {
 	}
 }
 
-// TestRequiresBothNamesKnownIsScopedToTheTabPattern keeps the stricter bar from
-// spreading. CalculateConfidenceWithComponents documents why the general rule is
-// surname-only (both-known costs 30 recall points), so exactly one pattern may opt
-// in to both-known.
-func TestRequiresBothNamesKnownIsScopedToTheTabPattern(t *testing.T) {
-	pm := NewPatternManager()
+// TestBothNamesKnownBarIsAnExplicitInventory keeps the stricter bar from spreading.
+// CalculateConfidenceWithComponents documents why the general rule is surname-only
+// (both-known costs 30 recall points), so every pattern that opts in has to be listed
+// here with a reason in requiresBothNamesKnown — adding one silently fails this test.
+func TestBothNamesKnownBarIsAnExplicitInventory(t *testing.T) {
+	want := map[string]bool{
+		tabSeparatedNamePattern: true, // tokens are in different table columns
+		"name_with_particle":    true, // "Applied de Morgan" is prose, not a data subject
+	}
 
-	var strict []string
-	for _, p := range pm.GetPatterns() {
+	got := map[string]bool{}
+	for _, p := range NewPatternManager().GetPatterns() {
 		if requiresBothNamesKnown(p.Name) {
-			strict = append(strict, p.Name)
+			got[p.Name] = true
 		}
 	}
 
-	if len(strict) != 1 || strict[0] != tabSeparatedNamePattern {
-		t.Errorf("both-known bar must apply to %q alone, got %v", tabSeparatedNamePattern, strict)
+	for name := range want {
+		if !got[name] {
+			t.Errorf("%q should require both names known", name)
+		}
+	}
+	for name := range got {
+		if !want[name] {
+			t.Errorf("%q newly requires both names known: add it to this inventory with "+
+				"a reason, or it silently costs recall", name)
+		}
 	}
 }

--- a/internal/validators/personname/technical_terms.go
+++ b/internal/validators/personname/technical_terms.go
@@ -403,6 +403,54 @@ var functionWordsMap = map[string]bool{
 	"attention": true, "subject": true, "bcc": true, "fwd": true,
 }
 
+// fontFamiliesMap holds multi-word font family names, which the patterns match as
+// two-and-three-token Title-Case names and the surname gate then accepts whenever the
+// LAST token happens to be a real surname (#406):
+//
+//	Times New Roman -> 81   Arial Black -> 80   Bitstream Vera -> 80
+//
+// Only three families actually fire, and that is the whole mechanism rather than a
+// coincidence: of 37 standard multi-word families measured, the other 34 are already
+// rejected because their final token ("Gothic", "Sans", "Linotype", "UI", "Pro") is not
+// in the surname list. Roman, Black and Vera are. The rest of the list is here so that
+// a future addition to the surname data cannot silently reopen the hole.
+//
+// Keyed on the WHOLE phrase, which is what makes it a safe suppressor: it can never
+// silence a person named Roman or Black, because the entire matched value has to equal
+// the family name. A token-level list would be the exact mistake this validator's
+// history warns about.
+//
+// Styled variants need no entries of their own. "Times New Roman Bold" is reported as
+// "Times New Roman" — the four-token span is rejected because "Bold" is not a surname —
+// so the value that reaches this map is already the base family.
+//
+// Deliberately NOT fixed in the extractor instead: these arrive from the legacy .doc
+// font table, and legacy-ole-extractor.go recovers body text by scanning for printable
+// runs, which cannot tell a font-table string from a sentence. A denylist there would be
+// the same list in a worse place, where it could delete real body text.
+var fontFamiliesMap = map[string]bool{
+	// the three measured false positives
+	"times new roman": true,
+	"arial black":     true,
+	"bitstream vera":  true,
+	// the rest of the standard multi-word families, silent today on the surname gate
+	"arial narrow": true, "arial unicode ms": true, "century gothic": true,
+	"book antiqua": true, "comic sans": true, "comic sans ms": true,
+	"courier new": true, "franklin gothic": true, "gill sans": true,
+	"lucida grande": true, "lucida console": true, "lucida sans": true,
+	"palatino linotype": true, "segoe ui": true, "segoe print": true,
+	"trebuchet ms": true, "bookman old style": true, "monotype corsiva": true,
+	"helvetica neue": true, "avenir next": true, "myriad pro": true,
+	"minion pro": true, "open sans": true, "source sans pro": true,
+	"noto sans": true, "noto serif": true, "dejavu sans": true,
+	"dejavu serif": true, "liberation sans": true, "liberation serif": true,
+	"pt sans": true, "pt serif": true, "yu gothic": true, "yu mincho": true,
+	"ms gothic": true, "ms mincho": true, "ms sans serif": true, "ms serif": true,
+	"malgun gothic": true, "microsoft sans serif": true, "microsoft yahei": true,
+	"hiragino sans": true, "songti sc": true, "apple chancery": true,
+	"andale mono": true, "brush script mt": true, "goudy old style": true,
+}
+
 // routingWordsMap is the subset of functionWordsMap that introduces a NAME — the
 // salutation and memo-header words. It drives maskNonNameGivenWords, which is a
 // narrower job than the gate above and must use a narrower list.

--- a/internal/validators/personname/technical_terms.go
+++ b/internal/validators/personname/technical_terms.go
@@ -385,9 +385,43 @@ var functionWordsMap = map[string]bool{
 	"should": true, "might": true, "must": true, "shall": true, "can": true,
 	"will": true, "may": true, "cannot": true,
 	"said": true, "says": true, "see": true, "note": true, "please": true,
-	// correspondence formalities that precede a name and are not part of it
+	// correspondence formalities that precede a name and are not part of it.
+	//
+	// "attention", "subject", "bcc" and "fwd" complete the set the abbreviations
+	// already covered: "attn" was here but its expansion was not, so the same memo
+	// header behaved two different wrong ways — "Attn Marcus Holloway" reported
+	// nothing at all, while "Attention Marcus Holloway" reported the routing word
+	// INSIDE the name at 81 (#434).
+	//
+	// Ordinary vocabulary that can also precede a name — "signed", "contact",
+	// "prepared", "reviewed" — is deliberately NOT here. Those are not correspondence
+	// formalities, and admitting them would widen a suppressor on a guess; their
+	// span-absorption is the pre-existing three_part_name shape already pinned by the
+	// fp__business_noun_phrases corpus case, not something this list should reach.
 	"dear": true, "sincerely": true, "regards": true, "thanks": true,
 	"thank": true, "yes": true, "attn": true, "cc": true, "re": true,
+	"attention": true, "subject": true, "bcc": true, "fwd": true,
+}
+
+// routingWordsMap is the subset of functionWordsMap that introduces a NAME — the
+// salutation and memo-header words. It drives maskNonNameGivenWords, which is a
+// narrower job than the gate above and must use a narrower list.
+//
+// Measured why, on 714 real Office/PDF documents: masking every Title-Case function
+// word recovered the salutation names it was written for but also exposed 18 findings
+// that had been hidden behind an ordinary Title-Case function word, almost all of them
+// false — "Firm Fixed Price" (7 hits, behind "For"), "Advice Regarding Grant" at 100,
+// "Fixed Price", "Epic House". Masking is only needed where a word plausibly PRECEDES
+// a person's name, and "For"/"The"/"About" introduce a noun phrase far more often than
+// they introduce a person.
+//
+// Kept as its own map rather than a flag on the entries above so the gate's list can
+// stay deliberately complete (see the note there) while this one stays deliberately
+// small.
+var routingWordsMap = map[string]bool{
+	"attn": true, "attention": true, "cc": true, "bcc": true, "fwd": true,
+	"re": true, "subject": true,
+	"dear": true, "sincerely": true, "regards": true, "thanks": true, "thank": true,
 }
 
 // emailPatternsMap for efficient email context analysis

--- a/internal/validators/personname/validator.go
+++ b/internal/validators/personname/validator.go
@@ -163,7 +163,7 @@ func (v *Validator) findNamesInLine(line string, lineNum int, filePath string) [
 	var matches []detector.Match
 
 	// Use pattern manager to find matches
-	patternMatches := v.patternManager.FindMatches(line)
+	patternMatches := v.findPatternCandidates(line)
 
 	// Per-line context work (lowercasing the line, keyword scans, pattern/regex
 	// scans, context-keyword list) is identical for every match on this line, so
@@ -250,7 +250,7 @@ func (v *Validator) findNamesInLineWithContext(line string, lineNum int, filePat
 	var matches []detector.Match
 
 	// Use pattern manager to find matches
-	patternMatches := v.patternManager.FindMatches(line)
+	patternMatches := v.findPatternCandidates(line)
 
 	// Per-line context work (lowercasing the line, keyword scans, pattern/regex
 	// scans, context-keyword list) is identical for every match on this line, so
@@ -853,6 +853,143 @@ func (v *Validator) isFunctionWordGiven(first string) bool {
 		return false
 	}
 	return true
+}
+
+// maskChar replaces a word that cannot be part of a name during the second candidate
+// pass. It must be a non-letter so wrapNamePattern treats it as a boundary, and it
+// must NOT be a space: nameSpace accepts a run of spaces, so blanking the word would
+// let a name token on each side join across the hole ("Holloway Attn Marcus" would
+// become the candidate "Holloway      Marcus", whose text in the original line is not
+// a name at all). '#' bounds without joining, and is the same byte width as any ASCII
+// letter it replaces, so every match offset still indexes the original line.
+const maskChar = '#'
+
+// maskNonNameGivenWords blanks each Title-Case word that cannot be the GIVEN half of a
+// name, and reports whether it changed anything.
+//
+// This exists because Go's regexp finds leftmost NON-OVERLAPPING matches, so a
+// capitalised non-name word in front of a real name does not merely get included in
+// the span — it CONSUMES the given name, and the real name is never offered as a
+// candidate at all:
+//
+//	"Attn Marcus Holloway"    basic_western_name claims "Attn Marcus", the scan
+//	                          resumes at "Holloway", and one token cannot match.
+//	                          Reported: nothing. The name never reached the report,
+//	                          so it was never redacted either.
+//	"X Marcus Holloway"       reported 92 — "X" is too short to start a name token,
+//	                          which is what pins the cause to the consumed token
+//	                          rather than to scoring.
+//
+// Masking rather than re-scanning at an offset keeps the pass linear: one extra
+// regexp sweep of the same line, not one sweep per rejected candidate. Offsets are
+// preserved byte-for-byte, so a match found in the masked line indexes the original
+// line unchanged — and a match can never contain a masked byte, because the mask is
+// not a letter and not a separator.
+//
+// The word list is routingWordsMap — the salutation and memo-header subset, NOT the
+// whole function-word list; see the measurement recorded there for why masking every
+// Title-Case function word costs more in exposed noun phrases than it recovers in
+// names. A word is only masked when the NEXT token is also Title-Case, because that is
+// the only arrangement in which it could have consumed a name.
+//
+// There is deliberately NO name-database check here, unlike isFunctionWordGiven.
+// Masking cannot lose a name: findPatternCandidates keeps the unmasked pass and ADDS
+// the masked one, so if a routing word ever collides with a real given name the
+// original candidate is still there ("Will Smith" is reported whether or not "will" is
+// masked). A database check would read as a safety net while protecting nothing, and an
+// earlier draft of this function had one — it survived every mutation, which is how it
+// was found to be dead.
+func (v *Validator) maskNonNameGivenWords(line string) (string, bool) {
+	type token struct {
+		start, end int
+		upper      bool
+	}
+
+	var tokens []token
+	inWord := false
+	start := 0
+	for i, r := range line {
+		if isNameLetter(r) {
+			if !inWord {
+				inWord, start = true, i
+			}
+			continue
+		}
+		if inWord {
+			tokens = append(tokens, token{start, i, unicode.IsUpper([]rune(line[start:i])[0])})
+			inWord = false
+		}
+	}
+	if inWord {
+		tokens = append(tokens, token{start, len(line), unicode.IsUpper([]rune(line[start:])[0])})
+	}
+
+	masked := []byte(line)
+	changed := false
+	for i, tk := range tokens {
+		if !tk.upper {
+			continue
+		}
+		// Only a word followed by another Title-Case token can have consumed a name.
+		if i+1 >= len(tokens) || !tokens[i+1].upper {
+			continue
+		}
+		if !routingWordsMap[strings.ToLower(line[tk.start:tk.end])] {
+			continue
+		}
+		for b := tk.start; b < tk.end; b++ {
+			masked[b] = maskChar
+		}
+		changed = true
+	}
+	if !changed {
+		return line, false
+	}
+	return string(masked), true
+}
+
+// isNameLetter reports whether r is one of the letters the name patterns accept, so
+// tokenisation here and matching there agree on where a word begins and ends.
+func isNameLetter(r rune) bool {
+	switch {
+	case r >= 'A' && r <= 'Z', r >= 'a' && r <= 'z':
+		return true
+	case r >= 0x00C0 && r <= 0x00D6, r >= 0x00D8 && r <= 0x00DE: // Latin-1 uppercase
+		return true
+	case r >= 0x00DF && r <= 0x00F6, r >= 0x00F8 && r <= 0x00FF: // Latin-1 lowercase
+		return true
+	}
+	return false
+}
+
+// findPatternCandidates returns the candidates for one line, including those hidden
+// behind a Title-Case non-name word (see maskNonNameGivenWords). Shared by both
+// findNames* paths so the two cannot drift.
+func (v *Validator) findPatternCandidates(line string) []PatternMatch {
+	candidates := v.patternManager.FindMatches(line)
+
+	masked, changed := v.maskNonNameGivenWords(line)
+	if !changed {
+		return candidates
+	}
+
+	seen := make(map[[2]int]struct{}, len(candidates))
+	for _, c := range candidates {
+		seen[[2]int{c.StartIndex, c.EndIndex}] = struct{}{}
+	}
+	for _, c := range v.patternManager.FindMatches(masked) {
+		key := [2]int{c.StartIndex, c.EndIndex}
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		// Read the text from the ORIGINAL line. The span cannot include a masked byte,
+		// so this is the same string the masked pass matched — but taking it from the
+		// original is what makes that an invariant rather than an assumption.
+		c.Text = line[c.StartIndex:c.EndIndex]
+		candidates = append(candidates, c)
+	}
+	return candidates
 }
 
 // isKnownShortName checks if a short name (< 4 chars) is in the known name databases

--- a/internal/validators/personname/validator.go
+++ b/internal/validators/personname/validator.go
@@ -1117,6 +1117,13 @@ func (v *Validator) isTechnicalTerm(match string) bool {
 		return true
 	}
 
+	// A font family name is document formatting, not a data subject (#406). Same
+	// exact-phrase lookup, kept as its own map so the vocabulary and its reasoning stay
+	// together — see fontFamiliesMap.
+	if fontFamiliesMap[lowerMatch] {
+		return true
+	}
+
 	// Check for business suffixes (company names) using package-level variable
 	for _, suffix := range businessSuffixes {
 		if strings.HasSuffix(lowerMatch, " "+suffix) || strings.HasSuffix(lowerMatch, suffix) {

--- a/internal/validators/personname/validator.go
+++ b/internal/validators/personname/validator.go
@@ -592,7 +592,7 @@ func (v *Validator) CalculateConfidenceWithComponents(match string, components N
 // getPatternConfidenceBoost returns confidence boost based on pattern type
 func (v *Validator) getPatternConfidenceBoost(patternName string) float64 {
 	switch patternName {
-	case "name_with_title", "name_with_multiple_titles":
+	case "name_with_title", "name_with_title_and_particle", "name_with_multiple_titles":
 		return 10.0 // Titles indicate formal names
 	case "name_with_suffix":
 		return 8.0 // Suffixes are strong indicators
@@ -895,7 +895,7 @@ const unverifiedSurnameCeiling = 65.0
 // evidence of personhood on its own. A title or suffix does.
 func (v *Validator) hasExplicitNameMarker(patternName string) bool {
 	switch patternName {
-	case "name_with_title", "name_with_multiple_titles",
+	case "name_with_title", "name_with_title_and_particle", "name_with_multiple_titles",
 		"name_with_suffix", "name_with_professional_suffix":
 		return true
 	}
@@ -905,6 +905,7 @@ func (v *Validator) hasExplicitNameMarker(patternName string) bool {
 func (v *Validator) isFormalNamePattern(patternName string) bool {
 	formalPatterns := []string{
 		"name_with_title",
+		"name_with_title_and_particle",
 		"name_with_multiple_titles",
 		"name_with_suffix",
 		"name_with_professional_suffix",

--- a/internal/validators/personname/validator.go
+++ b/internal/validators/personname/validator.go
@@ -178,6 +178,16 @@ func (v *Validator) findNamesInLine(line string, lineNum int, filePath string) [
 
 		confidence, validationChecks := v.CalculateConfidenceWithComponents(nameText, nameComponents)
 
+		// A tab-separated candidate carries a column boundary between its tokens, so
+		// it must clear the stricter both-known bar. Applied here rather than inside
+		// CalculateConfidenceWithComponents so it cannot be undone by a later
+		// context boost, and applied in BOTH findNames* paths — a check added to only
+		// one of them would be dead on whichever path the caller actually uses.
+		if requiresBothNamesKnown(patternMatch.Pattern.Name) &&
+			!(validationChecks["known_first_name"] && validationChecks["known_last_name"]) {
+			continue
+		}
+
 		// Apply basic context analysis (cached per-line; identical to AnalyzeContext
 		// for ContextInfo{FullLine: line}). The match's known byte offset is passed
 		// so the proximity check is a bounded window lookup rather than a full-line
@@ -254,6 +264,16 @@ func (v *Validator) findNamesInLineWithContext(line string, lineNum int, filePat
 		nameComponents := ParseNameComponents(nameText, patternMatch.Pattern)
 
 		confidence, validationChecks := v.CalculateConfidenceWithComponents(nameText, nameComponents)
+
+		// A tab-separated candidate carries a column boundary between its tokens, so
+		// it must clear the stricter both-known bar. Applied here rather than inside
+		// CalculateConfidenceWithComponents so it cannot be undone by a later
+		// context boost, and applied in BOTH findNames* paths — a check added to only
+		// one of them would be dead on whichever path the caller actually uses.
+		if requiresBothNamesKnown(patternMatch.Pattern.Name) &&
+			!(validationChecks["known_first_name"] && validationChecks["known_last_name"]) {
+			continue
+		}
 
 		// Apply basic context analysis (cached per-line; identical to AnalyzeContext
 		// for ContextInfo{FullLine: line}). Pass the match offset so proximity is a


### PR DESCRIPTION
Four `PERSON_NAME` defects that are all one question — **which bytes are the name?** Each is
measured against real documents, and each has its own commit.

Fixes #462. Fixes #422. Fixes #434. Fixes #406.

## What was wrong

| # | Input | Before | After |
|---|---|---|---|
| #462 | `Preventative<TAB>Strong` | `PERSON_NAME` **100** | not reported |
| #462 | `Nomination<TAB>Christian Kelley` | the whole glued string | `Christian Kelley` |
| #422 | `Dr. Ludwig van Beethoven` | nothing reported | reported |
| #422 | `Dr. Piet Van Der Berg` | `Dr. Piet Van` at **100** | full span |
| #434 | `Attn Marcus Whitfield` | nothing reported | `Marcus Whitfield` |
| #434 | `Attention Marcus Whitfield` | routing word inside the value | `Marcus Whitfield` |
| #406 | `Times New Roman` | `PERSON_NAME` 81 | not reported |

Two of these are cleartext leaks rather than cosmetic scoring issues, and the corpus proves it
rather than my asserting it: reverting the production change turns **9 labelled values into
`whole_leak`** in the redacted artifact, for both the simple and format-preserving strategies. A
truncated span is the worse kind — `Dr. Piet Van` at HIGH 100 is what the redactor replaces, so
`Der Berg` stayed in cleartext.

## The shape of each fix

**#462 — a tab is a column boundary, not a word space.** Every pattern joined tokens with `\s+`,
and Go's `\s` includes `\t`. The fix is *not* "a tab never joins a name": a real
`First Name | Last Name` roster row exists and was only reportable *because* `\s` accepted the tab.
A tab says the tokens are in **different cells**, which is weaker evidence than a space — so the
shared separator excludes it and one new low-priority pattern may span it on a stricter
both-names-known bar.

**#422 — nobiliary particles, both spellings.** A lowercase particle terminated the match, so the
title marker that admits an off-list surname never got a chance to apply; a capitalized one caused
the mirror-image bug, because `name_with_title` accepts exactly two tokens after the title. The
extra token is restricted to a **particle** rather than any fourth word, so
`Dr. John Smith Reviewed` still reports `Dr. John Smith`.

**#434 — reach the name the routing word consumed.** Go's regexp finds leftmost
*non-overlapping* matches, so `basic_western_name` claimed `Attn Marcus`, the scan resumed at
`Holloway`, and one token cannot match. The cause is the consumed token and not scoring:
`X Marcus Holloway` already reported 92, because a one-letter token cannot start a name token. Fix:
mask the routing word and sweep once more — linear, and offsets are preserved byte-for-byte. The
mask character is `#`, not a space, because `nameSpace` accepts a *run* of spaces and blanking the
word would let the two sides join into `Holloway Marcus`, a value never present in the document.

**#406 — a font family is formatting, not a data subject.** Suppressed as an exact **whole phrase**
via the existing `isTechnicalTerm` lookup, which is what makes it safe: it can never silence a
person named Roman, Black or Vera. A token-level list would be exactly the mistake this validator's
history warns about — and a mutation to token-level matching fails four tests plus a pre-existing
one.

## Where the corpus told me I was wrong

`fp__eponym_technical_terms` was already pinned negative with the note that *"a naive fix for the
missing-particle recall gap would light all four up"*. It did: `Discussed von Neumann` and
`Applied de Morgan` both appeared, because the token after the particle is a genuine surname.
`fp__latin_and_prose_particles` names the discriminator — a capitalized **given** name must precede
the particle — so the untitled particle pattern joins the tab arm in `requiresBothNamesKnown`. The
titled variant stays out: nothing writes "Dr. Applied de Morgan".

Two narrowings came from measurement, not taste:

- Masking **every** Title-Case function word recovered the salutation names *and* exposed 18
  findings on 714 real documents that had been hidden behind an ordinary one, almost all false —
  `Firm Fixed Price` (7 hits, behind "For"), `Advice Regarding Grant` at 100. So the mask list is
  salutations and memo headers only, pinned by a new negative case.
- An earlier draft consulted the name databases before masking. It **survived every mutation**,
  which is how it was found to be dead: the masked pass *adds* to the unmasked candidates, so
  masking a real name cannot lose it. Removed, and the property it appeared to protect is now a
  test that fails when the masked pass replaces instead of adds.

## Corpus movement

`internal/scorecorpus`, 154 cases / 202 labels:

```
PERSON_NAME   TP 17 -> 26    FP(H+M) 0 -> 0    prec_hm 1.0000    whole_leak 0
```

- `person_lowercase_particles_UNSUPPORTED` → **promoted** to `person_lowercase_particles_recovered`
  (4 asserted labels). The quarantine case is narrowed to `person_hyphenated_particle_UNSUPPORTED`,
  the shape that genuinely remains — isolated by holding the surname constant at one the database
  carries: `Ana de la Cruz` → 77, `Ana de-la-Cruz` → NONE, `Ana Cruz` → 92.
- New: `person_routing_word_before_name` (5 labels) and `fp__masking_is_limited_to_routing_words`.

**714 real Office/PDF documents**, `--checks PERSON_NAME --confidence all`:

```
findings          1931 -> 1857
tab-spanning        95 -> 1      (survivor "Hilton<TAB>Hilton": both cells are in both name lists)
HIGH (>=90)        878 -> 852    -32 tab FPs, +6 real names promoted to a correct HIGH span
gained              24 hits      0 with a tab, incl. 4 real names now reported with the right span
non-tab losses       1 distinct  "Nationale Du", superseded by the wider "Banque Nationale Du"
```

The particle and routing-word fixes are **zero-delta** on this corpus, and that is stated rather
than glossed: these documents contain no unpunctuated salutation line, and the two particle-shaped
names they do hold have a first token absent from the given-name list, so the both-known bar gates
them out. Neither was reported before this change either — recovering them needs first-name data
plus a pattern for a particle after a two-token name, both out of scope. Their recall win is
carried by the 9 asserted labels and the probes; the real corpus shows the change costs nothing.

## Test plan

`make pr-checklist BASE=origin/main` — **10 ran, 0 failed**, all 5 manual dimensions worked:

```
1 gofmt / go vet / go build      RAN — clean
2 full suite (-count=1)          RAN — 69 packages ok
3 golden regen                   RAN — 0 files changed
11 cross-platform vet            RAN — linux darwin windows
12 flake (3 repeats)             RAN — scorecorpus, personname
13 race (whole module)           RAN — 69 packages ok
-- -short mode / tree clean      RAN — ok
```

- **4 redaction** — all three strategies on a fixture holding every new behaviour: no cleartext
  leak. The particle names redact in full (no `Salvo` residue), the two-column row redacts, while
  `Preventative<TAB>Strong` and `Times New Roman` are correctly left alone.
- **5 suppression** — generated with the **parent** binary, applied with this one. On findings this
  PR leaves alone, 3/3 still suppress: no hash-input drift. On the changed fixture only the one
  finding whose value *and* confidence are unchanged carries over; the other four stop matching
  because their reported value was corrected or the finding is gone. The failure direction is safe
  — a stale rule shows a finding, it never silences a new one. **Upgrade note:** existing
  suppressions for these shapes will need re-approving against the corrected values.
- **6 timing** — N/2N/4N, best of 3, over a six-shape fixture: `380/740/1460ms` against
  `330/640/1240ms`, ratios **1.95/1.97 vs 1.94/1.94**. Linear in both; a constant ~15% for three
  new patterns, a per-line tokenizer and a conditional second sweep. Findings floor 2483–10008, so
  the measurement is not empty.
- **7 formats** — text, json, yaml, csv, junit, gitlab-sast, sarif: all valid, rc=0, 6 findings
  each (junit aggregates into one testcase with `6 security findings detected`, identical on the
  parent).
- **10 non-vacuity** — the corpus gate fails on parent production code (`TP 26 -> 17`,
  `whole_leak 0 -> 9`). Reverting production wholesale cannot compile against the new tests, so
  each element was mutated individually instead: restoring `\s+`, dropping the both-known bar,
  removing the tab arm, dropping lowercase particles, unregistering the titled pattern from the
  marker / parser, allowing any fourth token, disabling the masked pass, masking with a space,
  removing `attention`, widening the mask to all function words, and making the map token-level —
  **each caught by the test that should catch it**.

One addition after the initial review request: `internal/core/help_coverage_test.go`, a gate
asserting every validator in `validatorConstructors` exposes help, and that no developer note
reaches user-visible help text. The second half fails against `main` — PERSON_NAME's help printed
`// TODO: Document rationale for surname database reduction ...` to users — so it pins the docs
fix in this PR rather than merely describing it. All 19 validators pass the coverage half today.

Disjoint at file level from all 8 open PRs. Two limitations are pinned as tests rather than left
implicit: `Holloway Attn Marcus Whitfield` is still claimed whole by `four_part_name` (measured
identical at 82 before and after — `deduplicateMatches` compares lengths, not confidence), and
`Hilton<TAB>Hilton` survives the both-known bar because both cells hold a word in both name lists.
