### PR TITLE
refactor(preprocessors): remove unused manager facade

### DIFF
--- a/docs/development/text_extraction_integration.md
+++ b/docs/development/text_extraction_integration.md
@@ -14,15 +14,18 @@ The text extraction preprocessors allow Ferret-scan to analyze the content of do
 
 1. **Preprocessor Interface** (`internal/preprocessors/preprocessor.go`)
    - Defines the `Preprocessor` interface for all preprocessors
-   - Provides `PreprocessorManager` for managing multiple preprocessors
+   - Defines the shared `ProcessedContent` model
+
+2. **File Router** (`internal/router/file_router.go`)
+   - Registers and coordinates multiple preprocessors
    - Handles file type detection and routing
 
-2. **Text Preprocessor** (`internal/preprocessors/text_preprocessor.go`)
+3. **Text Preprocessor** (`internal/preprocessors/text_preprocessor.go`)
    - Implements text extraction for PDF and Office documents
    - Uses existing text extraction libraries
    - Returns structured `ProcessedContent`
 
-3. **Updated Validator Interface** (`internal/detector/detector.go`)
+4. **Updated Validator Interface** (`internal/detector/detector.go`)
    - Added `ValidateContent()` method for processing extracted text
    - Maintains backward compatibility with existing `Validate()` method
 

--- a/internal/preprocessors/preprocessor.go
+++ b/internal/preprocessors/preprocessor.go
@@ -3,11 +3,7 @@
 
 package preprocessors
 
-import (
-	"path/filepath"
-
-	"github.com/awslabs/ferret-scan/v2/internal/observability"
-)
+import "github.com/awslabs/ferret-scan/v2/internal/observability"
 
 // ProcessedContent represents content that has been processed by a preprocessor
 type ProcessedContent struct {
@@ -238,79 +234,6 @@ type Preprocessor interface {
 
 	// SetObserver sets the observability component
 	SetObserver(observer observability.Observer)
-}
-
-// PreprocessorManager manages all available preprocessors
-type PreprocessorManager struct {
-	preprocessors []Preprocessor
-}
-
-// NewPreprocessorManager creates a new preprocessor manager
-func NewPreprocessorManager() *PreprocessorManager {
-	return &PreprocessorManager{
-		preprocessors: make([]Preprocessor, 0),
-	}
-}
-
-// RegisterPreprocessor adds a preprocessor to the manager
-func (pm *PreprocessorManager) RegisterPreprocessor(p Preprocessor) {
-	pm.preprocessors = append(pm.preprocessors, p)
-}
-
-// GetPreprocessor returns the appropriate preprocessor for a file, or nil if none found
-func (pm *PreprocessorManager) GetPreprocessor(filePath string) Preprocessor {
-	for _, p := range pm.preprocessors {
-		if p.CanProcess(filePath) {
-			return p
-		}
-	}
-	return nil
-}
-
-// ProcessFile processes a file with all appropriate preprocessors
-func (pm *PreprocessorManager) ProcessFile(filePath string) (*ProcessedContent, error) {
-	// Get all preprocessors that can handle this file
-	var availablePreprocessors []Preprocessor
-	for _, p := range pm.preprocessors {
-		if p.CanProcess(filePath) {
-			availablePreprocessors = append(availablePreprocessors, p)
-		}
-	}
-
-	if len(availablePreprocessors) == 0 {
-		// No preprocessor available, return original file content as-is
-		return &ProcessedContent{
-			OriginalPath:  filePath,
-			Filename:      filepath.Base(filePath),
-			Text:          "", // Will be read by validators directly
-			ProcessorType: "none",
-			Success:       true,
-		}, nil
-	}
-
-	// Use the first successful preprocessor (maintaining backward compatibility)
-	var lastError error
-	for _, preprocessor := range availablePreprocessors {
-		result, err := preprocessor.Process(filePath)
-		if err == nil && result != nil && result.Success {
-			return result, nil
-		}
-		lastError = err
-	}
-
-	// All preprocessors failed, return the last error
-	return &ProcessedContent{
-		OriginalPath:  filePath,
-		Filename:      filepath.Base(filePath),
-		ProcessorType: "failed",
-		Success:       false,
-		Error:         lastError,
-	}, lastError
-}
-
-// GetAvailablePreprocessors returns all registered preprocessors
-func (pm *PreprocessorManager) GetAvailablePreprocessors() []Preprocessor {
-	return pm.preprocessors
 }
 
 // AddPositionMapping adds a position mapping to the processed content


### PR DESCRIPTION
*Issue #, if available:*

#384

*Description of changes:*

Removes the unreferenced `PreprocessorManager` facade and documents `FileRouter` as the component responsible for preprocessor registration and routing. The existing `TextPreprocessor` remains unchanged.

Tests:
- `GOTOOLCHAIN=go1.26.7 go test -count=1 ./internal/preprocessors/... ./internal/router/...`
- `GOTOOLCHAIN=go1.26.7 go vet ./...`
- `GOTOOLCHAIN=go1.26.7 go build ./...`
- Serialized full and short suites passed after excluding two failures reproduced on `origin/main`: unavailable Windows symlink privileges and the intermittent zero-duration timing assertion.

Local race testing could not run because CGO is disabled; the existing CI matrix covers race on all three hosted platforms.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

---

_Maintainer edit: adding a closing reference so the issue resolves on merge._

Closes #384
