### PR TITLE
fix(socialmedia): score against the platform that matched, and let an allowlist actually exclude (#390, #429)

### DIFF
--- a/docs/social-media-configuration.md
+++ b/docs/social-media-configuration.md
@@ -176,13 +176,36 @@ validators:
         - "developer"
         - "open source"
 
-    # False positive prevention
-    whitelist_patterns:
+    # False positive prevention. A match overlapping any of these is NOT reported.
+    allowlist_patterns:
       - "(?i)example\\.com"
       - "(?i)test\\.com"
       - "(?i)placeholder"
       - "(?i)demo"
 ```
+
+### allowlist_patterns
+
+A value overlapping an `allowlist_patterns` entry is **excluded from the report**, not
+scored down. It is an instruction rather than a heuristic, so it is applied as a veto
+before scoring.
+
+Matching is on byte SPANS, not on the reported value, and that difference matters in both
+directions:
+
+- An entry like `twitter\.com/companybrand` matches a *substring* of the reported value
+  `https://twitter.com/companybrand`, so the allowlisted span sits inside the finding.
+- An overlapping pattern from another platform can report a *fragment* of the same URL under
+  a different name — twitter's bare-handle pattern reports `@brandchannel` out of a YouTube
+  channel URL — so the finding sits inside the allowlisted span.
+
+Overlap covers both, and covers nothing else: a second profile elsewhere on the same line
+does not overlap the allowlisted span and is still reported.
+
+`whitelist_patterns` is accepted as a deprecated alias so existing configuration keeps
+working. If both keys are present, `allowlist_patterns` wins and the older key is ignored
+rather than merged — silently combining two lists would make the effective configuration
+depend on which key a reader noticed.
 
 ## Important Notes
 
@@ -247,7 +270,7 @@ redacted.
 ### Security Considerations
 - Social media detection is disabled by default
 - Only configure platforms you need to detect
-- Use whitelist patterns to reduce false positives
+- Use allowlist patterns to exclude known false positives
 - Consider privacy implications when scanning personal documents
 
 ## Usage Examples
@@ -282,7 +305,7 @@ ferret-scan --file document.pdf --checks SOCIAL_MEDIA --debug
 
 ### False positives
 1. Add negative keywords
-2. Use whitelist patterns
+2. Use allowlist patterns
 3. Refine regex patterns — give the pattern the platform's path prefix if it has one
 4. Check for email/social media conflicts
 
@@ -290,8 +313,12 @@ ferret-scan --file document.pdf --checks SOCIAL_MEDIA --debug
 
 The first path segment is not in the reserved tables for that platform. See
 [Platform system pages are not profiles](#platform-system-pages-are-not-profiles); the tables in
-`internal/validators/socialmedia/reserved_paths.go` are not exhaustive. A `whitelist_patterns`
-entry reduces the confidence of such a match but does not remove it.
+`internal/validators/socialmedia/reserved_paths.go` are not exhaustive. An
+[`allowlist_patterns`](#allowlist_patterns) entry removes such a match from the report.
+
+Before the fix for #429 it only reduced the confidence, and the reduction was invisible: the
+30-point penalty is applied to a raw total that exceeds 130 before the cap at 100, so an
+allowlisted URL and an ordinary one were both reported at HIGH 100.
 
 ### Email addresses detected as social media
 1. Remove email patterns from social media config

--- a/internal/validators/socialmedia/allowlist_test.go
+++ b/internal/validators/socialmedia/allowlist_test.go
@@ -1,0 +1,208 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package socialmedia
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/config"
+)
+
+// An allowlist entry is an operator INSTRUCTION, not a heuristic, so it has to be a veto.
+//
+// validateNotFalsePositive says "if match is allowlisted, exclude it", but its return value is
+// only advisory: the caller turns it into a 30-point penalty. Confidence is capped at 100 while
+// the raw total for a well-formed profile URL exceeds 130, so the penalty is absorbed entirely.
+// Measured on a two-line fixture where one URL was allowlisted and the other was not, both were
+// reported at HIGH 100 — indistinguishable, so the configuration had no visible effect at all.
+//
+// This is the same failure the reserved-path veto in reserved_paths.go was added for, and the
+// same reasoning: a penalty that the cap eats is not a control.
+
+const (
+	allowlistedURL = "https://twitter.com/companybrand"
+	realProfileURL = "https://twitter.com/realperson_x"
+)
+
+// configuredWithAllowlist builds a validator with two twitter patterns and one allowlist entry
+// covering only allowlistedURL.
+func configuredWithAllowlist(t *testing.T, key string) *Validator {
+	t.Helper()
+	v := NewValidator()
+	v.Configure(&config.Config{Validators: map[string]map[string]any{
+		"social_media": {
+			"platform_patterns": map[string]any{
+				"twitter": []any{`(?i)https?://(?:www\.)?twitter\.com/[a-zA-Z0-9_]{1,15}`},
+			},
+			key: []any{`twitter\.com/companybrand`},
+		},
+	}})
+	if len(v.allowlistPatterns) == 0 {
+		t.Fatalf("config key %q did not load any allowlist pattern, so the test would pass "+
+			"for the wrong reason", key)
+	}
+	return v
+}
+
+func reportedTexts(t *testing.T, v *Validator, content string) []string {
+	t.Helper()
+	matches, err := v.ValidateContent(content, "profiles.txt")
+	if err != nil {
+		t.Fatalf("ValidateContent: %v", err)
+	}
+	out := make([]string, 0, len(matches))
+	for _, m := range matches {
+		out = append(out, m.Text)
+	}
+	return out
+}
+
+// TestAllowlistedMatchIsNotReported is the whole point: absent, not merely scored lower.
+func TestAllowlistedMatchIsNotReported(t *testing.T) {
+	v := configuredWithAllowlist(t, "allowlist_patterns")
+	content := "Profile: " + allowlistedURL + "\nProfile: " + realProfileURL + "\n"
+
+	got := reportedTexts(t, v, content)
+	for _, text := range got {
+		if strings.Contains(text, "companybrand") {
+			t.Errorf("allowlisted value still reported as %q", text)
+		}
+	}
+	found := false
+	for _, text := range got {
+		if strings.Contains(text, "realperson_x") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("the NON-allowlisted profile disappeared too: %v — an allowlist must not "+
+			"silence anything it does not name", got)
+	}
+}
+
+// TestAllowlistIsAVetoNotAPenalty states the defect directly. Before the fix both URLs came out
+// at HIGH 100, so a confidence comparison could not tell them apart; the assertion has to be
+// about presence.
+func TestAllowlistIsAVetoNotAPenalty(t *testing.T) {
+	v := configuredWithAllowlist(t, "allowlist_patterns")
+
+	allowlisted, err := v.ValidateContent("Profile: "+allowlistedURL, "profiles.txt")
+	if err != nil {
+		t.Fatalf("ValidateContent: %v", err)
+	}
+	real, err := v.ValidateContent("Profile: "+realProfileURL, "profiles.txt")
+	if err != nil {
+		t.Fatalf("ValidateContent: %v", err)
+	}
+
+	if len(real) == 0 {
+		t.Fatalf("the comparison profile produced no finding, so this test cannot detect a " +
+			"veto that never fired")
+	}
+	if len(allowlisted) != 0 {
+		t.Errorf("allowlisted URL produced %d finding(s) at %.0f confidence; the "+
+			"non-allowlisted one scores %.0f, so a penalty cannot separate them",
+			len(allowlisted), allowlisted[0].Confidence, real[0].Confidence)
+	}
+}
+
+// TestAllowlistAcceptsBothConfigKeys covers the inclusive rename. "allowlist_patterns" is the
+// documented spelling; "whitelist_patterns" has to keep working or existing configs break
+// silently, which for a suppression control means findings reappearing.
+func TestAllowlistAcceptsBothConfigKeys(t *testing.T) {
+	for _, key := range []string{"allowlist_patterns", "whitelist_patterns"} {
+		t.Run(key, func(t *testing.T) {
+			v := configuredWithAllowlist(t, key)
+			got := reportedTexts(t, v, "Profile: "+allowlistedURL)
+			if len(got) != 0 {
+				t.Errorf("key %q did not take effect: reported %v", key, got)
+			}
+		})
+	}
+}
+
+// TestInclusiveKeyWinsWhenBothArePresent pins the precedence. Merging the two lists would make
+// the effective configuration depend on which key a reader happened to notice.
+func TestInclusiveKeyWinsWhenBothArePresent(t *testing.T) {
+	v := NewValidator()
+	v.Configure(&config.Config{Validators: map[string]map[string]any{
+		"social_media": {
+			"platform_patterns": map[string]any{
+				"twitter": []any{`(?i)https?://(?:www\.)?twitter\.com/[a-zA-Z0-9_]{1,15}`},
+			},
+			"allowlist_patterns": []any{`twitter\.com/companybrand`},
+			"whitelist_patterns": []any{`twitter\.com/realperson_x`},
+		},
+	}})
+
+	// The inclusive key names companybrand, so that one is vetoed and realperson_x is not.
+	got := reportedTexts(t, v, "A: "+allowlistedURL+"\nB: "+realProfileURL+"\n")
+	joined := strings.Join(got, " ")
+	if strings.Contains(joined, "companybrand") {
+		t.Errorf("allowlist_patterns was ignored: %v", got)
+	}
+	if !strings.Contains(joined, "realperson_x") {
+		t.Errorf("whitelist_patterns was applied as well: the two lists must not be merged, "+
+			"got %v", got)
+	}
+}
+
+// overlappingAllowlistValidator configures two platforms whose patterns both claim part of a
+// YouTube @-handle URL: youtube's URL pattern spans the whole thing, twitter's bare-handle
+// pattern spans "@brandchannel" inside it.
+func overlappingAllowlistValidator(t *testing.T) *Validator {
+	t.Helper()
+	v := NewValidator()
+	v.Configure(&config.Config{Validators: map[string]map[string]any{
+		"social_media": {
+			"platform_patterns": map[string]any{
+				"twitter": []any{
+					`(?i)@[a-zA-Z0-9_]{1,15}\b`,
+					`(?i)https?://(?:www\.)?twitter\.com/[a-zA-Z0-9_]+`,
+				},
+				"youtube": []any{`(?i)https?://(?:www\.)?youtube\.com/@[a-zA-Z0-9_-]+`},
+			},
+			"allowlist_patterns": []any{`youtube\.com/@brandchannel`},
+		},
+	}})
+	return v
+}
+
+// TestAllowlistVetoesAFragmentOfTheAllowlistedValue is why the veto works on SPANS.
+//
+// A second platform's pattern can claim a fragment of the allowlisted value under a different
+// name: twitter's bare-handle pattern reports "@brandchannel" out of an allowlisted YouTube
+// channel URL. Comparing the allowlist against each match's TEXT leaves that fragment reported
+// — measured at HIGH 100 — so the operator allowlists a channel and still gets a finding for it.
+func TestAllowlistVetoesAFragmentOfTheAllowlistedValue(t *testing.T) {
+	v := overlappingAllowlistValidator(t)
+
+	got := reportedTexts(t, v, "Follow: https://www.youtube.com/@brandchannel")
+	for _, text := range got {
+		if strings.Contains(text, "brandchannel") {
+			t.Errorf("reported %q despite the allowlist: a fragment of the allowlisted value "+
+				"is still the allowlisted value", text)
+		}
+	}
+}
+
+// TestAllowlistDoesNotSuppressAnotherProfileOnTheSameLine is the collateral gate, and the
+// reason the veto is span-based rather than line-based. A line-level "does the allowlist match
+// anywhere on this line" test would silence the real profile next to the allowlisted one.
+func TestAllowlistDoesNotSuppressAnotherProfileOnTheSameLine(t *testing.T) {
+	v := overlappingAllowlistValidator(t)
+
+	got := reportedTexts(t, v,
+		"Brand: https://www.youtube.com/@brandchannel and person: "+realProfileURL)
+
+	joined := strings.Join(got, " ")
+	if strings.Contains(joined, "brandchannel") {
+		t.Errorf("allowlisted value still reported: %v", got)
+	}
+	if !strings.Contains(joined, "realperson_x") {
+		t.Errorf("the real profile on the same line was suppressed too: %v — an allowlist "+
+			"must veto the spans it names and nothing else", got)
+	}
+}

--- a/internal/validators/socialmedia/help.go
+++ b/internal/validators/socialmedia/help.go
@@ -201,8 +201,9 @@ The validator includes sensible defaults but can be tailored to organizational n
 		"        - \"creator\"\n" +
 		"        - \"content\"\n" +
 		"    \n" +
-		"    # Whitelist patterns to exclude known false positives (optional)\n" +
-		"    whitelist_patterns:\n" +
+		"    # Allowlist patterns. A match overlapping one of these is EXCLUDED from the\n" +
+		"    # report, not scored down. \"whitelist_patterns\" is a deprecated alias.\n" +
+		"    allowlist_patterns:\n" +
 		"      - \"(?i)example\\.com\"  # Exclude example domains\n" +
 		"      - \"(?i)test.*social\"  # Exclude test social media references\n" +
 		"```\n\n" +

--- a/internal/validators/socialmedia/platform_identity_test.go
+++ b/internal/validators/socialmedia/platform_identity_test.go
@@ -1,0 +1,231 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package socialmedia
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// The platform is an INPUT to a social media score, not a label on the result: roughly ten
+// validations in calculateConfidenceForPlatform take it as an argument (validateURLFormat,
+// validateDomain, validateUsernameFormat, validatePatternSpecificity ...).
+//
+// identifyPlatform used to answer by ranging v.compiledPatterns and returning the first
+// platform whose pattern matched ANYWHERE. Both halves were wrong for an overlapping value:
+// Go randomizes map iteration, and a 7-character substring hit counted the same as a
+// 36-character whole-string hit. Measured through the CLI on
+// "https://www.youtube.com/@tkaminski_1", 30 identical runs of one binary: the underlying
+// match scored 100 in 18 runs and 17 in 12, and the split was visible in the report as the
+// original_confidences metadata.
+
+const overlappingHandleURL = "https://www.youtube.com/@tkaminski_1"
+
+// TestIdentifyPlatformIsDeterministic ranges the map many times in ONE process, which is
+// where Go's per-range randomization shows up. A cross-process comparison would be a weaker
+// test: it can also pass by luck.
+func TestIdentifyPlatformIsDeterministic(t *testing.T) {
+	v := newConfiguredValidator()
+
+	for _, match := range []string{
+		overlappingHandleURL,
+		"https://twitter.com/tkaminski_1",
+		"@tkaminski_1",
+		"https://www.linkedin.com/in/some-person",
+	} {
+		t.Run(match, func(t *testing.T) {
+			first := v.identifyPlatform(match)
+			if first == "" {
+				t.Fatalf("no platform identified for %q, so determinism is untested", match)
+			}
+			for i := 0; i < 500; i++ {
+				if got := v.identifyPlatform(match); got != first {
+					t.Fatalf("iteration %d returned %q, first call returned %q", i, got, first)
+				}
+			}
+		})
+	}
+}
+
+// TestIdentifyPlatformBreaksATieDeterministically is what makes the SORTED iteration
+// load-bearing rather than decorative.
+//
+// Longest-match-wins is already order-independent whenever one platform's pattern matches more
+// of the value than another's, which is the normal case — so a test using only realistic
+// patterns passes with map iteration restored. A genuine tie is the one case where the
+// iteration order decides, and two platforms claiming the identical span is exactly that.
+// Sorted order sends the tie to the lexicographically first platform, every time.
+func TestIdentifyPlatformBreaksATieDeterministically(t *testing.T) {
+	v := NewValidator()
+	const tied = `(?i)dualclaim\.example/[a-z0-9_]+`
+	v.platformPatterns = map[string][]string{
+		"zebra":    {tied},
+		"linkedin": {tied},
+		"alpha":    {tied},
+	}
+	v.patternsConfigured = true
+	v.compilePlatformPatterns()
+
+	const match = "dualclaim.example/person1"
+	if got := v.identifyPlatform(match); got != "alpha" {
+		t.Errorf("identifyPlatform(%q) = %q, want the lexicographically first tied platform "+
+			"%q", match, got, "alpha")
+	}
+	for i := 0; i < 500; i++ {
+		if got := v.identifyPlatform(match); got != "alpha" {
+			t.Fatalf("iteration %d returned %q: a tie is still resolved by map order", i, got)
+		}
+	}
+}
+
+// TestIdentifyPlatformPrefersTheLongerMatch is the correctness half. Determinism alone could
+// be satisfied by always answering "twitter" for a YouTube URL, which would be stably wrong.
+func TestIdentifyPlatformPrefersTheLongerMatch(t *testing.T) {
+	v := newConfiguredValidator()
+
+	// Both platforms match this value: youtube's URL pattern spans the whole string,
+	// twitter's bare "@handle" pattern spans 12 characters of it.
+	ytMatched, twMatched := false, false
+	for _, re := range v.compiledPatterns["youtube"] {
+		if re.MatchString(overlappingHandleURL) {
+			ytMatched = true
+		}
+	}
+	for _, re := range v.compiledPatterns["twitter"] {
+		if re.MatchString(overlappingHandleURL) {
+			twMatched = true
+		}
+	}
+	if !ytMatched || !twMatched {
+		t.Fatalf("fixture no longer overlaps (youtube=%v twitter=%v); pick a value both "+
+			"platforms match or this test proves nothing", ytMatched, twMatched)
+	}
+
+	if got := v.identifyPlatform(overlappingHandleURL); got != "youtube" {
+		t.Errorf("identifyPlatform(%q) = %q, want youtube: the platform whose pattern "+
+			"explains the whole value should win over one matching a substring",
+			overlappingHandleURL, got)
+	}
+}
+
+// TestScoreIsStableForAnOverlappingMatch drives the scoring entry point rather than the
+// helper, so it covers the path the scanner actually takes.
+func TestScoreIsStableForAnOverlappingMatch(t *testing.T) {
+	v := newConfiguredValidator()
+
+	first, _ := v.CalculateConfidence(overlappingHandleURL)
+	for i := 0; i < 500; i++ {
+		if got, _ := v.CalculateConfidence(overlappingHandleURL); got != first {
+			t.Fatalf("iteration %d scored %.0f, first call scored %.0f — the platform used "+
+				"for scoring is still being re-derived from a map range", i, got, first)
+		}
+	}
+	if first <= 0 {
+		t.Fatalf("scored %.0f, so stability is being measured on a rejected match", first)
+	}
+}
+
+// TestValidateContentIsStableAcrossRuns is the end-to-end form: the reported findings for one
+// input must be identical every time, values and confidences included.
+func TestValidateContentIsStableAcrossRuns(t *testing.T) {
+	v := newConfiguredValidator()
+	content := strings.Join([]string{
+		"Follow me: " + overlappingHandleURL,
+		"Connect with me: https://www.linkedin.com/in/some-person",
+		"Profile: https://www.instagram.com/user_42",
+	}, "\n")
+
+	fingerprint := func() string {
+		matches, err := v.ValidateContent(content, "profiles.txt")
+		if err != nil {
+			t.Fatalf("ValidateContent: %v", err)
+		}
+		rows := make([]string, 0, len(matches))
+		for _, m := range matches {
+			rows = append(rows, m.Text+"|"+m.Type)
+		}
+		sort.Strings(rows)
+		return strings.Join(rows, ",")
+	}
+
+	want := fingerprint()
+	if want == "" {
+		t.Fatalf("no findings, so stability is untested")
+	}
+	for i := 0; i < 100; i++ {
+		if got := fingerprint(); got != want {
+			t.Fatalf("run %d produced %q, first run produced %q", i, got, want)
+		}
+	}
+}
+
+// TestSortedPlatformsMatchesCompiledPatterns keeps the cached iteration order honest. It is
+// rebuilt wherever compiledPatterns is finalised, and a future assignment that forgets to
+// rebuild would leave identifyPlatform silently skipping a platform.
+func TestSortedPlatformsMatchesCompiledPatterns(t *testing.T) {
+	v := newConfiguredValidator()
+
+	want := make([]string, 0, len(v.compiledPatterns))
+	for platform := range v.compiledPatterns {
+		want = append(want, platform)
+	}
+	sort.Strings(want)
+
+	got := v.sortedCompiledPlatforms()
+	if len(got) != len(want) {
+		t.Fatalf("sortedCompiledPlatforms has %d entries, compiledPatterns has %d: %v vs %v",
+			len(got), len(want), got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("position %d: got %q, want %q (full: %v)", i, got[i], want[i], got)
+		}
+	}
+	if !sort.StringsAreSorted(got) {
+		t.Errorf("not sorted: %v", got)
+	}
+}
+
+// TestSortedPlatformsIsRebuiltOnReconfiguration covers the reset path: loading a second
+// configuration must not leave the previous platform list behind.
+func TestSortedPlatformsIsRebuiltOnReconfiguration(t *testing.T) {
+	v := newConfiguredValidator()
+	before := append([]string(nil), v.sortedCompiledPlatforms()...)
+	if len(before) < 2 {
+		t.Fatalf("fixture has %d platforms; need at least 2 to see a change", len(before))
+	}
+
+	v.platformPatterns = map[string][]string{
+		"twitter": {`(?i)https?://(?:www\.)?twitter\.com/[a-zA-Z0-9_]{1,15}`},
+	}
+	v.compilePlatformPatterns()
+
+	after := v.sortedCompiledPlatforms()
+	if len(after) != 1 || after[0] != "twitter" {
+		t.Errorf("after reconfiguration got %v, want [twitter]: the cached order is stale", after)
+	}
+}
+
+// TestIdentifyPlatformFallbackStillWorks pins the domain-based fallback chain, which is what
+// answers when no configured pattern matches. The longest-match loop must not shadow it.
+func TestIdentifyPlatformFallbackStillWorks(t *testing.T) {
+	v := NewValidator()
+	// No configured patterns at all: SOCIAL_MEDIA ships none, so this is the default state.
+	v.compiledPatterns = map[string][]*regexp.Regexp{}
+	v.rebuildSortedPlatforms()
+
+	for _, tc := range []struct{ match, want string }{
+		{"https://www.linkedin.com/in/person", "linkedin"},
+		{"https://twitter.com/person", "twitter"},
+		{"https://www.youtube.com/@person", "youtube"},
+		{"https://tiktok.com/@person", "tiktok"},
+		{"@person", "twitter"},
+	} {
+		if got := v.identifyPlatform(tc.match); got != tc.want {
+			t.Errorf("identifyPlatform(%q) = %q, want %q", tc.match, got, tc.want)
+		}
+	}
+}

--- a/internal/validators/socialmedia/validator.go
+++ b/internal/validators/socialmedia/validator.go
@@ -87,8 +87,8 @@ type Validator struct {
 	platformKeywords map[string][]string
 
 	// False positive prevention
-	whitelistPatterns         []string
-	compiledWhitelistPatterns []*regexp.Regexp
+	allowlistPatterns         []string
+	compiledAllowlistPatterns []*regexp.Regexp
 
 	// Configuration tracking
 	patternsConfigured bool
@@ -264,8 +264,8 @@ func NewValidator() *Validator {
 		},
 
 		// Initialize false positive prevention
-		whitelistPatterns:         []string{},
-		compiledWhitelistPatterns: []*regexp.Regexp{},
+		allowlistPatterns:         []string{},
+		compiledAllowlistPatterns: []*regexp.Regexp{},
 
 		// Track configuration status
 		patternsConfigured: false,
@@ -505,54 +505,63 @@ func (v *Validator) Configure(cfg *config.Config) {
 		}
 	}
 
-	// Update whitelist patterns if provided
-	if whitelistPatterns, ok := smConfig["whitelist_patterns"].([]any); ok {
-		customWhitelistPatterns := []string{}
-		validWhitelistPatterns := []string{}
+	// Update allowlist patterns if provided.
+	//
+	// "allowlist_patterns" is the documented key; "whitelist_patterns" is still read so
+	// existing configuration keeps working. If both are present the inclusive spelling
+	// wins, and the older one is ignored rather than merged — a silent union of two lists
+	// would make the effective configuration depend on which key the reader noticed.
+	allowlistKeyed, ok := smConfig["allowlist_patterns"].([]any)
+	if !ok {
+		allowlistKeyed, ok = smConfig["whitelist_patterns"].([]any)
+	}
+	if allowlistPatterns := allowlistKeyed; ok {
+		customAllowlistPatterns := []string{}
+		validAllowlistPatterns := []string{}
 		invalidCount := 0
 
-		for _, patternAny := range whitelistPatterns {
+		for _, patternAny := range allowlistPatterns {
 			if patternStr, ok := patternAny.(string); ok {
 				// Add case-insensitive flag if not already present
 				processedPattern := v.ensureCaseInsensitive(patternStr)
 
 				// Validate regex pattern
 				if _, err := regexp.Compile(processedPattern); err != nil {
-					// Log warning for invalid whitelist pattern but continue with valid ones
+					// Log warning for invalid allowlist pattern but continue with valid ones
 					if v.observer != nil && v.observer.Debug() != nil {
-						v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Invalid whitelist pattern '%s': %v", patternStr, err))
+						v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Invalid allowlist pattern '%s': %v", patternStr, err))
 					}
 
-					// Log invalid whitelist pattern in debug mode
+					// Log invalid allowlist pattern in debug mode
 					if os.Getenv("FERRET_DEBUG") == "1" {
-						fmt.Fprintf(os.Stderr, "[DEBUG] Social Media: Invalid whitelist pattern: %v\n", err)
+						fmt.Fprintf(os.Stderr, "[DEBUG] Social Media: Invalid allowlist pattern: %v\n", err)
 					}
 					invalidCount++
 					continue
 				}
-				customWhitelistPatterns = append(customWhitelistPatterns, patternStr)
-				validWhitelistPatterns = append(validWhitelistPatterns, processedPattern)
+				customAllowlistPatterns = append(customAllowlistPatterns, patternStr)
+				validAllowlistPatterns = append(validAllowlistPatterns, processedPattern)
 			}
 		}
 
-		if len(validWhitelistPatterns) > 0 {
-			v.whitelistPatterns = customWhitelistPatterns
-			v.compileWhitelistPatterns()
+		if len(validAllowlistPatterns) > 0 {
+			v.allowlistPatterns = customAllowlistPatterns
+			v.compileAllowlistPatterns()
 			if v.observer != nil && v.observer.Debug() != nil {
-				v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Loaded %d valid whitelist patterns (%d invalid patterns skipped)", len(validWhitelistPatterns), invalidCount))
-				for i, pattern := range customWhitelistPatterns {
-					v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("  Whitelist pattern %d: %s", i+1, pattern))
+				v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Loaded %d valid allowlist patterns (%d invalid patterns skipped)", len(validAllowlistPatterns), invalidCount))
+				for i, pattern := range customAllowlistPatterns {
+					v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("  Allowlist pattern %d: %s", i+1, pattern))
 				}
 			}
 
-			// Log whitelist patterns in debug mode
-			if os.Getenv("FERRET_DEBUG") == "1" && len(validWhitelistPatterns) > 0 {
-				fmt.Fprintf(os.Stderr, "[DEBUG] Social Media: Loaded %d whitelist patterns\n", len(validWhitelistPatterns))
+			// Log allowlist patterns in debug mode
+			if os.Getenv("FERRET_DEBUG") == "1" && len(validAllowlistPatterns) > 0 {
+				fmt.Fprintf(os.Stderr, "[DEBUG] Social Media: Loaded %d allowlist patterns\n", len(validAllowlistPatterns))
 			}
 		} else if invalidCount > 0 {
-			// All whitelist patterns were invalid
+			// All allowlist patterns were invalid
 			if v.observer != nil && v.observer.Debug() != nil {
-				v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("All %d configured whitelist patterns are invalid", invalidCount))
+				v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("All %d configured allowlist patterns are invalid", invalidCount))
 			}
 		}
 	}
@@ -1914,10 +1923,10 @@ func (v *Validator) validatePathStructure(match string, platform string) bool {
 // - Placeholder URL detection and exclusion
 // - Context-based false positive detection (code comments, documentation)
 // - Pattern specificity checks to avoid overly broad matches
-// - Whitelist pattern support for excluding known false positives
+// - Allowlist pattern support for excluding known false positives
 func (v *Validator) validateNotFalsePositive(match string, platform string) bool {
-	// 1. Check whitelist patterns first - if match is whitelisted, exclude it
-	if v.isWhitelistedMatch(match) {
+	// 1. Check allowlist patterns first - if match is allowlisted, exclude it
+	if v.isAllowlistedMatch(match) {
 		return false
 	}
 
@@ -1944,9 +1953,43 @@ func (v *Validator) validateNotFalsePositive(match string, platform string) bool
 	return true
 }
 
-// isWhitelistedMatch checks if the match should be excluded based on whitelist patterns
-func (v *Validator) isWhitelistedMatch(match string) bool {
-	for _, pattern := range v.compiledWhitelistPatterns {
+// allowlistedSpans returns the byte ranges of the line an operator has listed as noise, or nil
+// when no allowlist is configured (the default — SOCIAL_MEDIA ships none).
+//
+// Spans rather than value comparison, because the two are not the same shape. An allowlist
+// entry like `twitter\.com/companybrand` matches a SUBSTRING of the reported value
+// "https://twitter.com/companybrand", so the allowlist span sits inside the match span; while
+// an overlapping pattern from another platform can report "@companybrand", a fragment whose
+// span sits inside the allowlist span. Vetoing on OVERLAP covers both directions, and covers
+// nothing else: a second profile elsewhere on the same line does not overlap and is untouched.
+//
+// This is what makes the veto actually exclude the value the operator named. Measured before:
+// allowlisting a YouTube channel URL still reported "@brandchannel" at HIGH 100, because
+// twitter's bare-handle pattern claimed a fragment of the same URL under a different name.
+func (v *Validator) allowlistedSpans(line string) [][]int {
+	if len(v.compiledAllowlistPatterns) == 0 {
+		return nil
+	}
+	var spans [][]int
+	for _, pattern := range v.compiledAllowlistPatterns {
+		spans = append(spans, pattern.FindAllStringIndex(line, -1)...)
+	}
+	return spans
+}
+
+// overlapsAllowlistedSpan reports whether [start,end) intersects any allowlisted span.
+func overlapsAllowlistedSpan(spans [][]int, start, end int) bool {
+	for _, s := range spans {
+		if start < s[1] && s[0] < end {
+			return true
+		}
+	}
+	return false
+}
+
+// isAllowlistedMatch checks if the match should be excluded based on allowlist patterns
+func (v *Validator) isAllowlistedMatch(match string) bool {
+	for _, pattern := range v.compiledAllowlistPatterns {
 		if pattern.MatchString(match) {
 			return true
 		}
@@ -2571,32 +2614,32 @@ func (v *Validator) monitorMemoryUsage(operation string, metadata map[string]any
 	}
 }
 
-// compileWhitelistPatterns compiles the whitelist patterns into regex objects
+// compileAllowlistPatterns compiles the allowlist patterns into regex objects
 // for false positive prevention
-func (v *Validator) compileWhitelistPatterns() {
-	// Handle empty whitelist patterns gracefully
-	if len(v.whitelistPatterns) == 0 {
-		v.compiledWhitelistPatterns = []*regexp.Regexp{}
+func (v *Validator) compileAllowlistPatterns() {
+	// Handle empty allowlist patterns gracefully
+	if len(v.allowlistPatterns) == 0 {
+		v.compiledAllowlistPatterns = []*regexp.Regexp{}
 		if v.observer != nil && v.observer.Debug() != nil {
-			v.observer.Debug().LogDetail("socialmedia", "No whitelist patterns to compile - empty pattern list")
+			v.observer.Debug().LogDetail("socialmedia", "No allowlist patterns to compile - empty pattern list")
 		}
 		return
 	}
 
 	// Pre-allocate slice with exact capacity for better memory efficiency
-	v.compiledWhitelistPatterns = make([]*regexp.Regexp, 0, len(v.whitelistPatterns))
+	v.compiledAllowlistPatterns = make([]*regexp.Regexp, 0, len(v.allowlistPatterns))
 	compiledCount := 0
 	failedCount := 0
 
-	for i, pattern := range v.whitelistPatterns {
+	for i, pattern := range v.allowlistPatterns {
 		// Skip empty patterns gracefully
 		if pattern == "" {
 			failedCount++
 			if v.observer != nil && v.observer.Debug() != nil {
-				v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Skipping empty whitelist pattern at index %d", i+1))
+				v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Skipping empty allowlist pattern at index %d", i+1))
 			}
 			if os.Getenv("FERRET_DEBUG") == "1" {
-				fmt.Fprintf(os.Stderr, "[WARNING] Social Media Validator: Empty whitelist pattern at index %d - skipping\n", i+1)
+				fmt.Fprintf(os.Stderr, "[WARNING] Social Media Validator: Empty allowlist pattern at index %d - skipping\n", i+1)
 			}
 			continue
 		}
@@ -2612,12 +2655,12 @@ func (v *Validator) compileWhitelistPatterns() {
 
 			// Log compilation errors for debugging
 			if v.observer != nil && v.observer.Debug() != nil {
-				v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Failed to compile whitelist pattern %d: '%s' - Error: %v", i+1, pattern, err))
+				v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Failed to compile allowlist pattern %d: '%s' - Error: %v", i+1, pattern, err))
 			}
 
 			// Also log to stderr in debug mode
 			if os.Getenv("FERRET_DEBUG") == "1" {
-				fmt.Fprintf(os.Stderr, "[ERROR] Social Media Validator: Failed to compile whitelist pattern\n")
+				fmt.Fprintf(os.Stderr, "[ERROR] Social Media Validator: Failed to compile allowlist pattern\n")
 				fmt.Fprintf(os.Stderr, "[ERROR]   Pattern %d: %s\n", i+1, pattern)
 				fmt.Fprintf(os.Stderr, "[ERROR]   Error: %v\n", err)
 				fmt.Fprintf(os.Stderr, "[ERROR]   Action: Skipping pattern and continuing with remaining patterns\n")
@@ -2626,22 +2669,22 @@ func (v *Validator) compileWhitelistPatterns() {
 		}
 
 		// Successfully compiled pattern
-		v.compiledWhitelistPatterns = append(v.compiledWhitelistPatterns, regex)
+		v.compiledAllowlistPatterns = append(v.compiledAllowlistPatterns, regex)
 		compiledCount++
 	}
 
 	// Log compilation summary
 	if v.observer != nil && v.observer.Debug() != nil {
-		v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Whitelist pattern compilation: %d successful, %d failed", compiledCount, failedCount))
+		v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Allowlist pattern compilation: %d successful, %d failed", compiledCount, failedCount))
 		if compiledCount > 0 {
-			v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Successfully compiled %d whitelist regex patterns", compiledCount))
+			v.observer.Debug().LogDetail("socialmedia", fmt.Sprintf("Successfully compiled %d allowlist regex patterns", compiledCount))
 		}
 	}
 
 	// Also log to stderr in debug mode
 	if os.Getenv("FERRET_DEBUG") == "1" {
-		fmt.Fprintf(os.Stderr, "[DEBUG] Social Media Validator: Whitelist compilation summary\n")
-		fmt.Fprintf(os.Stderr, "[DEBUG]   Total patterns: %d\n", len(v.whitelistPatterns))
+		fmt.Fprintf(os.Stderr, "[DEBUG] Social Media Validator: Allowlist compilation summary\n")
+		fmt.Fprintf(os.Stderr, "[DEBUG]   Total patterns: %d\n", len(v.allowlistPatterns))
 		fmt.Fprintf(os.Stderr, "[DEBUG]   Successfully compiled: %d\n", compiledCount)
 		fmt.Fprintf(os.Stderr, "[DEBUG]   Failed to compile: %d\n", failedCount)
 	}
@@ -2759,6 +2802,10 @@ func (v *Validator) processLineForAllPatterns(line string, lineNum int, original
 	// match, which on a long packed line is O(matches × keywords × lineLen).
 	lineLower := strings.ToLower(line)
 
+	// Byte ranges the operator has listed as noise, computed once per line. nil unless an
+	// allowlist is configured, so the default path pays nothing.
+	allowSpans := v.allowlistedSpans(line)
+
 	// Check each platform's patterns
 	for platform, patterns := range v.compiledPatterns {
 		for patternIndex, regex := range patterns {
@@ -2774,6 +2821,17 @@ func (v *Validator) processLineForAllPatterns(line string, lineNum int, original
 				match := line[loc[0]:loc[1]]
 				// Skip empty matches
 				if len(strings.TrimSpace(match)) == 0 {
+					continue
+				}
+
+				// An operator's allowlist entry is an instruction, not a heuristic, so it is a
+				// veto here rather than a score adjustment (#429) — for the same measured
+				// reason as the reserved paths in processMatchOptimized:
+				// validateNotFalsePositive already says "if match is allowlisted, exclude it",
+				// but its result is only advisory, the caller turns it into a 30-point
+				// penalty, and the cap absorbs it. Before this, an allowlisted URL and an
+				// ordinary one were both reported at HIGH 100.
+				if overlapsAllowlistedSpan(allowSpans, loc[0], loc[1]) {
 					continue
 				}
 
@@ -4575,7 +4633,7 @@ func (v *Validator) reconstructSocialMediaCluster(matches []detector.Match) (det
 		//
 		// Held as lean copies with SecureText dropped: these carry the matched value, so
 		// they are withheld from output by the formatters' deny-by-default metadata
-		// whitelist unless --show-match is set, and a SecureString has no business being
+		// allowlist unless --show-match is set, and a SecureString has no business being
 		// serialized.
 		"cluster_members": leanClusterMembers(matches),
 

--- a/internal/validators/socialmedia/validator.go
+++ b/internal/validators/socialmedia/validator.go
@@ -73,6 +73,12 @@ type Validator struct {
 	platformPatterns map[string][]string
 	compiledPatterns map[string][]*regexp.Regexp
 
+	// sortedPlatforms holds the compiledPatterns keys in sorted order so identifyPlatform
+	// can iterate deterministically without sorting per match. Rebuilt by
+	// rebuildSortedPlatforms wherever compiledPatterns is finalised — read-only on the
+	// scanning path, which is what keeps it race-free.
+	sortedPlatforms []string
+
 	// Contextual analysis keywords
 	positiveKeywords []string
 	negativeKeywords []string
@@ -304,6 +310,7 @@ func (v *Validator) Configure(cfg *config.Config) {
 			v.patternsConfigured = false
 			v.platformPatterns = make(map[string][]string)
 			v.compiledPatterns = make(map[string][]*regexp.Regexp)
+			v.rebuildSortedPlatforms()
 		}
 	}()
 
@@ -825,9 +832,27 @@ func (v *Validator) processLineMatchesWithClustering(lineMatches map[int][]detec
 	return processedMatches
 }
 
-// CalculateConfidence implements the detector.Validator interface
-// with multi-factor validation and platform-specific confidence scoring
+// CalculateConfidence implements the detector.Validator interface.
+//
+// The interface hands over only the matched text, so the platform has to be re-derived
+// here. The scanner's own path does not come through this entry point: it calls
+// calculateConfidenceForPlatform with the platform its pattern loop already knows, which
+// is both correct and independent of map order. See #390.
 func (v *Validator) CalculateConfidence(match string) (float64, map[string]bool) {
+	return v.calculateConfidenceForPlatform(match, v.identifyPlatform(match))
+}
+
+// calculateConfidenceForPlatform scores a match against a KNOWN platform.
+//
+// Roughly ten validations below are platform-specific — validateURLFormat, validateDomain,
+// validateUsernameFormat, validatePatternSpecificity and friends — so the platform is not
+// a label on the result, it is an input to the score. Feeding it a re-derived guess made
+// the score a function of Go's map iteration order: for
+// "https://www.youtube.com/@handle", which the youtube URL pattern AND twitter's bare
+// "@handle" pattern both match, the same input in 30 identical runs of one binary scored
+// 100 in 18 runs and 17 in 12, and the split reached the report as the
+// original_confidences metadata.
+func (v *Validator) calculateConfidenceForPlatform(match string, platform string) (float64, map[string]bool) {
 	checks := make(map[string]bool)
 	var confidence float64 = 0
 
@@ -857,8 +882,8 @@ func (v *Validator) CalculateConfidence(match string) (float64, map[string]bool)
 	}
 	checks["valid_input"] = true
 
-	// Determine which platform this match belongs to
-	platform := v.identifyPlatform(match)
+	// The platform is supplied by the caller; see the doc comment above for why it must
+	// not be re-derived here.
 	if platform == "" {
 		// Unknown platform - assign low confidence with enhanced logging
 		if v.observer != nil && v.observer.Debug() != nil {
@@ -968,17 +993,65 @@ func (v *Validator) CalculateConfidence(match string) (float64, map[string]bool)
 	return confidence, checks
 }
 
+// sortedCompiledPlatforms returns the configured platform names in a stable order.
+//
+// Computed once per pattern-compilation rather than per call: identifyPlatform sits on a
+// per-match path, and sorting there would allocate for every match on every line.
+// compilePatterns resets this alongside compiledPatterns, so the two cannot disagree.
+func (v *Validator) sortedCompiledPlatforms() []string {
+	return v.sortedPlatforms
+}
+
+// rebuildSortedPlatforms recomputes the cache from compiledPatterns. Called wherever
+// compiledPatterns is finalised, never from a per-match path: a lazily-populated cache
+// would be a write on the scanning path, and validators are shared across the
+// per-file goroutines.
+func (v *Validator) rebuildSortedPlatforms() {
+	names := make([]string, 0, len(v.compiledPatterns))
+	for platform := range v.compiledPatterns {
+		names = append(names, platform)
+	}
+	sort.Strings(names)
+	v.sortedPlatforms = names
+}
+
 // identifyPlatform determines which platform a match belongs to
 func (v *Validator) identifyPlatform(match string) string {
 	matchLower := strings.ToLower(match)
 
-	// Check each platform's patterns to identify the match
-	for platform, patterns := range v.compiledPatterns {
-		for _, regex := range patterns {
-			if regex.MatchString(match) {
+	// Longest match wins, over platforms visited in sorted order.
+	//
+	// This used to range v.compiledPatterns and return the first platform whose pattern
+	// matched anywhere. Both halves of that were wrong for an overlapping match. Go
+	// randomizes map iteration, so the answer varied run to run; and "matched anywhere"
+	// treats a substring hit as equal to a whole-string hit, so twitter's bare "@handle"
+	// pattern competed with youtube's full URL pattern on
+	// "https://www.youtube.com/@handle" — a 7-character match against a 36-character one.
+	//
+	// Preferring the longest matched span resolves it on evidence rather than on order:
+	// the platform whose pattern explains more of the value wins. Sorted iteration then
+	// makes the remaining ties (two platforms matching the same span length) fall to the
+	// lexicographically first platform, so the result is a function of the input alone.
+	best, bestLen := "", 0
+	for _, platform := range v.sortedCompiledPlatforms() {
+		for _, regex := range v.compiledPatterns[platform] {
+			loc := regex.FindStringIndex(match)
+			if loc == nil {
+				continue
+			}
+			span := loc[1] - loc[0]
+			if span == len(match) {
+				// Spans the whole value; nothing can beat it, and sorted order means the
+				// first such platform is always the same one.
 				return platform
 			}
+			if span > bestLen {
+				best, bestLen = platform, span
+			}
 		}
+	}
+	if best != "" {
+		return best
 	}
 
 	// Fallback: identify by domain/content
@@ -2305,6 +2378,7 @@ func (v *Validator) compilePlatformPatterns() {
 	// Handle empty pattern maps gracefully
 	if len(v.platformPatterns) == 0 {
 		v.compiledPatterns = make(map[string][]*regexp.Regexp)
+		v.rebuildSortedPlatforms()
 		if v.observer != nil && v.observer.Debug() != nil {
 			v.observer.Debug().LogDetail("socialmedia", "No social media patterns to compile - empty pattern map")
 		}
@@ -2446,6 +2520,11 @@ func (v *Validator) compilePlatformPatterns() {
 	if totalCompiled == 0 && len(v.platformPatterns) > 0 {
 		v.logNoSocialMediaPatterns("all social media patterns failed to compile during regex compilation")
 	}
+
+	// compiledPatterns is now final for this configuration, so fix the iteration order
+	// identifyPlatform will use. Done here rather than lazily on first match: this is the
+	// only write, and it happens before any scanning goroutine reads it.
+	v.rebuildSortedPlatforms()
 }
 
 // compileOptimizedPattern compiles a regex pattern with performance optimizations
@@ -2754,8 +2833,9 @@ func (v *Validator) processMatchOptimized(match, platform string, patternIndex i
 		return nil
 	}
 
-	// Calculate confidence for this match
-	confidence, checks := v.CalculateConfidence(match)
+	// Score against the platform whose pattern actually produced this match, rather than
+	// letting CalculateConfidence re-derive it (#390).
+	confidence, checks := v.calculateConfidenceForPlatform(match, platform)
 
 	// Build context from the in-memory line. The previous code called
 	// contextExtractor.ExtractContext, which re-opens and re-reads the file from
@@ -4495,7 +4575,7 @@ func (v *Validator) reconstructSocialMediaCluster(matches []detector.Match) (det
 		//
 		// Held as lean copies with SecureText dropped: these carry the matched value, so
 		// they are withheld from output by the formatters' deny-by-default metadata
-		// allowlist unless --show-match is set, and a SecureString has no business being
+		// whitelist unless --show-match is set, and a SecureString has no business being
 		// serialized.
 		"cluster_members": leanClusterMembers(matches),
 

--- a/internal/validators/socialmedia/validator_test.go
+++ b/internal/validators/socialmedia/validator_test.go
@@ -668,16 +668,16 @@ func TestSocialMediaValidator_ValidateDomain(t *testing.T) {
 	}
 }
 
-// --- Whitelist Pattern Tests ---
+// --- Allowlist Pattern Tests ---
 
 func TestSocialMediaValidator_IsWhitelistedMatch(t *testing.T) {
 	v := newConfiguredValidator()
 
-	// With no whitelist patterns, nothing should be whitelisted
-	t.Run("empty whitelist", func(t *testing.T) {
-		result := v.isWhitelistedMatch("https://twitter.com/user")
+	// With no allowlist patterns, nothing should be allowlisted
+	t.Run("empty allowlist", func(t *testing.T) {
+		result := v.isAllowlistedMatch("https://twitter.com/user")
 		if result {
-			t.Error("Expected no whitelist match with empty whitelist")
+			t.Error("Expected no allowlist match with empty allowlist")
 		}
 	})
 }


### PR DESCRIPTION
Two `SOCIAL_MEDIA` defects that share a cause — **something the code already knew was thrown
away and guessed again**. One commit each.

Fixes #390. Fixes #429.

## #390 — the platform is an input to the score, not a label on it

About ten validations take the platform as an argument (`validateURLFormat`, `validateDomain`,
`validateUsernameFormat`, `validatePatternSpecificity` …). `CalculateConfidence` discarded the
platform its caller already knew and re-derived it by ranging `v.compiledPatterns`, returning
the first platform whose pattern matched **anywhere**. Both halves were wrong for a value two
platforms can claim:

- Go randomizes map iteration, so the answer varied per call.
- "matched anywhere" ranks a 12-character substring hit equal to a 36-character whole-string
  one, so twitter's bare `@handle` pattern competed with youtube's URL pattern on
  `https://www.youtube.com/@handle` — an ordinary YouTube handle URL.

Measured through the CLI with the shipped example patterns, **30 identical runs of one binary
on that one URL**:

```
18 runs  original_confidences=[100, 100]
12 runs  original_confidences=[17, 100]     <- same input, same binary
```

Both the split and the wrongness matter: **17 is what a valid YouTube profile URL scores when
it is graded as a Twitter handle.**

The fix threads the producing pattern's platform into scoring, so the score cannot disagree with
the pattern by construction, and makes the remaining derivation deterministic by preferring the
**longest matched span** over platforms visited in sorted order. After: 30/30 runs give
`[100, 100]` — and it settles on the *correct* value, not the stable-but-wrong one.

## #429 — an allowlist that discounts instead of excluding

`validateNotFalsePositive` says *"if match is allowlisted, exclude it"*, but its return value is
advisory: the caller turns it into a 30-point penalty. Confidence is capped at 100 while the raw
total for a well-formed profile URL exceeds 130, so the penalty is **absorbed entirely**:

```
https://twitter.com/companybrand   HIGH 100    not_false_positive=false   <- allowlisted
https://twitter.com/realperson_x   HIGH 100    not_false_positive=true
```

Indistinguishable in the report, so the configuration had no visible effect at all — and the
allowlisted value was redacted out of the copy too.

This is the same failure, with the same numbers, that `reserved_paths.go` was written for; its
veto sits a few lines away in the same function and documents the cap arithmetic. An operator's
allowlist entry is an instruction, not a heuristic, so it becomes a veto alongside it.

**The veto matches spans, not values,** because both directions occur:

| direction | example |
|---|---|
| allowlist span *inside* the finding | `twitter\.com/companybrand` matches a substring of `https://twitter.com/companybrand` |
| finding *inside* the allowlist span | twitter's bare-handle pattern reports `@brandchannel` out of an allowlisted YouTube channel URL — measured at HIGH 100 |

Overlap covers both and covers nothing else. The same-line case improves twice over:

```
before   1 finding: "twitter: brandchannel, realperson_x | youtube: brandchannel"  95
                    (a clustered value that appears nowhere in the file, mixing the
                     allowlisted brand with the real person)
after    1 finding: "https://twitter.com/realperson_x"                            100
```

## Inclusive language

Per the project rule, the Go identifiers and all prose become allowlist/allowlisted, and the
config key gains its inclusive spelling `allowlist_patterns`. **`whitelist_patterns` keeps
working** — the DevSecOps template in use elsewhere sets the old key, and silently ignoring it
would make suppressed findings reappear. If both are present the inclusive key wins and the
older one is ignored rather than merged, so the effective configuration cannot depend on which
key a reader noticed.

## Documentation

`docs/social-media-configuration.md` documented the OLD behaviour as if it were intended
(*"reduces the confidence of such a match but does not remove it"*). That sentence is now
correct instead, with the measurement of why the reduction was invisible, plus a new section on
span matching and the deprecated alias. The check's own `--help social_media` config snippet is
updated the same way.

## Test plan

`make pr-checklist BASE=origin/main` — **10 ran, 0 failed**, all 5 manual dimensions worked:

```
1 gofmt / go vet / go build      RAN — clean
2 full suite (-count=1)          RAN — 69 packages ok
3 golden regen                   RAN — 0 files changed
11 cross-platform vet            RAN — linux darwin windows
12 flake (3 repeats)             RAN — socialmedia
13 race (whole module)           RAN — 69 packages ok
-- -short mode / tree clean      RAN — ok
```

- **4 redaction** — all three strategies on a fixture holding every new behaviour: no cleartext
  leak of any reported value, and the **allowlisted** URL is correctly left in cleartext, since
  the operator said it is not sensitive. Before this change it was redacted, because it was
  reported at HIGH 100.
- **5 suppression** — generated with the **parent** binary, applied with this one: 2/2 still
  suppress under both. No hash-input drift.
- **6 timing** — N/2N/4N over a social-media-dense fixture, best of 3: `350/650/1280ms` against
  `350/660/1320ms`, i.e. marginally **faster** — the removed per-match derivation more than pays
  for the longest-match loop. 32000 findings at the largest size, so not an empty measurement.
- **7 formats** — text, json, yaml, csv, junit, gitlab-sast, sarif: all valid, rc=0, 3 findings
  each (4 URLs minus the vetoed one), and the allowlisted value appears in none of them.
- **10 non-vacuity** — six mutations. Four are caught: restoring the map range (fails the tie
  test), containment instead of overlap (8 tests), dropping the inclusive config key (7 tests),
  and first-wins instead of longest (invalid — does not compile). Two are reported honestly
  below rather than papered over.

### Two things this PR does NOT claim

- **The emit-path threading is belt-and-braces** once `identifyPlatform` is deterministic:
  reverting it fails no test, because longest-match-wins usually agrees with the producing
  pattern. Its justification is that the caller knows the answer, so re-deriving can only be
  right by luck — plus it removes work from the per-match path.
- **The nondeterminism does not reach my real-document corpus.** 714 real Office/PDF documents
  give 478 findings before and after, and 12 repeat runs per binary on the six highest-yield
  documents are byte-identical for *both* binaries — none of those files contains a value that
  two configured patterns both match. The defect is reproduced on the URL form above, which is
  ordinary enough to expect in the wild; the corpus shows the fix costs nothing.

Also measured and *not* claimed: the redaction label is unchanged (`[YOUTUBE-REDACTED]` in 12/12
runs on both binaries), because the label comes from the producing pattern rather than from the
derivation.

Disjoint at file level from all 9 other open PRs.
