### PR TITLE
test(ci): measure the #619 cycle clock and the #649 control margins on the real runners

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -170,7 +170,11 @@ jobs:
       # controls learned to disclose under instrumentation, and -race distorts these ratios
       # asymmetrically -- an emit-heavy base inflates 3.1x against its big's 1.6x.
       - name: CI experiment (#619 cycle clock, #649 control margins)
-        if: startsWith(github.head_ref, 'exp/') || startsWith(github.ref_name, 'exp/')
+        # always(): a measurement step must not be skipped because an EARLIER step failed. Without
+        # this the windows run of this very experiment produced zero data, because the unrelated
+        # TestTicksIsSufficient flake failed the race step first and GitHub skipped everything after
+        # it. continue-on-error covers this step failing; it does not cover this step being skipped.
+        if: always() && (startsWith(github.head_ref, 'exp/') || startsWith(github.ref_name, 'exp/'))
         continue-on-error: true
         env:
           FERRET_CI_EXPERIMENT: "1"

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -156,6 +156,28 @@ jobs:
         run: go test -race -count=1 $(go list ./... | grep -v /tests/integration)
         shell: bash
 
+      # CI-only measurement for #619 (is the Windows cycle counter a usable clock?) and #649 (do two
+      # maxGrowthRatio controls really sit under the 1.5x margin, and does the pair count move it?).
+      #
+      # Runs ONLY on exp/* branches, so it costs every other branch nothing. Gated a second time inside
+      # the tests by FERRET_CI_EXPERIMENT, so a stray invocation is a skip rather than five minutes of
+      # measurement.
+      #
+      # continue-on-error and assertion-free by construction: both questions are about what this runner
+      # reports, and a measurement that can fail the build would get switched off.
+      #
+      # NOT under -race. #649 is about the non-race path, which is the one that still asserts after the
+      # controls learned to disclose under instrumentation, and -race distorts these ratios
+      # asymmetrically -- an emit-heavy base inflates 3.1x against its big's 1.6x.
+      - name: CI experiment (#619 cycle clock, #649 control margins)
+        if: startsWith(github.head_ref, 'exp/') || startsWith(github.ref_name, 'exp/')
+        continue-on-error: true
+        env:
+          FERRET_CI_EXPERIMENT: "1"
+        run: |
+          go test -v -count=1 -run 'TestCIExperiment619CycleClock' ./internal/perfguard/
+          go test -v -count=1 -run 'TestCIExperiment649ControlMargins' ./internal/goldencorpus/
+
       - name: Report this runner's clock granularity
         # internal/perfguard measures algorithmic growth as a ratio of CPU-time readings, and the
         # threshold it will divide by (MinMeasurableCPU) is a fixed 2ms on every platform. Whether

--- a/internal/goldencorpus/ci_experiment_test.go
+++ b/internal/goldencorpus/ci_experiment_test.go
@@ -1,0 +1,102 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package goldencorpus
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/awslabs/ferret-scan/v2/internal/detector"
+	"github.com/awslabs/ferret-scan/v2/internal/perfguard"
+)
+
+// TestCIExperiment649ControlMargins answers #649 with data no developer machine can produce.
+//
+// Two of the four maxGrowthRatio controls sit under this repo's own >=1.5x margin convention on
+// macos-latest, and the linear control's 6.40x there is unexplained: this dev Mac reads a stable ~4.0x,
+// runs the fixtures 3.6x faster, and has 14 cores against that runner's 3-4.
+//
+// #649 names the experiment that would settle it, and this is it: per-pair samples for every control, on
+// every runner, at pairs=2 AND pairs=4. The question the pair count answers is directional and cannot be
+// reasoned out -- Ratio = min(big)/min(base), so more samples shrink BOTH minima and the net direction is
+// undetermined. Measured on the dev Mac the worst-of-4-trials went 4.61x at 2 pairs, 4.13x at 4, 4.39x at
+// 8: no trend, inside the noise, and on a machine that reproduces none of the problem.
+//
+// MEASUREMENT ONLY. Nothing is asserted, so this cannot redden CI. Gated on FERRET_CI_EXPERIMENT.
+func TestCIExperiment649ControlMargins(t *testing.T) {
+	if os.Getenv("FERRET_CI_EXPERIMENT") == "" {
+		t.Skip("set FERRET_CI_EXPERIMENT=1 to run the #649 measurement")
+	}
+
+	cpuTick, wallTick := perfguard.ClockResolution()
+	t.Logf("EXP649 platform: cpuTick=%v wallTick=%v maxGrowthRatio=%.1f raceDetector=%v",
+		cpuTick, wallTick, maxGrowthRatio, raceDetectorEnabled)
+
+	rescans := 0
+	controls := []struct {
+		name string
+		// direction: +1 means the reading must EXCEED maxGrowthRatio, -1 means it must stay at or below.
+		direction int
+		reps      int
+		newV      func() validatorUnderTest
+		unit      string
+		gen       func(int) string
+	}{
+		{"quadratic(catches)", +1, 3000, func() validatorUnderTest { return quadraticValidator{} }, "", quadraticUnit},
+		{"linear(stays-low)", -1, 40000, func() validatorUnderTest { return linearValidator{} }, linearUnit, nil},
+		{"emit-per-match(catches)", +1, 3000, func() validatorUnderTest { return emittingQuadraticValidator{} }, "", quadraticUnit},
+		{"sparse-4096(misses)", -1, 48000, func() validatorUnderTest {
+			return sparseQuadraticValidator{every: 4096, rescans: &rescans}
+		}, "", quadraticUnit},
+	}
+
+	const trials = 5
+	for _, c := range controls {
+		unit := c.unit
+		gen := c.gen
+		if unit == "" {
+			unit = gen(0)
+			gen = nil
+		}
+		base := buildComplexityInput(unit, gen, c.reps)
+		big := buildComplexityInput(unit, gen, c.reps*4)
+
+		for _, pairs := range []int{2, 4} {
+			var worst float64
+			var bestMargin = 9999.0
+			for trial := 0; trial < trials; trial++ {
+				g, err := perfguard.Measure(pairs,
+					func() { _, _ = c.newV().ValidateContent(base, "exp.txt") },
+					func() { _, _ = c.newV().ValidateContent(big, "exp.txt") })
+				if err != nil {
+					t.Logf("EXP649 %-24s pairs=%d trial=%d Measure error: %v", c.name, pairs, trial, err)
+					continue
+				}
+				// The margin, in the direction this control asserts. Below 1.5 is the #649 finding.
+				margin := maxGrowthRatio / g.Ratio
+				if c.direction > 0 {
+					margin = g.Ratio / maxGrowthRatio
+				}
+				if margin < bestMargin {
+					bestMargin = margin
+				}
+				if (c.direction < 0 && g.Ratio > worst) || (c.direction > 0 && (worst == 0 || g.Ratio < worst)) {
+					worst = g.Ratio
+				}
+				n, suff := g.Ticks()
+				t.Logf("EXP649 %-24s pairs=%d trial=%d ratio=%6.2fx margin=%4.2fx clock=%-4s base=%-11v big=%-11v ticks=%.0f(%v) per-pair %s",
+					c.name, pairs, trial, g.Ratio, margin, g.Clock, g.BaseMin, g.BigMin, n, suff,
+					perfguard.FormatRatios(g.Samples))
+			}
+			verdict := "OK"
+			if bestMargin < 1.5 {
+				verdict = fmt.Sprintf("UNDER 1.5x (%.2fx)", bestMargin)
+			}
+			t.Logf("EXP649 SUMMARY %-24s pairs=%d worstRatio=%6.2fx worstMargin=%4.2fx %s",
+				c.name, pairs, worst, bestMargin, verdict)
+		}
+	}
+	_ = detector.Match{}
+}

--- a/internal/goldencorpus/ci_experiment_test.go
+++ b/internal/goldencorpus/ci_experiment_test.go
@@ -86,9 +86,18 @@ func TestCIExperiment649ControlMargins(t *testing.T) {
 					worst = g.Ratio
 				}
 				n, suff := g.Ticks()
-				t.Logf("EXP649 %-24s pairs=%d trial=%d ratio=%6.2fx margin=%4.2fx clock=%-4s base=%-11v big=%-11v ticks=%.0f(%v) per-pair %s",
-					c.name, pairs, trial, g.Ratio, margin, g.Clock, g.BaseMin, g.BigMin, n, suff,
-					perfguard.FormatRatios(g.Samples))
+				// The CONTENTION SIGNAL: wall/cpu on the base reading. Under contention the wall clock
+				// keeps running while the process is descheduled, so this ratio rises; the CPU clock
+				// itself also inflates through cache and scheduler effects, which is what depresses the
+				// growth ratio. If this tracks the depressed ratios, it is a usable trustworthiness gate
+				// -- Growth already carries both numbers, so no new measurement would be needed.
+				inflation := 0.0
+				if g.BaseMin > 0 {
+					inflation = float64(g.BaseWallMin) / float64(g.BaseMin)
+				}
+				t.Logf("EXP649 %-24s pairs=%d trial=%d ratio=%6.2fx margin=%4.2fx clock=%-4s base=%-11v big=%-11v baseWall=%-11v wall/cpu=%5.2f ticks=%.0f(%v) per-pair %s",
+					c.name, pairs, trial, g.Ratio, margin, g.Clock, g.BaseMin, g.BigMin, g.BaseWallMin,
+					inflation, n, suff, perfguard.FormatRatios(g.Samples))
 			}
 			verdict := "OK"
 			if bestMargin < 1.5 {

--- a/internal/perfguard/ci_experiment_test.go
+++ b/internal/perfguard/ci_experiment_test.go
@@ -1,0 +1,190 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package perfguard
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestCIExperiment619CycleClock answers #619 with measurements that cannot be taken on a developer
+// machine: windows-latest advances its CPU clock in 15.625ms steps, and whether the cycle counter #624
+// landed is a usable replacement depends on properties only that runner can report.
+//
+// MEASUREMENT ONLY. Every finding is logged and nothing is asserted, so this can never redden CI. It is
+// gated on FERRET_CI_EXPERIMENT so it costs other branches nothing.
+//
+// The four properties #624 said one Windows run would settle, plus the one it did not ask:
+//
+//  1. does the counter advance, and never go backwards
+//  2. its smallest non-zero delta, against the 15.625ms of the CPU clock
+//  3. is SLEEPING charged -- the property a raw invariant TSC would lose, and the whole reason the CPU
+//     statistic exists rather than a wall-clock one
+//  4. does a 4x workload read ~4x and a quadratic ~16x on it
+//  5. NEW: how do all three clocks compare on the SAME workload, in one run? #619 assumed the choice was
+//     between a finer CPU clock and giving up; #645 has since moved windows onto its wall clock, so the
+//     honest question is whether cycles beat what is already shipping.
+func TestCIExperiment619CycleClock(t *testing.T) {
+	if os.Getenv("FERRET_CI_EXPERIMENT") == "" {
+		t.Skip("set FERRET_CI_EXPERIMENT=1 to run the #619 measurement")
+	}
+
+	cpuTick, wallTick := ClockResolution()
+	t.Logf("EXP619 platform: cpuTick=%v wallTick=%v MinTicks=%d cyclesSupported=%v",
+		cpuTick, wallTick, MinTicks, CyclesSupported())
+	t.Logf("EXP619 MinTicks costs: cpu=%v wall=%v (budget %v)",
+		time.Duration(MinTicks)*cpuTick, time.Duration(MinTicks)*wallTick, MinTicksBudget)
+
+	if !CyclesSupported() {
+		t.Log("EXP619 cycle counter unsupported on this platform; properties 1-4 are windows-only")
+	} else {
+		// 1 + 2: advance, monotonicity, and the smallest non-zero delta.
+		var smallest uint64 = 1 << 62
+		backwards := 0
+		prev, err := ProcessCPUCycles()
+		if err != nil {
+			t.Logf("EXP619 ProcessCPUCycles error: %v", err)
+		} else {
+			for i := 0; i < 200_000; i++ {
+				cur, err := ProcessCPUCycles()
+				if err != nil {
+					t.Logf("EXP619 ProcessCPUCycles error mid-loop: %v", err)
+					break
+				}
+				switch {
+				case cur < prev:
+					backwards++
+				case cur > prev:
+					if d := cur - prev; d < smallest {
+						smallest = d
+					}
+				}
+				prev = cur
+			}
+			t.Logf("EXP619 cycle counter: smallestNonZeroDelta=%d cycles, wentBackwards=%d times",
+				smallest, backwards)
+		}
+
+		// 3: is sleeping charged? A counter that charges sleep is a wall clock wearing a hat, and would
+		// reintroduce the contention sensitivity this package exists to remove.
+		before, _ := ProcessCPUCycles()
+		time.Sleep(100 * time.Millisecond)
+		after, _ := ProcessCPUCycles()
+		sleepCharged := after - before
+		busyBefore, _ := ProcessCPUCycles()
+		burnCycles(8_000_000)
+		busyAfter, _ := ProcessCPUCycles()
+		busyCharged := busyAfter - busyBefore
+		t.Logf("EXP619 100ms SLEEP charged %d cycles; 8M-step BUSY loop charged %d cycles (ratio busy/sleep=%s)",
+			sleepCharged, busyCharged, ratioStr(busyCharged, sleepCharged))
+	}
+
+	// 4 + 5: the same two workloads read on all three clocks, in one run.
+	//
+	// Read together rather than in separate Measure calls, so contention cannot differ between the
+	// clocks being compared -- comparing a cpu ratio from one run against a wall ratio from another is
+	// how this repo previously convinced itself of the wrong thing.
+	for _, c := range []struct {
+		name       string
+		base, big  func()
+		wantApprox string
+	}{
+		{"linear 4x", func() { burnCycles(8_000_000) }, func() { burnCycles(32_000_000) }, "~4x"},
+		{"quadratic 16x", func() { burnQuadratic(12_000_000) }, func() { burnQuadratic(48_000_000) }, "~16x"},
+	} {
+		cpuR, wallR, cycR := threeClockRatio(t, c.base, c.big)
+		t.Logf("EXP619 %-14s want %-4s  cpu=%s  wall=%s  cycles=%s", c.name, c.wantApprox, cpuR, wallR, cycR)
+	}
+}
+
+// threeClockRatio times base and big twice each, taking minimums, and reports the growth ratio each clock
+// gives for the same readings.
+func threeClockRatio(t *testing.T, base, big func()) (cpuRatio, wallRatio, cycleRatio string) {
+	t.Helper()
+
+	type reading struct {
+		cpu, wall time.Duration
+		cycles    uint64
+	}
+	take := func(fn func()) reading {
+		cpuBefore, _ := ProcessCPUTime()
+		cycBefore, _ := ProcessCPUCycles()
+		start := time.Now()
+		fn()
+		wall := time.Since(start)
+		cpuAfter, _ := ProcessCPUTime()
+		cycAfter, _ := ProcessCPUCycles()
+		return reading{cpu: cpuAfter - cpuBefore, wall: wall, cycles: cycAfter - cycBefore}
+	}
+
+	var bases, bigs []reading
+	WithGCOff(func() {
+		for i := 0; i < DefaultPairs; i++ {
+			bases = append(bases, take(base))
+			bigs = append(bigs, take(big))
+		}
+	})
+
+	minCPU := func(rs []reading) time.Duration {
+		m := rs[0].cpu
+		for _, r := range rs[1:] {
+			if r.cpu < m {
+				m = r.cpu
+			}
+		}
+		return m
+	}
+	minWall := func(rs []reading) time.Duration {
+		m := rs[0].wall
+		for _, r := range rs[1:] {
+			if r.wall < m {
+				m = r.wall
+			}
+		}
+		return m
+	}
+	minCyc := func(rs []reading) uint64 {
+		m := rs[0].cycles
+		for _, r := range rs[1:] {
+			if r.cycles < m {
+				m = r.cycles
+			}
+		}
+		return m
+	}
+
+	bc, gc := minCPU(bases), minCPU(bigs)
+	bw, gw := minWall(bases), minWall(bigs)
+	by, gy := minCyc(bases), minCyc(bigs)
+
+	cpuRatio = durRatio(bc, gc)
+	wallRatio = durRatio(bw, gw)
+	cycleRatio = ratioStr(gy, by)
+	return cpuRatio, wallRatio, cycleRatio
+}
+
+func durRatio(base, big time.Duration) string {
+	if base <= 0 {
+		return "base=0 (unmeasurable)"
+	}
+	n := float64(big) / float64(base)
+	ticksNote := ""
+	cpuTick, wallTick := ClockResolution()
+	_ = wallTick
+	if cpuTick > 0 {
+		ticksNote = " base=" + base.String()
+	}
+	return sprintf("%.2fx%s", n, ticksNote)
+}
+
+func ratioStr(big, base uint64) string {
+	if base == 0 {
+		return "base=0"
+	}
+	return sprintf("%.2fx (base=%d)", float64(big)/float64(base), base)
+}
+
+func sprintf(format string, a ...any) string { return fmt.Sprintf(format, a...) }


### PR DESCRIPTION
Measurement-only branch for the two questions that need CI hardware. Assertion-free, gated on `exp/*` + `FERRET_CI_EXPERIMENT`, `continue-on-error`. Not for merge as-is — the point is the numbers in the job logs.

Refs #619, #649.