### PR TITLE
docs(preprocessors): correct the config, output and failure samples in the text extraction guide

### DIFF
--- a/docs/development/text_extraction_integration.md
+++ b/docs/development/text_extraction_integration.md
@@ -47,9 +47,6 @@ defaults:
 preprocessors:
   text_extraction:
     enabled: true
-    types:
-      - pdf
-      - office
 
 profiles:
   thorough:
@@ -71,13 +68,29 @@ ferret-scan --file document.pdf --enable-preprocessors=false
 ferret-scan --file documents/ --profile thorough --recursive
 ```
 
-### Verbose Output
+### Preprocessing Output
 
-When using `--verbose`, the tool will show preprocessing information:
+`--preprocess-only` (`-p`) prints each file's preprocessing status followed by the
+extracted text:
 
 ```
-Preprocessed document.pdf: extracted 1250 words, 7890 characters
+=== FILE: document.docx ===
+Processor: Text Extractor+office_metadata
+Status: Success
+Content: 19 words, 127 characters
+
+Quarterly report text with several words in it for extraction.
+
+--- office_metadata ---
+DocumentType: Word Document
 ```
+
+`Processor` is the `+`-joined list of preprocessors that actually ran, and each
+non-body section is introduced by a `--- name ---` header. The `Content` line
+gains a `, N pages` suffix when the extractor reports a page count.
+
+`--verbose` does not print preprocessing information — it prints match details
+and the scan summary.
 
 ## Integration Details
 
@@ -86,7 +99,8 @@ Preprocessed document.pdf: extracted 1250 words, 7890 characters
 1. **File Detection**: Check if file extension requires preprocessing
 2. **Preprocessing**: Extract text content using appropriate extractor
 3. **Validation**: Pass extracted text to validators using `ValidateContent()`
-4. **Fallback**: If preprocessing fails, fall back to regular file validation
+4. **Failure**: If extraction fails there is no file-reading validation to fall
+   back to; the failure is surfaced as an extraction error for that file
 
 ### Validator Updates
 
@@ -97,9 +111,8 @@ Validators operate exclusively on pre-extracted content:
 
 > The former file-reading `Validate(filePath string)` method was removed in v2
 > (gap 3.2): every implementation was a no-op stub that never read the file, so
-> production always went through `ValidateContent`. The step-4 "fallback to
-> regular file validation" above is likewise obsolete — there is no file-reading
-> validation path to fall back to; extraction feeds `ValidateContent` directly.
+> production always went through `ValidateContent`. Extraction feeds
+> `ValidateContent` directly.
 
 ### Performance Considerations
 
@@ -140,4 +153,5 @@ Validators operate exclusively on pre-extracted content:
 
 ### Debug Information
 
-Use `--verbose` to see preprocessing status and statistics for each file.
+Use `--preprocess-only` to see the preprocessing status and statistics for each
+file. `--verbose` covers match details and the scan summary, not preprocessing.


### PR DESCRIPTION
*Issue #, if available:*

None — found while reviewing #469, which corrects a different claim in the same file.

*Description of changes:*

Four claims in `docs/development/text_extraction_integration.md` did not match the tool. Each was measured against a build of `origin/main`, not read off the source.

**1. The config sample set a key the schema does not have.** The "Configuration File" block included `preprocessors.text_extraction.types`. Running the tool with that exact snippet:

```
$ ferret-scan --config <doc-sample>.yaml --file probe.txt --checks SSN
Warning: unknown config key "types" — ignored (check for a typo)
No matches found.
```

With the key removed, the same snippet is silent. The other three keys in the sample are real (`preprocessors.text_extraction.enabled`, `defaults.enable_preprocessors`, `profiles.<name>.enable_preprocessors`).

**2. "Verbose Output" named the wrong flag and quoted a string that does not exist.** It claimed `--verbose` shows preprocessing information, sampled as `Preprocessed document.pdf: extracted 1250 words, 7890 characters`. That string appears nowhere in the tree. `--verbose` prints match details and the scan summary — I confirmed it prints nothing preprocessing-related, both with and without findings. The statistics come from `--preprocess-only` (`cmd/main.go`, `processPreprocessOnly`), so the section is renamed and now carries that mode's real output, captured from a genuine `.docx`:

```
=== FILE: document.docx ===
Processor: Text Extractor+office_metadata
Status: Success
Content: 19 words, 127 characters
```

That sample also documents two things worth knowing: `Processor` is the `+`-joined list of preprocessors that actually ran, and each non-body section carries a `--- name ---` header — both consequences of how `FileRouter` assembles a result.

**3. "Processing Flow" step 4 contradicted the same page.** It claimed a fallback to regular file validation; the blockquote two sections down already said that fallback is obsolete. Step 4 now states what happens instead, and the blockquote drops the annotation it no longer needs while keeping the v2 `Validate` removal note.

**4. "Debug Information" repeated the `--verbose` claim** and now points at `--preprocess-only`.

The supported-file-types list was checked against `TextPreprocessor.supportedExtensions` and is accurate, so it is left alone.

*Relationship to #469:*

Independent and order-independent. #469 edits the Components section (lines 14-29); this edits the Configuration, Output, Processing Flow and Troubleshooting sections. I test-merged both in all three orders — #469 first, this first, and this squash-merged first, since the repo squash-merges — and every one auto-merges with both changes intact. This deliberately leaves #469's Components wording alone so it cannot conflict.

*Test plan:*

`make pr-checklist BASE=origin/main` — **9 ran, 0 failed, 0 need manual work.**

```
=== scope ===
  docs/development/text_extraction_integration.md
  production (non-test) .go files: 0

=== dimensions ===
1 gofmt                            RAN — clean
1 go vet                           RAN — clean
1 go build                         RAN — ok
2 full suite (-count=1)            RAN — 69 packages ok
3 golden regen                     RAN — 0 files changed
4 redaction                        N/A — no production code changed
5 suppression                      N/A — no production code changed
6 timing / O(n^2)                  N/A — no production code changed
7 all 7 formats                    N/A — no production code changed
8 web / CSP                        N/A — no web/template/asset file touched
10 non-vacuity                     N/A — no test files added
11 cross-platform vet              RAN — linux darwin windows
13 race (whole module)             RAN — 69 packages ok
-- -short mode                     RAN — ok
-- tree clean                      RAN — this run dirtied nothing

=== summary: 9 ran, 0 failed, 0 need manual work ===
```

Beyond the checklist, the two behavioural claims were verified by running the tool: the corrected YAML sample no longer warns, and `--preprocess-only` produces the output now shown while `--verbose` produces none of it.
