### PR TITLE
DIAGNOSTIC — DO NOT MERGE: sample machine memory during the ubuntu suite to find the SIGTERM cause

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -101,5 +101,37 @@ jobs:
         # build assumptions, error-message assertions that don't match
         # actual binary output). Tracked separately from production-code
         # quality. Run them locally on Windows when working on those tests.
-        run: go test -race -count=1 $(go list ./... | grep -v /tests/integration)
+        run: |
+          # DIAGNOSTIC BRANCH ONLY. ubuntu-latest has been killed by SIGTERM ("the runner has received
+          # a shutdown signal") 6+ times, always mid-suite at 244-306s, never on windows or macos, with
+          # no test reporting FAIL. Six hypotheses are eliminated by measurement: test-suite OOM,
+          # -race compile OOM, disk exhaustion, concurrency cancellation, a configured timeout, and the
+          # redundant cache step (removed in #602 -- the SIGTERM happened anyway with the tar failure
+          # absent). Local measurement cannot settle it: this repo is developed on darwin/arm64, and
+          # ThreadSanitizer's shadow mapping is a different size on linux/amd64, so extrapolating is
+          # exactly the assumption that has been wrong twice already.
+          #
+          # So sample the machine WHILE the suite runs and let the runner answer. Total memory across
+          # all processes, not one process's RSS -- `go test` runs up to GOMAXPROCS race-instrumented
+          # binaries concurrently, so the sum is the number that matters and the one no local tool here
+          # reported.
+          echo "::group::machine"
+          nproc; free -m; df -h /; ulimit -a
+          echo "::endgroup::"
+          ( while true; do
+              printf '[SAMPLE t=%ss] mem: ' "$SECONDS"
+              free -m | awk '/^Mem:/{printf "used=%sMB avail=%sMB", $3, $7}'
+              printf ' | swap: '
+              free -m | awk '/^Swap:/{printf "used=%sMB", $3}'
+              printf ' | disk: '
+              df -m / | awk 'NR==2{printf "avail=%sMB", $4}'
+              printf ' | top-rss: '
+              ps -eo rss,comm --sort=-rss | awk 'NR>1 && NR<5{printf "%s=%sMB ", $2, int($1/1024)}'
+              echo
+              sleep 15
+            done ) &
+          SAMPLER=$!
+          trap 'kill $SAMPLER 2>/dev/null || true' EXIT
+          go test -race -count=1 $(go list ./... | grep -v /tests/integration)
         shell: bash
+        timeout-minutes: 25


### PR DESCRIPTION
**Not for merge. Close this once it has produced one ubuntu run.** It exists only to get a measurement I cannot take locally.

## Why

`ubuntu-latest` has been killed by `SIGTERM` — *"The runner has received a shutdown signal"* — **6+ times**, always mid-suite at **244–306 s**, never on windows or macos, with **no test reporting `FAIL`**. It passes roughly 5 runs in 12.

**Six hypotheses eliminated by measurement, not argument:**

| hypothesis | measured | verdict |
|---|---|---|
| test-suite OOM | 3.3 GB single-process peak vs 16 GB runner | ✗ |
| `-race` compile OOM | 377 MB | ✗ |
| disk exhaustion | 375 MB build cache vs ~14 GB free | ✗ |
| concurrency cancellation | no `concurrency` block; sibling jobs survive the same run | ✗ |
| configured timeout | none; default is 360 min | ✗ |
| failed cache restore | removed in #602 — **SIGTERM happened anyway with the tar failure absent** | ✗ |

I also had to retract two claims: *"it always dies at `internal/goldencorpus`"* was an artifact of `go test ./...` printing in **list order**, and the 4-of-4 cache correlation was coincidence.

## Why local measurement cannot settle it

This repo is developed on **darwin/arm64**. `-race` is ThreadSanitizer, whose shadow-memory mapping is a different size on **linux/amd64** — so extrapolating my local numbers is precisely the kind of assumption that has already been wrong twice here.

Worse, the local tool is measuring the wrong thing: `/usr/bin/time -l` reports the max RSS of a **single** process, not the **sum** across concurrently running test binaries. `go test ./...` runs up to `GOMAXPROCS` race-instrumented binaries at once, so the sum is the number that matters — and it is the one figure I have never had. Measured locally as a sanity check, `-p 2` reported a *higher* single-process peak (5.77 GB) than the default (3.29 GB), which is exactly what you would expect from a metric that cannot see concurrency.

## What this does

Every 15 s during the suite, on the runner:

- **total** memory used and available (`free -m`), not one process's RSS
- swap usage — if the runner starts swapping, that alone can look like a stall then a kill
- free disk on `/`
- the top 3 processes by RSS, so the culprit names itself
- plus `nproc`, `free -m`, `df -h`, `ulimit -a` up front, and `timeout-minutes: 25` so a **hang** is distinguishable from a **kill**

If memory climbs toward the runner's limit before the SIGTERM, that is the answer and the fix is to bound concurrency (`-p`) or split the job. If it stays flat, memory is eliminated too and the remaining explanation is hosted-runner reclamation, which is a report to GitHub rather than a code change.

Either way the next step stops being a guess.